### PR TITLE
Make the orderbook storage a trait as preparation for database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,6 +1263,7 @@ name = "orderbook"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "contracts",
  "futures 0.3.8",

--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -5,7 +5,7 @@ use model::{
     order::{OrderBuilder, OrderKind},
     DomainSeparator,
 };
-use orderbook::orderbook::OrderBook;
+use orderbook::storage::{InMemoryOrderBook, Storage};
 use secp256k1::SecretKey;
 use serde_json::json;
 use std::{str::FromStr, sync::Arc};
@@ -115,7 +115,7 @@ async fn test_with_ganache() {
             .await
             .expect("Couldn't query domain separator"),
     );
-    let orderbook = Arc::new(OrderBook::new(domain_separator));
+    let orderbook = Arc::new(InMemoryOrderBook::new(domain_separator));
     orderbook::serve_task(
         orderbook.clone(),
         API_HOST[7..].parse().expect("Couldn't parse API address"),
@@ -191,7 +191,7 @@ async fn test_with_ganache() {
     assert_eq!(balance, 62500000000000000000u128.into());
 
     // Drive orderbook in order to check the removal of settled order_b
-    orderbook.run_maintenance(&gp_settlement).await;
+    orderbook.run_maintenance(&gp_settlement).await.unwrap();
     let placement = client
         .get(&format!(
             "{}{}{}",

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 hex = { version = "0.4", default-features = false }
 model = { path = "../model" }

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -1,12 +1,12 @@
 mod filter;
 mod handler;
 
-use crate::orderbook::OrderBook;
+use crate::storage::Storage;
 use std::sync::Arc;
 use warp::Filter;
 
 pub fn handle_all_routes(
-    orderbook: Arc<OrderBook>,
+    orderbook: Arc<dyn Storage>,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     let order_creation = filter::create_order(orderbook.clone());
     let order_getter = filter::get_orders(orderbook.clone());

--- a/orderbook/src/api/handler.rs
+++ b/orderbook/src/api/handler.rs
@@ -1,5 +1,5 @@
-use crate::orderbook::{AddOrderError, OrderBook};
-
+use crate::storage::{AddOrderResult, Storage};
+use anyhow::Result;
 use chrono::prelude::{DateTime, FixedOffset, Utc};
 use model::{
     order::{OrderCreation, OrderUid},
@@ -7,11 +7,11 @@ use model::{
 };
 use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 use std::{convert::Infallible, sync::Arc};
 use warp::{
     http::StatusCode,
-    reply::{json, with_status},
+    reply::{json, with_status, Json},
+    Reply,
 };
 
 const STANDARD_VALIDITY_FOR_FEE_IN_SEC: i32 = 3600;
@@ -26,83 +26,100 @@ pub struct FeeInfo {
     pub fee_ratio: u32,
 }
 
-#[derive(PartialEq, Serialize, Deserialize, Debug)]
+#[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct OrderPostError {
-    error_type: String,
-    description: String,
+struct Error<'a> {
+    error_type: &'a str,
+    description: &'a str,
+}
+
+fn error(error_type: &str, description: impl AsRef<str>) -> Json {
+    json(&Error {
+        error_type,
+        description: description.as_ref(),
+    })
+}
+
+fn internal_error() -> Json {
+    json(&Error {
+        error_type: "InternalServerError",
+        description: "",
+    })
 }
 
 pub async fn add_order(
-    orderbook: Arc<OrderBook>,
+    storage: Arc<dyn Storage>,
     order: OrderCreation,
-) -> Result<impl warp::Reply, Infallible> {
-    let (body, status_code) = match orderbook.add_order(order).await {
-        Ok(uid) => (warp::reply::json(&uid), StatusCode::CREATED),
+) -> Result<impl Reply, Infallible> {
+    let (body, status_code) = match storage.add_order(order).await {
+        Ok(AddOrderResult::Added(uid)) => (warp::reply::json(&uid), StatusCode::CREATED),
+        Ok(AddOrderResult::DuplicatedOrder) => (
+            error("DuplicatedOrder", "order already exists"),
+            StatusCode::BAD_REQUEST,
+        ),
+        Ok(AddOrderResult::InvalidSignature) => (
+            error("InvalidSignature", "invalid signature"),
+            StatusCode::BAD_REQUEST,
+        ),
+        Ok(AddOrderResult::Forbidden) => (
+            error("Forbidden", "Forbidden, your account is deny-listed"),
+            StatusCode::FORBIDDEN,
+        ),
+        Ok(AddOrderResult::PastValidTo) => (
+            error("PastValidTo", "validTo is in the past"),
+            StatusCode::BAD_REQUEST,
+        ),
+        Ok(AddOrderResult::MissingOrderData) => (
+            error(
+                "MissingOrderData",
+                "at least 1 field of orderCreation is missing, please check the field",
+            ),
+            StatusCode::BAD_REQUEST,
+        ),
+        Ok(AddOrderResult::InsufficientFunds) => (
+            error(
+                "InsufficientFunds",
+                "order owner must have funds worth at least x in his account",
+            ),
+            StatusCode::BAD_REQUEST,
+        ),
         Err(err) => {
-            let (error_type, description, status_code) = match err {
-                AddOrderError::DuplicatedOrder => (
-                    "DuplicatedOrder",
-                    "order already exists",
-                    StatusCode::BAD_REQUEST,
-                ),
-                AddOrderError::InvalidSignature => (
-                    "InvalidSignature",
-                    "invalid signature",
-                    StatusCode::BAD_REQUEST,
-                ),
-                AddOrderError::Forbidden => (
-                    "Forbidden",
-                    "Forbidden, your account is deny-listed",
-                    StatusCode::FORBIDDEN,
-                ),
-                AddOrderError::PastValidTo => (
-                    "PastValidTo",
-                    "validTo is in the past",
-                    StatusCode::BAD_REQUEST,
-                ),
-                AddOrderError::MissingOrderData => (
-                    "MissingOrderData",
-                    "at least 1 field of orderCreation is missing, please check the field",
-                    StatusCode::BAD_REQUEST,
-                ),
-                AddOrderError::InsufficientFunds => (
-                    "InsufficientFunds",
-                    "order owner must have funds worth at least x in his account",
-                    StatusCode::BAD_REQUEST,
-                ),
-            };
-            let error = OrderPostError {
-                error_type: error_type.to_string(),
-                description: description.to_string(),
-            };
-            (json(&error), status_code)
+            tracing::error!(?err, ?order, "add_order error");
+            (internal_error(), StatusCode::INTERNAL_SERVER_ERROR)
         }
     };
     Ok(with_status(body, status_code))
 }
 
-pub async fn get_orders(orderbook: Arc<OrderBook>) -> Result<impl warp::Reply, Infallible> {
-    let orders = orderbook.get_orders().await;
-    Ok(with_status(json(&orders), StatusCode::OK))
+pub async fn get_orders(storage: Arc<dyn Storage>) -> Result<impl Reply, Infallible> {
+    Ok(match storage.get_orders().await {
+        Ok(orders) => with_status(json(&orders), StatusCode::OK),
+        Err(err) => {
+            tracing::error!(?err, "get_orders error");
+            with_status(internal_error(), StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    })
 }
 
 pub async fn get_order_by_uid(
     uid: OrderUid,
-    orderbook: Arc<OrderBook>,
-) -> Result<impl warp::Reply, Infallible> {
-    if let Some(order) = orderbook.get_order(&uid).await {
-        Ok(with_status(json(&order), StatusCode::OK))
-    } else {
-        Ok(with_status(
-            json(&json!({ "description": "Order was not found"})),
+    storage: Arc<dyn Storage>,
+) -> Result<impl Reply, Infallible> {
+    Ok(match storage.get_order(&uid).await {
+        Ok(Some(order)) => with_status(json(&order), StatusCode::OK),
+        Ok(None) => with_status(
+            error("NotFound", "Order was not found"),
             StatusCode::NOT_FOUND,
-        ))
-    }
+        ),
+        Err(err) => {
+            tracing::error!(?err, ?uid, "get_order error");
+            with_status(internal_error(), StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    })
 }
 
 #[allow(unused_variables)]
-pub async fn get_fee_info(sell_token: H160) -> Result<impl warp::Reply, Infallible> {
+pub async fn get_fee_info(sell_token: H160) -> Result<impl Reply, Infallible> {
     let fee_info = FeeInfo {
         expiration_date: chrono::offset::Utc::now()
             + FixedOffset::east(STANDARD_VALIDITY_FOR_FEE_IN_SEC),

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod api;
-pub mod orderbook;
+pub mod storage;
 
-use crate::orderbook::OrderBook;
+use crate::storage::Storage;
 use anyhow::{anyhow, Context as _, Result};
 use contracts::GPv2Settlement;
 use model::DomainSeparator;
@@ -9,12 +9,12 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::{task, task::JoinHandle};
 use warp::Filter;
 
-pub fn serve_task(orderbook: Arc<OrderBook>, address: SocketAddr) -> JoinHandle<()> {
+pub fn serve_task(storage: Arc<dyn Storage>, address: SocketAddr) -> JoinHandle<()> {
     let cors = warp::cors()
         .allow_any_origin()
         .allow_methods(vec!["GET", "POST", "DELETE", "OPTIONS", "PUT", "PATCH"])
         .allow_headers(vec!["Origin", "Content-Type", "X-Auth-Token", "X-AppId"]);
-    let filter = api::handle_all_routes(orderbook).with(cors);
+    let filter = api::handle_all_routes(storage).with(cors);
     tracing::info!(%address, "serving order book");
     task::spawn(warp::serve(filter).bind(address))
 }

--- a/orderbook/src/storage.rs
+++ b/orderbook/src/storage.rs
@@ -1,0 +1,34 @@
+mod memory;
+mod postgresql;
+
+use anyhow::Result;
+use contracts::GPv2Settlement;
+use model::order::{Order, OrderCreation, OrderUid};
+
+pub use memory::OrderBook as InMemoryOrderBook;
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum AddOrderResult {
+    Added(OrderUid),
+    DuplicatedOrder,
+    InvalidSignature,
+    Forbidden,
+    MissingOrderData,
+    PastValidTo,
+    InsufficientFunds,
+}
+
+#[derive(Debug)]
+pub enum RemoveOrderResult {
+    Removed,
+    DoesNotExist,
+}
+
+#[async_trait::async_trait]
+pub trait Storage: Send + Sync {
+    async fn add_order(&self, order: OrderCreation) -> Result<AddOrderResult>;
+    async fn remove_order(&self, uid: &OrderUid) -> Result<RemoveOrderResult>;
+    async fn get_order(&self, uid: &OrderUid) -> Result<Option<Order>>;
+    async fn get_orders(&self) -> Result<Vec<Order>>;
+    async fn run_maintenance(&self, settlement_contract: &GPv2Settlement) -> Result<()>;
+}

--- a/orderbook/src/storage/postgresql.rs
+++ b/orderbook/src/storage/postgresql.rs
@@ -1,0 +1,1 @@
+// TODO: implement Storage for PostgreSQL database.


### PR DESCRIPTION
I am not sure if we are going to keep the in memory orderbook around but
for the short term it is useful to have this as a trait so that we can
start implementing the postgresql storage.
Long term the in memory orderbook could still be useful for tests so
that no running postgres instance is needed for unit tests.

### Test Plan
tests still pass
