### PR TITLE
Run full CI on main

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,5 +1,10 @@
 name: pull request
-on: [pull_request]
+on:
+  pull_request:
+  # We require PRs to be up to date before merging so technically it is not needed run the rust job
+  # on main. However for the cache to be usable in PRs we do need the job on main.
+  push:
+    branches: [main]
 jobs:
   rust:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We require PRs to be up to date before merging so technically it is not needed run the rust job
on main. However for the cache to be usable in PRs we do need the job on main.

### Test Plan
After this PR a cache should be generated on main that can be used by PRs.