### PR TITLE
Pass domain separator as command line argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,6 +1904,7 @@ dependencies = [
 name = "shared-arguments"
 version = "0.1.0"
 dependencies = [
+ "model",
  "structopt",
 ]
 

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod h160_hexadecimal;
 pub mod u256_decimal;
 use chrono::{offset::Utc, DateTime, NaiveDateTime};
+use hex::{FromHex, FromHexError};
 use hex_literal::hex;
 use primitive_types::{H160, H256, U256};
 use secp256k1::{constants::SECRET_KEY_SIZE, SecretKey};
@@ -63,7 +64,7 @@ impl OrderCreation {
     }
 
     // If signature is valid returns the owner.
-    pub fn validate_signature(&self, domain_separator: &[u8; 32]) -> Option<H160> {
+    pub fn validate_signature(&self, domain_separator: &DomainSeparator) -> Option<H160> {
         // The signature related functionality is defined by the smart contract:
         // https://github.com/gnosis/gp-v2-contracts/blob/main/src/contracts/libraries/GPv2Encoding.sol
 
@@ -85,9 +86,9 @@ impl OrderCreation {
 
 // Intended to be used by tests that need signed orders.
 impl OrderCreation {
-    pub const TEST_DOMAIN_SEPARATOR: [u8; 32] = [0u8; 32];
+    pub const TEST_DOMAIN_SEPARATOR: DomainSeparator = DomainSeparator([0u8; 32]);
 
-    pub fn sign_self_with(&mut self, domain_separator: &[u8; 32], key: SecretKeyRef) {
+    pub fn sign_self_with(&mut self, domain_separator: &DomainSeparator, key: SecretKeyRef) {
         let message = self.signing_digest_message(domain_separator);
         // Unwrap because the only error is for invalid messages which we don't create.
         let signature = Key::sign(&key, &message, None).unwrap();
@@ -130,23 +131,23 @@ impl OrderCreation {
         signing::keccak256(&hash_data)
     }
 
-    fn signing_digest_typed_data(&self, domain_separator: &[u8; 32]) -> [u8; 32] {
+    fn signing_digest_typed_data(&self, domain_separator: &DomainSeparator) -> [u8; 32] {
         let mut hash_data = [0u8; 66];
         hash_data[0..2].copy_from_slice(&[0x19, 0x01]);
-        hash_data[2..34].copy_from_slice(domain_separator);
+        hash_data[2..34].copy_from_slice(&domain_separator.0);
         hash_data[34..66].copy_from_slice(&self.order_digest());
         signing::keccak256(&hash_data)
     }
 
-    fn signing_digest_message(&self, domain_separator: &[u8; 32]) -> [u8; 32] {
+    fn signing_digest_message(&self, domain_separator: &DomainSeparator) -> [u8; 32] {
         let mut hash_data = [0u8; 92];
         hash_data[0..28].copy_from_slice(b"\x19Ethereum Signed Message:\n64");
-        hash_data[28..60].copy_from_slice(domain_separator);
+        hash_data[28..60].copy_from_slice(&domain_separator.0);
         hash_data[60..92].copy_from_slice(&self.order_digest());
         signing::keccak256(&hash_data)
     }
 
-    fn signing_digest(&self, domain_separator: &[u8; 32]) -> [u8; 32] {
+    fn signing_digest(&self, domain_separator: &DomainSeparator) -> [u8; 32] {
         if self.signature.v & 0x80 == 0 {
             self.signing_digest_typed_data(domain_separator)
         } else {
@@ -300,6 +301,28 @@ impl TokenPair {
     }
 }
 
+#[derive(Copy, Clone, Default)]
+pub struct DomainSeparator(pub [u8; 32]);
+
+// For command line argument parsing.
+impl std::str::FromStr for DomainSeparator {
+    type Err = FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(FromHex::from_hex(s)?))
+    }
+}
+
+impl std::fmt::Debug for DomainSeparator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut hex = [0u8; 64];
+        // Unwrap because we know the length is correct.
+        hex::encode_to_slice(self.0, &mut hex).unwrap();
+        // Unwrap because we know it is valid utf8.
+        f.write_str(std::str::from_utf8(&hex).unwrap())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -381,8 +404,9 @@ mod tests {
     // from two of the tests in https://github.com/gnosis/gp-v2-contracts/blob/main/test/GPv2Encoding.test.ts .
     #[test]
     fn signature_typed_data() {
-        let domain_separator =
-            hex!("f8a1143d44c67470a791201b239ff6b0ecc8910aa9682bebd08145f5fd84722b");
+        let domain_separator = DomainSeparator(hex!(
+            "f8a1143d44c67470a791201b239ff6b0ecc8910aa9682bebd08145f5fd84722b"
+        ));
         let order = OrderCreation {
             sell_token: hex!("0101010101010101010101010101010101010101").into(),
             buy_token: hex!("0202020202020202020202020202020202020202").into(),
@@ -409,8 +433,9 @@ mod tests {
 
     #[test]
     fn signature_message() {
-        let domain_separator =
-            hex!("f8a1143d44c67470a791201b239ff6b0ecc8910aa9682bebd08145f5fd84722b");
+        let domain_separator = DomainSeparator(hex!(
+            "f8a1143d44c67470a791201b239ff6b0ecc8910aa9682bebd08145f5fd84722b"
+        ));
         let order = OrderCreation {
             sell_token: hex!("0101010101010101010101010101010101010101").into(),
             buy_token: hex!("0202020202020202020202020202020202020202").into(),
@@ -440,5 +465,10 @@ mod tests {
             order.validate_signature(&OrderCreation::TEST_DOMAIN_SEPARATOR),
             Some(owner)
         );
+    }
+
+    #[test]
+    fn domain_separator_does_not_panic_in_debug() {
+        println!("{:?}", DomainSeparator::default());
     }
 }

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -30,7 +30,7 @@ async fn main() {
     let args = Arguments::from_args();
     tracing_setup::initialize(args.shared.log_filter.as_str());
     tracing::info!("running order book with {:#?}", args);
-    let orderbook = Arc::new(OrderBook::default());
+    let orderbook = Arc::new(OrderBook::new(args.shared.domain_separator));
     let filter = api::handle_all_routes(orderbook.clone())
         .map(|reply| warp::reply::with_header(reply, "Access-Control-Allow-Origin", "*"));
     let address = SocketAddr::new([0, 0, 0, 0].into(), 8080);

--- a/shared-arguments/Cargo.toml
+++ b/shared-arguments/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+model = { path = "../model" }
 structopt = { version = "0.3", default-features = false }

--- a/shared-arguments/src/lib.rs
+++ b/shared-arguments/src/lib.rs
@@ -1,5 +1,6 @@
 //! Contains command line arguments and related helpers that are shared between the binaries.
 
+use model::DomainSeparator;
 use std::{num::ParseFloatError, time::Duration};
 
 #[derive(Debug, structopt::StructOpt)]
@@ -10,6 +11,13 @@ pub struct Arguments {
         default_value = "warn,orderbook=debug,solver=debug"
     )]
     pub log_filter: String,
+
+    #[structopt(
+        long,
+        env = "DOMAIN_SEPARATOR",
+        default_value = "0000000000000000000000000000000000000000000000000000000000000000"
+    )]
+    pub domain_separator: DomainSeparator,
 }
 
 pub fn duration_from_seconds(s: &str) -> Result<Duration, ParseFloatError> {


### PR DESCRIPTION
This has to be configurable for different deployments and us using the
correct value early helps the frontend.

Alex is working on a better version of  that uses the contract address and ethabi's abi encoding. When we have that we can remove the command line argument.

### Test Plan
`cargo run --bin orderbook` prints the domain separator
