### PR TITLE
Update ethcontract, web3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,12 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+
+[[package]]
+name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
@@ -149,7 +155,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding",
+ "block-padding 0.1.5",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.3",
@@ -161,6 +167,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
+ "block-padding 0.2.1",
  "generic-array 0.14.4",
 ]
 
@@ -172,6 +179,12 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "buf_redux"
@@ -243,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.41"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
@@ -454,7 +467,7 @@ dependencies = [
  "model",
  "orderbook",
  "reqwest",
- "secp256k1 0.17.2",
+ "secp256k1",
  "serde_json",
  "solver",
  "tokio",
@@ -492,45 +505,47 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052a565e3de82944527d6d10a465697e6bb92476b772ca7141080c901f6a63c6"
+checksum = "53d4e679d6864bc26210feb5cf044e245741cd9d7701b35c00440a6e84d61399"
 dependencies = [
+ "anyhow",
  "ethereum-types",
- "rustc-hex",
+ "hex",
  "serde",
  "serde_json",
- "tiny-keccak 1.5.0",
+ "sha3",
+ "thiserror",
  "uint",
 ]
 
 [[package]]
 name = "ethbloom"
-version = "0.9.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a6567e6fd35589fea0c63b94b4cf2e55573e413901bdbe60ab15cf0e25e5df"
+checksum = "22a621dcebea74f2a6f2002d0a885c81ccf6cbdf86760183316a7722b5707ca4"
 dependencies = [
  "crunchy",
  "fixed-hash",
  "impl-rlp",
  "impl-serde",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
 name = "ethcontract"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f81b28370c3b253a27c8773e7e7f8cd72df927722a55998db528ad7a7a250d"
+checksum = "35b4cc7775cded7a186ed4a8f76e23e893dfb60430de947c958e964d4603a211"
 dependencies = [
  "ethcontract-common",
- "futures 0.3.10",
+ "futures",
  "futures-timer",
  "hex",
  "jsonrpc-core",
  "lazy_static",
  "primitive-types",
- "secp256k1 0.19.0",
+ "secp256k1",
  "serde",
  "serde_json",
  "thiserror",
@@ -541,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-common"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88513ab5b700836b2520fa1c3cfbff196eaf9c0aca406073bd3b38f11ad28f67"
+checksum = "075fb9804a2767e448d5026decc6c550b9e3e9130a3c4d4b3f1bb4e473553d33"
 dependencies = [
  "ethabi",
  "hex",
@@ -551,15 +566,15 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "thiserror",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
  "web3",
 ]
 
 [[package]]
 name = "ethcontract-generate"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d276cadfc189527226cbd866479108bdc50c1c6c0a305e42ded793895de9d61b"
+checksum = "e6c8f75df99d9d13b70fea71ce278d90113a3fe5130a8225b9b6e07e1ca725e9"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -573,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.9.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473aecff686bd8e7b9db0165cbbb53562376b39bf35b427f0c60446a9e1634b0"
+checksum = "05dc5f0df4915fa6dff7f975a8366ecfaaa8959c74235469495153e7bb1b280e"
 dependencies = [
  "ethbloom",
  "fixed-hash",
@@ -605,12 +620,12 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
- "rand 0.7.3",
+ "rand 0.8.2",
  "rustc-hex",
  "static_assertions",
 ]
@@ -667,12 +682,6 @@ name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
-name = "futures"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
 name = "futures"
@@ -983,6 +992,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-proxy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ec5be69758dfc06b9b29efa9d6e9306e387c85eb362c603912eead2ad98c7"
+dependencies = [
+ "bytes 0.5.6",
+ "futures",
+ "http",
+ "hyper",
+ "hyper-tls",
+ "native-tls",
+ "tokio",
+ "tokio-tls",
+ "tower-service",
+ "typed-headers",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "impl-rlp"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
 dependencies = [
  "rlp",
 ]
@@ -1093,16 +1120,22 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "14.2.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0747307121ffb9703afd93afbd0fb4f854c38fb873f2c8b90e0e902f27c7b62"
+checksum = "6a47c4c3ac843f9a4238943f97620619033dadef4b378cd1e8addd170de396b3"
 dependencies = [
- "futures 0.1.30",
+ "futures",
  "log",
  "serde",
  "serde_derive",
  "serde_json",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "kernel32-sys"
@@ -1275,7 +1308,7 @@ dependencies = [
  "hex-literal",
  "lazy_static",
  "primitive-types",
- "secp256k1 0.17.2",
+ "secp256k1",
  "serde",
  "serde_json",
  "web3",
@@ -1486,12 +1519,12 @@ dependencies = [
  "chrono",
  "contracts",
  "ethcontract",
- "futures 0.3.10",
+ "futures",
  "hex",
  "hex-literal",
  "model",
  "primitive-types",
- "secp256k1 0.17.2",
+ "secp256k1",
  "serde",
  "serde_json",
  "shared-arguments",
@@ -1628,9 +1661,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "primitive-types"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
+checksum = "b3824ae2c5e27160113b9e029a10ec9e3f0237bad8029f69c7724393c9fdefd8"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -1882,10 +1915,11 @@ dependencies = [
 
 [[package]]
 name = "rlp"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1190dcc8c3a512f1eef5d09bb8c84c7f39e1054e174d1795482e18f5272f2e73"
+checksum = "e54369147e3e7796c9b885c7304db87ca3d09a0a98f72843d532868675bbfba8"
 dependencies = [
+ "bytes 1.0.1",
  "rustc-hex",
 ]
 
@@ -1931,36 +1965,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "secp256k1"
-version = "0.17.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2932dc07acd2066ff2e3921a4419606b220ba6cd03a9935123856cc534877056"
+checksum = "fcfd0eece5bc8fca7ca07a0c17ffd334b028f72ffbe9dd8ec924a8c885753278"
 dependencies = [
- "secp256k1-sys 0.1.2",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6179428c22c73ac0fbb7b5579a56353ce78ba29759b3b8575183336ea74cdfb"
-dependencies = [
- "secp256k1-sys 0.3.0",
+ "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.1.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab2c26f0d3552a0f12e639ae8a64afc2e3db9c52fe32f5fc6c289d38519f220"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11553d210db090930f4432bea123b31f70bbf693ace14504ea2a35e796c28dd2"
+checksum = "67e4b6455ee49f5901c8985b88f98fb0a0e1d90a6661f5a03f4888bd987dad29"
 dependencies = [
  "cc",
 ]
@@ -2101,6 +2117,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,7 +2176,7 @@ dependencies = [
  "async-trait",
  "contracts",
  "ethcontract",
- "futures 0.3.10",
+ "futures",
  "hex",
  "hex-literal",
  "jsonrpc-core",
@@ -2242,7 +2270,7 @@ dependencies = [
  "cargo_metadata",
  "dotenv",
  "either",
- "futures 0.3.10",
+ "futures",
  "heck",
  "lazy_static",
  "proc-macro2",
@@ -2403,15 +2431,6 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -2653,6 +2672,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-headers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3179a61e9eccceead5f1574fd173cf2e162ac42638b9bf214c6ad0baf7efa24a"
+dependencies = [
+ "base64 0.11.0",
+ "bytes 0.5.6",
+ "chrono",
+ "http",
+ "mime",
+]
+
+[[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,13 +2698,13 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
+checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
 dependencies = [
  "byteorder",
  "crunchy",
- "rustc-hex",
+ "hex",
  "static_assertions",
 ]
 
@@ -2786,7 +2818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41be6df54c97904af01aa23e613d4521eed7ab23537cede692d4058f6449407"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.10",
+ "futures",
  "headers",
  "http",
  "hyper",
@@ -2899,29 +2931,32 @@ dependencies = [
 
 [[package]]
 name = "web3"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d03f64be59921dbc5791f05af61a87594bb454518fe4e97d827405422279a0"
+checksum = "4080a844bbb41437f0d432138f0a7543780a40b43345b76dc0338c59bdfd1336"
 dependencies = [
  "arrayvec",
- "base64 0.12.3",
+ "base64 0.13.0",
  "derive_more",
  "ethabi",
  "ethereum-types",
- "futures 0.3.10",
+ "futures",
  "futures-timer",
+ "hex",
  "hyper",
+ "hyper-proxy",
  "hyper-tls",
  "jsonrpc-core",
  "log",
  "native-tls",
  "parking_lot",
+ "pin-project 1.0.4",
  "rlp",
- "rustc-hex",
- "secp256k1 0.17.2",
+ "secp256k1",
  "serde",
  "serde_json",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
+ "typed-headers",
  "url",
 ]
 

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -25,18 +25,18 @@ bin = [
 ]
 
 [dependencies]
-ethcontract = { version = "0.9",  default-features = false, features = ["http"] }
+ethcontract = { version = "0.10",  default-features = false, features = ["http"] }
 serde = "1.0"
 
 # [bin-dependencies]
 anyhow = { version = "1.0", optional = true }
 env_logger = { version = "0.8", optional = true }
-ethcontract-generate = { version = "0.9", optional = true}
+ethcontract-generate = { version = "0.10", optional = true}
 filetime = { version = "0.2.13", optional = true }
 log = { version = "0.4", optional = true }
 serde_json = { version = "1.0", optional = true }
 tokio = { version = "0.2", optional = true, features = ["macros"] }
 
 [build-dependencies]
-ethcontract-generate = "0.9"
+ethcontract-generate = "0.10"
 maplit = "1.0"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -5,15 +5,14 @@ edition = "2018"
 
 [dev-dependencies]
 contracts = { path = "../contracts" }
-ethcontract = { version = "0.9",  default-features = false, features = ["http"] }
+ethcontract = { version = "0.10",  default-features = false, features = ["http"] }
 hex-literal = "0.3"
 model = { path = "../model" }
 orderbook = { path = "../orderbook" }
-secp256k1 = "0.17"
+secp256k1 = "0.20"
 reqwest = "0.10"
 tokio = { version = "0.2", features =[ "macros"] }
-web3 = { version = "0.13", default-features = false }
+web3 = { version = "0.15", default-features = false }
 serde_json = "1.0"
 solver = { path = "../solver" }
 tracing-setup = { path = "../tracing-setup" }
-

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2018"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 hex = { version = "0.4", default-features = false }
 hex-literal = "0.3"
-primitive-types = { version = "0.7" }
-secp256k1 = "0.17"
+primitive-types = { version = "0.8" }
+secp256k1 = "0.20"
 serde = { version = "1.0", features = ["derive"] }
-web3 = { version = "0.13", default-features = false }
+web3 = { version = "0.15", default-features = false }
 lazy_static = "1.4"
-ethabi = "12.0"
+ethabi = "13.0"
 
 
 [dev-dependencies]

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -16,11 +16,11 @@ anyhow = "1.0"
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 contracts = { path = "../contracts" }
-ethcontract = { version = "0.9", default-features = false }
+ethcontract = { version = "0.10", default-features = false }
 futures = "0.3.9"
 hex = { version = "0.4", default-features = false }
 model = { path = "../model" }
-primitive-types = "0.7"
+primitive-types = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shared-arguments = { path = "../shared-arguments" }
@@ -30,8 +30,8 @@ tokio = { version = "0.2", features =[ "macros", "time"] }
 tracing = "0.1"
 tracing-setup = { path = "../tracing-setup" }
 warp = "0.2"
-web3 = { version = "0.13", default-features = false, features = ["http-tls"] }
+web3 = { version = "0.15", default-features = false, features = ["http-tls"] }
 
 [dev-dependencies]
 hex-literal = "0.3"
-secp256k1 = "0.17"
+secp256k1 = "0.20"

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -15,15 +15,15 @@ path = "src/main.rs"
 anyhow = "1.0"
 async-trait = "0.1"
 contracts = { path = "../contracts" }
-ethcontract = { version = "0.9", default-features = false }
+ethcontract = { version = "0.10", default-features = false }
 futures = "0.3"
 hex = "0.4"
 hex-literal = "0.3"
-jsonrpc-core = "14.0"
+jsonrpc-core = "16.0"
 maplit = "1.0"
 model = { path = "../model" }
 num = "0.3"
-primitive-types = "0.7"
+primitive-types = "0.8"
 reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -32,7 +32,7 @@ structopt = { version = "0.3" }
 tokio = { version = "0.2", features =[ "macros", "time"] }
 tracing = "0.1"
 tracing-setup = { path = "../tracing-setup" }
-web3 = { version = "0.13", default-features = false, features = ["http-tls"] }
+web3 = { version = "0.15", default-features = false, features = ["http-tls"] }
 
 [dev-dependencies]
 tracing-subscriber = "0.2"


### PR DESCRIPTION
and transitive dependencies.
Context: We just had an ethcontract release with the newest web3 version.

### Test Plan
CI