### PR TITLE
[Refactoring 2] Introducing concrete liquidity implementations

### DIFF
--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use model::{order::OrderKind, TokenPair};
 use num_rational::Rational;
 use primitive_types::{H160, U256};

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -9,6 +9,9 @@ use mockall::automock;
 
 use crate::settlement;
 
+pub mod offchain_orderbook;
+pub mod uniswap;
+
 /// Defines the different types of liquidity our solvers support
 pub enum Liquidity {
     Limit(LimitOrder),

--- a/solver/src/liquidity/offchain_orderbook.rs
+++ b/solver/src/liquidity/offchain_orderbook.rs
@@ -1,0 +1,46 @@
+use crate::orderbook::OrderBookApi;
+use crate::settlement::{Interaction, Trade};
+use anyhow::{Context, Result};
+use model::order::OrderCreation;
+use primitive_types::U256;
+use std::sync::Arc;
+
+use super::{LimitOrder, LimitOrderSettlementHandling, Liquidity, LiquiditySource};
+
+#[async_trait::async_trait]
+impl LiquiditySource for OrderBookApi {
+    async fn get_liquidity(
+        &self,
+        _: impl Iterator<Item = &Liquidity> + Send + 'async_trait,
+    ) -> Result<Vec<Liquidity>> {
+        Ok(self
+            .get_orders()
+            .await
+            .context("failed to get orderbook")?
+            .into_iter()
+            .map(|order| Liquidity::Limit(order.order_creation.into()))
+            .collect())
+    }
+}
+
+impl Into<LimitOrder> for OrderCreation {
+    fn into(self) -> LimitOrder {
+        LimitOrder {
+            sell_token: self.sell_token,
+            // TODO handle ETH buy token address (0xe...e) by making the handler include an WETH.unwrap() interaction
+            buy_token: self.buy_token,
+            // TODO discount previously executed sell amount
+            sell_amount: self.sell_amount,
+            buy_amount: self.buy_amount,
+            kind: self.kind,
+            partially_fillable: self.partially_fillable,
+            settlement_handling: Arc::new(self),
+        }
+    }
+}
+
+impl LimitOrderSettlementHandling for OrderCreation {
+    fn settle(&self, executed_amount: U256) -> (Option<Trade>, Vec<Box<dyn Interaction>>) {
+        (Some(Trade::matched(*self, executed_amount)), Vec::new())
+    }
+}

--- a/solver/src/liquidity/offchain_orderbook.rs
+++ b/solver/src/liquidity/offchain_orderbook.rs
@@ -5,20 +5,17 @@ use model::order::OrderCreation;
 use primitive_types::U256;
 use std::sync::Arc;
 
-use super::{LimitOrder, LimitOrderSettlementHandling, Liquidity, LiquiditySource};
+use super::{LimitOrder, LimitOrderSettlementHandling};
 
-#[async_trait::async_trait]
-impl LiquiditySource for OrderBookApi {
-    async fn get_liquidity(
-        &self,
-        _: impl Iterator<Item = &Liquidity> + Send + 'async_trait,
-    ) -> Result<Vec<Liquidity>> {
+impl OrderBookApi {
+    /// Returns a list of limit orders coming from the offchain orderbook API
+    async fn get_liquidity(&self) -> Result<Vec<LimitOrder>> {
         Ok(self
             .get_orders()
             .await
             .context("failed to get orderbook")?
             .into_iter()
-            .map(|order| Liquidity::Limit(order.order_creation.into()))
+            .map(|order| order.order_creation.into())
             .collect())
     }
 }

--- a/solver/src/liquidity/uniswap.rs
+++ b/solver/src/liquidity/uniswap.rs
@@ -1,0 +1,99 @@
+use anyhow::{Context, Result};
+use contracts::{GPv2Settlement, UniswapV2Factory, UniswapV2Router02};
+use model::TokenPair;
+use num_rational::Rational;
+use primitive_types::{H160, U256};
+use std::collections::{hash_map::Entry, HashMap};
+use std::sync::Arc;
+
+use crate::interactions::UniswapInteraction;
+use crate::settlement::Interaction;
+use crate::uniswap;
+use crate::uniswap::Pool;
+
+use super::{AmmOrder, AmmSettlementHandling, Liquidity, LiquiditySource};
+
+pub struct UniswapLiquidity {
+    inner: Arc<Inner>,
+}
+
+impl UniswapLiquidity {
+    pub fn new(
+        factory: UniswapV2Factory,
+        router: UniswapV2Router02,
+        gpv2_settlement: GPv2Settlement,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                factory,
+                router,
+                gpv2_settlement,
+            }),
+        }
+    }
+}
+
+struct Inner {
+    factory: UniswapV2Factory,
+    router: UniswapV2Router02,
+    gpv2_settlement: GPv2Settlement,
+}
+
+#[async_trait::async_trait]
+impl LiquiditySource for UniswapLiquidity {
+    async fn get_liquidity(
+        &self,
+        liquidity_so_far: impl Iterator<Item = &Liquidity> + Send + Sync + 'async_trait,
+    ) -> Result<Vec<Liquidity>> {
+        // TODO: include every token with ETH pair in the pools
+        let mut pools = HashMap::new();
+        for order in liquidity_so_far.filter_map(|l| match l {
+            Liquidity::Limit(order) => Some(order),
+            _ => None,
+        }) {
+            let pair =
+                TokenPair::new(order.buy_token, order.sell_token).expect("buy token = sell token");
+            let vacant = match pools.entry(pair) {
+                Entry::Occupied(_) => continue,
+                Entry::Vacant(vacant) => vacant,
+            };
+            let pool = match uniswap::Pool::from_token_pair(&self.inner.factory, &pair)
+                .await
+                .context("failed to get uniswap pool")?
+            {
+                None => continue,
+                Some(pool) => pool,
+            };
+            vacant.insert(pool);
+        }
+        Ok(pools
+            .values()
+            .map(|pool| pool_to_amm_order(pool, self.inner.clone()))
+            .map(Liquidity::Amm)
+            .collect())
+    }
+}
+
+impl AmmSettlementHandling for Inner {
+    fn settle(&self, input: (H160, U256), output: (H160, U256)) -> Vec<Box<dyn Interaction>> {
+        vec![Box::new(UniswapInteraction {
+            contract: self.router.clone(),
+            settlement: self.gpv2_settlement.clone(),
+            // TODO(fleupold) Only set allowance if we need to
+            set_allowance: true,
+            amount_in: input.1,
+            amount_out_min: output.1,
+            token_in: input.0,
+            token_out: output.0,
+        })]
+    }
+}
+
+fn pool_to_amm_order(pool: &Pool, settlement_handling: Arc<dyn AmmSettlementHandling>) -> AmmOrder {
+    AmmOrder {
+        tokens: pool.token_pair.get(),
+        reserves: (pool.reserve0, pool.reserve1),
+        fee: Rational::new_raw(3, 1000),
+        settlement_handling,
+    }
+}

