### PR TITLE
Fix mainnet api url

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -3,7 +3,7 @@ info:
   version: 0.0.1
   title: Order Book API
 servers:
-  - url: https://protocol.dev.gnosisdev.com
+  - url: https://protocol-mainnet.dev.gnosisdev.com
     description: Mainnet (Staging)
   - url: https://protocol-rinkeby.dev.gnosisdev.com
     description: Rinkeby (Staging)


### PR DESCRIPTION
This was changed in staging today.

# Test Plan
Make request to new url
