### PR TITLE
Approve in Uniswap Interaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,125 +50,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "async-channel"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "once_cell",
- "vec-arena",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04"
-dependencies = [
- "async-executor",
- "async-io",
- "futures-lite",
- "num_cpus",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
-dependencies = [
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "libc",
- "log",
- "nb-connect",
- "once_cell",
- "parking",
- "polling",
- "vec-arena",
- "waker-fn",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "async-mutex"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-native-tls"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9e7a929bd34c68a82d58a4de7f86fffdaf97fb2af850162a7bb19dd7269b33"
-dependencies = [
- "async-std",
- "native-tls",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "async-std"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f84f1280a2b436a2c77c2582602732b6c2f4321d5494d6e799e6c367859a8"
-dependencies = [
- "async-channel",
- "async-global-executor",
- "async-io",
- "async-mutex",
- "blocking",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "num_cpus",
- "once_cell",
- "pin-project-lite 0.2.0",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
-
-[[package]]
-name = "atomic-waker"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,20 +131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
-dependencies = [
- "async-channel",
- "async-task",
- "atomic-waker",
- "fastrand",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
 name = "buf_redux"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,12 +169,6 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "cache-padded"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
@@ -366,15 +227,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
-dependencies = [
- "cache-padded",
-]
-
-[[package]]
 name = "contracts"
 version = "0.1.0"
 dependencies = [
@@ -411,17 +263,6 @@ name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 1.0.0",
- "lazy_static",
-]
 
 [[package]]
 name = "crunchy"
@@ -574,7 +415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f81b28370c3b253a27c8773e7e7f8cd72df927722a55998db528ad7a7a250d"
 dependencies = [
  "ethcontract-common",
- "ethcontract-derive",
  "futures 0.3.8",
  "futures-timer",
  "hex",
@@ -604,19 +444,6 @@ dependencies = [
  "thiserror",
  "tiny-keccak 2.0.2",
  "web3",
-]
-
-[[package]]
-name = "ethcontract-derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b78022b200e99e3a1cd116e5c73a30a56affc11cfe4b78546a2b3a4c18a0efc"
-dependencies = [
- "ethcontract-common",
- "ethcontract-generate",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -650,25 +477,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
-
-[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
-name = "fastrand"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
-dependencies = [
- "instant",
-]
 
 [[package]]
 name = "filetime"
@@ -802,21 +614,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
 
 [[package]]
-name = "futures-lite"
-version = "1.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6c079abfac3ab269e2927ec048dabc89d009ebfdda6b8ee86624f30c689658"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite 0.1.11",
- "waker-fn",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,19 +707,6 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1202,15 +986,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,16 +1167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nb-connect"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "net2"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,16 +1194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg 1.0.1",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -1524,12 +1279,6 @@ dependencies = [
  "byte-slice-cast",
  "serde",
 ]
-
-[[package]]
-name = "parking"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -1625,19 +1374,6 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
-
-[[package]]
-name = "polling"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "log",
- "wepoll-sys",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -2214,21 +1950,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "soketto"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c71ed3d54db0a699f4948e1bb3e45b450fa31fe602621dee6680361d569c88"
-dependencies = [
- "base64 0.12.3",
- "bytes",
- "futures 0.3.8",
- "httparse",
- "log",
- "rand 0.7.3",
- "sha-1 0.9.2",
-]
-
-[[package]]
 name = "solver"
 version = "0.1.0"
 dependencies = [
@@ -2698,12 +2419,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
-name = "vec-arena"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
-
-[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,12 +2429,6 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-
-[[package]]
-name = "waker-fn"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "want"
@@ -2856,8 +2565,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d03f64be59921dbc5791f05af61a87594bb454518fe4e97d827405422279a0"
 dependencies = [
  "arrayvec",
- "async-native-tls",
- "async-std",
  "base64 0.12.3",
  "derive_more",
  "ethabi",
@@ -2875,18 +2582,8 @@ dependencies = [
  "secp256k1 0.17.2",
  "serde",
  "serde_json",
- "soketto",
  "tiny-keccak 2.0.2",
  "url",
-]
-
-[[package]]
-name = "wepoll-sys"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,15 +50,123 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "async-trait"
-version = "0.1.42"
+name = "async-channel"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
 ]
+
+[[package]]
+name = "async-executor"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "vec-arena",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "futures-lite",
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
+dependencies = [
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "libc",
+ "log",
+ "nb-connect",
+ "once_cell",
+ "parking",
+ "polling",
+ "vec-arena",
+ "waker-fn",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-native-tls"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9e7a929bd34c68a82d58a4de7f86fffdaf97fb2af850162a7bb19dd7269b33"
+dependencies = [
+ "async-std",
+ "native-tls",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "async-std"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f84f1280a2b436a2c77c2582602732b6c2f4321d5494d6e799e6c367859a8"
+dependencies = [
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-mutex",
+ "blocking",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite 0.2.0",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -142,6 +250,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "buf_redux"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +302,12 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
@@ -238,6 +366,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
 name = "contracts"
 version = "0.1.0"
 dependencies = [
@@ -274,6 +411,17 @@ name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg 1.0.1",
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
 
 [[package]]
 name = "crunchy"
@@ -426,6 +574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f81b28370c3b253a27c8773e7e7f8cd72df927722a55998db528ad7a7a250d"
 dependencies = [
  "ethcontract-common",
+ "ethcontract-derive",
  "futures 0.3.8",
  "futures-timer",
  "hex",
@@ -455,6 +604,19 @@ dependencies = [
  "thiserror",
  "tiny-keccak 2.0.2",
  "web3",
+]
+
+[[package]]
+name = "ethcontract-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b78022b200e99e3a1cd116e5c73a30a56affc11cfe4b78546a2b3a4c18a0efc"
+dependencies = [
+ "ethcontract-common",
+ "ethcontract-generate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -488,10 +650,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fastrand"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "filetime"
@@ -625,6 +802,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
 
 [[package]]
+name = "futures-lite"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6c079abfac3ab269e2927ec048dabc89d009ebfdda6b8ee86624f30c689658"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite 0.1.11",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +910,19 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -997,6 +1202,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1392,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nb-connect"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1429,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg 1.0.1",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1290,6 +1524,12 @@ dependencies = [
  "byte-slice-cast",
  "serde",
 ]
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -1385,6 +1625,19 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "polling"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "log",
+ "wepoll-sys",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1961,13 +2214,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "soketto"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5c71ed3d54db0a699f4948e1bb3e45b450fa31fe602621dee6680361d569c88"
+dependencies = [
+ "base64 0.12.3",
+ "bytes",
+ "futures 0.3.8",
+ "httparse",
+ "log",
+ "rand 0.7.3",
+ "sha-1 0.9.2",
+]
+
+[[package]]
 name = "solver"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "contracts",
+ "ethcontract",
  "futures 0.3.8",
+ "hex-literal",
  "jsonrpc-core",
  "maplit",
  "model",
@@ -2429,6 +2698,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
+name = "vec-arena"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2714,12 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "want"
@@ -2575,6 +2856,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d03f64be59921dbc5791f05af61a87594bb454518fe4e97d827405422279a0"
 dependencies = [
  "arrayvec",
+ "async-native-tls",
+ "async-std",
  "base64 0.12.3",
  "derive_more",
  "ethabi",
@@ -2592,8 +2875,18 @@ dependencies = [
  "secp256k1 0.17.2",
  "serde",
  "serde_json",
+ "soketto",
  "tiny-keccak 2.0.2",
  "url",
+]
+
+[[package]]
+name = "wepoll-sys"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 contracts = { path = "../contracts" }
-ethcontract = "0.9"
+ethcontract = { version = "0.9", default-features = false }
 futures = "0.3"
 hex-literal = "0.3"
 jsonrpc-core = "14.0"

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -13,9 +13,10 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-async-trait = "0.1"
 contracts = { path = "../contracts" }
+ethcontract = "0.9"
 futures = "0.3"
+hex-literal = "0.3"
 jsonrpc-core = "14.0"
 maplit = "1.0"
 model = { path = "../model" }

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -75,7 +75,7 @@ impl Driver {
                 )
                 .gas(8_000_000u32.into())
         };
-        //settle().call().await.context("settle simulation failed")?;
+        settle().call().await.context("settle simulation failed")?;
         settle().send().await.context("settle execution failed")?;
         Ok(())
     }

--- a/solver/src/interactions.rs
+++ b/solver/src/interactions.rs
@@ -7,18 +7,17 @@ use anyhow::anyhow;
 use anyhow::Result;
 use primitive_types::H160;
 pub use uniswap::UniswapInteraction;
-use web3::types::Bytes;
 
 fn encode_interaction(
     target: H160,
-    calldata: Bytes,
+    calldata: Vec<u8>,
     writer: &mut dyn std::io::Write,
 ) -> Result<()> {
     writer.write_all(target.as_fixed_bytes())?;
     writer.write_all(
-        &encoding::encode_interaction_data_length(calldata.0.len())
+        &encoding::encode_interaction_data_length(calldata.len())
             .ok_or_else(|| anyhow!("interaction data too long"))?,
     )?;
-    writer.write_all(calldata.0.as_slice())?;
+    writer.write_all(calldata.as_slice())?;
     Ok(())
 }

--- a/solver/src/interactions.rs
+++ b/solver/src/interactions.rs
@@ -2,4 +2,23 @@
 pub mod dummy_web3;
 mod uniswap;
 
+use crate::encoding;
+use anyhow::anyhow;
+use anyhow::Result;
+use primitive_types::H160;
 pub use uniswap::UniswapInteraction;
+use web3::types::Bytes;
+
+fn encode_interaction(
+    target: H160,
+    calldata: Bytes,
+    writer: &mut dyn std::io::Write,
+) -> Result<()> {
+    writer.write_all(target.as_fixed_bytes())?;
+    writer.write_all(
+        &encoding::encode_interaction_data_length(calldata.0.len())
+            .ok_or_else(|| anyhow!("interaction data too long"))?,
+    )?;
+    writer.write_all(calldata.0.as_slice())?;
+    Ok(())
+}

--- a/solver/src/interactions/uniswap.rs
+++ b/solver/src/interactions/uniswap.rs
@@ -1,33 +1,54 @@
-use crate::{encoding, settlement::Interaction};
+use super::encode_interaction;
+use crate::settlement::Interaction;
 use anyhow::Result;
-use contracts::UniswapV2Router02;
+use contracts::{GPv2Settlement, UniswapV2Router02, IERC20};
 use primitive_types::{H160, U256};
 
 #[derive(Debug)]
 pub struct UniswapInteraction {
     pub contract: UniswapV2Router02,
+    pub settlement: GPv2Settlement,
+    pub set_allowance: bool,
     pub amount_in: U256,
     pub amount_out_min: U256,
     pub token_in: H160,
     pub token_out: H160,
-    pub payout_to: H160,
 }
 
 impl Interaction for UniswapInteraction {
-    fn encode(&self, writer: &mut dyn std::io::Write) -> Result<()> {
+    fn encode(&self, writer: &mut (dyn std::io::Write + Send)) -> Result<()> {
+        self.encode_approve(writer)?;
+        self.encode_swap(writer)
+    }
+}
+
+impl UniswapInteraction {
+    fn encode_approve(&self, writer: &mut (dyn std::io::Write + Send)) -> Result<()> {
+        let token = IERC20::at(&self.web3(), self.token_in);
+        if self.set_allowance {
+            let method = token.approve(self.contract.address(), U256::MAX);
+            encode_interaction(self.token_in, method.tx.data.expect("no calldata"), writer)?;
+        }
+        Ok(())
+    }
+
+    fn encode_swap(&self, writer: &mut dyn std::io::Write) -> Result<()> {
         let method = self.contract.swap_exact_tokens_for_tokens(
             self.amount_in,
             self.amount_out_min,
             vec![self.token_in, self.token_out],
-            self.payout_to,
+            self.settlement.address(),
             U256::MAX,
         );
-        let data = method.tx.data.expect("no calldata").0;
-        writer.write_all(self.contract.address().as_fixed_bytes())?;
-        // Unwrap because we know uniswap data size can be stored in 3 bytes.
-        writer.write_all(&encoding::encode_interaction_data_length(data.len()).unwrap())?;
-        writer.write_all(data.as_slice())?;
-        Ok(())
+        encode_interaction(
+            self.contract.address(),
+            method.tx.data.expect("no calldata"),
+            writer,
+        )
+    }
+
+    fn web3(&self) -> web3::Web3<ethcontract::transport::DynTransport> {
+        self.contract.raw_instance().web3()
     }
 }
 
@@ -36,42 +57,61 @@ mod tests {
     use super::*;
     use crate::encoding::tests::u8_as_32_bytes_be;
     use crate::interactions::dummy_web3;
+    use hex_literal::hex;
     use std::io::Cursor;
 
     #[test]
-    fn encode_uniswap_call_() {
+    fn encode_uniswap_call() {
         let amount_in = 5;
         let amount_out_min = 6;
-        let token_in = 7;
+        let token_in = H160::from_low_u64_be(7);
         let token_out = 8;
-        let payout_to = 9;
+        let payout_to = 9u8;
         let contract = UniswapV2Router02::at(&dummy_web3::dummy_web3(), H160::from_low_u64_be(4));
+        let settlement = GPv2Settlement::at(
+            &dummy_web3::dummy_web3(),
+            H160::from_low_u64_be(payout_to as u64),
+        );
         let interaction = UniswapInteraction {
             contract: contract.clone(),
+            settlement,
+            set_allowance: true,
             amount_in: amount_in.into(),
             amount_out_min: amount_out_min.into(),
-            token_in: H160::from_low_u64_be(token_in as u64),
+            token_in,
             token_out: H160::from_low_u64_be(token_out as u64),
-            payout_to: H160::from_low_u64_be(payout_to as u64),
         };
         let mut cursor = Cursor::new(Vec::new());
         interaction.encode(&mut cursor).unwrap();
-        let encoded = cursor.into_inner();
-        assert_eq!(&encoded[0..20], contract.address().as_fixed_bytes());
-        assert_eq!(encoded[20..23], [0, 1, 4]);
-        let call = &encoded[23..];
-        let signature = [0x38u8, 0xed, 0x17, 0x39];
+
+        // Verify Approve
+        let mut approve_call = cursor.into_inner();
+        assert_eq!(&approve_call[0..20], token_in.as_fixed_bytes());
+        assert_eq!(approve_call[20..23], [0, 0, 68]);
+
+        let call = &approve_call[23..];
+        let approve_signature = hex!("095ea7b3");
+        assert_eq!(call[0..4], approve_signature);
+        assert_eq!(&call[16..36], contract.address().as_fixed_bytes()); //spender
+        assert_eq!(call[36..68], [0xffu8; 32]); // amount
+
+        // Verify Swap
+        let swap_call = approve_call.split_off(91);
+        assert_eq!(&swap_call[0..20], contract.address().as_fixed_bytes());
+        assert_eq!(swap_call[20..23], [0, 1, 4]);
+        let call = &swap_call[23..];
+        let swap_signature = [0x38u8, 0xed, 0x17, 0x39];
         let path_offset = 160;
         let path_size = 2;
         let deadline = [0xffu8; 32];
-        assert_eq!(call[0..4], signature);
+        assert_eq!(call[0..4], swap_signature);
         assert_eq!(call[4..36], u8_as_32_bytes_be(amount_in));
         assert_eq!(call[36..68], u8_as_32_bytes_be(amount_out_min));
         assert_eq!(call[68..100], u8_as_32_bytes_be(path_offset));
         assert_eq!(call[100..132], u8_as_32_bytes_be(payout_to));
         assert_eq!(call[132..164], deadline);
         assert_eq!(call[164..196], u8_as_32_bytes_be(path_size));
-        assert_eq!(call[196..228], u8_as_32_bytes_be(token_in));
+        assert_eq!(&call[208..228], token_in.as_fixed_bytes());
         assert_eq!(call[228..260], u8_as_32_bytes_be(token_out));
     }
 }

--- a/solver/src/interactions/uniswap.rs
+++ b/solver/src/interactions/uniswap.rs
@@ -91,7 +91,7 @@ mod tests {
         // Verify Approve
         let mut approve_call = cursor.into_inner();
         assert_eq!(&approve_call[0..20], token_in.as_fixed_bytes());
-        assert_eq!(approve_call[20..23], [0, 0, 68]);
+        assert_eq!(approve_call[20..23], [0, 0, 68]); // length of calldata below
 
         let call = &approve_call[23..];
         let approve_signature = hex!("095ea7b3");
@@ -102,7 +102,8 @@ mod tests {
         // Verify Swap
         let swap_call = approve_call.split_off(91);
         assert_eq!(&swap_call[0..20], contract.address().as_fixed_bytes());
-        assert_eq!(swap_call[20..23], [0, 1, 4]);
+        assert_eq!(swap_call[20..23], [0, 1, 4]); // length of calldata below
+
         let call = &swap_call[23..];
         let swap_signature = [0x38u8, 0xed, 0x17, 0x39];
         let path_offset = 160;

--- a/solver/src/interactions/uniswap.rs
+++ b/solver/src/interactions/uniswap.rs
@@ -16,14 +16,14 @@ pub struct UniswapInteraction {
 }
 
 impl Interaction for UniswapInteraction {
-    fn encode(&self, writer: &mut (dyn std::io::Write + Send)) -> Result<()> {
+    fn encode(&self, writer: &mut dyn std::io::Write) -> Result<()> {
         self.encode_approve(writer)?;
         self.encode_swap(writer)
     }
 }
 
 impl UniswapInteraction {
-    fn encode_approve(&self, writer: &mut (dyn std::io::Write + Send)) -> Result<()> {
+    fn encode_approve(&self, writer: &mut dyn std::io::Write) -> Result<()> {
         let token = IERC20::at(&self.web3(), self.token_in);
         if self.set_allowance {
             let method = token.approve(self.contract.address(), U256::MAX);

--- a/solver/src/interactions/uniswap.rs
+++ b/solver/src/interactions/uniswap.rs
@@ -27,7 +27,11 @@ impl UniswapInteraction {
         let token = IERC20::at(&self.web3(), self.token_in);
         if self.set_allowance {
             let method = token.approve(self.contract.address(), U256::MAX);
-            encode_interaction(self.token_in, method.tx.data.expect("no calldata"), writer)?;
+            encode_interaction(
+                self.token_in,
+                method.tx.data.expect("no calldata").0,
+                writer,
+            )?;
         }
         Ok(())
     }
@@ -42,7 +46,7 @@ impl UniswapInteraction {
         );
         encode_interaction(
             self.contract.address(),
-            method.tx.data.expect("no calldata"),
+            method.tx.data.expect("no calldata").0,
             writer,
         )
     }

--- a/solver/src/naive_solver/two_order_settlement.rs
+++ b/solver/src/naive_solver/two_order_settlement.rs
@@ -2,7 +2,7 @@ use crate::{
     interactions::UniswapInteraction,
     settlement::{Interaction, Settlement, Trade},
 };
-use contracts::UniswapV2Router02;
+use contracts::{GPv2Settlement, UniswapV2Router02};
 use model::{OrderCreation, OrderKind};
 use primitive_types::{H160, U256};
 use std::collections::HashMap;
@@ -15,16 +15,22 @@ pub struct TwoOrderSettlement {
 }
 
 impl TwoOrderSettlement {
-    pub fn into_settlement(self, uniswap: UniswapV2Router02, payout_to: &H160) -> Settlement {
+    pub fn into_settlement(
+        self,
+        uniswap: UniswapV2Router02,
+        gpv2_settlement: GPv2Settlement,
+    ) -> Settlement {
         let mut interactions = Vec::<Box<dyn Interaction>>::new();
         if let Some(interaction) = self.interaction {
             interactions.push(Box::new(UniswapInteraction {
                 contract: uniswap,
+                settlement: gpv2_settlement,
+                // TODO(fleupold) Only set allowance if we need to
+                set_allowance: true,
                 amount_in: interaction.amount_in,
                 amount_out_min: interaction.amount_out_min,
                 token_in: interaction.token_in,
                 token_out: interaction.token_out,
-                payout_to: *payout_to,
             }));
         }
         Settlement {

--- a/solver/src/settlement.rs
+++ b/solver/src/settlement.rs
@@ -19,7 +19,7 @@ pub trait Interaction: std::fmt::Debug {
     // Write::write returns a result but we know we write to a vector in memory so we know it will
     // never fail. Then the question becomes whether interactions should be allowed to fail encoding
     // for other reasons.
-    fn encode(&self, writer: &mut (dyn Write + Send)) -> Result<()>;
+    fn encode(&self, writer: &mut dyn Write) -> Result<()>;
 }
 
 #[derive(Debug, Default)]

--- a/solver/src/settlement.rs
+++ b/solver/src/settlement.rs
@@ -19,7 +19,7 @@ pub trait Interaction: std::fmt::Debug {
     // Write::write returns a result but we know we write to a vector in memory so we know it will
     // never fail. Then the question becomes whether interactions should be allowed to fail encoding
     // for other reasons.
-    fn encode(&self, writer: &mut dyn Write) -> Result<()>;
+    fn encode(&self, writer: &mut (dyn Write + Send)) -> Result<()>;
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
This PR adds functionality to encode the approval tx of the sell token to Uniswap (which is required for the e2e test). In order to keep encoding synchronous, this is atm just passed in from above (in the future we should probably keep track of which approvals we have already given and only add them for newly traded tokens).

### Test Plan
Fully working e2e test (in two PRs). For now CI
