### PR TITLE
Sightly less naive solver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,12 +99,6 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-
-[[package]]
-name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
@@ -209,15 +203,21 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cargo-platform"
@@ -235,8 +235,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11a47b6286279a9998588ef7050d1ebc2500c69892a557c90fe5d071c64415dc"
 dependencies = [
  "cargo-platform",
- "semver 0.11.0",
- "semver-parser 0.10.2",
+ "semver",
+ "semver-parser",
  "serde",
  "serde_json",
 ]
@@ -286,15 +286,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -361,7 +352,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -449,9 +440,9 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dtoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
 
 [[package]]
 name = "e2e"
@@ -533,7 +524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f81b28370c3b253a27c8773e7e7f8cd72df927722a55998db528ad7a7a250d"
 dependencies = [
  "ethcontract-common",
- "futures 0.3.9",
+ "futures 0.3.10",
  "futures-timer",
  "hex",
  "jsonrpc-core",
@@ -608,7 +599,7 @@ checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "winapi 0.3.9",
 ]
 
@@ -656,12 +647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,9 +676,9 @@ checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
 name = "futures"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70be434c505aee38639abccb918163b63158a4b4bb791b45b7023044bdc3c9c"
+checksum = "309f13e3f4be6d5917178c84db67c0b9a09177ac16d4f9a7313a767a68adaa77"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -706,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01c61843314e95f96cc9245702248733a3a3d744e43e2e755e3c7af8348a0a9"
+checksum = "7a3b03bd32f6ec7885edeb99acd1e47e20e34fd4dfd3c6deed6fcac8a9d28f6a"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -716,15 +701,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8d3b0917ff63a2a96173133c02818fac4a746b0a57569d3baca9ec0e945e08"
+checksum = "ed8aeae2b6ab243ebabe6f54cd4cf53054d98883d5d326128af7d57a9ca5cd3d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee9ca2f7eb4475772cf39dd1cd06208dce2670ad38f4d9c7262b3e15f127068"
+checksum = "3f7836b36b7533d16fd5937311d98ba8965ab81030de8b0024c299dd5d51fb9b"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -733,15 +718,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37c1a51b037b80922864b8eed90692c5cd8abd4c71ce49b77146caa47f3253b"
+checksum = "d41234e71d5e8ca73d01563974ef6f50e516d71e18f1a2f1184742e31f5d469f"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8719ca0e1f3c5e34f3efe4570ef2c0610ca6da85ae7990d472e9cbfba13664"
+checksum = "3520e0eb4e704e88d771b92d51273ee212997f0d8282f17f5d8ff1cb39104e42"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -751,15 +736,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6adabac1290109cfa089f79192fb6244ad2c3f1cc2281f3e1dd987592b71feb"
+checksum = "c72d188479368953c6c8c7140e40d7a4401674ab3b98a41e60e515d6cbdbe5de"
 
 [[package]]
 name = "futures-task"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92a0843a2ff66823a8f7c77bffe9a09be2b64e533562c412d63075643ec0038"
+checksum = "08944cea9021170d383287169859c0ca8147d9ec285978393109954448f33cc7"
 dependencies = [
  "once_cell",
 ]
@@ -772,9 +757,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "036a2107cdeb57f6d7322f1b6c363dad67cd63ca3b7d1b925bdf75bd5d96cda9"
+checksum = "d3dd206efbe2ca683b2ce138ccdf61e1b0a63f5816dcedc9d8654c500ba0cea6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -783,24 +768,11 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.4",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
-]
-
-[[package]]
-name = "generator"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustc_version",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -824,11 +796,11 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -841,7 +813,7 @@ checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.10.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -850,7 +822,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -890,7 +862,7 @@ checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
 dependencies = [
  "base64 0.12.3",
  "bitflags",
- "bytes",
+ "bytes 0.5.6",
  "headers-core",
  "http",
  "mime",
@@ -909,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -949,11 +921,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "itoa",
 ]
@@ -964,7 +936,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "http",
 ]
 