--- a/solver/src/settlement.rs
+++ b/solver/src/settlement.rs
@@ -36,7 +36,7 @@ impl Trade {
     }
 }
 
-pub trait Interaction: std::fmt::Debug + Send + Sync {
+pub trait Interaction: std::fmt::Debug + Send {
     // TODO: not sure if this should return a result.
     // Write::write returns a result but we know we write to a vector in memory so we know it will
     // never fail. Then the question becomes whether interactions should be allowed to fail encoding

--- a/solver/src/settlement.rs
+++ b/solver/src/settlement.rs
@@ -26,9 +26,17 @@ impl Trade {
             fee_discount: 0,
         }
     }
+
+    pub fn matched(order: OrderCreation, executed_amount: U256) -> Self {
+        Self {
+            order,
+            executed_amount,
+            fee_discount: 0,
+        }
+    }
 }
 
-pub trait Interaction: std::fmt::Debug {
+pub trait Interaction: std::fmt::Debug + Send + Sync {
     // TODO: not sure if this should return a result.
     // Write::write returns a result but we know we write to a vector in memory so we know it will
     // never fail. Then the question becomes whether interactions should be allowed to fail encoding


### PR DESCRIPTION
Part of #194

This PR implements the two liquidity sources we support at the moment (offchain orderbook and uniswap) in the new architecture.

In the future I'd expect additional liquidity sources (e.g. SCP's RFQ system) to be separate implementations of the LiquiditySource trait.

### Test Plan
Unit tests in next PR
