### PR TITLE
Add minimal driver run loop

### DIFF
--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -14,5 +14,5 @@ model = { path = "../model" }
 primitive-types = "0.7"
 reqwest = { version = "0.10", features = ["json"] }
 serde_json = "1.0"
-tokio = { version = "0.2", features =[ "macros"] }
-web3 = { version = "0.13", default-features = false, features = [] }
+tokio = { version = "0.2", features =[ "macros", "time"] }
+web3 = { version = "0.13", default-features = false }

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -1,7 +1,47 @@
-use crate::ethereum::SettlementContract;
+use crate::{ethereum::SettlementContract, naive_solver, orderbook::OrderBookApi};
+use anyhow::{Context, Result};
 use std::{sync::Arc, time::Duration};
+
+const SETTLE_INTERVAL: Duration = Duration::from_secs(30);
 
 pub struct Driver {
     contract: Arc<dyn SettlementContract>,
-    max_order_age: Duration,
+    orderbook: OrderBookApi,
+}
+
+impl Driver {
+    async fn run_forever(&mut self) {
+        loop {
+            println!("starting settle attempt");
+            match self.single_run().await {
+                Ok(()) => println!("ok"),
+                Err(err) => println!("error: {:?}", err),
+            }
+            tokio::time::delay_for(SETTLE_INTERVAL).await;
+        }
+    }
+
+    async fn single_run(&mut self) -> Result<()> {
+        let orders = self.orderbook.get_orders().await?;
+        // TODO: order validity checks
+        // Decide what is handled by orderbook service and what by us.
+        // We likely want to at least mark orders we know we have settled so that we don't
+        // attempt to settle them again when they are still in the orderbook.
+        let settlement =
+            match naive_solver::settle(orders.into_iter().map(|order| order.order_creation)) {
+                None => return Ok(()),
+                Some(settlement) => settlement,
+            };
+        // TODO: encode settlement, check if we need to approve spending to uniswap
+        // TODO: use retry transaction sending crate for updating gas prices
+        self.contract
+            .settle_call(&settlement)
+            .await
+            .context("settle call failed")?;
+        self.contract
+            .settle_send(&settlement)
+            .await
+            .context("settle send failed")?;
+        Ok(())
+    }
 }

--- a/solver/src/ethereum.rs
+++ b/solver/src/ethereum.rs
@@ -9,7 +9,10 @@ use primitive_types::H160;
 #[async_trait]
 pub trait SettlementContract {
     async fn get_nonce(&self, token_pair: TokenPair) -> Result<u32>;
-    async fn settle(&self, settlement: Settlement) -> Result<()>;
+    // Call simulates the transaction.
+    async fn settle_call(&self, settlement: &Settlement) -> Result<()>;
+    // Send really executes the transaction.
+    async fn settle_send(&self, settlement: &Settlement) -> Result<()>;
 }
 
 #[async_trait]

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -10,6 +10,5 @@ mod settlement;
 
 #[tokio::main]
 async fn main() {
-    // TODO: create driver, call settle_if_needed every 10 seconds
     todo!("run driver")
 }


### PR DESCRIPTION
in order to add more structure to the solver code. This outlines a very
simple run loop that attempts to settle every 30 seconds. No
transactions run in parallel which means we won't need code to keep track of multiple running transactions for the demo.
For now uses `println` but want to use the tracing crate in the future instead of logging. Will make another PR for that.

### Test Plan
not yet testable. can test this once we have the settlement contract and maybe ganache.