@@ -992,7 +964,7 @@ version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1002,7 +974,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.2",
+ "pin-project 1.0.4",
  "socket2",
  "tokio",
  "tower-service",
@@ -1016,7 +988,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "hyper",
  "native-tls",
  "tokio",
@@ -1063,11 +1035,11 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "hashbrown",
 ]
 
@@ -1077,7 +1049,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
 ]
 
 [[package]]
@@ -1106,9 +1078,9 @@ checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
@@ -1163,9 +1135,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "libz-sys"
@@ -1190,24 +1162,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3aeeb5dad71cdfb031ff8899db3e3e2bdcbc5abe7ad48e58857e42488dc4aa"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "loom"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
- "generator",
- "scoped-tls",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1324,9 +1283,9 @@ dependencies = [
 
 [[package]]
 name = "multipart"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8209c33c951f07387a8497841122fc6f712165e3f9bda3e6be4645b58188f676"
+checksum = "d050aeedc89243f5347c3e237e3e13dc76fbe4ae3742a57b94dc14f69acf76d4"
 dependencies = [
  "buf_redux",
  "httparse",
@@ -1334,7 +1293,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "quick-error",
- "rand 0.6.5",
+ "rand 0.7.3",
  "safemem",
  "tempfile",
  "twoway",
@@ -1342,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcc7939b5edc4e4f86b1b4a04bb1498afaaf871b1a6691838ed06fcb48d3a3f"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1382,12 +1341,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1397,7 +1413,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -1430,9 +1446,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.31"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d008f51b1acffa0d3450a68606e6a51c123012edaacb0f4e1426bd978869187"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1450,11 +1466,11 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.59"
+version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de52d8eabd217311538a39bba130d7dea1f1e118010fee7a033d966845e7d5fe"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -1470,7 +1486,7 @@ dependencies = [
  "chrono",
  "contracts",
  "ethcontract",
- "futures 0.3.9",
+ "futures 0.3.10",
  "hex",
  "hex-literal",
  "model",
@@ -1490,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
+checksum = "79602888a81ace83e3d1d4b2873286c1f5f906c84db667594e8db8da3506c383"
 dependencies = [
  "arrayvec",
  "bitvec 0.17.4",
@@ -1513,14 +1529,14 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c6d9b8427445284a09c55be860a15855ab580a417ccad9da88f5a06787ced0"
+checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -1551,11 +1567,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
+checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
 dependencies = [
- "pin-project-internal 1.0.2",
+ "pin-project-internal 1.0.4",
 ]
 
 [[package]]
@@ -1571,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
+checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1588,9 +1604,9 @@ checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -1676,9 +1692,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
 ]
@@ -1697,30 +1713,11 @@ checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.7",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
@@ -1728,13 +1725,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.1.1"
+name = "rand"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
 dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.3.1",
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1748,19 +1747,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.3.1"
+name = "rand_chacha"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
- "rand_core 0.4.2",
+ "ppv-lite86",
+ "rand_core 0.6.1",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1768,16 +1762,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.1.0"
+name = "rand_core"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
- "rand_core 0.3.1",
+ "getrandom 0.2.1",
 ]
 
 [[package]]
@@ -1790,65 +1784,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_isaac"
-version = "0.1.1"
+name = "rand_hc"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -1858,10 +1799,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
-name = "regex"
-version = "1.4.2"
+name = "redox_syscall"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1881,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "remove_dir_all"
@@ -1901,7 +1851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
 dependencies = [
  "base64 0.13.0",
- "bytes",
+ "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1917,7 +1867,7 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.4",
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.0",
@@ -1944,15 +1894,6 @@ name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
 
 [[package]]
 name = "ryu"
@@ -2049,28 +1990,13 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
  "serde",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -2176,12 +2102,11 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
 dependencies = [
  "lazy_static",
- "loom",
 ]
 
 [[package]]
@@ -2200,19 +2125,18 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi 0.3.9",
 ]
 
@@ -2224,12 +2148,13 @@ dependencies = [
  "async-trait",
  "contracts",
  "ethcontract",
- "futures 0.3.9",
+ "futures 0.3.10",
  "hex",
  "hex-literal",
  "jsonrpc-core",
  "maplit",
  "model",
+ "num",
  "primitive-types",
  "reqwest",
  "serde",
@@ -2277,7 +2202,7 @@ dependencies = [
  "base64 0.13.0",
  "bitflags",
  "byteorder",
- "bytes",
+ "bytes 0.5.6",
  "crossbeam-channel",
  "crossbeam-queue",
  "crossbeam-utils",
@@ -2317,7 +2242,7 @@ dependencies = [
  "cargo_metadata",
  "dotenv",
  "either",
- "futures 0.3.9",
+ "futures 0.3.10",
  "heck",
  "lazy_static",
  "proc-macro2",
@@ -2411,14 +2336,14 @@ checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "rand 0.7.3",
- "redox_syscall",
+ "rand 0.8.2",
+ "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -2443,18 +2368,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2463,21 +2388,20 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
@@ -2520,7 +2444,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
@@ -2585,7 +2509,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
@@ -2607,7 +2531,7 @@ checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.4",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -2708,7 +2632,7 @@ checksum = "f0308d80d86700c5878b9ef6321f020f29b1bb9d5ff3cab25e75e23f3a492a23"
 dependencies = [
  "base64 0.12.3",
  "byteorder",
- "bytes",
+ "bytes 0.5.6",
  "http",
  "httparse",
  "input_buffer",
@@ -2861,8 +2785,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41be6df54c97904af01aa23e613d4521eed7ab23537cede692d4058f6449407"
 dependencies = [
- "bytes",
- "futures 0.3.9",
+ "bytes 0.5.6",
+ "futures 0.3.10",
  "headers",
  "http",
  "hyper",
@@ -2891,9 +2815,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "wasm-bindgen"
@@ -2984,7 +2908,7 @@ dependencies = [
  "derive_more",
  "ethabi",
  "ethereum-types",
- "futures 0.3.9",
+ "futures 0.3.10",
  "futures-timer",
  "hyper",
  "hyper-tls",

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -22,6 +22,7 @@ hex-literal = "0.3"
 jsonrpc-core = "14.0"
 maplit = "1.0"
 model = { path = "../model" }
+num = "0.3.1"
 primitive-types = "0.7"
 reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -22,7 +22,7 @@ hex-literal = "0.3"
 jsonrpc-core = "14.0"
 maplit = "1.0"
 model = { path = "../model" }
-num = "0.3.1"
+num = "0.3"
 primitive-types = "0.7"
 reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/solver/src/naive_solver.rs
+++ b/solver/src/naive_solver.rs
@@ -1,3 +1,4 @@
+mod multi_order_solver;
 mod single_pair_settlement;
 
 use self::single_pair_settlement::SinglePairSettlement;

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -74,7 +74,7 @@ fn split_into_contexts(
             reserve: u256_to_bigint(
                 reserves
                     .get(&order.buy_token)
-                    .ok_or(anyhow!("No reserve for token {}", &order.buy_token))?,
+                    .ok_or_else(|| anyhow!("No reserve for token {}", &order.buy_token))?,
             ),
             ..Default::default()
         });
@@ -83,7 +83,7 @@ fn split_into_contexts(
             reserve: u256_to_bigint(
                 reserves
                     .get(&order.sell_token)
-                    .ok_or(anyhow!("No reserve for token {}", &order.sell_token))?,
+                    .ok_or_else(|| anyhow!("No reserve for token {}", &order.sell_token))?,
             ),
             ..Default::default()
         });

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -1,0 +1,369 @@
+#![allow(dead_code)]
+
+use super::single_pair_settlement::{AmmSwapExactTokensForTokens, SinglePairSettlement};
+use crate::settlement::Trade;
+use anyhow::{anyhow, Result};
+use model::order::{OrderCreation, OrderKind};
+use num::{bigint::Sign, BigInt};
+use std::collections::HashMap;
+use web3::types::{Address, U256};
+
+#[derive(Default)]
+struct TokenContext {
+    address: Address,
+    reserve: BigInt,
+    buy_volume: BigInt,
+    sell_volume: BigInt,
+}
+
+impl TokenContext {
+    pub fn is_excess(&self, other: &TokenContext) -> bool {
+        &self.reserve * (&other.sell_volume - &other.buy_volume)
+            < &other.reserve * (&self.sell_volume - &self.buy_volume)
+    }
+}
+
+/**
+ * Computes a settlement using orders of a single pair and the direct AMM between those tokens.
+ * Returns an error if computation fails, orders are not already filtered for a specific token pair, or the reserve information for that
+ * pair is not available.
+ */
+pub fn solve(
+    orders: impl Iterator<Item = OrderCreation> + Clone,
+    reserves: &HashMap<Address, U256>,
+) -> Result<SinglePairSettlement> {
+    let (context_a, context_b) = split_into_contexts(orders.clone(), reserves)?;
+    let (shortage, excess) = if context_a.is_excess(&context_b) {
+        (context_b, context_a)
+    } else {
+        (context_a, context_b)
+    };
+    let uniswap_out = compute_uniswap_out(&shortage, &excess);
+    let uniswap_in = bigint_to_u256(&compute_uniswap_in(&uniswap_out, &shortage, &excess))?;
+    let uniswap_out = bigint_to_u256(&uniswap_out)?;
+    let interaction = if uniswap_out > U256::zero() {
+        Some(AmmSwapExactTokensForTokens {
+            amount_in: uniswap_in,
+            amount_out_min: uniswap_out,
+            token_in: excess.address,
+            token_out: shortage.address,
+        })
+    } else {
+        // TODO(fleupold) set correct clearing prices when supply/demand already match current uniswap price
+        None
+    };
+    // TODO(fleupold) check that all orders comply with the computed price. Otherwise, remove the least favorable excess order and try again.
+    Ok(SinglePairSettlement {
+        clearing_prices: maplit::hashmap! {
+            shortage.address => uniswap_in,
+            excess.address => uniswap_out,
+        },
+        trades: orders.into_iter().map(Trade::fully_matched).collect(),
+        interaction,
+    })
+}
+
+fn split_into_contexts(
+    orders: impl Iterator<Item = OrderCreation>,
+    reserves: &HashMap<Address, U256>,
+) -> Result<(TokenContext, TokenContext)> {
+    let mut contexts = HashMap::new();
+    for order in orders {
+        contexts.entry(order.buy_token).or_insert(TokenContext {
+            address: order.buy_token,
+            reserve: u256_to_bigint(
+                reserves
+                    .get(&order.buy_token)
+                    .ok_or(anyhow!("No reserve for token {}", &order.buy_token))?,
+            ),
+            ..Default::default()
+        });
+        contexts.entry(order.sell_token).or_insert(TokenContext {
+            address: order.sell_token,
+            reserve: u256_to_bigint(
+                reserves
+                    .get(&order.sell_token)
+                    .ok_or(anyhow!("No reserve for token {}", &order.sell_token))?,
+            ),
+            ..Default::default()
+        });
+        match order.kind {
+            OrderKind::Buy => {
+                contexts.get_mut(&order.buy_token).unwrap().buy_volume +=
+                    u256_to_bigint(&order.buy_amount)
+            }
+            OrderKind::Sell => {
+                contexts.get_mut(&order.sell_token).unwrap().sell_volume +=
+                    u256_to_bigint(&order.sell_amount)
+            }
+        }
+    }
+    if contexts.len() != 2 {
+        return Err(anyhow!("Orders contain more than two tokens"));
+    }
+    let mut contexts = contexts.drain().map(|(_, v)| v);
+    Ok((contexts.next().unwrap(), contexts.next().unwrap()))
+}
+
+/**
+ * Given information about the shortage token (the one we need to take from Uniswap) and the excess token (the one we gie to Uniswap), this function
+ * computes the exact out_amount required from Uniswap to perfectly match demand and supply at the effective Uniswap price (the one used for that in/out swap).
+ *
+ * The derivation of this formula is described in https://docs.google.com/document/d/1jS22wxbCqo88fGsqEMZgRQgiAcHlPqxoMw3CJTHst6c/edit
+ * It assumes GP fee (φ) to be 1 and Uniswap fee (Φ) to be 0.997
+ */
+fn compute_uniswap_out(shortage: &TokenContext, excess: &TokenContext) -> BigInt {
+    let numerator_minuend = 997 * (&excess.sell_volume - &excess.buy_volume) * &shortage.reserve;
+    let numerator_subtrahend =
+        1000 * (&shortage.sell_volume - &shortage.buy_volume) * &excess.reserve;
+    let denominator = (1000 * &excess.reserve) + (997 * (&excess.sell_volume - &excess.buy_volume));
+
+    (numerator_minuend - numerator_subtrahend) / denominator
+}
+
+/**
+ * Given the desired amount to receive and the state of the pool, this computes the required amount
+ * of tokens to be sent to the pool.
+ * Taken from: https://github.com/Uniswap/uniswap-v2-periphery/blob/4123f93278b60bcf617130629c69d4016f9e7584/contracts/libraries/UniswapV2Library.sol#L53
+ */
+fn compute_uniswap_in(out: &BigInt, shortage: &TokenContext, excess: &TokenContext) -> BigInt {
+    1000 * out * &excess.reserve / (997 * (&shortage.reserve - out)) + 1
+}
+
+fn u256_to_bigint(input: &U256) -> BigInt {
+    let mut bytes = [0; 32];
+    input.to_big_endian(&mut bytes);
+    BigInt::from_bytes_be(Sign::Plus, &bytes)
+}
+
+fn bigint_to_u256(input: &BigInt) -> Result<U256> {
+    let (sign, bytes) = input.to_bytes_be();
+    if sign == Sign::Minus {
+        return Err(anyhow!("Negative BigInt to U256 conversion"));
+    }
+    if bytes.len() > 32 {
+        return Err(anyhow!("BigInt too big for U256 conversion"));
+    }
+    Ok(U256::from_big_endian(&bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn to_wei(base: u32) -> U256 {
+        U256::from(base) * U256::from(10).pow(18.into())
+    }
+
+    #[test]
+    fn finds_clearing_price_with_sell_orders_on_both_sides() {
+        let token_a = Address::from_low_u64_be(0);
+        let token_b = Address::from_low_u64_be(1);
+        let orders = vec![
+            OrderCreation {
+                sell_token: token_a,
+                buy_token: token_b,
+                sell_amount: to_wei(40),
+                buy_amount: to_wei(30),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+            OrderCreation {
+                sell_token: token_b,
+                buy_token: token_a,
+                sell_amount: to_wei(100),
+                buy_amount: to_wei(90),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+        ];
+
+        let reserves = maplit::hashmap! {
+            token_a => to_wei(1000),
+            token_b => to_wei(1000)
+        };
+        let result = solve(orders.clone().into_iter(), &reserves).unwrap();
+
+        // Make sure the uniswap interaction is using the correct direction
+        let interaction = result.interaction.unwrap();
+        assert_eq!(interaction.token_in, token_b);
+        assert_eq!(interaction.token_out, token_a);
+
+        // Make sure the sell amounts +/- uniswap interaction satisfy min_buy amounts
+        assert!(orders[0].sell_amount + interaction.amount_out_min >= orders[1].buy_amount);
+        assert!(orders[1].sell_amount - interaction.amount_in > orders[0].buy_amount);
+
+        // Make sure the sell amounts +/- uniswap interaction satisfy expected buy amounts given clearing price
+        let price_a = result.clearing_prices.get(&token_a).unwrap();
+        let price_b = result.clearing_prices.get(&token_b).unwrap();
+
+        // Multiplying sellAmount with priceA, gives us sell value in "$", divided by priceB gives us value in buy token
+        // We should have at least as much to give (sell amount +/- uniswap) as is expected by the buyer
+        let expected_buy = orders[0].sell_amount * price_a / price_b;
+        assert!(orders[1].sell_amount - interaction.amount_in >= expected_buy);
+
+        let expected_buy = orders[1].sell_amount * price_b / price_a;
+        assert!(orders[0].sell_amount + interaction.amount_out_min >= expected_buy);
+    }
+
+    #[test]
+    fn finds_clearing_price_with_sell_orders_on_one_side() {
+        let token_a = Address::from_low_u64_be(0);
+        let token_b = Address::from_low_u64_be(1);
+        let orders = vec![
+            OrderCreation {
+                sell_token: token_a,
+                buy_token: token_b,
+                sell_amount: to_wei(40),
+                buy_amount: to_wei(30),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+            OrderCreation {
+                sell_token: token_a,
+                buy_token: token_b,
+                sell_amount: to_wei(100),
+                buy_amount: to_wei(90),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+        ];
+
+        let reserves = maplit::hashmap! {
+            token_a => to_wei(1000),
+            token_b => to_wei(1000)
+        };
+        let result = solve(orders.clone().into_iter(), &reserves).unwrap();
+
+        // Make sure the uniswap interaction is using the correct direction
+        let interaction = result.interaction.unwrap();
+        assert_eq!(interaction.token_in, token_a);
+        assert_eq!(interaction.token_out, token_b);
+
+        // Make sure the sell amounts cover the uniswap in, and min buy amounts are covered by uniswap out
+        assert!(orders[0].sell_amount + orders[1].sell_amount >= interaction.amount_in);
+        assert!(interaction.amount_out_min >= orders[0].buy_amount + orders[1].buy_amount);
+
+        // Make sure expected buy amounts (given prices) are also covered by uniswap out amounts
+        let price_a = result.clearing_prices.get(&token_a).unwrap();
+        let price_b = result.clearing_prices.get(&token_b).unwrap();
+
+        let first_expected_buy = orders[0].sell_amount * price_a / price_b;
+        let second_expected_buy = orders[1].sell_amount * price_a / price_b;
+        assert!(interaction.amount_out_min >= first_expected_buy + second_expected_buy);
+    }
+
+    #[test]
+    fn finds_clearing_price_with_buy_orders_on_both_sides() {
+        let token_a = Address::from_low_u64_be(0);
+        let token_b = Address::from_low_u64_be(1);
+        let orders = vec![
+            OrderCreation {
+                sell_token: token_a,
+                buy_token: token_b,
+                sell_amount: to_wei(40),
+                buy_amount: to_wei(30),
+                kind: OrderKind::Buy,
+                partially_fillable: false,
+                ..Default::default()
+            },
+            OrderCreation {
+                sell_token: token_b,
+                buy_token: token_a,
+                sell_amount: to_wei(100),
+                buy_amount: to_wei(90),
+                kind: OrderKind::Buy,
+                partially_fillable: false,
+                ..Default::default()
+            },
+        ];
+
+        let reserves = maplit::hashmap! {
+            token_a => to_wei(1000),
+            token_b => to_wei(1000)
+        };
+        let result = solve(orders.clone().into_iter(), &reserves).unwrap();
+
+        // Make sure the uniswap interaction is using the correct direction
+        let interaction = result.interaction.unwrap();
+        assert_eq!(interaction.token_in, token_b);
+        assert_eq!(interaction.token_out, token_a);
+
+        // Make sure the buy amounts +/- uniswap interaction satisfy max_sell amounts
+        assert!(orders[0].sell_amount >= orders[1].buy_amount - interaction.amount_out_min);
+        assert!(orders[1].sell_amount >= orders[0].buy_amount + interaction.amount_in);
+
+        // Make sure buy sell amounts +/- uniswap interaction satisfy expected sell amounts given clearing price
+        let price_a = result.clearing_prices.get(&token_a).unwrap();
+        let price_b = result.clearing_prices.get(&token_b).unwrap();
+
+        // Multiplying buyAmount with priceB, gives us sell value in "$", divided by priceA gives us value in sell token
+        // The seller should expect to sell at least as much as we require for the buyer + uniswap.
+        let expected_sell = orders[0].buy_amount * price_b / price_a;
+        assert!(orders[1].buy_amount - interaction.amount_in <= expected_sell);
+
+        let expected_sell = orders[1].buy_amount * price_a / price_b;
+        assert!(orders[0].buy_amount + interaction.amount_out_min <= expected_sell);
+    }
+
+    #[test]
+    fn finds_clearing_price_with_buy_orders_and_sell_orders() {
+        let token_a = Address::from_low_u64_be(0);
+        let token_b = Address::from_low_u64_be(1);
+        let orders = vec![
+            OrderCreation {
+                sell_token: token_a,
+                buy_token: token_b,
+                sell_amount: to_wei(40),
+                buy_amount: to_wei(30),
+                kind: OrderKind::Buy,
+                partially_fillable: false,
+                ..Default::default()
+            },
+            OrderCreation {
+                sell_token: token_b,
+                buy_token: token_a,
+                sell_amount: to_wei(100),
+                buy_amount: to_wei(90),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+        ];
+
+        let reserves = maplit::hashmap! {
+            token_a => to_wei(1000),
+            token_b => to_wei(1000)
+        };
+        let result = solve(orders.clone().into_iter(), &reserves).unwrap();
+
+        // Make sure the uniswap interaction is using the correct direction
+        let interaction = result.interaction.unwrap();
+        assert_eq!(interaction.token_in, token_b);
+        assert_eq!(interaction.token_out, token_a);
+
+        // Make sure the buy order's sell amount - uniswap interaction satisfies sell order's limit
+        assert!(orders[0].sell_amount >= orders[1].buy_amount - interaction.amount_out_min);
+
+        // Make sure the sell order's buy amount + uniswap interaction satisfies buy order's limit
+        assert!(orders[1].buy_amount + interaction.amount_in >= orders[0].sell_amount);
+
+        // Make sure buy sell amounts +/- uniswap interaction satisfy expected sell amounts given clearing price
+        let price_a = result.clearing_prices.get(&token_a).unwrap();
+        let price_b = result.clearing_prices.get(&token_b).unwrap();
+
+        // Multiplying buy_amount with priceB, gives us sell value in "$", divided by priceA gives us value in sell token
+        // The seller should expect to sell at least as much as we require for the buyer + uniswap.
+        let expected_sell = orders[0].buy_amount * price_b / price_a;
+        assert!(orders[1].buy_amount - interaction.amount_in <= expected_sell);
+
+        // Multiplying sell_amount with priceA, gives us sell value in "$", divided by priceB gives us value in buy token
+        // We should have at least as much to give (sell amount + uniswap out) as is expected by the buyer
+        let expected_buy = orders[1].sell_amount * price_b / price_a;
+        assert!(orders[0].sell_amount + interaction.amount_out_min >= expected_buy);
+    }
+}

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -424,7 +424,7 @@ mod tests {
             token_a => to_wei(1_000_001),
             token_b => to_wei(1_000_000)
         };
-        let result = solve(orders.clone().into_iter(), &reserves);
+        let result = solve(orders.into_iter(), &reserves);
         assert_eq!(result.interaction, None);
         assert_eq!(
             result.clearing_prices,

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -25,11 +25,11 @@ impl TokenContext {
     }
 }
 
-/// 
+///
 /// Computes a settlement using orders of a single pair and the direct AMM between those tokens.
 /// Panics orders are not already filtered for a specific token pair, or the reserve information for that
 /// pair is not available.
-/// 
+///
 pub fn solve(
     orders: impl Iterator<Item = OrderCreation> + Clone,
     reserves: &HashMap<Address, U256>,
@@ -101,13 +101,13 @@ fn split_into_contexts(
     (contexts.next().unwrap(), contexts.next().unwrap())
 }
 
-/// 
+///
 /// Given information about the shortage token (the one we need to take from Uniswap) and the excess token (the one we give to Uniswap), this function
 /// computes the exact out_amount required from Uniswap to perfectly match demand and supply at the effective Uniswap price (the one used for that in/out swap).
-/// 
+///
 /// The derivation of this formula is described in https://docs.google.com/document/d/1jS22wxbCqo88fGsqEMZgRQgiAcHlPqxoMw3CJTHst6c/edit
 /// It assumes GP fee (φ) to be 1 and Uniswap fee (Φ) to be 0.997
-/// 
+///
 fn compute_uniswap_out(shortage: &TokenContext, excess: &TokenContext) -> U256 {
     let numerator_minuend = 997
         * (u256_to_bigint(&excess.sell_volume) - u256_to_bigint(&excess.buy_volume))
@@ -121,11 +121,11 @@ fn compute_uniswap_out(shortage: &TokenContext, excess: &TokenContext) -> U256 {
         .expect("uniswap_out should always be U256 compatible if excess is chosen correctly")
 }
 
-/// 
+///
 /// Given the desired amount to receive and the state of the pool, this computes the required amount
 /// of tokens to be sent to the pool.
 /// Taken from: https://github.com/Uniswap/uniswap-v2-periphery/blob/4123f93278b60bcf617130629c69d4016f9e7584/contracts/libraries/UniswapV2Library.sol#L53
-/// 
+///
 fn compute_uniswap_in(out: U256, shortage: &TokenContext, excess: &TokenContext) -> U256 {
     U256::from(1000) * out * excess.reserve / (U256::from(997) * (shortage.reserve - out)) + 1
 }

--- a/solver/src/naive_solver/single_pair_settlement.rs
+++ b/solver/src/naive_solver/single_pair_settlement.rs
@@ -9,9 +9,9 @@ use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct SinglePairSettlement {
-    clearing_prices: HashMap<H160, U256>,
-    trades: Vec<Trade>,
-    interaction: Option<AmmSwapExactTokensForTokens>,
+    pub clearing_prices: HashMap<H160, U256>,
+    pub trades: Vec<Trade>,
+    pub interaction: Option<AmmSwapExactTokensForTokens>,
 }
 
 impl SinglePairSettlement {
@@ -43,11 +43,11 @@ impl SinglePairSettlement {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-struct AmmSwapExactTokensForTokens {
-    amount_in: U256,
-    amount_out_min: U256,
-    token_in: H160,
-    token_out: H160,
+pub struct AmmSwapExactTokensForTokens {
+    pub amount_in: U256,
+    pub amount_out_min: U256,
+    pub token_in: H160,
+    pub token_out: H160,
 }
 
 // Assume both orders are fill-or-kill sell orders and that sell/buy tokens match.

--- a/solver/src/settlement.rs
+++ b/solver/src/settlement.rs
@@ -14,6 +14,20 @@ pub struct Trade {
     pub fee_discount: u16,
 }
 
+impl Trade {
+    pub fn fully_matched(order: OrderCreation) -> Self {
+        let executed_amount = match order.kind {
+            model::order::OrderKind::Buy => order.buy_amount,
+            model::order::OrderKind::Sell => order.sell_amount,
+        };
+        Self {
+            order,
+            executed_amount,
+            fee_discount: 0,
+        }
+    }
+}
+
 pub trait Interaction: std::fmt::Debug {
     // TODO: not sure if this should return a result.
     // Write::write returns a result but we know we write to a vector in memory so we know it will


### PR DESCRIPTION
This PR introduces a solver that can match an arbitrary number of buy/sell orders on both sides of the same token pair in a single settlement with a uniswap AMM.

The mathematical logic behind the approach has been described here: https://docs.google.com/document/d/1jS22wxbCqo88fGsqEMZgRQgiAcHlPqxoMw3CJTHst6c

For now we assume some simplifications just to get the basic algorithm reviewed before the logic is getting too large.

Follow ups:
- If there is no uniswap trade required (perfect balanced of both sides), we should not report a price of 0 but take the existing reserves
- We need to verify limit prices and iteratively kick out the least favorable excess order in case we don't match and try solving again
- We should better handle the case if the desired trade amount exceeds the reserve in the Uniswap pool (right now this would result in a bigint -> u256 conversion error.

### Test Plan
Added unit tests
