### PR TITLE
Fix CI deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,4 +15,4 @@ jobs:
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     steps:
       - uses: actions/checkout@v2
-      - run: docker/deploy.sh ${GITHUB_REF#refs/(tags|heads)/}
+      - run: docker/deploy.sh ${GITHUB_REF#refs/*/}


### PR DESCRIPTION
The previous syntax was a zsh speciality that isn't part of normal bash.