### PR TITLE
Trivial, renaming orderKind to kind

### DIFF
--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -52,7 +52,7 @@ pub struct OrderCreation {
     pub app_data: u32,
     #[serde(with = "u256_decimal")]
     pub fee_amount: U256,
-    pub order_kind: OrderKind,
+    pub kind: OrderKind,
     pub partially_fillable: bool,
     pub signature: Signature,
 }
@@ -122,7 +122,7 @@ impl OrderCreation {
         hash_data[188..192].copy_from_slice(&self.valid_to.to_be_bytes());
         hash_data[220..224].copy_from_slice(&self.app_data.to_be_bytes());
         self.fee_amount.to_big_endian(&mut hash_data[224..256]);
-        hash_data[287] = match self.order_kind {
+        hash_data[287] = match self.kind {
             OrderKind::Sell => 0,
             OrderKind::Buy => 1,
         };
@@ -321,7 +321,7 @@ mod tests {
             "validTo": 4294967295u32,
             "appData": 0,
             "feeAmount": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-            "orderKind": "buy",
+            "kind": "buy",
             "partiallyFillable": false,
             "signature": "0102000000000000000000000000000000000000000000000000000000000000030400000000000000000000000000000000000000000000000000000000000005",
         });
@@ -339,7 +339,7 @@ mod tests {
                 valid_to: u32::MAX,
                 app_data: 0,
                 fee_amount: U256::MAX,
-                order_kind: OrderKind::Buy,
+                kind: OrderKind::Buy,
                 partially_fillable: false,
                 signature: Signature {
                     v: 1,
@@ -394,7 +394,7 @@ mod tests {
             app_data: 101058054,
             fee_amount: hex!("0707070707070707070707070707070707070707070707070707070707070707")
                 .into(),
-            order_kind: OrderKind::Buy,
+            kind: OrderKind::Buy,
             partially_fillable: true,
             signature: Signature {
                 v: 0x1b,
@@ -419,7 +419,7 @@ mod tests {
             valid_to: 4294967295,
             app_data: 0,
             fee_amount: hex!("0de0b6b3a7640000").as_ref().into(),
-            order_kind: OrderKind::Sell,
+            kind: OrderKind::Sell,
             partially_fillable: false,
             signature: Signature {
                 v: 0x1b | 0x80,

--- a/solver/src/encoding.rs
+++ b/solver/src/encoding.rs
@@ -32,7 +32,7 @@ pub fn encode_trade(
 
 fn encode_order_flags(order: &OrderCreation) -> u8 {
     let mut result = 0u8;
-    if matches!(order.order_kind, OrderKind::Buy) {
+    if matches!(order.kind, OrderKind::Buy) {
         result |= 0b00000001;
     };
     if order.partially_fillable {
@@ -106,7 +106,7 @@ mod tests {
             valid_to: 6,
             app_data: 7,
             fee_amount: 8.into(),
-            order_kind: OrderKind::Buy,
+            kind: OrderKind::Buy,
             partially_fillable: true,
             signature: Signature {
                 v: 9,

--- a/solver/src/naive_solver.rs
+++ b/solver/src/naive_solver.rs
@@ -44,7 +44,7 @@ fn organize_orders_by_token_pair(
 }
 
 fn usable_order(order: &OrderCreation) -> bool {
-    matches!(order.order_kind, OrderKind::Sell)
+    matches!(order.kind, OrderKind::Sell)
         && !order.sell_amount.is_zero()
         && !order.buy_amount.is_zero()
         && !order.partially_fillable
@@ -103,7 +103,7 @@ mod tests {
                 buy_token: H160::from_low_u64_be(1),
                 sell_amount: 4.into(),
                 buy_amount: 9.into(),
-                order_kind: OrderKind::Sell,
+                kind: OrderKind::Sell,
                 partially_fillable: false,
                 ..Default::default()
             },
@@ -112,7 +112,7 @@ mod tests {
                 buy_token: H160::from_low_u64_be(1),
                 sell_amount: 4.into(),
                 buy_amount: 8.into(),
-                order_kind: OrderKind::Sell,
+                kind: OrderKind::Sell,
                 partially_fillable: false,
                 ..Default::default()
             },
@@ -121,7 +121,7 @@ mod tests {
                 buy_token: H160::from_low_u64_be(0),
                 sell_amount: 10.into(),
                 buy_amount: 11.into(),
-                order_kind: OrderKind::Sell,
+                kind: OrderKind::Sell,
                 partially_fillable: false,
                 ..Default::default()
             },
@@ -130,7 +130,7 @@ mod tests {
                 buy_token: H160::from_low_u64_be(0),
                 sell_amount: 6.into(),
                 buy_amount: 2.into(),
-                order_kind: OrderKind::Sell,
+                kind: OrderKind::Sell,
                 partially_fillable: false,
                 ..Default::default()
             },

--- a/solver/src/naive_solver/two_order_settlement.rs
+++ b/solver/src/naive_solver/two_order_settlement.rs
@@ -11,7 +11,7 @@ pub fn settle_two_fillkill_sell_orders(
 ) -> Option<Settlement> {
     assert!(&[sell_a, sell_b]
         .iter()
-        .all(|order| matches!(order.order_kind, OrderKind::Sell) && !order.partially_fillable));
+        .all(|order| matches!(order.kind, OrderKind::Sell) && !order.partially_fillable));
     assert!(sell_a.sell_token == sell_b.buy_token && sell_b.sell_token == sell_a.buy_token);
     // In a direct match the price and amount requirements and trivially fulfilled.
     let is_direct_match =
@@ -143,7 +143,7 @@ mod tests {
             buy_token: H160::from_low_u64_be(1),
             sell_amount: 5.into(),
             buy_amount: 10.into(),
-            order_kind: OrderKind::Sell,
+            kind: OrderKind::Sell,
             partially_fillable: false,
             ..Default::default()
         };
@@ -152,7 +152,7 @@ mod tests {
             buy_token: H160::from_low_u64_be(0),
             sell_amount: 10.into(),
             buy_amount: 5.into(),
-            order_kind: OrderKind::Sell,
+            kind: OrderKind::Sell,
             partially_fillable: false,
             ..Default::default()
         };
@@ -175,7 +175,7 @@ mod tests {
             buy_token: H160::from_low_u64_be(1),
             sell_amount: 10.into(),
             buy_amount: 10.into(),
-            order_kind: OrderKind::Sell,
+            kind: OrderKind::Sell,
             partially_fillable: false,
             ..Default::default()
         };
@@ -184,7 +184,7 @@ mod tests {
             buy_token: H160::from_low_u64_be(0),
             sell_amount: 15.into(),
             buy_amount: 5.into(),
-            order_kind: OrderKind::Sell,
+            kind: OrderKind::Sell,
             partially_fillable: false,
             ..Default::default()
         };
@@ -207,7 +207,7 @@ mod tests {
             buy_token: H160::from_low_u64_be(1),
             sell_amount: 10.into(),
             buy_amount: 10.into(),
-            order_kind: OrderKind::Sell,
+            kind: OrderKind::Sell,
             partially_fillable: false,
             ..Default::default()
         };
@@ -217,7 +217,7 @@ mod tests {
             buy_token: H160::from_low_u64_be(0),
             sell_amount: 1.into(),
             buy_amount: 2.into(),
-            order_kind: OrderKind::Sell,
+            kind: OrderKind::Sell,
             partially_fillable: false,
             ..Default::default()
         };
@@ -232,7 +232,7 @@ mod tests {
             buy_token: H160::from_low_u64_be(1),
             sell_amount: 10.into(),
             buy_amount: 15.into(),
-            order_kind: OrderKind::Sell,
+            kind: OrderKind::Sell,
             partially_fillable: false,
             ..Default::default()
         };
@@ -241,7 +241,7 @@ mod tests {
             buy_token: H160::from_low_u64_be(0),
             sell_amount: 6.into(),
             buy_amount: 4.into(),
-            order_kind: OrderKind::Sell,
+            kind: OrderKind::Sell,
             partially_fillable: false,
             ..Default::default()
         };
@@ -272,7 +272,7 @@ mod tests {
             buy_token: H160::from_low_u64_be(1),
             sell_amount: 10.into(),
             buy_amount: 20.into(),
-            order_kind: OrderKind::Sell,
+            kind: OrderKind::Sell,
             partially_fillable: false,
             ..Default::default()
         };
@@ -282,7 +282,7 @@ mod tests {
             buy_token: H160::from_low_u64_be(0),
             sell_amount: 4.into(),
             buy_amount: 1.into(),
-            order_kind: OrderKind::Sell,
+            kind: OrderKind::Sell,
             partially_fillable: false,
             ..Default::default()
         };


### PR DESCRIPTION
According to this document: https://github.com/gnosis/gp-v2-contracts/blob/main/src/contracts/libraries/GPv2Encoding.sol, it should be called `kind`.

I renamed it also in the openAPI pr.

