### PR TITLE
Implement order book trait with postgres

### DIFF
--- a/orderbook/src/api/filter.rs
+++ b/orderbook/src/api/filter.rs
@@ -93,7 +93,10 @@ pub fn get_fee_info() -> impl Filter<Extract = (impl warp::Reply,), Error = warp
 #[cfg(test)]
 pub mod test_util {
     use super::*;
-    use crate::storage::{AddOrderResult, InMemoryOrderBook as OrderBook};
+    use crate::{
+        database::OrderFilter,
+        storage::{AddOrderResult, InMemoryOrderBook as OrderBook},
+    };
     use hex_literal::hex;
     use model::order::Order;
     use model::{order::OrderBuilder, DomainSeparator};
@@ -112,7 +115,7 @@ pub mod test_util {
         let response = request().path("/orders").method("GET").reply(&filter).await;
         assert_eq!(response.status(), StatusCode::OK);
         let response_orders: Vec<Order> = serde_json::from_slice(response.body()).unwrap();
-        let orderbook_orders = orderbook.get_orders().await.unwrap();
+        let orderbook_orders = orderbook.get_orders(&OrderFilter::default()).await.unwrap();
         assert_eq!(response_orders, orderbook_orders);
     }
 
@@ -190,7 +193,7 @@ pub mod test_util {
             .await;
         assert_eq!(response.status(), StatusCode::OK);
         let response_orders: Order = serde_json::from_slice(response.body()).unwrap();
-        let orderbook_orders = orderbook.get_orders().await.unwrap();
+        let orderbook_orders = orderbook.get_orders(&OrderFilter::default()).await.unwrap();
         assert_eq!(response_orders, orderbook_orders[0]);
     }
     #[tokio::test]

--- a/orderbook/src/storage.rs
+++ b/orderbook/src/storage.rs
@@ -1,9 +1,11 @@
 mod memory;
 mod postgresql;
 
+use crate::database::OrderFilter;
 use anyhow::Result;
 use contracts::GPv2Settlement;
 use model::order::{Order, OrderCreation, OrderUid};
+use std::time::SystemTime;
 
 pub use memory::OrderBook as InMemoryOrderBook;
 
@@ -28,7 +30,17 @@ pub enum RemoveOrderResult {
 pub trait Storage: Send + Sync {
     async fn add_order(&self, order: OrderCreation) -> Result<AddOrderResult>;
     async fn remove_order(&self, uid: &OrderUid) -> Result<RemoveOrderResult>;
-    async fn get_order(&self, uid: &OrderUid) -> Result<Option<Order>>;
-    async fn get_orders(&self) -> Result<Vec<Order>>;
+    async fn get_orders(&self, filter: &OrderFilter<'_>) -> Result<Vec<Order>>;
     async fn run_maintenance(&self, settlement_contract: &GPv2Settlement) -> Result<()>;
+}
+
+fn now_in_epoch_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("now earlier than epoch")
+        .as_secs()
+}
+
+fn has_future_valid_to(now_in_epoch_seconds: u64, order: &OrderCreation) -> bool {
+    order.valid_to as u64 > now_in_epoch_seconds
 }

--- a/orderbook/src/storage/postgresql.rs
+++ b/orderbook/src/storage/postgresql.rs
@@ -1,1 +1,50 @@
-// TODO: implement Storage for PostgreSQL database.
+use super::*;
+use crate::database::{Database, OrderFilter};
+use anyhow::Result;
+use contracts::GPv2Settlement;
+use futures::TryStreamExt;
+use model::{
+    order::{Order, OrderCreation, OrderUid},
+    DomainSeparator,
+};
+
+pub struct OrderBook {
+    domain_separator: DomainSeparator,
+    database: Database,
+}
+
+impl OrderBook {
+    pub fn _new(domain_separator: DomainSeparator, database: Database) -> Self {
+        Self {
+            domain_separator,
+            database,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Storage for OrderBook {
+    async fn add_order(&self, order: OrderCreation) -> Result<AddOrderResult> {
+        if !has_future_valid_to(now_in_epoch_seconds(), &order) {
+            return Ok(AddOrderResult::PastValidTo);
+        }
+        let order = match Order::from_order_creation(order, &self.domain_separator) {
+            Some(order) => order,
+            None => return Ok(AddOrderResult::InvalidSignature),
+        };
+        self.database.insert_order(&order).await?;
+        Ok(AddOrderResult::Added(order.order_meta_data.uid))
+    }
+
+    async fn remove_order(&self, _uid: &OrderUid) -> Result<RemoveOrderResult> {
+        todo!()
+    }
+
+    async fn get_orders(&self, filter: &OrderFilter<'_>) -> Result<Vec<Order>> {
+        self.database.orders(filter).try_collect::<Vec<_>>().await
+    }
+
+    async fn run_maintenance(&self, _settlement_contract: &GPv2Settlement) -> Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
as a replacement for the in memory order book which is being used at the
moment.

Before we switch we still need a database running in staging and I need to think about how to organize the warp route tests that currently require a functioning orderbook. I am tending towards making them e2e tests.

### Test Plan
the only visible logic change is moving the order filtering from the warp filter into the in memory order book. this is still being tested in the existing unit test.
