### PR TITLE
Fix clippy warnings for Rust 1.49

### DIFF
--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -265,7 +265,7 @@ impl Default for OrderMetaData {
         Self {
             creation_date: DateTime::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
             owner: Default::default(),
-            uid: OrderUid([0 as u8; 56]),
+            uid: OrderUid([0u8; 56]),
         }
     }
 }
@@ -277,7 +277,7 @@ pub struct OrderUid(pub [u8; 56]);
 impl FromStr for OrderUid {
     type Err = hex::FromHexError;
     fn from_str(s: &str) -> Result<OrderUid, hex::FromHexError> {
-        let mut value = [0 as u8; 56];
+        let mut value = [0u8; 56];
         let s_without_prefix = s.strip_prefix("0x").unwrap_or(s);
         hex::decode_to_slice(s_without_prefix, value.as_mut())?;
         Ok(OrderUid(value))
@@ -328,7 +328,7 @@ impl<'de> Deserialize<'de> for OrderUid {
                         s
                     ))
                 })?;
-                let mut value = [0 as u8; 56];
+                let mut value = [0u8; 56];
                 hex::decode_to_slice(s, value.as_mut()).map_err(|err| {
                     de::Error::custom(format!("failed to decode {:?} as hex uid: {}", s, err))
                 })?;
@@ -383,7 +383,7 @@ mod tests {
             order_meta_data: OrderMetaData {
                 creation_date: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(3, 0), Utc),
                 owner: H160::from_low_u64_be(1),
-                uid: OrderUid([17 as u8; 56]),
+                uid: OrderUid([17u8; 56]),
             },
             order_creation: OrderCreation {
                 sell_token: H160::from_low_u64_be(10),

--- a/orderbook/src/api/filter.rs
+++ b/orderbook/src/api/filter.rs
@@ -106,7 +106,7 @@ pub mod test_util {
     async fn get_order_by_uid_for_non_existent_order_() {
         let orderbook = Arc::new(OrderBook::default());
         let filter = get_order_by_uid(orderbook.clone());
-        let uid = OrderUid([0 as u8; 56]);
+        let uid = OrderUid([0u8; 56]);
         let response = request()
             .path(&format!("/orders/{:}", uid))
             .method("GET")

--- a/orderbook/src/api/handler.rs
+++ b/orderbook/src/api/handler.rs
@@ -107,7 +107,7 @@ pub async fn get_fee_info(sell_token: H160) -> Result<impl warp::Reply, Infallib
         expiration_date: chrono::offset::Utc::now()
             + FixedOffset::east(STANDARD_VALIDITY_FOR_FEE_IN_SEC),
         minimal_fee: U256::zero(),
-        fee_ratio: 0 as u32,
+        fee_ratio: 0u32,
     };
     Ok(with_status(warp::reply::json(&fee_info), StatusCode::OK))
 }

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -124,7 +124,7 @@ impl OrderBook {
             .filled_amount(uid.0.to_vec())
             .call()
             .await
-            .unwrap_or(U256::zero());
+            .unwrap_or_else(|_| U256::zero());
         // As a simplification the function is returning the uid,
         // if the order was already partially settled
         // or if it was canceled.
@@ -181,8 +181,10 @@ pub mod test_util {
     #[tokio::test]
     async fn removes_expired_orders() {
         let orderbook = OrderBook::default();
-        let mut order = OrderCreation::default();
-        order.valid_to = u32::MAX - 10;
+        let order = OrderCreation {
+            valid_to: u32::MAX - 10,
+            ..Default::default()
+        };
         orderbook.add_order(order).await.unwrap();
         assert_eq!(orderbook.get_orders().await.len(), 1);
         orderbook


### PR DESCRIPTION
Extracted for Alex' PR so we can merge this immediately.

### Test Plan
CI, but github is still on 1.48 which is why we didn't notice this
