### PR TITLE
Rename TwoOrderSettlement into SinglePairSettlement

### DIFF
--- a/solver/src/naive_solver.rs
+++ b/solver/src/naive_solver.rs
@@ -1,6 +1,6 @@
-mod two_order_settlement;
+mod single_pair_settlement;
 
-use self::two_order_settlement::TwoOrderSettlement;
+use self::single_pair_settlement::SinglePairSettlement;
 use crate::settlement::Settlement;
 use contracts::{GPv2Settlement, UniswapV2Router02};
 use model::{
@@ -23,10 +23,10 @@ pub fn settle(
         .map(|settlement| settlement.into_settlement(uniswap.clone(), gpv2_settlement.clone()))
 }
 
-fn settle_pair(orders: TokenPairOrders) -> Option<TwoOrderSettlement> {
+fn settle_pair(orders: TokenPairOrders) -> Option<SinglePairSettlement> {
     let most_lenient_a = orders.sell_token_0.into_iter().min_by(order_by_price)?;
     let most_lenient_b = orders.sell_token_1.into_iter().min_by(order_by_price)?;
-    two_order_settlement::settle_two_fillkill_sell_orders(&most_lenient_a, &most_lenient_b)
+    single_pair_settlement::settle_two_fillkill_sell_orders(&most_lenient_a, &most_lenient_b)
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
I'm working on a slightly less naive solver that can take an arbitrary number of orders on a single pair. For this, I'd like to reuse the intermediary settlement struct from the existing naive solver.

This PR renames the struct to be applicable for the slightly less naive solver and changes the trade type from `[Trade; 2]` to `Vec<Trade>`.

### Test Plan
CI
