### PR TITLE
Make interactions a trait instead of an enum

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -1,5 +1,5 @@
 use crate::{naive_solver, orderbook::OrderBookApi};
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use contracts::{GPv2Settlement, UniswapV2Router02};
 use std::time::Duration;
 
@@ -7,7 +7,7 @@ const SETTLE_INTERVAL: Duration = Duration::from_secs(30);
 
 pub struct Driver {
     settlement_contract: GPv2Settlement,
-    uniswap_router: UniswapV2Router02,
+    uniswap_contract: UniswapV2Router02,
     orderbook: OrderBookApi,
 }
 
@@ -29,24 +29,28 @@ impl Driver {
         // Decide what is handled by orderbook service and what by us.
         // We likely want to at least mark orders we know we have settled so that we don't
         // attempt to settle them again when they are still in the orderbook.
-        let settlement =
-            match naive_solver::settle(orders.into_iter().map(|order| order.order_creation)) {
-                None => return Ok(()),
-                Some(settlement) => settlement,
-            };
+        let settlement = match naive_solver::settle(
+            orders.into_iter().map(|order| order.order_creation),
+            &self.uniswap_contract,
+            &self.settlement_contract.address(),
+        ) {
+            None => return Ok(()),
+            Some(settlement) => settlement,
+        };
         // TODO: check if we need to approve spending to uniswap
         // TODO: use retry transaction sending crate for updating gas prices
+        let encoded_interactions = settlement
+            .encode_interactions()
+            .context("interaction encoding failed")?;
+        let encoded_trades = settlement
+            .encode_trades()
+            .ok_or_else(|| anyhow!("trade encoding failed"))?;
         let settle = || {
             self.settlement_contract.settle(
                 settlement.tokens(),
                 settlement.clearing_prices(),
-                settlement
-                    .encode_trades()
-                    .expect("naive solver created invalid settlement"),
-                settlement.encode_interactions(
-                    &self.uniswap_router.address(),
-                    &self.settlement_contract.address(),
-                ),
+                encoded_trades.clone(),
+                encoded_interactions.clone(),
                 Vec::new(),
             )
         };

--- a/solver/src/interactions.rs
+++ b/solver/src/interactions.rs
@@ -1,0 +1,5 @@
+#[cfg(test)]
+pub mod dummy_web3;
+mod uniswap;
+
+pub use uniswap::UniswapInteraction;

--- a/solver/src/interactions/dummy_web3.rs
+++ b/solver/src/interactions/dummy_web3.rs
@@ -1,0 +1,21 @@
+use jsonrpc_core::Call as RpcCall;
+use serde_json::Value;
+use web3::{api::Web3, Transport};
+
+// To create an ethcontract instance we need to provide a web3 even though we never use it. This
+// module provides a dummy transport and web3.
+#[derive(Clone, Debug)]
+pub struct DummyTransport;
+impl Transport for DummyTransport {
+    type Out = futures::future::Pending<web3::Result<Value>>;
+    fn prepare(&self, _method: &str, _params: Vec<Value>) -> (web3::RequestId, RpcCall) {
+        unimplemented!()
+    }
+    fn send(&self, _id: web3::RequestId, _request: RpcCall) -> Self::Out {
+        unimplemented!()
+    }
+}
+
+pub fn dummy_web3() -> Web3<DummyTransport> {
+    Web3::new(DummyTransport)
+}

--- a/solver/src/interactions/uniswap.rs
+++ b/solver/src/interactions/uniswap.rs
@@ -1,0 +1,77 @@
+use crate::{encoding, settlement::Interaction};
+use anyhow::Result;
+use contracts::UniswapV2Router02;
+use primitive_types::{H160, U256};
+
+#[derive(Debug)]
+pub struct UniswapInteraction {
+    pub contract: UniswapV2Router02,
+    pub amount_in: U256,
+    pub amount_out_min: U256,
+    pub token_in: H160,
+    pub token_out: H160,
+    pub payout_to: H160,
+}
+
+impl Interaction for UniswapInteraction {
+    fn encode(&self, writer: &mut dyn std::io::Write) -> Result<()> {
+        let method = self.contract.swap_exact_tokens_for_tokens(
+            self.amount_in,
+            self.amount_out_min,
+            vec![self.token_in, self.token_out],
+            self.payout_to,
+            U256::MAX,
+        );
+        let data = method.tx.data.expect("no calldata").0;
+        writer.write_all(self.contract.address().as_fixed_bytes())?;
+        // Unwrap because we know uniswap data size can be stored in 3 bytes.
+        writer.write_all(&encoding::encode_interaction_data_length(data.len()).unwrap())?;
+        writer.write_all(data.as_slice())?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encoding::{tests::u8_as_32_bytes_be, INTERACTION_BASE_SIZE};
+    use crate::interactions::dummy_web3;
+    use std::io::Cursor;
+
+    #[test]
+    fn encode_uniswap_call_() {
+        let amount_in = 5;
+        let amount_out_min = 6;
+        let token_in = 7;
+        let token_out = 8;
+        let payout_to = 9;
+        let contract = UniswapV2Router02::at(&dummy_web3::dummy_web3(), H160::from_low_u64_be(4));
+        let interaction = UniswapInteraction {
+            contract: contract.clone(),
+            amount_in: amount_in.into(),
+            amount_out_min: amount_out_min.into(),
+            token_in: H160::from_low_u64_be(token_in as u64),
+            token_out: H160::from_low_u64_be(token_out as u64),
+            payout_to: H160::from_low_u64_be(payout_to as u64),
+        };
+        let mut cursor = Cursor::new(Vec::new());
+        interaction.encode(&mut cursor).unwrap();
+        let encoded = cursor.into_inner();
+        assert_eq!(&encoded[0..20], contract.address().as_fixed_bytes());
+        assert_eq!(encoded[20..23], [0, 1, 4]);
+        let call = &encoded[INTERACTION_BASE_SIZE..];
+        let signature = [0x38u8, 0xed, 0x17, 0x39];
+        let path_offset = 160;
+        let path_size = 2;
+        let deadline = [0xffu8; 32];
+        assert_eq!(call[0..4], signature);
+        assert_eq!(call[4..36], u8_as_32_bytes_be(amount_in));
+        assert_eq!(call[36..68], u8_as_32_bytes_be(amount_out_min));
+        assert_eq!(call[68..100], u8_as_32_bytes_be(path_offset));
+        assert_eq!(call[100..132], u8_as_32_bytes_be(payout_to));
+        assert_eq!(call[132..164], deadline);
+        assert_eq!(call[164..196], u8_as_32_bytes_be(path_size));
+        assert_eq!(call[196..228], u8_as_32_bytes_be(token_in));
+        assert_eq!(call[228..260], u8_as_32_bytes_be(token_out));
+    }
+}

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -3,6 +3,7 @@
 mod batcher;
 mod driver;
 mod encoding;
+mod interactions;
 mod naive_solver;
 mod orderbook;
 mod settlement;


### PR DESCRIPTION
This is much more flexible for the future because it allows interactions
to locally encapsulate the data they need instead of having everything
in one big enum.

The meat of this change is that now  there is a trait that Interactions implement to encode themself:
```rust
    fn encode(&self, writer: &mut dyn Write) -> Result<()>;
```
Following from that the uniswap interaction has been moved into it's own module away from encoding.rs.

### Test Plan
the uniswap interaction unit test has been adapted