### PR TITLE
[LessNaiveSolver] Prune orders that don't satisfy solutions limit price

### DIFF
--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -36,7 +36,7 @@ pub fn solve(
     pool: &Pool,
 ) -> SinglePairSettlement {
     let mut orders: Vec<OrderCreation> = orders.collect();
-    while orders.len() > 0 {
+    while !orders.is_empty() {
         let (context_a, context_b) = split_into_contexts(orders.clone().into_iter(), pool);
         let solution = solve_orders(orders.clone().into_iter(), &context_a, &context_b);
         if is_valid_solution(&solution) {
@@ -199,7 +199,7 @@ fn compute_uniswap_in(out: U256, shortage: &TokenContext, excess: &TokenContext)
 /// Returns true if for each trade the executed price is not smaller than the limit price
 /// Thus we ensure that `buy_token_price / sell_token_price >= limit_buy_amount / limit_sell_amount`
 ///
-fn is_valid_solution<'a>(solution: &SinglePairSettlement) -> bool {
+fn is_valid_solution(solution: &SinglePairSettlement) -> bool {
     for trade in solution.trades.iter() {
         let order = trade.order;
         let buy_token_price = match solution.clearing_prices.get(&order.buy_token) {

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -22,6 +22,43 @@ impl TokenContext {
                 * u256_to_bigint(&deficit.reserve)
                 * (u256_to_bigint(&self.sell_volume) - u256_to_bigint(&self.buy_volume))
     }
+
+    pub fn is_excess_before_fees(&self, deficit: &TokenContext) -> bool {
+        u256_to_bigint(&self.reserve)
+            * (u256_to_bigint(&deficit.sell_volume) - u256_to_bigint(&deficit.buy_volume))
+            < u256_to_bigint(&deficit.reserve)
+                * (u256_to_bigint(&self.sell_volume) - u256_to_bigint(&self.buy_volume))
+    }
+}
+
+pub fn solve(
+    orders: impl Iterator<Item = OrderCreation> + Clone,
+    pool: &Pool,
+) -> SinglePairSettlement {
+    let mut orders: Vec<OrderCreation> = orders.collect();
+    while orders.len() > 0 {
+        let (context_a, context_b) = split_into_contexts(orders.clone().into_iter(), pool);
+        let solution = solve_orders(orders.clone().into_iter(), &context_a, &context_b);
+        if is_valid_solution(&solution) {
+            return solution;
+        } else {
+            // remove order with worst limit price that is selling excess token (to make it less excessive) and try again
+            let excess_token = if context_a.is_excess_before_fees(&context_b) {
+                context_a.address
+            } else {
+                context_b.address
+            };
+            orders.sort_by(price_comparator_for_selling_excess_token(excess_token));
+            orders.pop();
+        }
+    }
+
+    // At last we return the trivial solution which doesn't match any orders
+    SinglePairSettlement {
+        clearing_prices: HashMap::new(),
+        trades: Vec::new(),
+        interaction: None,
+    }
 }
 
 ///
@@ -29,11 +66,11 @@ impl TokenContext {
 /// Panics if orders are not already filtered for a specific token pair, or the reserve information
 /// for that pair is not available.
 ///
-pub fn solve(
+fn solve_orders(
     orders: impl Iterator<Item = OrderCreation> + Clone,
-    pool: &Pool,
+    context_a: &TokenContext,
+    context_b: &TokenContext,
 ) -> SinglePairSettlement {
-    let (context_a, context_b) = split_into_contexts(orders.clone(), pool);
     if context_a.is_excess_after_fees(&context_b) {
         solve_with_uniswap(orders, &context_b, &context_a)
     } else if context_b.is_excess_after_fees(&context_a) {
@@ -56,7 +93,6 @@ fn solve_without_uniswap(
             context_a.address => context_b.reserve,
             context_b.address => context_a.reserve,
         },
-        // TODO(fleupold) check that all orders comply with the computed price. Otherwise, remove the least favorable excess order and try again.
         trades: orders.into_iter().map(Trade::fully_matched).collect(),
         interaction: None,
     }
@@ -79,7 +115,6 @@ fn solve_with_uniswap(
         token_in: excess.address,
         token_out: shortage.address,
     });
-    // TODO(fleupold) check that all orders comply with the computed price. Otherwise, remove the least favorable excess order and try again.
     SinglePairSettlement {
         clearing_prices: maplit::hashmap! {
             shortage.address => uniswap_in,
@@ -158,6 +193,54 @@ fn compute_uniswap_out(shortage: &TokenContext, excess: &TokenContext) -> U256 {
 ///
 fn compute_uniswap_in(out: U256, shortage: &TokenContext, excess: &TokenContext) -> U256 {
     U256::from(1000) * out * excess.reserve / (U256::from(997) * (shortage.reserve - out)) + 1
+}
+
+///
+/// Returns true if for each trade the executed price is not smaller than the limit price
+/// Thus we ensure that `buy_token_price / sell_token_price >= limit_buy_amount / limit_sell_amount`
+///
+fn is_valid_solution<'a>(solution: &SinglePairSettlement) -> bool {
+    for trade in solution.trades.iter() {
+        let order = trade.order;
+        let buy_token_price = match solution.clearing_prices.get(&order.buy_token) {
+            Some(price) => price,
+            None => return false,
+        };
+        let sell_token_price = match solution.clearing_prices.get(&order.sell_token) {
+            Some(price) => price,
+            None => return false,
+        };
+
+        if order.sell_amount * buy_token_price < order.buy_amount * sell_token_price {
+            return false;
+        }
+    }
+
+    true
+}
+
+///
+/// Returns a comparator function that can be used e.g. to sort a vector or Orders
+/// Orders that don't sell the excess token are treated like they had a price of 0.
+///
+fn price_comparator_for_selling_excess_token(
+    excess_token: Address,
+) -> impl FnMut(&OrderCreation, &OrderCreation) -> std::cmp::Ordering {
+    move |lhs: &OrderCreation, rhs: &OrderCreation| {
+        let lhs_price = if lhs.sell_token == excess_token {
+            (lhs.buy_amount, lhs.sell_amount)
+        } else {
+            (U256::zero(), U256::one())
+        };
+
+        let rhs_price = if rhs.sell_token == excess_token {
+            (rhs.buy_amount, rhs.sell_amount)
+        } else {
+            (U256::zero(), U256::one())
+        };
+
+        (lhs_price.0 * rhs_price.1).cmp(&(lhs_price.1 * rhs_price.0))
+    }
 }
 
 fn u256_to_bigint(input: &U256) -> BigInt {
@@ -424,7 +507,7 @@ mod tests {
             OrderCreation {
                 sell_token: token_b,
                 buy_token: token_a,
-                sell_amount: to_wei(1000),
+                sell_amount: to_wei(1001),
                 buy_amount: to_wei(1000),
                 kind: OrderKind::Sell,
                 partially_fillable: false,
@@ -447,5 +530,264 @@ mod tests {
                 token_b => to_wei(1_000_001)
             }
         );
+    }
+
+    #[test]
+    fn finds_solution_excluding_orders_whose_limit_price_is_not_satisfiable() {
+        let token_a = Address::from_low_u64_be(0);
+        let token_b = Address::from_low_u64_be(1);
+        let orders = vec![
+            // Unreasonable order a -> b
+            OrderCreation {
+                sell_token: token_a,
+                buy_token: token_b,
+                sell_amount: to_wei(1),
+                buy_amount: to_wei(1000),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+            // Reasonable order a -> b
+            OrderCreation {
+                sell_token: token_a,
+                buy_token: token_b,
+                sell_amount: to_wei(1000),
+                buy_amount: to_wei(1000),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+            // Reasonable order b -> a
+            OrderCreation {
+                sell_token: token_b,
+                buy_token: token_a,
+                sell_amount: to_wei(1000),
+                buy_amount: to_wei(1000),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+            // Unreasonable order b -> a
+            OrderCreation {
+                sell_token: token_b,
+                buy_token: token_a,
+                sell_amount: to_wei(2),
+                buy_amount: to_wei(1000),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+        ];
+
+        let pool = Pool {
+            token_pair: TokenPair::new(token_a, token_b).unwrap(),
+            reserve0: to_wei(1_000_000).as_u128(),
+            reserve1: to_wei(1_000_000).as_u128(),
+            address: Default::default(),
+        };
+        let result = solve(orders.into_iter(), &pool);
+
+        assert_eq!(result.trades.len(), 2);
+        assert_eq!(is_valid_solution(&result), true);
+    }
+
+    #[test]
+    fn returns_empty_solution_if_orders_have_no_overlap() {
+        let token_a = Address::from_low_u64_be(0);
+        let token_b = Address::from_low_u64_be(1);
+        let orders = vec![
+            OrderCreation {
+                sell_token: token_a,
+                buy_token: token_b,
+                sell_amount: to_wei(900),
+                buy_amount: to_wei(1000),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+            OrderCreation {
+                sell_token: token_b,
+                buy_token: token_a,
+                sell_amount: to_wei(900),
+                buy_amount: to_wei(1000),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+        ];
+
+        let pool = Pool {
+            token_pair: TokenPair::new(token_a, token_b).unwrap(),
+            reserve0: to_wei(1_000_001).as_u128(),
+            reserve1: to_wei(1_000_000).as_u128(),
+            address: Default::default(),
+        };
+        let result = solve(orders.into_iter(), &pool);
+        assert_eq!(result.trades.len(), 0);
+    }
+
+    #[test]
+    fn test_is_valid_solution() {
+        let token_a = Address::from_low_u64_be(0);
+        let token_b = Address::from_low_u64_be(1);
+        let orders = vec![
+            OrderCreation {
+                sell_token: token_a,
+                buy_token: token_b,
+                sell_amount: to_wei(10),
+                buy_amount: to_wei(9),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+            OrderCreation {
+                sell_token: token_b,
+                buy_token: token_a,
+                sell_amount: to_wei(10),
+                buy_amount: to_wei(9),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+        ];
+
+        // Price in the middle is ok
+        assert_eq!(
+            is_valid_solution(&SinglePairSettlement {
+                clearing_prices: maplit::hashmap! {
+                    token_a => to_wei(1),
+                    token_b => to_wei(1)
+                },
+                interaction: None,
+                trades: orders
+                    .clone()
+                    .into_iter()
+                    .map(Trade::fully_matched)
+                    .collect()
+            }),
+            true
+        );
+
+        // Price at the limit of first order is ok
+        assert_eq!(
+            is_valid_solution(&SinglePairSettlement {
+                clearing_prices: maplit::hashmap! {
+                    token_a => to_wei(9),
+                    token_b => to_wei(10)
+                },
+                interaction: None,
+                trades: orders
+                    .clone()
+                    .into_iter()
+                    .map(Trade::fully_matched)
+                    .collect()
+            }),
+            true
+        );
+
+        // Price at the limit of second order is ok
+        assert_eq!(
+            is_valid_solution(&SinglePairSettlement {
+                clearing_prices: maplit::hashmap! {
+                    token_a => to_wei(10),
+                    token_b => to_wei(9)
+                },
+                interaction: None,
+                trades: orders
+                    .clone()
+                    .into_iter()
+                    .map(Trade::fully_matched)
+                    .collect()
+            }),
+            true
+        );
+
+        // Price violating first order is not ok
+        assert_eq!(
+            is_valid_solution(&SinglePairSettlement {
+                clearing_prices: maplit::hashmap! {
+                    token_a => to_wei(8),
+                    token_b => to_wei(10)
+                },
+                interaction: None,
+                trades: orders
+                    .clone()
+                    .into_iter()
+                    .map(Trade::fully_matched)
+                    .collect()
+            }),
+            false
+        );
+
+        // Price violating second order is not ok
+        assert_eq!(
+            is_valid_solution(&SinglePairSettlement {
+                clearing_prices: maplit::hashmap! {
+                    token_a => to_wei(10),
+                    token_b => to_wei(8)
+                },
+                interaction: None,
+                trades: orders.into_iter().map(Trade::fully_matched).collect()
+            }),
+            false
+        );
+    }
+
+    #[test]
+    fn test_price_comparator_for_selling_excess_token() {
+        let token_a = Address::from_low_u64_be(0);
+        let token_b = Address::from_low_u64_be(1);
+        let orders = vec![
+            // Largest Price a -> b
+            OrderCreation {
+                sell_token: token_a,
+                buy_token: token_b,
+                sell_amount: to_wei(1),
+                buy_amount: to_wei(1000),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+            // Lower limit a -> b
+            OrderCreation {
+                sell_token: token_a,
+                buy_token: token_b,
+                sell_amount: to_wei(1000),
+                buy_amount: to_wei(1000),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+            // Lower limit b -> a
+            OrderCreation {
+                sell_token: token_b,
+                buy_token: token_a,
+                sell_amount: to_wei(1000),
+                buy_amount: to_wei(1000),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+            // Larger limit b -> a
+            OrderCreation {
+                sell_token: token_b,
+                buy_token: token_a,
+                sell_amount: to_wei(2),
+                buy_amount: to_wei(1000),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+        ];
+
+        let mut sorted = orders.clone();
+
+        sorted.sort_by(price_comparator_for_selling_excess_token(token_a));
+        assert_eq!(sorted[3], orders[0]);
+        assert_eq!(sorted[2], orders[1]);
+
+        sorted.sort_by(price_comparator_for_selling_excess_token(token_b));
+        assert_eq!(sorted[3], orders[3]);
+        assert_eq!(sorted[2], orders[2]);
     }
 }


### PR DESCRIPTION
This PR implements verification of limit prices of the orders we add to our solution (a remaining TODO). 

After computing a solution (initially with all orders for the given token pair regardless of limit price), we check that all trades satisfy their order's limit. This is normally true, if orders have been submitted via the UI since we account for potential slippage and make sure the spread is sufficient. It is not true however, if the AMM's price changed significantly or users created a manual order via the API. 
If a limit price is violated, we remove one order from the problem set and restart computation. 

We remove the order with the most strict limit price of the ones selling the token we are in excess of (the token we are providing to the AMM). By doing so, we reduce the overall excess and as such the AMM price should move less (which might in the next run satisfy other orders that are also in violation with the computed price now but still close enough to the previous AMM price). 

We continue to iterate until eventually there are no more orders in the Set. In this case we return an empty/trivial solution (might be worthwhile to return None instead).

The intuition of the approach is that if we keep removing the "outliers" (worst limit prices) from the problem set, at some point we should end up with a set of orders that can be matched partially with one another and the AMM's liquidity.

### Test Plan

Unit tests added (most of the line count)
