### PR TITLE
Set allow origin header so that openapi works with localhost

### DIFF
--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -7,7 +7,7 @@ use warp::Filter;
 
 pub fn handle_all_routes(
     orderbook: Arc<OrderBook>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     let order_creation = filter::create_order(orderbook.clone());
     let order_getter = filter::get_orders(orderbook);
     let fee_info = filter::get_fee_info();

--- a/orderbook/src/api/filter.rs
+++ b/orderbook/src/api/filter.rs
@@ -21,7 +21,7 @@ fn extract_user_order() -> impl Filter<Extract = (OrderCreation,), Error = warp:
 
 pub fn create_order(
     orderbook: Arc<OrderBook>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("orders")
         .and(warp::post())
         .and(with_orderbook(orderbook))
@@ -31,14 +31,15 @@ pub fn create_order(
 
 pub fn get_orders(
     orderbook: Arc<OrderBook>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("orders")
         .and(warp::get())
         .and(with_orderbook(orderbook))
         .and_then(handler::get_orders)
 }
 
-pub fn get_fee_info() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+pub fn get_fee_info() -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
+{
     warp::path!("fee" / H160)
         .and(warp::get())
         .and_then(handler::get_fee_info)


### PR DESCRIPTION
We're doing the same thing for the v1 price estimator.

### Test Plan
`cargo run --bin orderbook` and https://protocol-rinkeby.dev.gnosisdev.com/api/#/default/get_api_v1_orders with localhost.
