### PR TITLE
Use multi order solver

### DIFF
--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -168,7 +168,8 @@ async fn test_with_ganache() {
         std::time::Duration::from_secs(10),
     );
     let solver = solver::naive_solver::NaiveSolver {
-        uniswap: uniswap_router,
+        uniswap_router,
+        uniswap_factory,
         gpv2_settlement: gp_settlement.clone(),
     };
     let mut driver =
@@ -181,14 +182,14 @@ async fn test_with_ganache() {
         .call()
         .await
         .expect("Couldn't fetch TokenB's balance");
-    assert_eq!(balance, to_wei(80));
+    assert_eq!(balance, U256::from(99650498453042316810u128));
 
     let balance = token_a
         .balance_of(trader_b.address())
         .call()
         .await
         .expect("Couldn't fetch TokenA's balance");
-    assert_eq!(balance, 62500000000000000000u128.into());
+    assert_eq!(balance, U256::from(50175363672226073522u128));
 
     // Drive orderbook in order to check the removal of settled order_b
     orderbook.run_maintenance(&gp_settlement).await.unwrap();

--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -182,14 +182,14 @@ async fn test_with_ganache() {
         .call()
         .await
         .expect("Couldn't fetch TokenB's balance");
-    assert_eq!(balance, U256::from(99650498453042316810u128));
+    assert_eq!(balance, U256::from(99_650_498_453_042_316_810u128));
 
     let balance = token_a
         .balance_of(trader_b.address())
         .call()
         .await
         .expect("Couldn't fetch TokenA's balance");
-    assert_eq!(balance, U256::from(50175363672226073522u128));
+    assert_eq!(balance, U256::from(50_175_363_672_226_073_522u128));
 
     // Drive orderbook in order to check the removal of settled order_b
     orderbook.run_maintenance(&gp_settlement).await.unwrap();

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -100,6 +100,12 @@ impl TokenPair {
     }
 }
 
+impl Default for TokenPair {
+    fn default() -> Self {
+        Self::new(H160::from_low_u64_be(0), H160::from_low_u64_be(1)).unwrap()
+    }
+}
+
 #[derive(Copy, Eq, PartialEq, Clone, Default)]
 pub struct DomainSeparator(pub [u8; 32]);
 

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -39,7 +39,10 @@ async fn main() {
     let transport = web3::transports::Http::new(args.shared.node_url.as_str())
         .expect("transport creation failed");
     let web3 = web3::Web3::new(transport);
-    let uniswap_contract = contracts::UniswapV2Router02::deployed(&web3)
+    let uniswap_router = contracts::UniswapV2Router02::deployed(&web3)
+        .await
+        .expect("couldn't load deployed uniswap router");
+    let uniswap_factory = contracts::UniswapV2Factory::deployed(&web3)
         .await
         .expect("couldn't load deployed uniswap router");
     let chain_id = web3
@@ -55,7 +58,8 @@ async fn main() {
     let orderbook_api =
         solver::orderbook::OrderBookApi::new(args.orderbook_url, args.orderbook_timeout);
     let solver = NaiveSolver {
-        uniswap: uniswap_contract,
+        uniswap_router,
+        uniswap_factory,
         gpv2_settlement: settlement_contract.clone(),
     };
     let mut driver = Driver::new(settlement_contract, orderbook_api, Box::new(solver));

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -6,7 +6,7 @@ use num::{bigint::Sign, BigInt};
 use std::collections::HashMap;
 use web3::types::{Address, U256};
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 struct TokenContext {
     address: Address,
     reserve: U256,
@@ -104,7 +104,8 @@ fn split_into_contexts(
                     .get_reserve(&order.buy_token)
                     .unwrap_or_else(|| panic!("No reserve for token {}", &order.buy_token))
                     .into(),
-                ..Default::default()
+                buy_volume: U256::zero(),
+                sell_volume: U256::zero(),
             });
         if matches!(order.kind, OrderKind::Buy) {
             buy_context.buy_volume += order.buy_amount
@@ -118,7 +119,8 @@ fn split_into_contexts(
                     .get_reserve(&order.sell_token)
                     .unwrap_or_else(|| panic!("No reserve for token {}", &order.sell_token))
                     .into(),
-                ..Default::default()
+                buy_volume: U256::zero(),
+                sell_volume: U256::zero(),
             });
         if matches!(order.kind, OrderKind::Sell) {
             sell_context.sell_volume += order.sell_amount
@@ -214,7 +216,7 @@ mod tests {
             token_pair: TokenPair::new(token_a, token_b).unwrap(),
             reserve0: to_wei(1000).as_u128(),
             reserve1: to_wei(1000).as_u128(),
-            ..Default::default()
+            address: Default::default(),
         };
         let result = solve(orders.clone().into_iter(), &pool);
 
@@ -269,7 +271,7 @@ mod tests {
             token_pair: TokenPair::new(token_a, token_b).unwrap(),
             reserve0: to_wei(1000).as_u128(),
             reserve1: to_wei(1000).as_u128(),
-            ..Default::default()
+            address: Default::default(),
         };
         let result = solve(orders.clone().into_iter(), &pool);
 
@@ -320,7 +322,7 @@ mod tests {
             token_pair: TokenPair::new(token_a, token_b).unwrap(),
             reserve0: to_wei(1000).as_u128(),
             reserve1: to_wei(1000).as_u128(),
-            ..Default::default()
+            address: Default::default(),
         };
         let result = solve(orders.clone().into_iter(), &pool);
 
@@ -375,7 +377,7 @@ mod tests {
             token_pair: TokenPair::new(token_a, token_b).unwrap(),
             reserve0: to_wei(1000).as_u128(),
             reserve1: to_wei(1000).as_u128(),
-            ..Default::default()
+            address: Default::default(),
         };
         let result = solve(orders.clone().into_iter(), &pool);
 
@@ -434,7 +436,7 @@ mod tests {
             token_pair: TokenPair::new(token_a, token_b).unwrap(),
             reserve0: to_wei(1_000_001).as_u128(),
             reserve1: to_wei(1_000_000).as_u128(),
-            ..Default::default()
+            address: Default::default(),
         };
         let result = solve(orders.into_iter(), &pool);
         assert_eq!(result.interaction, None);

--- a/solver/src/naive_solver/single_pair_settlement.rs
+++ b/solver/src/naive_solver/single_pair_settlement.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use crate::{
     interactions::UniswapInteraction,
     settlement::{Interaction, Settlement, Trade},

--- a/solver/src/uniswap.rs
+++ b/solver/src/uniswap.rs
@@ -3,7 +3,7 @@ use contracts::{UniswapV2Factory, UniswapV2Pair};
 use model::TokenPair;
 use primitive_types::H160;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Pool {
     pub address: H160,
     pub token_pair: TokenPair,

--- a/solver/src/uniswap.rs
+++ b/solver/src/uniswap.rs
@@ -3,6 +3,7 @@ use contracts::{UniswapV2Factory, UniswapV2Pair};
 use model::TokenPair;
 use primitive_types::H160;
 
+#[derive(Debug, Default)]
 pub struct Pool {
     pub address: H160,
     pub token_pair: TokenPair,
@@ -33,5 +34,15 @@ impl Pool {
             reserve0: reserves.0,
             reserve1: reserves.1,
         }))
+    }
+
+    pub fn get_reserve(&self, token_address: &H160) -> Option<u128> {
+        if self.token_pair.get().0 == *token_address {
+            Some(self.reserve0)
+        } else if self.token_pair.get().1 == *token_address {
+            Some(self.reserve1)
+        } else {
+            None
+        }
     }
 }


### PR DESCRIPTION
This PR makes use of the slightly less naive solver. For this we need to fetch the current "reserves" of the direct AMM between the tokens we are trying to match and pass it down into the logic.

To get the reserves, we need to query the `UniswapPair` (I added this contract artefact) from the UniswapFactory instance and then call `get_reserves` on it.

Overall the architecture is a little bit hacky as a lot of components are passed through large parts of the stack. I'd like to abstract "smart contract orders" such as Uniswap or Sushiswap pools (but later also Balancer, Curve, Prediction Market outcome tokens, etc) away from the solver interface so that we only hand an abstract set of orders which can be UserOrders or some form of smart contract order trait. Each solver can then work with the subset of orders they can handle.

However, in order to make sure the less naive solver works and to make the demo slightly more usable for external people it might be worthwhile merging like this and then refactor.

### Test Plan
I needed to remove the naive solver unit tests as we now rely on a smart contract call which is not yet easily mockable. However, the logic should still be covered by the multi order solver specific unit tests and the e2e test.

I can now trade e.g. STAKE for WXDAI on our xdai Demo interface (https://pr91--gpv2swap.review.gnosisdev.com/#/swap) directly without requiring a counter trade. This makes the demo more usable for external people who want to try it out and get a feeling for the e2e flow (in order to demonstrate coincedence of wants better we might have to prolong the solver sleep interval a bit to have more opportunity for overlap).

https://blockscout.com/poa/xdai/tx/0x1aedffc0c9a51bc1ace77303a8e5b622f4624a506a55d4ab9327abe15d3452a8/token-transfers is the first settlement using this solver.
