### PR TITLE
Filter fully executed orders in postgres

### DIFF
--- a/orderbook/src/database/trades.rs
+++ b/orderbook/src/database/trades.rs
@@ -7,6 +7,8 @@ use primitive_types::U256;
 use sqlx::{Connection, Executor, Postgres, Transaction};
 use std::convert::TryInto;
 
+// TODO: invalidated orders
+
 #[derive(Debug, Default)]
 pub struct Trade {
     pub block_number: u64,

--- a/orderbook/src/integer_conversions.rs
+++ b/orderbook/src/integer_conversions.rs
@@ -6,15 +6,15 @@ use std::convert::TryInto;
 // TODO: It would be nice to avoid copying the underlying BigInt when converting BigDecimal to
 // anything else but the simple big_decimal.to_bigint makes a copy internally.
 
-pub fn u256_to_big_int(input: &U256) -> BigInt {
+pub fn u256_to_big_uint(input: &U256) -> BigUint {
     let mut bytes = [0; 32];
     input.to_big_endian(&mut bytes);
-    BigInt::from_bytes_be(Sign::Plus, &bytes)
+    BigUint::from_bytes_be(&bytes)
 }
 
 pub fn u256_to_big_decimal(u256: &U256) -> BigDecimal {
-    let big_int = u256_to_big_int(u256);
-    BigDecimal::from(big_int)
+    let big_uint = u256_to_big_uint(u256);
+    BigDecimal::from(BigInt::from(big_uint))
 }
 
 pub fn bigint_to_u256(input: &BigInt) -> Option<U256> {


### PR DESCRIPTION
While doing this I realized that there is another piece missing: handling order invalidated events. These make an order unexecutable without a trade so we need to track them too. Will happen in another PR.

### Test Plan
new unit tests
