### PR TITLE
Verify EIP712 constants on deployed instance

### DIFF
--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -196,7 +196,7 @@ impl OrderCreation {}
 
 // See https://github.com/gnosis/gp-v2-contracts/blob/main/src/contracts/libraries/GPv2Encoding.sol
 impl OrderCreation {
-    const ORDER_TYPE_HASH: [u8; 32] =
+    pub const ORDER_TYPE_HASH: [u8; 32] =
         hex!("b2b38b9dcbdeb41f7ad71dea9aed79fb47f7bbc3436576fe994b43d5b16ecdec");
 
     // keccak256("sell")

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -1,7 +1,10 @@
 pub mod api;
 pub mod orderbook;
 
+use anyhow::{anyhow, Result, Context as _};
 use crate::orderbook::OrderBook;
+use contracts::GPv2Settlement;
+use model::DomainSeparator;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::{task, task::JoinHandle};
 use warp::Filter;
@@ -14,4 +17,23 @@ pub fn serve_task(orderbook: Arc<OrderBook>, address: SocketAddr) -> JoinHandle<
     let filter = api::handle_all_routes(orderbook).with(cors);
     tracing::info!(%address, "serving order book");
     task::spawn(warp::serve(filter).bind(address))
+}
+
+/**
+ * Check that important constants such as the EIP 712 Domain Separator and Order Type Hash used in this binary match the ones on the deployed contract instance.
+ * Signature inconsistencies due to a mismatch of these constants are hard to debug.
+ */
+pub async fn verify_deployed_contract_constants(contract: &GPv2Settlement, chain_id: u64) -> Result<()> {
+    let web3 = contract.raw_instance().web3();
+    let bytecode = hex::encode(web3.eth().code(contract.address(), None).await.context("Could not load deployed bytecode")?.0);
+
+    let domain_separator = DomainSeparator::get_domain_separator(chain_id, contract.address());
+    if !bytecode.contains(&hex::encode(domain_separator.0)) {
+        return Err(anyhow!("Bytecode did not contain domain separator"));
+    }
+
+    if !bytecode.contains(&hex::encode(model::order::OrderCreation::ORDER_TYPE_HASH)) {
+        return Err(anyhow!("Bytecode did not contain order type hash"));
+    }
+    Ok(())
 }

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod api;
 pub mod orderbook;
 
-use anyhow::{anyhow, Result, Context as _};
 use crate::orderbook::OrderBook;
+use anyhow::{anyhow, Context as _, Result};
 use contracts::GPv2Settlement;
 use model::DomainSeparator;
 use std::{net::SocketAddr, sync::Arc};
@@ -23,9 +23,18 @@ pub fn serve_task(orderbook: Arc<OrderBook>, address: SocketAddr) -> JoinHandle<
  * Check that important constants such as the EIP 712 Domain Separator and Order Type Hash used in this binary match the ones on the deployed contract instance.
  * Signature inconsistencies due to a mismatch of these constants are hard to debug.
  */
-pub async fn verify_deployed_contract_constants(contract: &GPv2Settlement, chain_id: u64) -> Result<()> {
+pub async fn verify_deployed_contract_constants(
+    contract: &GPv2Settlement,
+    chain_id: u64,
+) -> Result<()> {
     let web3 = contract.raw_instance().web3();
-    let bytecode = hex::encode(web3.eth().code(contract.address(), None).await.context("Could not load deployed bytecode")?.0);
+    let bytecode = hex::encode(
+        web3.eth()
+            .code(contract.address(), None)
+            .await
+            .context("Could not load deployed bytecode")?
+            .0,
+    );
 
     let domain_separator = DomainSeparator::get_domain_separator(chain_id, contract.address());
     if !bytecode.contains(&hex::encode(domain_separator.0)) {

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -1,7 +1,7 @@
 use contracts::GPv2Settlement;
 use model::DomainSeparator;
 use orderbook::orderbook::OrderBook;
-use orderbook::serve_task;
+use orderbook::{serve_task, verify_deployed_contract_constants};
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 use structopt::StructOpt;
 use tokio::task;
@@ -39,9 +39,10 @@ async fn main() {
     let settlement_contract = GPv2Settlement::deployed(&web3)
         .await
         .expect("Couldn't load deployed settlement");
-    let chain_id = web3.eth().chain_id().await.expect("Could not get chainId");
+    let chain_id = web3.eth().chain_id().await.expect("Could not get chainId").as_u64();
+    verify_deployed_contract_constants(&settlement_contract, chain_id).await.expect("Deployed contract constants don't match the ones in this binary");
     let domain_separator =
-        DomainSeparator::get_domain_separator(chain_id.as_u64(), settlement_contract.address());
+        DomainSeparator::get_domain_separator(chain_id, settlement_contract.address());
     let orderbook = Arc::new(OrderBook::new(domain_separator));
     let serve_task = serve_task(orderbook.clone(), args.bind_address);
     let maintenance_task = task::spawn(orderbook_maintenance(orderbook, settlement_contract));

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -39,8 +39,15 @@ async fn main() {
     let settlement_contract = GPv2Settlement::deployed(&web3)
         .await
         .expect("Couldn't load deployed settlement");
-    let chain_id = web3.eth().chain_id().await.expect("Could not get chainId").as_u64();
-    verify_deployed_contract_constants(&settlement_contract, chain_id).await.expect("Deployed contract constants don't match the ones in this binary");
+    let chain_id = web3
+        .eth()
+        .chain_id()
+        .await
+        .expect("Could not get chainId")
+        .as_u64();
+    verify_deployed_contract_constants(&settlement_contract, chain_id)
+        .await
+        .expect("Deployed contract constants don't match the ones in this binary");
     let domain_separator =
         DomainSeparator::get_domain_separator(chain_id, settlement_contract.address());
     let orderbook = Arc::new(OrderBook::new(domain_separator));


### PR DESCRIPTION
This PR makes it so we cannot start the API if its internal magic numbers (in accordance with EIP 712) used for signature verification don't match the ones on the smart contract.

This is approximated by requiring that the hex representation of our local constants are contained in the deployed bytecode on chain. Since the identifiers are 32bytes, I think the chance for false negatives is negligible.

While the domain separator could be queried via a view method invocation, the OrderTypeHash cannot as it is stored as an internal constant on a linked library. Even if made public, we would have to explicitly expose it on the Settlement contract via a handwritten accessor or a StorageReading extension (cf. [this SO question](https://ethereum.stackexchange.com/questions/16082/solidity-accessing-a-library-constant-in-a-contract-that-imports-the-library)). It would also add up to one RPC roundtrip call per constant we want to check whereas fetching the bytecode and checking containment only requires only one roundtrip total.

### Test Plan
Change one byte in TypeHash constant, see we panic at startup
