### PR TITLE
Remove dependabot PR automerge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,13 +10,3 @@ pull_request_rules:
         method: squash
         strict: smart+fasttrack
         commit_message: title+body
-  - name: Automatic merge for Dependabot pull requests
-    conditions:
-      - author~=^dependabot(|-preview)\[bot\]$
-      - status-success=Travis CI - Pull Request
-      - base=main
-    actions:
-      merge:
-        method: squash
-        strict: smart+fasttrack
-        commit_message: title+body


### PR DESCRIPTION
We can discuss this in this PR.
Imo it is better if we have full control over what gets merged because
* it prevents the staging deployment from randomly restarting when we might not want it to
* there are some crate updates that even though they pass CI we might not want to apply. I feel more comfortable reading the changelog first.

### Test Plan
next time dependabot makes a mergable PR it shouldn't be automerged