### PR TITLE
Update order signature and encoding to smart contract

### DIFF
--- a/orderbook/src/api/filter.rs
+++ b/orderbook/src/api/filter.rs
@@ -108,7 +108,7 @@ pub mod test_util {
         order.valid_to = u32::MAX;
         order.sign_self();
         let expected_uid = json!(
-            "0x98f26f9847f4e365ea530784ce5976f56ea2a67e9cde05fd16fca9a1fadbe5211a642f0e3c3af545e7acbd38b07251b3990914f1ffffffff"
+            "0xbd185ee633752c56b3eabec61259e8a65c765943665a2c17ad8b74a119e5f1ca1a642f0e3c3af545e7acbd38b07251b3990914f1ffffffff"
         );
         let post = || async {
             request()

--- a/solver/src/encoding.rs
+++ b/solver/src/encoding.rs
@@ -4,7 +4,7 @@ use contracts::UniswapV2Router02;
 use model::{OrderCreation, OrderKind};
 use primitive_types::{H160, U256};
 
-pub const TRADE_STRIDE: usize = 204;
+pub const TRADE_STRIDE: usize = 206;
 const INTERACTION_BASE_SIZE: usize = 20 + 3; // target address + data length
 const UNISWAP_DATA_SIZE: usize = 260;
 const UNISWAP_TOTAL_SIZE: usize = INTERACTION_BASE_SIZE + UNISWAP_DATA_SIZE;
@@ -15,6 +15,7 @@ pub fn encode_trade(
     sell_token_index: u8,
     buy_token_index: u8,
     executed_amount: &U256,
+    fee_discount: u16,
 ) -> [u8; TRADE_STRIDE] {
     let mut result = [0u8; TRADE_STRIDE];
     result[0] = sell_token_index;
@@ -26,9 +27,10 @@ pub fn encode_trade(
     order.fee_amount.to_big_endian(&mut result[74..106]);
     result[106] = encode_order_flags(order);
     executed_amount.to_big_endian(&mut result[107..139]);
-    result[139] = order.signature.v;
-    result[140..172].copy_from_slice(order.signature.r.as_bytes());
-    result[172..204].copy_from_slice(order.signature.s.as_bytes());
+    result[139..141].copy_from_slice(&fee_discount.to_be_bytes());
+    result[141] = order.signature.v;
+    result[142..174].copy_from_slice(order.signature.r.as_bytes());
+    result[174..206].copy_from_slice(order.signature.s.as_bytes());
     result
 }
 
@@ -134,7 +136,7 @@ mod tests {
                 s: H256::from_low_u64_be(11),
             },
         };
-        let encoded = encode_trade(&order, 1, 2, &3.into());
+        let encoded = encode_trade(&order, 1, 2, &3.into(), 4);
         assert_eq!(encoded[0], 1);
         assert_eq!(encoded[1], 2);
         assert_eq!(encoded[2..34], u8_as_32_bytes_be(4));
@@ -144,9 +146,10 @@ mod tests {
         assert_eq!(encoded[74..106], u8_as_32_bytes_be(8));
         assert_eq!(encoded[106], 0b11);
         assert_eq!(encoded[107..139], u8_as_32_bytes_be(3));
-        assert_eq!(encoded[139], 9);
-        assert_eq!(encoded[140..172], u8_as_32_bytes_be(10));
-        assert_eq!(encoded[172..204], u8_as_32_bytes_be(11));
+        assert_eq!(encoded[139..141], [0, 4]);
+        assert_eq!(encoded[141], 9);
+        assert_eq!(encoded[142..174], u8_as_32_bytes_be(10));
+        assert_eq!(encoded[174..206], u8_as_32_bytes_be(11));
     }
 
     #[test]

--- a/solver/src/naive_solver/two_order_settlement.rs
+++ b/solver/src/naive_solver/two_order_settlement.rs
@@ -48,10 +48,12 @@ fn direct_match(sell_a: &OrderCreation, sell_b: &OrderCreation) -> Settlement {
             Trade {
                 order: *sell_a,
                 executed_amount: sell_a.sell_amount,
+                fee_discount: 0,
             },
             Trade {
                 order: *sell_b,
                 executed_amount: sell_b.sell_amount,
+                fee_discount: 0,
             },
         ],
         ..Default::default()
@@ -98,10 +100,12 @@ fn amm_match(sell_a: &OrderCreation, sell_b: &OrderCreation) -> Option<Settlemen
             Trade {
                 order: *sell_a,
                 executed_amount: sell_a.sell_amount,
+                fee_discount: 0,
             },
             Trade {
                 order: *sell_b,
                 executed_amount: sell_b.sell_amount,
+                fee_discount: 0,
             },
         ],
         interactions: vec![Interaction::AmmSwapExactTokensForTokens {

--- a/solver/src/settlement.rs
+++ b/solver/src/settlement.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 pub struct Trade {
     pub order: OrderCreation,
     pub executed_amount: U256,
+    pub fee_discount: u16,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -52,6 +53,7 @@ impl Settlement {
                 *token_index.get(&order.sell_token)?,
                 *token_index.get(&order.buy_token)?,
                 &trade.executed_amount,
+                trade.fee_discount,
             );
             bytes.extend_from_slice(&encoded);
         }


### PR DESCRIPTION
For the encoding of trades there is a new field `fee_discount` and for the signature the way the order type (buy or sell) is computed has changed.

### Test Plan
adjusted unit tests
