### PR TITLE
Make solver a trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-trait"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +1966,7 @@ name = "solver"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "contracts",
  "ethcontract",
  "futures 0.3.8",

--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -167,8 +167,12 @@ async fn test_with_ganache() {
         reqwest::Url::from_str(API_HOST).unwrap(),
         std::time::Duration::from_secs(10),
     );
+    let solver = solver::naive_solver::NaiveSolver {
+        uniswap: uniswap_router,
+        gpv2_settlement: gp_settlement.clone(),
+    };
     let mut driver =
-        solver::driver::Driver::new(gp_settlement.clone(), uniswap_router, orderbook_api);
+        solver::driver::Driver::new(gp_settlement.clone(), orderbook_api, Box::new(solver));
     driver.single_run().await.unwrap();
 
     // Check matching

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 contracts = { path = "../contracts" }
 ethcontract = { version = "0.9", default-features = false }
 futures = "0.3"

--- a/solver/src/lib.rs
+++ b/solver/src/lib.rs
@@ -4,6 +4,7 @@ pub mod interactions;
 pub mod naive_solver;
 pub mod orderbook;
 pub mod settlement;
+pub mod solver;
 
 use anyhow::Result;
 use ethcontract::{contract::MethodDefaults, Account, GasPrice, Http, PrivateKey, Web3};

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -1,6 +1,6 @@
 use ethcontract::PrivateKey;
 use reqwest::Url;
-use solver::driver::Driver;
+use solver::{driver::Driver, naive_solver::NaiveSolver};
 use std::time::Duration;
 use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
@@ -54,6 +54,10 @@ async fn main() {
             .expect("couldn't load deployed settlement");
     let orderbook =
         solver::orderbook::OrderBookApi::new(args.orderbook_url, args.orderbook_timeout);
-    let mut driver = Driver::new(settlement_contract, uniswap_contract, orderbook);
+    let solver = NaiveSolver {
+        gpv2_settlement: settlement_contract.clone(),
+        uniswap: uniswap_contract,
+    };
+    let mut driver = Driver::new(settlement_contract, orderbook, Box::new(solver));
     driver.run_forever().await;
 }

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -52,12 +52,12 @@ async fn main() {
         solver::get_settlement_contract(&web3, chain_id, args.private_key, args.gas_price_factor)
             .await
             .expect("couldn't load deployed settlement");
-    let orderbook =
+    let orderbook_api =
         solver::orderbook::OrderBookApi::new(args.orderbook_url, args.orderbook_timeout);
     let solver = NaiveSolver {
-        gpv2_settlement: settlement_contract.clone(),
         uniswap: uniswap_contract,
+        gpv2_settlement: settlement_contract.clone(),
     };
-    let mut driver = Driver::new(settlement_contract, orderbook, Box::new(solver));
+    let mut driver = Driver::new(settlement_contract, orderbook_api, Box::new(solver));
     driver.run_forever().await;
 }

--- a/solver/src/naive_solver.rs
+++ b/solver/src/naive_solver.rs
@@ -1,7 +1,8 @@
 mod single_pair_settlement;
 
 use self::single_pair_settlement::SinglePairSettlement;
-use crate::settlement::Settlement;
+use crate::{settlement::Settlement, solver::Solver};
+use anyhow::Result;
 use contracts::{GPv2Settlement, UniswapV2Router02};
 use model::{
     order::{OrderCreation, OrderKind},
@@ -9,6 +10,22 @@ use model::{
 };
 use primitive_types::U512;
 use std::{cmp::Ordering, collections::HashMap};
+
+pub struct NaiveSolver {
+    pub uniswap: UniswapV2Router02,
+    pub gpv2_settlement: GPv2Settlement,
+}
+
+#[async_trait::async_trait]
+impl Solver for NaiveSolver {
+    async fn solve(&self, orders: Vec<model::order::Order>) -> Result<Option<Settlement>> {
+        Ok(settle(
+            orders.into_iter().map(|order| order.order_creation),
+            &self.uniswap,
+            &self.gpv2_settlement,
+        ))
+    }
+}
 
 pub fn settle(
     orders: impl Iterator<Item = OrderCreation>,

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -1,0 +1,8 @@
+use crate::settlement::Settlement;
+use anyhow::Result;
+use model::order::Order;
+
+#[async_trait::async_trait]
+pub trait Solver {
+    async fn solve(&self, orders: Vec<Order>) -> Result<Option<Settlement>>;
+}


### PR DESCRIPTION
In order to disentangle solvers from the driver we introduce a Solver
trait that is implemented for the naive solver.
Similarily we will implement this trait for the python solver.
Solvers are responsible for gathering the information they need
themself. So the python solver implementation would in the solve
implementation  fetch the state of the uniswap pools and then call the
python solver with that information.

### Test Plan
CI, no logic change