### PR TITLE
Getting ready for mainnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,6 +1957,7 @@ dependencies = [
  "contracts",
  "ethcontract",
  "futures 0.3.8",
+ "hex",
  "hex-literal",
  "jsonrpc-core",
  "maplit",

--- a/contracts/build.rs
+++ b/contracts/build.rs
@@ -19,12 +19,16 @@ fn main() {
     generate_contract("ERC20Mintable", hashmap! {});
     generate_contract(
         "UniswapV2Router02",
-        hashmap! {4 => Address::from_str("7a250d5630B4cF539739dF2C5dAcb4c659F2488D").unwrap()},
+        hashmap! {
+        1 => Address::from_str("7a250d5630B4cF539739dF2C5dAcb4c659F2488D").unwrap(),
+        4 => Address::from_str("7a250d5630B4cF539739dF2C5dAcb4c659F2488D").unwrap()},
     );
     generate_contract("UniswapV2Factory", hashmap! {});
     generate_contract(
         "GPv2Settlement",
-        hashmap! {4 => Address::from_str("4E608b7Da83f8E9213F554BDAA77C72e125529d0").unwrap()},
+        hashmap! {
+        1 => Address::from_str("4E608b7Da83f8E9213F554BDAA77C72e125529d0").unwrap(),
+        4 => Address::from_str("4E608b7Da83f8E9213F554BDAA77C72e125529d0").unwrap()},
     );
     generate_contract("GPv2AllowListAuthentication", hashmap! {});
 }

--- a/contracts/src/bin/vendor.rs
+++ b/contracts/src/bin/vendor.rs
@@ -28,11 +28,11 @@ const NPM_CONTRACTS: &[(&str, &str)] = &[
         "UniswapV2Factory.json",
     ),
     (
-        "@gnosis.pm/gp-v2-contracts@0.0.1-alpha.8/deployments/rinkeby/GPv2Settlement.json",
+        "@gnosis.pm/gp-v2-contracts@0.0.1-alpha.10/deployments/rinkeby/GPv2Settlement.json",
         "GPv2Settlement.json",
     ),
     (
-        "@gnosis.pm/gp-v2-contracts@0.0.1-alpha.8/deployments/rinkeby/GPv2AllowListAuthentication.json",
+        "@gnosis.pm/gp-v2-contracts@0.0.1-alpha.10/deployments/rinkeby/GPv2AllowListAuthentication.json",
         "GPv2AllowListAuthentication.json",
     ),
 ];

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -17,6 +17,7 @@ contracts = { path = "../contracts" }
 ethcontract = { version = "0.9", default-features = false }
 futures = "0.3"
 hex-literal = "0.3"
+hex = "0.4"
 jsonrpc-core = "14.0"
 maplit = "1.0"
 model = { path = "../model" }

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -75,6 +75,10 @@ impl Driver {
                 )
                 .gas(8_000_000u32.into())
         };
+        tracing::info!(
+            "Settlement call: {}",
+            hex::encode(settle().tx.data.expect("data").0),
+        );
         settle().call().await.context("settle simulation failed")?;
         settle().send().await.context("settle execution failed")?;
         Ok(())

--- a/solver/src/lib.rs
+++ b/solver/src/lib.rs
@@ -6,18 +6,19 @@ pub mod orderbook;
 pub mod settlement;
 
 use anyhow::Result;
-use ethcontract::{contract::MethodDefaults, Account, Http, PrivateKey, Web3};
+use ethcontract::{contract::MethodDefaults, Account, GasPrice, Http, PrivateKey, Web3};
 
 pub async fn get_settlement_contract(
     web3: &Web3<Http>,
     chain_id: u64,
     key: PrivateKey,
+    gas_price_factor: f64,
 ) -> Result<contracts::GPv2Settlement> {
     let mut settlement_contract = contracts::GPv2Settlement::deployed(&web3).await?;
     *settlement_contract.defaults_mut() = MethodDefaults {
         from: Some(Account::Offline(key, Some(chain_id))),
         gas: None,
-        gas_price: None,
+        gas_price: Some(GasPrice::Scaled(gas_price_factor)),
     };
     Ok(settlement_contract)
 }

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -24,6 +24,10 @@ struct Arguments {
     /// The private key used by the driver to sign transactions.
     #[structopt(short = "k", long, env = "PRIVATE_KEY", hide_env_values = true)]
     private_key: PrivateKey,
+
+    /// The factor by which the gas price estimate is multiplied (to ensure fast settlement)
+    #[structopt(long, env = "GAS_PRICE_FACTOR", default_value = "1.0")]
+    gas_price_factor: f64,
 }
 
 #[tokio::main]
@@ -44,9 +48,10 @@ async fn main() {
         .await
         .expect("Could not get chainId")
         .as_u64();
-    let settlement_contract = solver::get_settlement_contract(&web3, chain_id, args.private_key)
-        .await
-        .expect("couldn't load deployed settlement");
+    let settlement_contract =
+        solver::get_settlement_contract(&web3, chain_id, args.private_key, args.gas_price_factor)
+            .await
+            .expect("couldn't load deployed settlement");
     let orderbook =
         solver::orderbook::OrderBookApi::new(args.orderbook_url, args.orderbook_timeout);
     let mut driver = Driver::new(settlement_contract, uniswap_contract, orderbook);


### PR DESCRIPTION
This PR prepares the backend for a mainnet demo. As far as I can tell we only need the updated addresses (URLs can be configured in kubernetes) and provide a hacky way of ensuring we use enough gas. Given that ethcontracts ships with web3 gas estimation, I thought the easiest way is to just hardcode a factor for now.

### Test Plan

![image](https://user-images.githubusercontent.com/1200333/102474440-f06e6b00-4058-11eb-99ef-297278f88178.png)

