### PR TITLE
Use github native dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-dependencies-updated-automatically
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
As https://github.com/marketplace/dependabot-preview says this now a
built in github feature so we can move to that instead.
I like how it has a configuration file that is in the repository.

Before we merge this we should remove the old dependabot application. I don't know how to do that. @fleupold maybe?