### PR TITLE
Split CI up into {fmt, clippy} and {test}

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,14 +6,11 @@ on:
   push:
     branches: [main]
 jobs:
-  rust:
+  rust-misc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
-      - run: |
-          npm install ganache-cli
-          node_modules/.bin/ganache-cli --networkId 5777 --gasLimit 10000000 --gasPrice 0&
       - run: |
           rustup --version
           rustup show
@@ -21,10 +18,13 @@ jobs:
           cargo fmt --version
           cargo clippy --version
       - run: cargo fmt --all -- --check
-      - run: cargo run --bin deploy --features bin
-        working-directory: contracts
       - run: cargo clippy --locked --workspace --all-features --all-targets -- -D warnings
-      - run: cargo test --locked --workspace --all-features
+  rust-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
+      - run: cargo test --locked --all-features
       - run: |
           sudo systemctl start postgresql.service
           sudo -u postgres createuser $USER
@@ -32,6 +32,12 @@ jobs:
           psql -f database/schema.sql
           # Postgres tests should not run in parallel because they use the same database.
           cargo test --locked --workspace --all-features --jobs 1 postgres -- --ignored --test-threads 1
+      - run: |
+          npm install ganache-cli
+          node_modules/.bin/ganache-cli --networkId 5777 --gasLimit 10000000 --gasPrice 0&
+      - run: cargo run --bin deploy --features bin
+        working-directory: contracts
+      - run: cargo test --locked --package e2e
   openapi:
     runs-on: ubuntu-latest
     steps:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,8 @@ pull_request_rules:
   - name: Merge approved and green PRs with `merge when green` label
     conditions:
       - "#approved-reviews-by>=1"
-      - check-success=rust
+      - check-success=rust-misc
+      - check-success=rust-test
       - check-success=openapi
       - base=main
       - label=merge when green


### PR DESCRIPTION
Because they build separate dependencies anyway (clippy compiles like
`check`) so this can speed up CI a little.

Switched around the order of operations for tests so that it runs the fast unit tests first, then the postgres and tests and finally the e2e ganache test.

### Test Plan
CI has separate jobs
