### PR TITLE
Filter for invalidated orders

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -35,6 +35,13 @@ CREATE TABLE trades (
     PRIMARY KEY (block_number, log_index)
 );
 
+CREATE TABLE invalidations (
+    block_number bigint NOT NULL,
+    log_index bigint NOT NULL,
+    order_uid bytea NOT NULL,
+    PRIMARY KEY (block_number, log_index)
+);
+
 -- Indexes for common operations that should be efficient.
 
 -- Get a specific user's orders.
@@ -45,3 +52,6 @@ CREATE INDEX order_valid_to ON orders USING BTREE (valid_to);
 
 -- Get all trades belonging to an order.
 CREATE INDEX trade_order_uid on trades USING BTREE (order_uid, block_number, log_index);
+
+-- Get all trades belonging to an order.
+CREATE INDEX invalidations_order_uid on invalidations USING BTREE (order_uid, block_number, log_index);

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -266,6 +266,7 @@ pub struct OrderMetaData {
     pub executed_sell_amount: BigUint,
     #[serde(with = "serde_with::rust::display_fromstr")]
     pub executed_fee_amount: BigUint,
+    pub invalidated: bool,
 }
 
 impl Default for OrderMetaData {
@@ -277,6 +278,7 @@ impl Default for OrderMetaData {
             executed_buy_amount: Default::default(),
             executed_sell_amount: Default::default(),
             executed_fee_amount: Default::default(),
+            invalidated: Default::default(),
         }
     }
 }
@@ -388,6 +390,7 @@ mod tests {
             "executedBuyAmount": "3",
             "executedSellAmount": "4",
             "executedFeeAmount": "5",
+            "invalidated": true,
             "sellToken": "0x000000000000000000000000000000000000000a",
             "buyToken": "0x0000000000000000000000000000000000000009",
             "sellAmount": "1",
@@ -407,6 +410,7 @@ mod tests {
                 executed_buy_amount: BigUint::from_bytes_be(&[3]),
                 executed_sell_amount: BigUint::from_bytes_be(&[4]),
                 executed_fee_amount: BigUint::from_bytes_be(&[5]),
+                invalidated: true,
             },
             order_creation: OrderCreation {
                 sell_token: H160::from_low_u64_be(10),

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -226,6 +226,9 @@ components:
         executedFeeAmount:
           description: "The total amount of fees that have been executed for this order."
           $ref: "#/components/schemas/BigUint"
+        invalidated:
+          description: Has this order been invalidated?
+          type: boolean
     Order:
       allOf:
         - $ref: "#/components/schemas/OrderCreation"

--- a/orderbook/src/database.rs
+++ b/orderbook/src/database.rs
@@ -33,6 +33,9 @@ impl Database {
         use sqlx::Executor;
         self.pool.execute(sqlx::query("TRUNCATE orders;")).await?;
         self.pool.execute(sqlx::query("TRUNCATE trades;")).await?;
+        self.pool
+            .execute(sqlx::query("TRUNCATE invalidations;"))
+            .await?;
         Ok(())
     }
 }


### PR DESCRIPTION
Users can manually invalidate orders in the smart contract which we need
to handle in the database.

In future PRs: query and insert invalidation events into the db, allow this filter to be used in the http api

### Test Plan
New unit test
