### PR TITLE
[Trivial] Add rinkeby staging url to openapi.yml

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -3,8 +3,10 @@ info:
   version: 0.0.1
   title: Order Book API
 servers:
-- url: http://localhost:8080
-  description: Local
+  - url: https://protocol-rinkeby.dev.gnosisdev.com
+    description: Rinkeby (Staging)
+  - url: http://localhost:8080
+    description: Local
 paths:
   /api/v1/orders:
     post:


### PR DESCRIPTION
This way we can run the swagger UI against the actual deployment:

![image](https://user-images.githubusercontent.com/1200333/101504706-d1dee480-3973-11eb-8350-15e17c5f195c.png)

### Test Plan
After merging make sure that in swagger we get the real responses of the current rinkeby endpoints.
