### PR TITLE
Only encode uniswap approval when needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-trait"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +1966,7 @@ name = "solver"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "contracts",
  "ethcontract",
  "futures 0.3.8",

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 contracts = { path = "../contracts" }
 ethcontract = { version = "0.9", default-features = false }
 futures = "0.3"

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -60,6 +60,7 @@ impl Driver {
         // TODO: use retry transaction sending crate for updating gas prices
         let encoded_interactions = settlement
             .encode_interactions()
+            .await
             .context("interaction encoding failed")?;
         let encoded_trades = settlement
             .encode_trades()

--- a/solver/src/naive_solver/two_order_settlement.rs
+++ b/solver/src/naive_solver/two_order_settlement.rs
@@ -22,16 +22,14 @@ impl TwoOrderSettlement {
     ) -> Settlement {
         let mut interactions = Vec::<Box<dyn Interaction>>::new();
         if let Some(interaction) = self.interaction {
-            interactions.push(Box::new(UniswapInteraction {
-                contract: uniswap,
-                settlement: gpv2_settlement,
-                // TODO(fleupold) Only set allowance if we need to
-                set_allowance: true,
-                amount_in: interaction.amount_in,
-                amount_out_min: interaction.amount_out_min,
-                token_in: interaction.token_in,
-                token_out: interaction.token_out,
-            }));
+            interactions.push(Box::new(UniswapInteraction::new(
+                uniswap,
+                gpv2_settlement,
+                interaction.amount_in,
+                interaction.amount_out_min,
+                interaction.token_in,
+                interaction.token_out,
+            )));
         }
         Settlement {
             clearing_prices: self.clearing_prices,


### PR DESCRIPTION
to save gas. This is coupled with a change to the Interaction trait to make the encoding function async. An alternative to this is to move this work into the constructor of the interaction itself or add another function to the trait like prepare_interaction. I don't like the latter because you would always call it before encode anyway and could make the internal state of the interaction more complicated. Doing it in the constructor has the advantage that the self encode stays simpler but it makes it more complicated to create an interaction in the first place.
For the uniswap interaction specifically we could later add a cache to remember that we have already given approval.

### Test Plan
e2e test
