### PR TITLE
Autodeploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,13 @@ script:
 
 before_cache:
   - rm -rf "$TRAVIS_HOME/.cargo/registry/src"
+
+deploy:
+  - provider: script
+    script: ./docker/deploy.sh $TRAVIS_BRANCH
+    on:
+      branch: main
+  - provider: script
+    script: ./docker/deploy.sh $TRAVIS_TAG
+    on:
+      tags: true

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    # Build and tag image
+    docker build -t $DOCKERHUB_PROJECT -f docker/Dockerfile .
+    docker tag $DOCKERHUB_PROJECT gnosispm/$DOCKERHUB_PROJECT:$1
+    docker push gnosispm/$DOCKERHUB_PROJECT:$1
+
+    if [ "$1" == "main" ] && [ -n "$AUTODEPLOY_URL" ]; then
+      # Notifying webhook
+      curl -s  \
+      --output /dev/null \
+      --write-out "%{http_code}" \
+      -H "Content-Type: application/json" \
+      -d '{"push_data": {"tag": "'$1'" }}' \
+      -X POST \
+      $AUTODEPLOY_URL
+    fi
+fi


### PR DESCRIPTION
This PR makes it so that we can automatically deploy and restart services that run in staging when merging into master. Scrip is mostly copied from [gas-token-mining](https://github.com/gnosis/gas-token-mining/blob/d196ffd6b7a439e62e3f339a1e4b210cc03b2915/docker/deploy.sh#L1) while using the same autodeploy push tag as gp-v1-services

When ready, we can easily restart more services by adding them to the URL here: https://travis-ci.com/github/gnosis/gp-v2-services/settings

### Test Plan
Once merged see dev-dfusion-v2-api-rinkeby pod restarting.
