### PR TITLE
Filter settled order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,6 +1254,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "contracts",
+ "futures 0.3.8",
  "hex",
  "model",
  "primitive-types",

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -27,3 +27,4 @@ tracing = "0.1"
 tracing-setup = { path = "../tracing-setup" }
 warp = "0.2"
 web3 = { version = "0.13", default-features = false, features = ["http-tls"] }
+futures = "0.3.8"

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -1,6 +1,5 @@
 use contracts::GPv2Settlement;
-use futures::future::join_all;
-use futures::join;
+use futures::{future::join_all, join};
 use model::{DomainSeparator, Order, OrderCreation, OrderMetaData, OrderUid};
 use primitive_types::U256;
 use std::{

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -121,7 +121,7 @@ impl OrderBook {
             .filled_amount(uid.0.to_vec())
             .call()
             .await
-            .unwrap_or(U256::MAX);
+            .unwrap_or(U256::zero());
         // As a simplification the function is returning the uid,
         // if the order was already partially settled
         // or if it was canceled.


### PR DESCRIPTION
As the proper solution for updating the settled orders should only be implemented after we have the db solution, this PR delivers an interim solution: Each order is checked for the filledAmount in the smart contract directly via an RPC call.

Improvement options:
- batched request: Here, I would have to investigate more on how to do it. Currently, the rpc calls are just happening in parallel. I think it is good enough for an implementation that is anyway just temporary.
- proper testing: Here, I need to investigate how to mock the smart contract calls. 
- better readability: Actually I tried to implement a sequential order filtering that is much easier to read:
```
async fn remove_settled_orders(&self, settlement_contract: &GPv2Settlement) {
        let mut orders = self.orders.write().await;
         orders.retain(async move |uid, _| self.has_not_yet_been_settled(*uid).await);
    }
  ```
  But I was not smart enough to get this async operation into the iter, even though I tried to work with stream::iter...
  
  
I think we should do the proper testing. The other options are not so important to me.

### Test Plan
Unit tests.