### PR TITLE
[Refactoring 1] Introducing abstract liquidity object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,6 +439,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +467,12 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "downcast"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 
 [[package]]
 name = "dtoa"
@@ -642,6 +654,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +692,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -1310,6 +1337,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619634fd9149c4a06e66d8fd9256e85326d8eeee75abee4565ff76c92e4edfe0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83714c95dbf4c24202f0f1b208f0f248e6bd65abfa8989303611a71c0f781548"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "model"
 version = "0.1.0"
 dependencies = [
@@ -1385,6 +1439,12 @@ dependencies = [
  "memchr",
  "version_check",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num"
@@ -1673,6 +1733,35 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "predicates"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73dd9b7b200044694dfede9edf907c1ca19630908443e9447e624993700c6932"
+dependencies = [
+ "difference",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3dbeaaf793584e29c58c7e3a82bbb3c7c06b63cea68d13b0e3cddc124104dc"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee95d988ee893cb35c06b148c80ed2cd52c8eea927f50ba7a0be1a786aeab73"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
 
 [[package]]
 name = "primitive-types"
@@ -2205,8 +2294,10 @@ dependencies = [
  "hex-literal",
  "jsonrpc-core",
  "maplit",
+ "mockall",
  "model",
  "num",
+ "num-rational",
  "primitive-types",
  "reqwest",
  "serde",
@@ -2663,6 +2754,12 @@ dependencies = [
  "tracing-log",
  "tracing-serde",
 ]
+
+[[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "try-lock"

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -23,6 +23,7 @@ jsonrpc-core = "16.0"
 maplit = "1.0"
 model = { path = "../model" }
 num = "0.3"
+num-rational = "0.3"
 primitive-types = "0.8"
 reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -36,3 +37,4 @@ web3 = { version = "0.15", default-features = false, features = ["http-tls"] }
 
 [dev-dependencies]
 tracing-subscriber = "0.2"
+mockall = "0.9"

--- a/solver/src/lib.rs
+++ b/solver/src/lib.rs
@@ -2,6 +2,7 @@ pub mod driver;
 pub mod encoding;
 pub mod http_solver;
 pub mod interactions;
+pub mod liquidity;
 pub mod naive_solver;
 pub mod orderbook;
 pub mod settlement;

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -1,4 +1,4 @@
-use model::order::OrderKind;
+use model::{order::OrderKind, TokenPair};
 use num_rational::Rational;
 use primitive_types::{H160, U256};
 use settlement::{Interaction, Trade};
@@ -9,16 +9,12 @@ use mockall::automock;
 
 use crate::settlement;
 
-///
 /// Defines the different types of liquidity our solvers support
-///
 pub enum Liquidity {
     Limit(LimitOrder),
     Amm(AmmOrder),
 }
-///
 /// Basic limit sell and buy orders
-///
 #[derive(Clone)]
 pub struct LimitOrder {
     pub sell_token: H160,
@@ -30,28 +26,22 @@ pub struct LimitOrder {
     pub settlement_handling: Arc<dyn LimitOrderSettlementHandling>,
 }
 
-///
 /// Specifies how a limit order fulfillment translates into Trade and Interactions for the settlement
-///
 #[cfg_attr(test, automock)]
 pub trait LimitOrderSettlementHandling: Send + Sync {
     fn settle(&self, executed_amount: U256) -> (Option<Trade>, Vec<Box<dyn Interaction>>);
 }
 
-///
 /// 2 sided constant product automated market maker with equal reserve value and a trading fee (e.g. Uniswap, Sushiswap)
-///
 #[derive(Clone)]
 pub struct AmmOrder {
-    pub tokens: (H160, H160),
+    pub tokens: TokenPair,
     pub reserves: (u128, u128),
     pub fee: Rational,
     pub settlement_handling: Arc<dyn AmmSettlementHandling>,
 }
 
-///
 /// Specifies how a AMM order fulfillment translates into Interactions for the settlement
-///
 #[cfg_attr(test, automock)]
 pub trait AmmSettlementHandling: Send + Sync {
     fn settle(&self, input: (H160, U256), output: (H160, U256)) -> Vec<Box<dyn Interaction>>;

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use model::order::OrderKind;
 use num_rational::Rational;
 use primitive_types::{H160, U256};
@@ -17,22 +16,6 @@ pub enum Liquidity {
     Limit(LimitOrder),
     Amm(AmmOrder),
 }
-
-///
-/// Trait to fetch any kind of liquidity (onchain & off-chain)
-///
-#[async_trait::async_trait]
-pub trait LiquiditySource {
-    ///
-    /// Given all liquidity sourced so far, returns the additional liquidity that can be sourced from
-    /// the concrete implementation.
-    ///
-    async fn get_liquidity(
-        &self,
-        liquidity_so_far: impl Iterator<Item = &Liquidity> + Send + Sync + 'async_trait,
-    ) -> Result<Vec<Liquidity>>;
-}
-
 ///
 /// Basic limit sell and buy orders
 ///

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use model::order::OrderKind;
+use num_rational::Rational;
+use primitive_types::{H160, U256};
+use settlement::{Interaction, Trade};
+use std::sync::Arc;
+
+#[cfg(test)]
+use mockall::automock;
+
+use crate::settlement;
+
+///
+/// Defines the different types of liquidity our solvers support
+///
+pub enum Liquidity {
+    Limit(LimitOrder),
+    Amm(AmmOrder),
+}
+
+///
+/// Trait to fetch any kind of liquidity (onchain & off-chain)
+///
+#[async_trait::async_trait]
+pub trait LiquiditySource {
+    ///
+    /// Given all liquidity sourced so far, returns the additional liquidity that can be sourced from
+    /// the concrete implementation.
+    ///
+    async fn get_liquidity(
+        &self,
+        liquidity_so_far: impl Iterator<Item = &Liquidity> + Send + Sync + 'async_trait,
+    ) -> Result<Vec<Liquidity>>;
+}
+
+///
+/// Basic limit sell and buy orders
+///
+#[derive(Clone)]
+pub struct LimitOrder {
+    pub sell_token: H160,
+    pub buy_token: H160,
+    pub sell_amount: U256,
+    pub buy_amount: U256,
+    pub kind: OrderKind,
+    pub partially_fillable: bool,
+    pub settlement_handling: Arc<dyn LimitOrderSettlementHandling>,
+}
+
+///
+/// Specifies how a limit order fulfillment translates into Trade and Interactions for the settlement
+///
+#[cfg_attr(test, automock)]
+pub trait LimitOrderSettlementHandling: Send + Sync {
+    fn settle(&self, executed_amount: U256) -> (Option<Trade>, Vec<Box<dyn Interaction>>);
+}
+
+///
+/// 2 sided constant product automated market maker with equal reserve value and a trading fee (e.g. Uniswap, Sushiswap)
+///
+#[derive(Clone)]
+pub struct AmmOrder {
+    pub tokens: (H160, H160),
+    pub reserves: (u128, u128),
+    pub fee: Rational,
+    pub settlement_handling: Arc<dyn AmmSettlementHandling>,
+}
+
+///
+/// Specifies how a AMM order fulfillment translates into Interactions for the settlement
+///
+#[cfg_attr(test, automock)]
+pub trait AmmSettlementHandling: Send + Sync {
+    fn settle(&self, input: (H160, U256), output: (H160, U256)) -> Vec<Box<dyn Interaction>>;
+}


### PR DESCRIPTION
Part of #194

*This is a proposal for how we can separate liquidity sources and solver handling logic to allow the two to grow more independently. Read in the context of the three PRs in this stack*

This PR defines an abstract Liquidity type, which can be interpreted by the solver(s). For now this datatype is shared between the two solvers (naive & http). If we see more solvers evolve in the future (with fundamentally different order types) it might make sense to have different liquidity types, one for each solver. This way, we could e.g. still model a Curve pool as limit orders for more naive solvers, but e.g. provide native support in the http_solver.

On the other hand, we have many liquidity sources (e.g. Offchain Orderbook, SCP RFQ system, Uniswap, SushiSwap. Balancer, Curve, Compound cToken converter, etc...). Each liquidity source yields a lot of abstract liquidity and provides a callback handler into how a specific "match" of this liquidity translates into trades and interactions.

As an example, if we have a user selling GNO for ETH, our source would provide a LimitOrder object selling GNO for WETH. In the settlement handler we would return a GNO/WETH trade **and** an interaction to unwrap the amount of WETH bought into ETH (we might build additional logic towards how to order/merge interactions in the end to avoid e.g. doing multiple unwrap calls).

Similarly an AMM liquidity source (e.g. Uniswap or Sushiswap) would yield an AMM liquidity object. In the settlement handler it could perform things such as approving the settlement contract if necessary.

An external market maker's RFQ system can be implemented as a liquidity source with a list of partially matchable limit orders that get matched via a 0x bridge (opposed to native GPv2 EOA orders).

PredictionMarket outcome tokens or other "split and mergeable" tokens (e.g. LP tokens) would become a new liquidity subtype (once the solvers support it) with potentially many sources.

### Test Plan
Unit tests at the end of the PR stack
