### PR TITLE
Include executed amounts in order meta data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,10 +1318,12 @@ dependencies = [
  "hex",
  "hex-literal",
  "lazy_static",
+ "num-bigint",
  "primitive-types",
  "secp256k1",
  "serde",
  "serde_json",
+ "serde_with",
  "web3",
 ]
 
@@ -2088,6 +2090,15 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f6201e064705553ece353a736a64be975680bd244908cf63e8fa71e478a51a"
+dependencies = [
  "serde",
 ]
 

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -5,15 +5,16 @@ edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
+ethabi = "13.0"
 hex = { version = "0.4", default-features = false }
 hex-literal = "0.3"
+lazy_static = "1.4"
+num-bigint = "0.3"
 primitive-types = { version = "0.8" }
 secp256k1 = "0.20"
 serde = { version = "1.0", features = ["derive"] }
+serde_with = { version = "1.6", default-features = false }
 web3 = { version = "0.15", default-features = false }
-lazy_static = "1.4"
-ethabi = "13.0"
-
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -136,6 +136,10 @@ components:
       description: Ethereum 40 byte address encoded as a hex with `0x` prefix.
       type: string
       example: "0x6810e776880c02933d47db1b9fc05908e5386b96"
+    BigUint:
+      description: A big unsigned integer encoded in decimal.
+      type: string
+      example: "1234567890"
     TokenAmount:
       description: Amount of a token. uint256 encoded in decimal.
       type: string
@@ -213,6 +217,15 @@ components:
           $ref: "#/components/schemas/Address"
         UID:
           $ref: "#/components/schemas/UID"
+        executedSellAmount:
+          description: "The total amount of sellToken that has been executed for this order."
+          $ref: "#/components/schemas/BigUint"
+        executedBuyAmount:
+          description: "The total amount of buyToken that has been executed for this order."
+          $ref: "#/components/schemas/BigUint"
+        executedFeeAmount:
+          description: "The total amount of fees that have been executed for this order."
+          $ref: "#/components/schemas/BigUint"
     Order:
       allOf:
         - $ref: "#/components/schemas/OrderCreation"

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -1,5 +1,5 @@
 use super::Database;
-use crate::u256_conversions::*;
+use crate::integer_conversions::*;
 use anyhow::{anyhow, Context, Result};
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
@@ -150,6 +150,12 @@ impl OrdersQueryRow {
                     .try_into()
                     .map_err(|_| anyhow!("order uid has wrong length"))?,
             ),
+            executed_buy_amount: big_decimal_to_big_uint(&self.sum_buy)
+                .ok_or_else(|| anyhow!("sum_buy is not an unsigned integer"))?,
+            executed_sell_amount: big_decimal_to_big_uint(&self.sum_sell)
+                .ok_or_else(|| anyhow!("sum_sell is not an unsigned integer"))?,
+            executed_fee_amount: big_decimal_to_big_uint(&self.sum_fee)
+                .ok_or_else(|| anyhow!("sum_fee is not an unsigned integer"))?,
         };
         let order_creation = OrderCreation {
             sell_token: h160_from_vec(self.sell_token)?,

--- a/orderbook/src/database/trades.rs
+++ b/orderbook/src/database/trades.rs
@@ -1,5 +1,5 @@
 use super::Database;
-use crate::u256_conversions::*;
+use crate::integer_conversions::*;
 use anyhow::{Context, Result};
 use futures::FutureExt;
 use model::order::OrderUid;

--- a/orderbook/src/integer_conversions.rs
+++ b/orderbook/src/integer_conversions.rs
@@ -1,6 +1,10 @@
 use bigdecimal::BigDecimal;
-use num_bigint::{BigInt, Sign, ToBigInt};
+use num_bigint::{BigInt, BigUint, Sign, ToBigInt};
 use primitive_types::U256;
+use std::convert::TryInto;
+
+// TODO: It would be nice to avoid copying the underlying BigInt when converting BigDecimal to
+// anything else but the simple big_decimal.to_bigint makes a copy internally.
 
 pub fn u256_to_big_int(input: &U256) -> BigInt {
     let mut bytes = [0; 32];
@@ -19,6 +23,10 @@ pub fn bigint_to_u256(input: &BigInt) -> Option<U256> {
         return None;
     }
     Some(U256::from_big_endian(&bytes))
+}
+
+pub fn big_decimal_to_big_uint(big_decimal: &BigDecimal) -> Option<BigUint> {
+    big_decimal.to_bigint()?.try_into().ok()
 }
 
 pub fn big_decimal_to_u256(big_decimal: &BigDecimal) -> Option<U256> {

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod api;
 pub mod database;
+pub mod integer_conversions;
 pub mod storage;
 pub mod trade_events;
-pub mod u256_conversions;
 
 use crate::storage::Storage;
 use anyhow::{anyhow, Context as _, Result};


### PR DESCRIPTION
The solver needs at least the filled amount (depending on order type)
and I figured this could be useful information in general so we might as
well put them all in the api.
On the other hand we could decide that this shouldn't be part of the
public api because we do not want to guarantee that we provide it and
find another way to get this information to the solver.
The type is BigUint and not U256 because every amount except the filled
amount can technically sum up to an amount larger than U256::MAX over
multiple trades. The filled amount cannot because it is stored as a U256
in the smart contract.

### Test Plan
Serialization unit test has been adjusted
