### PR TITLE
Cache rust files in CI

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -3,10 +3,9 @@ on: [pull_request]
 jobs:
   rust:
     runs-on: ubuntu-latest
-    env:
-      CARGO_INCREMENTAL: 0
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - run: |
           npm install ganache-cli
           node_modules/.bin/ganache-cli --networkId 5777 --gasLimit 10000000 --gasPrice 0&


### PR DESCRIPTION
I tested manually caching, using sccache and finally this pre made
action. The action works very well and is a clean one line solution.
Internally it caches the cargo registry and the target folder but not
crates from this workspace. The cache gets invalidated if Cargo.lock
changes.
sccache makes the build more complicated and doesn't give a speedup when
we already cache like this.
A PR were no dependencies change causes only the top level crates from this workspace to be rebuilt in which case the whole ci run completes in 1 minute.

### Test Plan
After this PR we should have faster CI times.