### PR TITLE
Returning UID as string

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -3,8 +3,10 @@ info:
   version: 0.0.1
   title: Order Book API
 servers:
-- url: http://localhost:8080
-  description: Local
+  - url: https://protocol-rinkeby.dev.gnosisdev.com
+    description: Rinkeby (Staging)
+  - url: http://localhost:8080
+    description: Local
 paths:
   /api/v1/orders:
     post:

--- a/orderbook/src/api/filter.rs
+++ b/orderbook/src/api/filter.rs
@@ -101,7 +101,7 @@ pub mod test_util {
         let orderbook = Arc::new(OrderBook::default());
         let filter = create_order(orderbook.clone());
         let order = OrderCreation::default();
-        let expected_uid = json!({"UID": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"});
+        let expected_uid = json!("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
         let post = || async {
             request()
                 .path("/api/v1/orders")


### PR DESCRIPTION
... and not as a json object. Good catch from Felix.

Nick mentioned that we might even should use the "0x" prefix as it as specified like that, but I think we should not do it, as we don't do it in any other place.


