### PR TITLE
Allow 0x prefix in fee info route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "hex",
  "model",
  "primitive-types",
  "serde",

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+hex = { version = "0.4", default-features = false }
 model = { path = "../model" }
 primitive-types = "0.7"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
I forgot about this when I changed the other routes to use the prefix.

### Test Plan
adapted unit test
