### PR TITLE
frist try, getting trade events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-channel"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "vec-arena",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "futures-lite",
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
+dependencies = [
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "libc",
+ "log",
+ "nb-connect",
+ "once_cell",
+ "parking",
+ "polling",
+ "vec-arena",
+ "waker-fn",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-native-tls"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9e7a929bd34c68a82d58a4de7f86fffdaf97fb2af850162a7bb19dd7269b33"
+dependencies = [
+ "async-std",
+ "native-tls",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "async-std"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f84f1280a2b436a2c77c2582602732b6c2f4321d5494d6e799e6c367859a8"
+dependencies = [
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-mutex",
+ "blocking",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite 0.2.0",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+
+[[package]]
 name = "async-trait"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +172,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -142,6 +261,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "buf_redux"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +313,12 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
@@ -238,6 +377,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
 name = "contracts"
 version = "0.1.0"
 dependencies = [
@@ -274,6 +422,17 @@ name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg 1.0.1",
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
 
 [[package]]
 name = "crunchy"
@@ -426,6 +585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f81b28370c3b253a27c8773e7e7f8cd72df927722a55998db528ad7a7a250d"
 dependencies = [
  "ethcontract-common",
+ "ethcontract-derive",
  "futures 0.3.8",
  "futures-timer",
  "hex",
@@ -455,6 +615,19 @@ dependencies = [
  "thiserror",
  "tiny-keccak 2.0.2",
  "web3",
+]
+
+[[package]]
+name = "ethcontract-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b78022b200e99e3a1cd116e5c73a30a56affc11cfe4b78546a2b3a4c18a0efc"
+dependencies = [
+ "ethcontract-common",
+ "ethcontract-generate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -488,10 +661,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fastrand"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "filetime"
@@ -625,6 +813,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
 
 [[package]]
+name = "futures-lite"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6c079abfac3ab269e2927ec048dabc89d009ebfdda6b8ee86624f30c689658"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite 0.1.11",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +921,19 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -997,6 +1213,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1403,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nb-connect"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1440,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg 1.0.1",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1265,6 +1510,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "contracts",
+ "ethcontract",
  "hex",
  "model",
  "primitive-types",
@@ -1290,6 +1536,12 @@ dependencies = [
  "byte-slice-cast",
  "serde",
 ]
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -1385,6 +1637,19 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "polling"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "log",
+ "wepoll-sys",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1961,6 +2226,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "soketto"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5c71ed3d54db0a699f4948e1bb3e45b450fa31fe602621dee6680361d569c88"
+dependencies = [
+ "base64 0.12.3",
+ "bytes",
+ "futures 0.3.8",
+ "httparse",
+ "log",
+ "rand 0.7.3",
+ "sha-1 0.9.2",
+]
+
+[[package]]
 name = "solver"
 version = "0.1.0"
 dependencies = [
@@ -2429,6 +2709,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
+name = "vec-arena"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2725,12 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "want"
@@ -2575,6 +2867,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d03f64be59921dbc5791f05af61a87594bb454518fe4e97d827405422279a0"
 dependencies = [
  "arrayvec",
+ "async-native-tls",
+ "async-std",
  "base64 0.12.3",
  "derive_more",
  "ethabi",
@@ -2592,8 +2886,18 @@ dependencies = [
  "secp256k1 0.17.2",
  "serde",
  "serde_json",
+ "soketto",
  "tiny-keccak 2.0.2",
  "url",
+]
+
+[[package]]
+name = "wepoll-sys"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -27,3 +27,5 @@ tracing = "0.1"
 tracing-setup = { path = "../tracing-setup" }
 warp = "0.2"
 web3 = { version = "0.13", default-features = false, features = ["http-tls"] }
+ethcontract = "0.9.1"
+

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod on_chain_state;
 pub mod orderbook;
 
 use crate::orderbook::OrderBook;

--- a/orderbook/src/on_chain_state.rs
+++ b/orderbook/src/on_chain_state.rs
@@ -1,0 +1,94 @@
+use anyhow::{ensure, Result};
+use contracts::GPv2Settlement;
+
+use ethcontract::futures::stream::{Stream, StreamExt as _};
+use ethcontract::{errors::EventError, BlockNumber, EventStatus};
+use model::OrderUid;
+use primitive_types::U256;
+use std::collections::HashMap;
+use tracing::info;
+use web3::Web3;
+
+type Event = ethcontract::Event<EventStatus<contracts::g_pv_2_settlement::event_data::Trade>>;
+
+pub struct SettledOrderUpdater {
+    settlement_contract: GPv2Settlement,
+    web3: Web3<web3::transports::Http>,
+    settled_orders: HashMap<OrderUid, U256>,
+    last_handled_block: u64,
+    block_page_size: u64,
+}
+
+// TODO: Implement proper revertion with BLOCK_CONFIRMATION_COUNT>0
+const BLOCK_CONFIRMATION_COUNT: u64 = 0;
+
+impl SettledOrderUpdater {
+    fn new(contract: GPv2Settlement, web3: Web3<web3::transports::Http>) -> Self {
+        Self {
+            settlement_contract: contract,
+            web3,
+            settled_orders: HashMap::new(),
+            last_handled_block: 0,
+            block_page_size: 20,
+        }
+    }
+    /// Gather all new events since the last update and update the orderbook.
+    async fn update_settled_orders(&mut self) -> Result<()> {
+        // We cannot use BlockNumber::Pending here because we are not guaranteed to get metadata for
+        // pending blocks but we need the metadata in the functions below.
+        let current_block = self.web3.eth().block_number().await?.as_u64();
+        let from_block = self
+            .last_handled_block
+            .saturating_sub(BLOCK_CONFIRMATION_COUNT);
+        ensure!(
+            from_block <= current_block,
+            format!(
+                "current block number according to node is {} which is more than {} blocks in the \
+             past compared to previous current block {}",
+                current_block, BLOCK_CONFIRMATION_COUNT, from_block
+            )
+        );
+        info!(
+            "Updating event based orderbook from block {} to block {}.",
+            from_block, current_block,
+        );
+        self.update_with_events_between_blocks(from_block, current_block)
+            .await
+    }
+
+    async fn update_with_events_between_blocks(
+        &mut self,
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<()> {
+        let mut events = self.chunked_events(from_block, to_block).await?;
+        while let Some(chunk) = events.next().await {
+            let events = chunk;
+            for event in events {
+                println!("{:?}", event);
+                //ToDo remove the orders for now, as rinkeby does not reorg.
+            }
+            self.last_handled_block = to_block;
+        }
+
+        Ok(())
+    }
+
+    async fn chunked_events(
+        &self,
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<impl Stream<Item = Result<Vec<Event>, EventError>> + '_> {
+        let trade_builder = self
+            .settlement_contract
+            .events()
+            .trade()
+            .from_block(BlockNumber::Number(from_block.into()))
+            .to_block(BlockNumber::Number(to_block.into()));
+        let event_stream = trade_builder.stream();
+        let event_chunks = event_stream
+            .ready_chunks(self.block_page_size as usize)
+            .map(|chunk| chunk.into_iter().collect::<Result<Vec<_>, _>>());
+        Ok(event_chunks)
+    }
+}


### PR DESCRIPTION
I need your help :( Reading through all the future and stream documentation takes forever.

With this code, I am trying to just parse the Trade events+eventstatus using streams. This would be great, as it would allow me to set invalidity dates for settled orders.

But I am getting these error messages:
```
`from_generator::GenFuture<[static generator@LogFilterBuilder::<T>::stream::{closure#0} for<'r, 's> {ResumeTy, &'r web3::Web3<DynTransport>, web3::Web3<DynTransport>, EthFilter<DynTransport>, &'s FilterBuilder, FilterBuilder, web3::types::Filter, CreateFilter<DynTransport, web3::types::Log>, ()}]>` cannot be unpinned
  --> orderbook/src/on_chain_state.rs:65:33
   |
65 |         while let Some(chunk) = events.next().await {
   |                                 ^^^^^^^^^^^^^^^^^^^ within `futures_util::future::try_future::try_flatten::_::__TryFlatten<'_, impl futures::Future, futures::stream::MapErr<FilterStream<DynTransport, web3::types::Log>, fn(web3::Error) -> ExecutionError {<ExecutionError as From<web3::Error>>::from}>>`, the trait `Unpin` is not implemented for `from_generator::GenFuture<[static generator@LogFilterBuilder::<T>::stream::{closure#0} for<'r, 's> {ResumeTy, &'r web3::Web3<DynTransport>, web3::Web3<DynTransport>, EthFilter<DynTransport>, &'s FilterBuilder, FilterBuilder, web3::types::Filter, CreateFilter<DynTransport, web3::types::Log>, ()}]>`
```
