### PR TITLE
Verify order signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,9 +1037,12 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "hex",
+ "hex-literal",
  "primitive-types",
+ "secp256k1 0.17.2",
  "serde",
  "serde_json",
+ "web3",
 ]
 
 [[package]]
@@ -1165,7 +1168,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "hex-literal",
  "model",
  "primitive-types",
  "serde",

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -6,8 +6,11 @@ edition = "2018"
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 hex = { version = "0.4", default-features = false }
+hex-literal = "0.3"
 primitive-types = { version = "0.7" }
+secp256k1 = "0.17"
 serde = { version = "1.0", features = ["derive"] }
+web3 = { version = "0.13", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-hex-literal = "0.3"
 model = { path = "../model" }
 primitive-types = "0.7"
 serde = { version = "1.0", features = ["derive"] }

--- a/orderbook/src/api/filter.rs
+++ b/orderbook/src/api/filter.rs
@@ -62,7 +62,8 @@ pub mod test_util {
     async fn get_orders_() {
         let orderbook = Arc::new(OrderBook::default());
         let filter = get_orders(orderbook.clone());
-        let order = OrderCreation::default();
+        let mut order = OrderCreation::default();
+        order.sign_self();
         orderbook.add_order(order).await.unwrap();
         let response = request()
             .path("/api/v1/orders")
@@ -74,6 +75,7 @@ pub mod test_util {
         let orderbook_orders = orderbook.get_orders().await;
         assert_eq!(response_orders, orderbook_orders);
     }
+
     #[tokio::test]
     async fn get_fee_info_() {
         let filter = get_fee_info();
@@ -96,12 +98,14 @@ pub mod test_util {
         assert_eq!(body.fee_ratio, 0);
         assert!(body.expiration_date.gt(&chrono::offset::Utc::now()))
     }
+
     #[tokio::test]
     async fn create_order_() {
         let orderbook = Arc::new(OrderBook::default());
         let filter = create_order(orderbook.clone());
-        let order = OrderCreation::default();
-        let expected_uid = json!({"UID": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"});
+        let mut order = OrderCreation::default();
+        order.sign_self();
+        let expected_uid = json!({"UID": "5ffa6cfc98b68d14b6546dda3e1d233d7f739e4941e71165c19489521a6038751a642f0e3c3af545e7acbd38b07251b3990914f100000000"});
         let post = || async {
             request()
                 .path("/api/v1/orders")

--- a/orderbook/src/api/handler.rs
+++ b/orderbook/src/api/handler.rs
@@ -45,12 +45,7 @@ pub async fn add_order(
     order: OrderCreation,
 ) -> Result<impl warp::Reply, Infallible> {
     let (body, status_code) = match orderbook.add_order(order).await {
-        Ok(()) => (
-            warp::reply::json(&UidResponse {
-                uid: order.order_uid(),
-            }),
-            StatusCode::CREATED,
-        ),
+        Ok(uid) => (warp::reply::json(&UidResponse { uid }), StatusCode::CREATED),
         Err(err) => {
             let (error_type, description, status_code) = match err {
                 AddOrderError::DuplicatedOrder => (


### PR DESCRIPTION
and allow creation of signed orders for tests.
Resides in the model crate because this will be useful for the order
book and the solver.
Also moved uid creation to model for the same reason.

### Test Plan
new unit tests
