### PR TITLE
[Easy] Adjust travis build premise for main branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
   - name: Merge approved and green PRs with `merge when green` label
     conditions:
       - "#approved-reviews-by>=1"
-      - status-success=build
+      - status-success=Travis CI - Pull Request
       - base=main
       - label=merge when green
     actions:
@@ -13,7 +13,7 @@ pull_request_rules:
   - name: Automatic merge for Dependabot pull requests
     conditions:
       - author~=^dependabot(|-preview)\[bot\]$
-      - status-success=build
+      - status-success=Travis CI - Pull Request
       - base=main
     actions:
       merge:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
-if: (branch = master) OR (type = pull_request) OR (tag IS present)
+branches:
+  only:
+    - main
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+
 language: rust
 rust:
   - stable


### PR DESCRIPTION
When checking #76 I noticed we are not building on the main branch.

For PC reasons, we changed our default branch name from master to main, however the travis file was likely copied from an older repo and still targeted for the master branch.

This PR replaces the if statement with the more modern [safelisting](https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches) approach and will ensure we build on main branches and release tag (in the for vX.Y[.Z]) 

### Test Plan

See us building on the main branch.