### PR TITLE
Disable logging with colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,15 +20,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,16 +2116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-setup"
 version = "0.1.0"
 dependencies = [
@@ -2148,20 +2129,16 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
 dependencies = [
- "ansi_term",
  "chrono",
  "lazy_static",
  "matchers",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/tracing-setup/Cargo.toml
+++ b/tracing-setup/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2018"
 
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = "0.2"
+# All default features but not `ansi` because kibana has problems with ansi color codes.
+tracing-subscriber = { version = "0.2", default-features = false, features = ["chrono", "env-filter", "fmt", "smallvec", "tracing-log"] }


### PR DESCRIPTION
Edit: Scratch that. We *can* control it at runtime. Making new PR.

In kibana the terminal ansi color codes aren't displayed so they
introduce random characters like `[2m` into the output.
This does mean they are disabled for local development too even though
there they work. A better fix would be to allow colors in the output to
be controlled by a command line argument but I didn't see a way to set
this in tracing-subscriber at runtime. Maybe I'll add support in my next
ecosystem friday.

### Test Plan
`cargo run --bin orderbook` and see colors are gone.
