### PR TITLE
Create a shared OrderbookReading trait between API and Driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,6 +1120,8 @@ dependencies = [
 name = "model"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "chrono",
  "hex",
  "hex-literal",
@@ -1252,6 +1254,7 @@ name = "orderbook"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "model",
  "primitive-types",

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0"
+async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 hex = { version = "0.4", default-features = false }
 hex-literal = "0.3"

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -3,7 +3,11 @@
 //! This is in its own crate because we want to share this module between the orderbook and the solver.
 
 pub mod h160_hexadecimal;
+pub mod orderbook;
 pub mod u256_decimal;
+
+pub use orderbook::OrderbookReading;
+
 use chrono::{offset::Utc, DateTime, NaiveDateTime};
 use hex_literal::hex;
 use primitive_types::{H160, H256, U256};

--- a/model/src/orderbook.rs
+++ b/model/src/orderbook.rs
@@ -1,0 +1,9 @@
+use crate::Order;
+use anyhow::Result;
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait OrderbookReading {
+    // Read all "valid" orders (according to the implementation's definition of validity)
+    async fn get_orders(&self) -> Result<Vec<Order>>;
+}

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 model = { path = "../model" }
 primitive-types = "0.7"

--- a/orderbook/src/api/filter.rs
+++ b/orderbook/src/api/filter.rs
@@ -48,7 +48,7 @@ pub fn get_fee_info() -> impl Filter<Extract = (impl warp::Reply,), Error = warp
 #[cfg(test)]
 pub mod test_util {
     use super::*;
-    use model::Order;
+    use model::{Order, OrderbookReading as _};
     use primitive_types::U256;
     use serde_json::json;
     use warp::{http::StatusCode, test::request};
@@ -64,7 +64,7 @@ pub mod test_util {
         let response = request().path("/orders").method("GET").reply(&filter).await;
         assert_eq!(response.status(), StatusCode::OK);
         let response_orders: Vec<Order> = serde_json::from_slice(response.body()).unwrap();
-        let orderbook_orders = orderbook.get_orders().await;
+        let orderbook_orders = orderbook.get_orders().await.unwrap();
         assert_eq!(response_orders, orderbook_orders);
     }
 

--- a/orderbook/src/api/handler.rs
+++ b/orderbook/src/api/handler.rs
@@ -1,7 +1,7 @@
 use crate::orderbook::{AddOrderError, OrderBook};
 
 use chrono::prelude::{DateTime, FixedOffset, Utc};
-use model::{u256_decimal, OrderCreation};
+use model::{u256_decimal, OrderCreation, OrderbookReading as _};
 use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, sync::Arc};
@@ -80,7 +80,13 @@ pub async fn add_order(
 
 pub async fn get_orders(orderbook: Arc<OrderBook>) -> Result<impl warp::Reply, Infallible> {
     let orders = orderbook.get_orders().await;
-    Ok(with_status(json(&orders), StatusCode::OK))
+    match orders {
+        Ok(orders) => Ok(with_status(json(&orders), StatusCode::OK)),
+        Err(_) => Ok(with_status(
+            json(&"Error Fetching Orders"),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )),
+    }
 }
 
 #[allow(unused_variables)]

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -1,5 +1,6 @@
 use crate::{ethereum::SettlementContract, naive_solver, orderbook::OrderBookApi};
 use anyhow::{Context, Result};
+use model::OrderbookReading as _;
 use std::{sync::Arc, time::Duration};
 
 const SETTLE_INTERVAL: Duration = Duration::from_secs(30);

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -1,13 +1,13 @@
-use crate::{ethereum::SettlementContract, naive_solver, orderbook::OrderBookApi};
+use crate::{ethereum::SettlementContract, naive_solver};
 use anyhow::{Context, Result};
-use model::OrderbookReading as _;
+use model::OrderbookReading;
 use std::{sync::Arc, time::Duration};
 
 const SETTLE_INTERVAL: Duration = Duration::from_secs(30);
 
 pub struct Driver {
     contract: Arc<dyn SettlementContract>,
-    orderbook: OrderBookApi,
+    orderbook: Box<dyn OrderbookReading>,
 }
 
 impl Driver {

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -11,6 +11,7 @@ mod settlement;
 use reqwest::Url;
 use std::time::Duration;
 use structopt::StructOpt;
+use model::OrderbookReading as _;
 
 #[derive(Debug, StructOpt)]
 struct Arguments {

--- a/solver/src/orderbook.rs
+++ b/solver/src/orderbook.rs
@@ -1,4 +1,6 @@
-use model::Order;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use model::{Order, OrderbookReading};
 use reqwest::{Client, Url};
 use std::time::Duration;
 
@@ -14,12 +16,21 @@ impl OrderBookApi {
         let client = Client::builder().timeout(request_timeout).build().unwrap();
         Self { base, client }
     }
+}
 
-    pub async fn get_orders(&self) -> reqwest::Result<Vec<Order>> {
+#[async_trait]
+impl OrderbookReading for OrderBookApi {
+    async fn get_orders(&self) -> Result<Vec<Order>> {
         const PATH: &str = "/api/v1/orders";
         let mut url = self.base.clone();
         url.set_path(PATH);
-        self.client.get(url).send().await?.json().await
+        self.client
+            .get(url)
+            .send()
+            .await?
+            .json()
+            .await
+            .context("API Request failed")
     }
 }
 


### PR DESCRIPTION
This is a suggestion that I'd like to get feedback on. By introducing a shared OrderbookReading trait we could use the in-memory Orderbook directly inside the driver (rather than going via the API using HTTP).

While I'm not sure the symmetry between the two concepts can be guaranteed in the long run (have not yet come up with a good example for why not) it would make e2e-testing the system much more direct: We could create a driver that is using the in-memory book directly into which we can insert an order. We can then call `driver.single_run()` inside the test and when the method returns we know we can check the smart contract if our orders where matched as expected.

Otherwise (if everything was run as separate processes) we would somehow have to "drive" the actual driver from the outside and might run into some timing/waiting issues since we don't tightly control the runloop. While this would likely be more e2e in that it actually tests everything it might also be more brittle and less deterministic.

Let me know what you think...

### Test Plan
CI for now...
