### PR TITLE
Set up command line argument parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,15 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -202,6 +211,21 @@ dependencies = [
  "serde",
  "time",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term 0.11.0",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -724,6 +748,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,6 +1242,8 @@ dependencies = [
  "primitive-types",
  "serde",
  "serde_json",
+ "shared-arguments",
+ "structopt",
  "tokio",
  "tracing",
  "tracing-setup",
@@ -1339,6 +1374,30 @@ dependencies = [
  "impl-rlp",
  "impl-serde",
  "uint",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1842,6 +1901,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared-arguments"
+version = "0.1.0"
+dependencies = [
+ "structopt",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,6 +1945,8 @@ dependencies = [
  "primitive-types",
  "reqwest",
  "serde_json",
+ "shared-arguments",
+ "structopt",
  "tokio",
  "tracing",
  "tracing-setup",
@@ -1890,6 +1958,36 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -1923,6 +2021,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -2148,7 +2255,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.12.1",
  "chrono",
  "lazy_static",
  "matchers",
@@ -2244,6 +2351,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2397,12 @@ name = "vcpkg"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "contracts",
     "model",
     "orderbook",
+    "shared-arguments",
     "solver",
     "tracing-setup",
 ]

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -10,6 +10,8 @@ model = { path = "../model" }
 primitive-types = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+shared-arguments = { path = "../shared-arguments" }
+structopt = { version = "0.3" }
 tokio = { version = "0.2", features =[ "macros", "time"] }
 tracing = "0.1"
 tracing-setup = { path = "../tracing-setup" }

--- a/shared-arguments/Cargo.toml
+++ b/shared-arguments/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "shared-arguments"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+structopt = { version = "0.3", default-features = false }

--- a/shared-arguments/src/lib.rs
+++ b/shared-arguments/src/lib.rs
@@ -1,0 +1,17 @@
+//! Contains command line arguments and related helpers that are shared between the binaries.
+
+use std::{num::ParseFloatError, time::Duration};
+
+#[derive(Debug, structopt::StructOpt)]
+pub struct Arguments {
+    #[structopt(
+        long,
+        env = "LOG_FILTER",
+        default_value = "warn,orderbook=debug,solver=debug"
+    )]
+    pub log_filter: String,
+}
+
+pub fn duration_from_seconds(s: &str) -> Result<Duration, ParseFloatError> {
+    Ok(Duration::from_secs_f32(s.parse()?))
+}

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -14,6 +14,8 @@ model = { path = "../model" }
 primitive-types = "0.7"
 reqwest = { version = "0.10", features = ["json"] }
 serde_json = "1.0"
+shared-arguments = { path = "../shared-arguments" }
+structopt = { version = "0.3" }
 tokio = { version = "0.2", features =[ "macros", "time"] }
 tracing = "0.1"
 tracing-setup = { path = "../tracing-setup" }

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -8,9 +8,35 @@ mod naive_solver;
 mod orderbook;
 mod settlement;
 
+use reqwest::Url;
+use std::time::Duration;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Arguments {
+    #[structopt(flatten)]
+    shared: shared_arguments::Arguments,
+
+    #[structopt(long, env = "ORDERBOOK_URL", default_value = "http://localhost:8080")]
+    orderbook_url: Url,
+
+    #[structopt(
+        long,
+        env = "ORDERBOOK_TIMEOUT",
+        default_value = "10",
+        parse(try_from_str = shared_arguments::duration_from_seconds),
+    )]
+    orderbook_timeout: Duration,
+}
+
 #[tokio::main]
 async fn main() {
-    tracing_setup::initialize("WARN,solver=DEBUG");
-    tracing::info!("starting solver");
-    todo!("run driver")
+    let args = Arguments::from_args();
+    tracing_setup::initialize(args.shared.log_filter.as_str());
+    tracing::info!("running solver with {:#?}", args);
+    let orderbook = orderbook::OrderBookApi::new(args.orderbook_url, args.orderbook_timeout);
+    // TODO: start driver, for now just fetch orders as placeholder
+    tracing::info!("fetching orders");
+    let orders = orderbook.get_orders().await;
+    tracing::info!(?orders);
 }


### PR DESCRIPTION
Using a helper crate to share common arguments between both binaries. Having to copy paste them was a gripe we had with v1-services.

### Test Plan
`cargo run --bin orderbook -- --help`
`cargo run --bin solver -- --help`