### PR TITLE
Make all hex serialization use `0x` prefix

### DIFF
--- a/model/src/h160_hexadecimal.rs
+++ b/model/src/h160_hexadecimal.rs
@@ -6,9 +6,10 @@ pub fn serialize<S>(value: &H160, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    let mut bytes = [0u8; 20 * 2];
+    let mut bytes = [0u8; 2 + 20 * 2];
+    bytes[..2].copy_from_slice(b"0x");
     // Can only fail if the buffer size does not match but we know it is correct.
-    hex::encode_to_slice(value, &mut bytes).unwrap();
+    hex::encode_to_slice(value, &mut bytes[2..]).unwrap();
     // Hex encoding is always valid utf8.
     let s = std::str::from_utf8(&bytes).unwrap();
     serializer.serialize_str(s)
@@ -30,6 +31,12 @@ where
         where
             E: de::Error,
         {
+            let s = s.strip_prefix("0x").ok_or_else(|| {
+                de::Error::custom(format!(
+                    "{:?} can't be decoded as hex h160 because it does not start with '0x'",
+                    s
+                ))
+            })?;
             let mut value = H160::zero();
             hex::decode_to_slice(s, value.as_mut()).map_err(|err| {
                 de::Error::custom(format!("failed to decode {:?} as hex h160: {}", s, err))

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -79,7 +79,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Order"
-        404: 
+        404:
           description: Order was not found
     delete:
       summary: Deletes order from order service,
@@ -96,14 +96,14 @@ paths:
       responses:
         200:
           description: Order deleted
-        404: 
+        404:
           description: Order was not found
   /api/v1/fee/{sellToken}:
     get:
       description: |
-        The fee that is charged for placing an order. 
+        The fee that is charged for placing an order.
         The fee is described by a minimum fee - in order to cover the gas costs for onchain settling - and
-        a feeRatio charged to the users for using the service. 
+        a feeRatio charged to the users for using the service.
       parameters:
         - name: sellToken
           in: path
@@ -122,21 +122,21 @@ paths:
 components:
   schemas:
     Address:
-      description: Ethereum 40 byte address encoded as a hex without `0x` prefix.
+      description: Ethereum 40 byte address encoded as a hex with `0x` prefix.
       type: string
-      example: "6810e776880c02933d47db1b9fc05908e5386b96"
+      example: "0x6810e776880c02933d47db1b9fc05908e5386b96"
     TokenAmount:
       description: Amount of a token. uint256 encoded in decimal.
       type: string
       example: "1234567890"
     FeeInformation:
       description: |
-        Provides the information to calculate the fees. 
+        Provides the information to calculate the fees.
       type: object
       properties:
         expirationDate:
           description: |
-            Expiration date of the offered fee. Order service might not accept 
+            Expiration date of the offered fee. Order service might not accept
             the fee after this expiration date. Encoded as ISO 8601 UTC.
           type: string
           example: "2020-12-03T18:35:18.814523Z"
@@ -186,11 +186,11 @@ components:
           description: Is this a fill-or-kill order or a partially fillable order?
           type: boolean
         signature:
-          description: 65 bytes encoded as hex without `0x` prefix. v + r + s from the spec.
-          example: "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+          description: 65 bytes encoded as hex with `0x` prefix. v + r + s from the spec.
+          example: "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
     OrderMetaData:
       description: |
-        Extra order data that is returned to users when querying orders 
+        Extra order data that is returned to users when querying orders
         but not provided by users when creating orders.
       type: object
       properties:
@@ -208,7 +208,7 @@ components:
         - $ref: "#/components/schemas/OrderMetaData"
     UID:
      description: |
-      Unique identifier for the order: 56 bytes encoded as hex without 0x. 
+      Unique identifier for the order: 56 bytes encoded as hex with `0x` prefix.
       Bytes 0 to 32 are the order digest, bytes 30 to 52 the owner address
       and bytes 52..56 valid to,
      type: string

--- a/orderbook/src/api/filter.rs
+++ b/orderbook/src/api/filter.rs
@@ -96,7 +96,7 @@ pub mod test_util {
         order.valid_to = u32::MAX;
         order.sign_self();
         let expected_uid = json!(
-            "98f26f9847f4e365ea530784ce5976f56ea2a67e9cde05fd16fca9a1fadbe5211a642f0e3c3af545e7acbd38b07251b3990914f1ffffffff"
+            "0x98f26f9847f4e365ea530784ce5976f56ea2a67e9cde05fd16fca9a1fadbe5211a642f0e3c3af545e7acbd38b07251b3990914f1ffffffff"
         );
         let post = || async {
             request()


### PR DESCRIPTION
This is what most people prefer. I do not want to accept both encodings
so this change requires the 0x always. Better to define the format more
exactly and not have amibguity.

Note to self: tag Anxo when this is merged

### Test Plan
adjusted unit tests
