### PR TITLE
[Refactoring 3] Using abstract liquidity in solver

### DIFF
--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -8,6 +8,7 @@ use model::{
 use orderbook::{orderbook::Orderbook, storage::InMemoryOrderBook};
 use secp256k1::SecretKey;
 use serde_json::json;
+use solver::liquidity::uniswap::UniswapLiquidity;
 use std::{str::FromStr, sync::Arc};
 use web3::signing::SecretKeyRef;
 
@@ -170,13 +171,22 @@ async fn test_with_ganache() {
         reqwest::Url::from_str(API_HOST).unwrap(),
         std::time::Duration::from_secs(10),
     );
+    let uniswap_liquidity = UniswapLiquidity::new(
+        uniswap_factory.clone(),
+        uniswap_router.clone(),
+        gp_settlement.clone(),
+    );
     let solver = solver::naive_solver::NaiveSolver {
         uniswap_router,
         uniswap_factory,
         gpv2_settlement: gp_settlement.clone(),
     };
-    let mut driver =
-        solver::driver::Driver::new(gp_settlement.clone(), orderbook_api, Box::new(solver));
+    let mut driver = solver::driver::Driver::new(
+        gp_settlement.clone(),
+        uniswap_liquidity,
+        orderbook_api,
+        Box::new(solver),
+    );
     driver.single_run().await.unwrap();
 
     // Check matching

--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -60,7 +60,7 @@ impl HttpSolver {
                     std::iter::once(order.sell_token).chain(std::iter::once(order.buy_token))
                 }
                 Liquidity::Amm(amm) => {
-                    std::iter::once(amm.tokens.0).chain(std::iter::once(amm.tokens.1))
+                    std::iter::once(amm.tokens.get().0).chain(std::iter::once(amm.tokens.get().1))
                 }
             })
             .collect::<HashSet<_>>()
@@ -106,8 +106,8 @@ impl HttpSolver {
             .enumerate()
             .map(|(index, amm)| {
                 let uniswap = UniswapModel {
-                    token1: self.token_to_string(&amm.tokens.0),
-                    token2: self.token_to_string(&amm.tokens.1),
+                    token1: self.token_to_string(&amm.tokens.get().0),
+                    token2: self.token_to_string(&amm.tokens.get().1),
                     balance1: amm.reserves.0,
                     balance2: amm.reserves.1,
                     // TODO use AMM fee

--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -1,14 +1,10 @@
-use crate::{settlement::Settlement, solver::Solver, uniswap};
+use crate::{liquidity::Liquidity, settlement::Settlement, solver::Solver};
 use anyhow::{Context, Result};
-use contracts::UniswapV2Factory;
-use model::{
-    order::{Order, OrderKind},
-    u256_decimal,
-};
+use model::{order::OrderKind, u256_decimal};
 use primitive_types::{H160, U256};
 use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize, Serializer};
-use std::collections::{hash_map::Entry, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
 /// The configuration passed as url parameters to the solver.
 #[derive(Debug, Default)]
@@ -34,16 +30,10 @@ pub struct HttpSolver {
     client: Client,
     api_key: Option<String>,
     config: SolverConfig,
-    uniswap: UniswapV2Factory,
 }
 
 impl HttpSolver {
-    pub fn new(
-        base: Url,
-        api_key: Option<String>,
-        config: SolverConfig,
-        uniswap: UniswapV2Factory,
-    ) -> Self {
+    pub fn new(base: Url, api_key: Option<String>, config: SolverConfig) -> Self {
         // Unwrap because we cannot handle client creation failing.
         let client = Client::builder().build().unwrap();
         Self {
@@ -51,7 +41,6 @@ impl HttpSolver {
             client,
             api_key,
             config,
-            uniswap,
         }
     }
 
@@ -63,12 +52,16 @@ impl HttpSolver {
         format!("t{:x}", token)
     }
 
-    fn tokens(&self, orders: &[Order]) -> HashMap<String, TokenInfoModel> {
+    fn tokens(&self, orders: &[Liquidity]) -> HashMap<String, TokenInfoModel> {
         orders
             .iter()
-            .flat_map(|order| {
-                let order = order.order_creation;
-                std::iter::once(order.sell_token).chain(std::iter::once(order.buy_token))
+            .flat_map(|liquidity| match liquidity {
+                Liquidity::Limit(order) => {
+                    std::iter::once(order.sell_token).chain(std::iter::once(order.buy_token))
+                }
+                Liquidity::Amm(amm) => {
+                    std::iter::once(amm.tokens.0).chain(std::iter::once(amm.tokens.1))
+                }
             })
             .collect::<HashSet<_>>()
             .into_iter()
@@ -80,12 +73,15 @@ impl HttpSolver {
             .collect()
     }
 
-    fn orders(&self, orders: &[Order]) -> HashMap<String, OrderModel> {
+    fn orders(&self, orders: &[Liquidity]) -> HashMap<String, OrderModel> {
         orders
             .iter()
+            .filter_map(|liquidity| match liquidity {
+                Liquidity::Limit(order) => Some(order),
+                Liquidity::Amm(_) => None,
+            })
             .enumerate()
             .map(|(index, order)| {
-                let order = order.order_creation;
                 let order = OrderModel {
                     sell_token: self.token_to_string(&order.sell_token),
                     buy_token: self.token_to_string(&order.buy_token),
@@ -99,41 +95,31 @@ impl HttpSolver {
             .collect()
     }
 
-    async fn uniswaps(&self, orders: &[Order]) -> Result<HashMap<String, UniswapModel>> {
+    async fn uniswaps(&self, orders: &[Liquidity]) -> Result<HashMap<String, UniswapModel>> {
         // TODO: use a cache
-        // TODO: include every token with ETH pair in the pools
-        let mut uniswaps = HashMap::new();
-        for order in orders {
-            let pair = order.order_creation.token_pair().expect("invalid order");
-            let vacant = match uniswaps.entry(pair) {
-                Entry::Occupied(_) => continue,
-                Entry::Vacant(vacant) => vacant,
-            };
-            let pool = match uniswap::Pool::from_token_pair(&self.uniswap, &pair)
-                .await
-                .context("failed to get uniswap pool")?
-            {
-                None => continue,
-                Some(pool) => pool,
-            };
-            let uniswap = UniswapModel {
-                token1: self.token_to_string(&pool.token_pair.get().0),
-                token2: self.token_to_string(&pool.token_pair.get().1),
-                balance1: pool.reserve0,
-                balance2: pool.reserve1,
-                fee: 0.003,
-                mandatory: false,
-            };
-            vacant.insert(uniswap);
-        }
-        Ok(uniswaps
-            .into_iter()
+        Ok(orders
+            .iter()
+            .filter_map(|liquidity| match liquidity {
+                Liquidity::Limit(_) => None,
+                Liquidity::Amm(amm) => Some(amm),
+            })
             .enumerate()
-            .map(|(index, (_token_pair, uniswap))| (index.to_string(), uniswap))
+            .map(|(index, amm)| {
+                let uniswap = UniswapModel {
+                    token1: self.token_to_string(&amm.tokens.0),
+                    token2: self.token_to_string(&amm.tokens.1),
+                    balance1: amm.reserves.0,
+                    balance2: amm.reserves.1,
+                    // TODO use AMM fee
+                    fee: 0.003,
+                    mandatory: false,
+                };
+                (index.to_string(), uniswap)
+            })
             .collect())
     }
 
-    async fn create_body(&self, orders: &[Order]) -> Result<BatchAuctionModel> {
+    async fn create_body(&self, orders: &[Liquidity]) -> Result<BatchAuctionModel> {
         Ok(BatchAuctionModel {
             tokens: self.tokens(orders),
             orders: self.orders(orders),
@@ -146,7 +132,7 @@ impl HttpSolver {
 
 #[async_trait::async_trait]
 impl Solver for HttpSolver {
-    async fn solve(&self, orders: Vec<Order>) -> Result<Option<Settlement>> {
+    async fn solve(&self, orders: Vec<Liquidity>) -> Result<Option<Settlement>> {
         let mut url = self.base.clone();
         url.set_path("/solve");
         self.config.add_to_query(&mut url);
@@ -233,7 +219,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use model::order::{OrderCreation, OrderMetaData};
+    use crate::liquidity::{LimitOrder, MockLimitOrderSettlementHandling};
+    use std::sync::Arc;
 
     use super::*;
 
@@ -244,10 +231,6 @@ mod tests {
         tracing_subscriber::fmt::fmt()
             .with_env_filter("debug")
             .init();
-        let node_url = "https://dev-openethereum.mainnet.gnosisdev.com";
-        let transport = web3::transports::Http::new(node_url).unwrap();
-        let web3 = web3::Web3::new(transport);
-        let uniswap = contracts::UniswapV2Factory::deployed(&web3).await.unwrap();
         let solver = HttpSolver::new(
             "http://localhost:8000".parse().unwrap(),
             None,
@@ -255,17 +238,16 @@ mod tests {
                 max_nr_exec_orders: 100,
                 time_limit: 100,
             },
-            uniswap,
         );
-        let orders = vec![Order {
-            order_meta_data: OrderMetaData::default(),
-            order_creation: OrderCreation {
-                sell_token: H160::from_low_u64_be(1),
-                buy_amount: 1.into(),
-                sell_amount: 1.into(),
-                ..Default::default()
-            },
-        }];
+        let orders = vec![Liquidity::Limit(LimitOrder {
+            buy_token: H160::zero(),
+            sell_token: H160::from_low_u64_be(1),
+            buy_amount: 1.into(),
+            sell_amount: 1.into(),
+            kind: OrderKind::Sell,
+            partially_fillable: false,
+            settlement_handling: Arc::new(MockLimitOrderSettlementHandling::new()),
+        })];
         solver.solve(orders).await.unwrap();
     }
 }

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use model::{order::OrderKind, TokenPair};
 use num_rational::Rational;
 use primitive_types::{H160, U256};

--- a/solver/src/liquidity/offchain_orderbook.rs
+++ b/solver/src/liquidity/offchain_orderbook.rs
@@ -9,7 +9,7 @@ use super::{LimitOrder, LimitOrderSettlementHandling};
 
 impl OrderBookApi {
     /// Returns a list of limit orders coming from the offchain orderbook API
-    async fn get_liquidity(&self) -> Result<Vec<LimitOrder>> {
+    pub async fn get_liquidity(&self) -> Result<Vec<LimitOrder>> {
         Ok(self
             .get_orders()
             .await

--- a/solver/src/liquidity/uniswap.rs
+++ b/solver/src/liquidity/uniswap.rs
@@ -39,7 +39,7 @@ impl UniswapLiquidity {
     }
 
     /// Given a list of offchain orders returns the list of AMM liquidity to be considered
-    async fn get_liquidity(
+    pub async fn get_liquidity(
         &self,
         offchain_orders: impl Iterator<Item = &LimitOrder> + Send + Sync,
     ) -> Result<Vec<AmmOrder>> {

--- a/solver/src/naive_solver.rs
+++ b/solver/src/naive_solver.rs
@@ -1,11 +1,14 @@
 mod multi_order_solver;
 mod single_pair_settlement;
 
-use self::single_pair_settlement::SinglePairSettlement;
-use crate::{settlement::Settlement, solver::Solver, uniswap::Pool};
+use crate::{
+    liquidity::{AmmOrder, LimitOrder, Liquidity},
+    settlement::Settlement,
+    solver::Solver,
+};
 use anyhow::Result;
 use contracts::{GPv2Settlement, UniswapV2Factory, UniswapV2Router02};
-use model::{order::OrderCreation, TokenPair};
+use model::TokenPair;
 use std::collections::HashMap;
 
 pub struct NaiveSolver {
@@ -16,30 +19,34 @@ pub struct NaiveSolver {
 
 #[async_trait::async_trait]
 impl Solver for NaiveSolver {
-    async fn solve(&self, orders: Vec<model::order::Order>) -> Result<Option<Settlement>> {
-        Ok(settle(
-            orders.into_iter().map(|order| order.order_creation),
-            &self.uniswap_router,
-            &self.uniswap_factory,
-            &self.gpv2_settlement,
-        )
-        .await)
+    async fn solve(&self, liquidity: Vec<Liquidity>) -> Result<Option<Settlement>> {
+        let mut limit_orders = Vec::new();
+        let mut uniswaps = HashMap::new();
+        for liquidity in liquidity {
+            match liquidity {
+                Liquidity::Limit(order) => limit_orders.push(order),
+                Liquidity::Amm(uniswap) => {
+                    let pair = uniswap.tokens;
+                    uniswaps.insert(
+                        TokenPair::new(pair.0, pair.1).expect("Invalid Pair"),
+                        uniswap,
+                    );
+                }
+            }
+        }
+        Ok(settle(limit_orders.into_iter(), uniswaps).await)
     }
 }
 
 async fn settle(
-    orders: impl Iterator<Item = OrderCreation>,
-    uniswap_router: &UniswapV2Router02,
-    uniswap_factory: &UniswapV2Factory,
-    gpv2_settlement: &GPv2Settlement,
+    orders: impl Iterator<Item = LimitOrder>,
+    uniswaps: HashMap<TokenPair, AmmOrder>,
 ) -> Option<Settlement> {
     let orders = organize_orders_by_token_pair(orders);
     // TODO: Settle multiple token pairs in one settlement.
     for (pair, orders) in orders {
-        if let Some(settlement) = settle_pair(pair, orders, &uniswap_factory).await {
-            return Some(
-                settlement.into_settlement(uniswap_router.clone(), gpv2_settlement.clone()),
-            );
+        if let Some(settlement) = settle_pair(pair, orders, &uniswaps).await {
+            return Some(settlement);
         }
     }
     None
@@ -47,32 +54,32 @@ async fn settle(
 
 async fn settle_pair(
     pair: TokenPair,
-    orders: Vec<OrderCreation>,
-    factory: &UniswapV2Factory,
-) -> Option<SinglePairSettlement> {
-    let pool = match Pool::from_token_pair(factory, &pair).await {
-        Ok(pool) => pool,
-        Err(err) => {
-            tracing::warn!("Error getting AMM reserves: {}", err);
+    orders: Vec<LimitOrder>,
+    uniswaps: &HashMap<TokenPair, AmmOrder>,
+) -> Option<Settlement> {
+    let uniswap = match uniswaps.get(&pair) {
+        Some(uniswap) => uniswap,
+        None => {
+            tracing::warn!("No AMM for: {:?}", pair);
             return None;
         }
-    }?;
-    Some(multi_order_solver::solve(orders.into_iter(), &pool))
+    };
+    Some(multi_order_solver::solve(orders.into_iter(), &uniswap))
 }
 
 fn organize_orders_by_token_pair(
-    orders: impl Iterator<Item = OrderCreation>,
-) -> HashMap<TokenPair, Vec<OrderCreation>> {
-    let mut result = HashMap::<_, Vec<OrderCreation>>::new();
-    for (order, token_pair) in orders
-        .filter(usable_order)
-        .filter_map(|order| Some((order, order.token_pair()?)))
-    {
+    orders: impl Iterator<Item = LimitOrder>,
+) -> HashMap<TokenPair, Vec<LimitOrder>> {
+    let mut result = HashMap::<_, Vec<LimitOrder>>::new();
+    for (order, token_pair) in orders.filter(usable_order).filter_map(|order| {
+        let pair = TokenPair::new(order.buy_token, order.sell_token)?;
+        Some((order, pair))
+    }) {
         result.entry(token_pair).or_default().push(order);
     }
     result
 }
 
-fn usable_order(order: &OrderCreation) -> bool {
+fn usable_order(order: &LimitOrder) -> bool {
     !order.sell_amount.is_zero() && !order.buy_amount.is_zero()
 }

--- a/solver/src/naive_solver.rs
+++ b/solver/src/naive_solver.rs
@@ -28,7 +28,7 @@ impl Solver for NaiveSolver {
                 Liquidity::Amm(uniswap) => {
                     let pair = uniswap.tokens;
                     uniswaps.insert(
-                        TokenPair::new(pair.0, pair.1).expect("Invalid Pair"),
+                        TokenPair::new(pair.get().0, pair.get().1).expect("Invalid Pair"),
                         uniswap,
                     );
                 }

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -1,7 +1,10 @@
-use super::single_pair_settlement::{AmmSwapExactTokensForTokens, SinglePairSettlement};
-use crate::{settlement::Trade, uniswap::Pool};
+use crate::{
+    liquidity,
+    settlement::{Interaction, Settlement, Trade},
+};
 use anyhow::{anyhow, Result};
-use model::order::{OrderCreation, OrderKind};
+use liquidity::{AmmOrder, LimitOrder};
+use model::order::OrderKind;
 use num::{bigint::Sign, BigInt};
 use std::collections::HashMap;
 use web3::types::{Address, U256};
@@ -14,6 +17,7 @@ struct TokenContext {
     sell_volume: U256,
 }
 
+// TODO use concrete fee from AMMOrder
 impl TokenContext {
     pub fn is_excess_after_fees(&self, deficit: &TokenContext) -> bool {
         1000 * u256_to_bigint(&self.reserve)
@@ -31,14 +35,11 @@ impl TokenContext {
     }
 }
 
-pub fn solve(
-    orders: impl Iterator<Item = OrderCreation> + Clone,
-    pool: &Pool,
-) -> SinglePairSettlement {
-    let mut orders: Vec<OrderCreation> = orders.collect();
+pub fn solve(orders: impl Iterator<Item = LimitOrder> + Clone, pool: &AmmOrder) -> Settlement {
+    let mut orders: Vec<LimitOrder> = orders.collect();
     while !orders.is_empty() {
         let (context_a, context_b) = split_into_contexts(orders.clone().into_iter(), pool);
-        let solution = solve_orders(orders.clone().into_iter(), &context_a, &context_b);
+        let solution = solve_orders(orders.clone().into_iter(), &pool, &context_a, &context_b);
         if is_valid_solution(&solution) {
             return solution;
         } else {
@@ -64,10 +65,11 @@ pub fn solve(
     }
 
     // At last we return the trivial solution which doesn't match any orders
-    SinglePairSettlement {
+    Settlement {
         clearing_prices: HashMap::new(),
         trades: Vec::new(),
-        interaction: None,
+        interactions: Vec::new(),
+        ..Default::default()
     }
 }
 
@@ -77,14 +79,15 @@ pub fn solve(
 /// for that pair is not available.
 ///
 fn solve_orders(
-    orders: impl Iterator<Item = OrderCreation> + Clone,
+    orders: impl Iterator<Item = LimitOrder> + Clone,
+    pool: &AmmOrder,
     context_a: &TokenContext,
     context_b: &TokenContext,
-) -> SinglePairSettlement {
+) -> Settlement {
     if context_a.is_excess_after_fees(&context_b) {
-        solve_with_uniswap(orders, &context_b, &context_a)
+        solve_with_uniswap(orders, pool, &context_b, &context_a)
     } else if context_b.is_excess_after_fees(&context_a) {
-        solve_with_uniswap(orders, &context_a, &context_b)
+        solve_with_uniswap(orders, pool, &context_a, &context_b)
     } else {
         solve_without_uniswap(orders, &context_a, &context_b)
     }
@@ -94,17 +97,19 @@ fn solve_orders(
 /// Creates a solution using the current AMM spot price, without using any of its liquidity
 ///
 fn solve_without_uniswap(
-    orders: impl Iterator<Item = OrderCreation> + Clone,
+    orders: impl Iterator<Item = LimitOrder> + Clone,
     context_a: &TokenContext,
     context_b: &TokenContext,
-) -> SinglePairSettlement {
-    SinglePairSettlement {
+) -> Settlement {
+    let (trades, interactions) = fully_matched(orders);
+    Settlement {
         clearing_prices: maplit::hashmap! {
             context_a.address => context_b.reserve,
             context_b.address => context_a.reserve,
         },
-        trades: orders.into_iter().map(Trade::fully_matched).collect(),
-        interaction: None,
+        trades,
+        interactions,
+        ..Default::default()
     }
 }
 
@@ -113,31 +118,64 @@ fn solve_without_uniswap(
 /// The clearing price is the effective exchange rate used by the AMM interaction.
 ///
 fn solve_with_uniswap(
-    orders: impl Iterator<Item = OrderCreation> + Clone,
+    orders: impl Iterator<Item = LimitOrder> + Clone,
+    pool: &AmmOrder,
     shortage: &TokenContext,
     excess: &TokenContext,
-) -> SinglePairSettlement {
+) -> Settlement {
     let uniswap_out = compute_uniswap_out(&shortage, &excess);
     let uniswap_in = compute_uniswap_in(uniswap_out, &shortage, &excess);
-    let interaction = Some(AmmSwapExactTokensForTokens {
-        amount_in: uniswap_in,
-        amount_out_min: uniswap_out,
-        token_in: excess.address,
-        token_out: shortage.address,
-    });
-    SinglePairSettlement {
+
+    let (trades, mut interactions) = fully_matched(orders);
+    interactions.extend(pool.settlement_handling.settle(
+        (excess.address, uniswap_in),
+        (shortage.address, uniswap_out),
+    ));
+    Settlement {
         clearing_prices: maplit::hashmap! {
             shortage.address => uniswap_in,
             excess.address => uniswap_out,
         },
-        trades: orders.into_iter().map(Trade::fully_matched).collect(),
-        interaction,
+        trades,
+        interactions,
+        ..Default::default()
+    }
+}
+
+fn fully_matched(
+    orders: impl Iterator<Item = LimitOrder> + Clone,
+) -> (Vec<Trade>, Vec<Box<dyn Interaction>>) {
+    let mut trades = Vec::new();
+    let mut interactions = Vec::new();
+    for order in orders {
+        let executed_amount = match order.kind {
+            model::order::OrderKind::Buy => order.buy_amount,
+            model::order::OrderKind::Sell => order.sell_amount,
+        };
+        let (trade, trade_interactions) = order.settlement_handling.settle(executed_amount);
+        if let Some(trade) = trade {
+            trades.push(trade)
+        }
+        interactions.extend(trade_interactions);
+    }
+    (trades, interactions)
+}
+
+impl AmmOrder {
+    fn get_reserve(&self, token: &Address) -> Option<U256> {
+        if &self.tokens.0 == token {
+            Some(self.reserves.0.into())
+        } else if &self.tokens.1 == token {
+            Some(self.reserves.1.into())
+        } else {
+            None
+        }
     }
 }
 
 fn split_into_contexts(
-    orders: impl Iterator<Item = OrderCreation>,
-    pool: &Pool,
+    orders: impl Iterator<Item = LimitOrder>,
+    pool: &AmmOrder,
 ) -> (TokenContext, TokenContext) {
     let mut contexts = HashMap::new();
     for order in orders {
@@ -147,8 +185,7 @@ fn split_into_contexts(
                 address: order.buy_token,
                 reserve: pool
                     .get_reserve(&order.buy_token)
-                    .unwrap_or_else(|| panic!("No reserve for token {}", &order.buy_token))
-                    .into(),
+                    .unwrap_or_else(|| panic!("No reserve for token {}", &order.buy_token)),
                 buy_volume: U256::zero(),
                 sell_volume: U256::zero(),
             });
@@ -162,8 +199,7 @@ fn split_into_contexts(
                 address: order.sell_token,
                 reserve: pool
                     .get_reserve(&order.sell_token)
-                    .unwrap_or_else(|| panic!("No reserve for token {}", &order.sell_token))
-                    .into(),
+                    .unwrap_or_else(|| panic!("No reserve for token {}", &order.sell_token)),
                 buy_volume: U256::zero(),
                 sell_volume: U256::zero(),
             });
@@ -209,7 +245,7 @@ fn compute_uniswap_in(out: U256, shortage: &TokenContext, excess: &TokenContext)
 /// Returns true if for each trade the executed price is not smaller than the limit price
 /// Thus we ensure that `buy_token_price / sell_token_price >= limit_buy_amount / limit_sell_amount`
 ///
-fn is_valid_solution(solution: &SinglePairSettlement) -> bool {
+fn is_valid_solution(solution: &Settlement) -> bool {
     for trade in solution.trades.iter() {
         let order = trade.order;
         let buy_token_price = solution
@@ -248,7 +284,12 @@ fn bigint_to_u256(input: &BigInt) -> Result<U256> {
 
 #[cfg(test)]
 mod tests {
-    use model::TokenPair;
+    use liquidity::{
+        AmmSettlementHandling, LimitOrderSettlementHandling, MockLimitOrderSettlementHandling,
+    };
+    use model::order::OrderCreation;
+    use num::Rational;
+    use std::sync::{Arc, Mutex};
 
     use super::*;
 
@@ -256,46 +297,84 @@ mod tests {
         U256::from(base) * U256::from(10).pow(18.into())
     }
 
+    fn noop_limit_order_handling() -> Arc<dyn LimitOrderSettlementHandling> {
+        let mut limit_order_handling = MockLimitOrderSettlementHandling::new();
+        limit_order_handling
+            .expect_settle()
+            .returning(|_| (None, Vec::new()));
+        Arc::new(limit_order_handling)
+    }
+
+    #[derive(Clone, Copy)]
+    struct AmmSettlement {
+        token_in: Address,
+        token_out: Address,
+        amount_in: U256,
+        amount_out: U256,
+    }
+
+    #[derive(Default)]
+    struct AmmSettlementHandler {
+        settlement: Mutex<Option<AmmSettlement>>,
+    }
+
+    impl AmmSettlementHandling for AmmSettlementHandler {
+        fn settle(
+            &self,
+            input: (Address, U256),
+            output: (Address, U256),
+        ) -> Vec<Box<dyn Interaction>> {
+            self.settlement.lock().unwrap().replace(AmmSettlement {
+                token_in: input.0,
+                token_out: output.0,
+                amount_in: input.1,
+                amount_out: input.1,
+            });
+            Vec::new()
+        }
+    }
+
     #[test]
     fn finds_clearing_price_with_sell_orders_on_both_sides() {
         let token_a = Address::from_low_u64_be(0);
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
-            OrderCreation {
+            LimitOrder {
                 sell_token: token_a,
                 buy_token: token_b,
                 sell_amount: to_wei(40),
                 buy_amount: to_wei(30),
                 kind: OrderKind::Sell,
                 partially_fillable: false,
-                ..Default::default()
+                settlement_handling: noop_limit_order_handling(),
             },
-            OrderCreation {
+            LimitOrder {
                 sell_token: token_b,
                 buy_token: token_a,
                 sell_amount: to_wei(100),
                 buy_amount: to_wei(90),
                 kind: OrderKind::Sell,
                 partially_fillable: false,
-                ..Default::default()
+                settlement_handling: noop_limit_order_handling(),
             },
         ];
 
-        let pool = Pool {
-            token_pair: TokenPair::new(token_a, token_b).unwrap(),
-            reserve0: to_wei(1000).as_u128(),
-            reserve1: to_wei(1000).as_u128(),
-            address: Default::default(),
+        let amm_handler = Arc::new(AmmSettlementHandler::default());
+        let pool = AmmOrder {
+            tokens: (token_a, token_b),
+            reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
+            fee: Rational::new(3, 1000),
+            settlement_handling: amm_handler.clone(),
         };
         let result = solve(orders.clone().into_iter(), &pool);
 
         // Make sure the uniswap interaction is using the correct direction
-        let interaction = result.interaction.unwrap();
+        let interaction = amm_handler.settlement.lock().unwrap().unwrap();
         assert_eq!(interaction.token_in, token_b);
         assert_eq!(interaction.token_out, token_a);
 
         // Make sure the sell amounts +/- uniswap interaction satisfy min_buy amounts
-        assert!(orders[0].sell_amount + interaction.amount_out_min >= orders[1].buy_amount);
+        assert!(orders[0].sell_amount + interaction.amount_out >= orders[1].buy_amount);
         assert!(orders[1].sell_amount - interaction.amount_in > orders[0].buy_amount);
 
         // Make sure the sell amounts +/- uniswap interaction satisfy expected buy amounts given clearing price
@@ -308,7 +387,7 @@ mod tests {
         assert!(orders[1].sell_amount - interaction.amount_in >= expected_buy);
 
         let expected_buy = orders[1].sell_amount * price_b / price_a;
-        assert!(orders[0].sell_amount + interaction.amount_out_min >= expected_buy);
+        assert!(orders[0].sell_amount + interaction.amount_out >= expected_buy);
     }
 
     #[test]
@@ -316,42 +395,43 @@ mod tests {
         let token_a = Address::from_low_u64_be(0);
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
-            OrderCreation {
+            LimitOrder {
                 sell_token: token_a,
                 buy_token: token_b,
                 sell_amount: to_wei(40),
                 buy_amount: to_wei(30),
                 kind: OrderKind::Sell,
                 partially_fillable: false,
-                ..Default::default()
+                settlement_handling: noop_limit_order_handling(),
             },
-            OrderCreation {
+            LimitOrder {
                 sell_token: token_a,
                 buy_token: token_b,
                 sell_amount: to_wei(100),
                 buy_amount: to_wei(90),
                 kind: OrderKind::Sell,
                 partially_fillable: false,
-                ..Default::default()
+                settlement_handling: noop_limit_order_handling(),
             },
         ];
 
-        let pool = Pool {
-            token_pair: TokenPair::new(token_a, token_b).unwrap(),
-            reserve0: to_wei(1_000_000).as_u128(),
-            reserve1: to_wei(1_000_000).as_u128(),
-            address: Default::default(),
+        let amm_handler = Arc::new(AmmSettlementHandler::default());
+        let pool = AmmOrder {
+            tokens: (token_a, token_b),
+            reserves: (to_wei(1_000_000).as_u128(), to_wei(1_000_000).as_u128()),
+            fee: Rational::new(3, 1000),
+            settlement_handling: amm_handler.clone(),
         };
         let result = solve(orders.clone().into_iter(), &pool);
 
         // Make sure the uniswap interaction is using the correct direction
-        let interaction = result.interaction.unwrap();
+        let interaction = amm_handler.settlement.lock().unwrap().unwrap();
         assert_eq!(interaction.token_in, token_a);
         assert_eq!(interaction.token_out, token_b);
 
         // Make sure the sell amounts cover the uniswap in, and min buy amounts are covered by uniswap out
         assert!(orders[0].sell_amount + orders[1].sell_amount >= interaction.amount_in);
-        assert!(interaction.amount_out_min >= orders[0].buy_amount + orders[1].buy_amount);
+        assert!(interaction.amount_out >= orders[0].buy_amount + orders[1].buy_amount);
 
         // Make sure expected buy amounts (given prices) are also covered by uniswap out amounts
         let price_a = result.clearing_prices.get(&token_a).unwrap();
@@ -359,7 +439,7 @@ mod tests {
 
         let first_expected_buy = orders[0].sell_amount * price_a / price_b;
         let second_expected_buy = orders[1].sell_amount * price_a / price_b;
-        assert!(interaction.amount_out_min >= first_expected_buy + second_expected_buy);
+        assert!(interaction.amount_out >= first_expected_buy + second_expected_buy);
     }
 
     #[test]
@@ -367,41 +447,42 @@ mod tests {
         let token_a = Address::from_low_u64_be(0);
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
-            OrderCreation {
+            LimitOrder {
                 sell_token: token_a,
                 buy_token: token_b,
                 sell_amount: to_wei(40),
                 buy_amount: to_wei(30),
                 kind: OrderKind::Buy,
                 partially_fillable: false,
-                ..Default::default()
+                settlement_handling: noop_limit_order_handling(),
             },
-            OrderCreation {
+            LimitOrder {
                 sell_token: token_b,
                 buy_token: token_a,
                 sell_amount: to_wei(100),
                 buy_amount: to_wei(90),
                 kind: OrderKind::Buy,
                 partially_fillable: false,
-                ..Default::default()
+                settlement_handling: noop_limit_order_handling(),
             },
         ];
 
-        let pool = Pool {
-            token_pair: TokenPair::new(token_a, token_b).unwrap(),
-            reserve0: to_wei(1000).as_u128(),
-            reserve1: to_wei(1000).as_u128(),
-            address: Default::default(),
+        let amm_handler = Arc::new(AmmSettlementHandler::default());
+        let pool = AmmOrder {
+            tokens: (token_a, token_b),
+            reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
+            fee: Rational::new(3, 1000),
+            settlement_handling: amm_handler.clone(),
         };
         let result = solve(orders.clone().into_iter(), &pool);
 
         // Make sure the uniswap interaction is using the correct direction
-        let interaction = result.interaction.unwrap();
+        let interaction = amm_handler.settlement.lock().unwrap().unwrap();
         assert_eq!(interaction.token_in, token_b);
         assert_eq!(interaction.token_out, token_a);
 
         // Make sure the buy amounts +/- uniswap interaction satisfy max_sell amounts
-        assert!(orders[0].sell_amount >= orders[1].buy_amount - interaction.amount_out_min);
+        assert!(orders[0].sell_amount >= orders[1].buy_amount - interaction.amount_out);
         assert!(orders[1].sell_amount >= orders[0].buy_amount + interaction.amount_in);
 
         // Make sure buy sell amounts +/- uniswap interaction satisfy expected sell amounts given clearing price
@@ -414,7 +495,7 @@ mod tests {
         assert!(orders[1].buy_amount - interaction.amount_in <= expected_sell);
 
         let expected_sell = orders[1].buy_amount * price_a / price_b;
-        assert!(orders[0].buy_amount + interaction.amount_out_min <= expected_sell);
+        assert!(orders[0].buy_amount + interaction.amount_out <= expected_sell);
     }
 
     #[test]
@@ -422,41 +503,42 @@ mod tests {
         let token_a = Address::from_low_u64_be(0);
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
-            OrderCreation {
+            LimitOrder {
                 sell_token: token_a,
                 buy_token: token_b,
                 sell_amount: to_wei(40),
                 buy_amount: to_wei(30),
                 kind: OrderKind::Buy,
                 partially_fillable: false,
-                ..Default::default()
+                settlement_handling: noop_limit_order_handling(),
             },
-            OrderCreation {
+            LimitOrder {
                 sell_token: token_b,
                 buy_token: token_a,
                 sell_amount: to_wei(100),
                 buy_amount: to_wei(90),
                 kind: OrderKind::Sell,
                 partially_fillable: false,
-                ..Default::default()
+                settlement_handling: noop_limit_order_handling(),
             },
         ];
 
-        let pool = Pool {
-            token_pair: TokenPair::new(token_a, token_b).unwrap(),
-            reserve0: to_wei(1000).as_u128(),
-            reserve1: to_wei(1000).as_u128(),
-            address: Default::default(),
+        let amm_handler = Arc::new(AmmSettlementHandler::default());
+        let pool = AmmOrder {
+            tokens: (token_a, token_b),
+            reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
+            fee: Rational::new(3, 1000),
+            settlement_handling: amm_handler.clone(),
         };
         let result = solve(orders.clone().into_iter(), &pool);
 
         // Make sure the uniswap interaction is using the correct direction
-        let interaction = result.interaction.unwrap();
+        let interaction = amm_handler.settlement.lock().unwrap().unwrap();
         assert_eq!(interaction.token_in, token_b);
         assert_eq!(interaction.token_out, token_a);
 
         // Make sure the buy order's sell amount - uniswap interaction satisfies sell order's limit
-        assert!(orders[0].sell_amount >= orders[1].buy_amount - interaction.amount_out_min);
+        assert!(orders[0].sell_amount >= orders[1].buy_amount - interaction.amount_out);
 
         // Make sure the sell order's buy amount + uniswap interaction satisfies buy order's limit
         assert!(orders[1].buy_amount + interaction.amount_in >= orders[0].sell_amount);
@@ -473,7 +555,7 @@ mod tests {
         // Multiplying sell_amount with priceA, gives us sell value in "$", divided by priceB gives us value in buy token
         // We should have at least as much to give (sell amount + uniswap out) as is expected by the buyer
         let expected_buy = orders[1].sell_amount * price_b / price_a;
-        assert!(orders[0].sell_amount + interaction.amount_out_min >= expected_buy);
+        assert!(orders[0].sell_amount + interaction.amount_out >= expected_buy);
     }
 
     #[test]
@@ -481,34 +563,35 @@ mod tests {
         let token_a = Address::from_low_u64_be(0);
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
-            OrderCreation {
+            LimitOrder {
                 sell_token: token_a,
                 buy_token: token_b,
                 sell_amount: to_wei(1001),
                 buy_amount: to_wei(1000),
                 kind: OrderKind::Sell,
                 partially_fillable: false,
-                ..Default::default()
+                settlement_handling: noop_limit_order_handling(),
             },
-            OrderCreation {
+            LimitOrder {
                 sell_token: token_b,
                 buy_token: token_a,
                 sell_amount: to_wei(1001),
                 buy_amount: to_wei(1000),
                 kind: OrderKind::Sell,
                 partially_fillable: false,
-                ..Default::default()
+                settlement_handling: noop_limit_order_handling(),
             },
         ];
 
-        let pool = Pool {
-            token_pair: TokenPair::new(token_a, token_b).unwrap(),
-            reserve0: to_wei(1_000_001).as_u128(),
-            reserve1: to_wei(1_000_000).as_u128(),
-            address: Default::default(),
+        let amm_handler = Arc::new(AmmSettlementHandler::default());
+        let pool = AmmOrder {
+            tokens: (token_a, token_b),
+            reserves: (to_wei(1_000_001).as_u128(), to_wei(1_000_000).as_u128()),
+            fee: Rational::new(3, 1000),
+            settlement_handling: amm_handler.clone(),
         };
         let result = solve(orders.into_iter(), &pool);
-        assert_eq!(result.interaction, None);
+        assert!(amm_handler.settlement.lock().unwrap().is_none());
         assert_eq!(
             result.clearing_prices,
             maplit::hashmap! {
@@ -532,7 +615,8 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 ..Default::default()
-            },
+            }
+            .into(),
             // Reasonable order a -> b
             OrderCreation {
                 sell_token: token_a,
@@ -542,7 +626,8 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 ..Default::default()
-            },
+            }
+            .into(),
             // Reasonable order b -> a
             OrderCreation {
                 sell_token: token_b,
@@ -552,7 +637,8 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 ..Default::default()
-            },
+            }
+            .into(),
             // Unreasonable order b -> a
             OrderCreation {
                 sell_token: token_b,
@@ -562,14 +648,16 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 ..Default::default()
-            },
+            }
+            .into(),
         ];
 
-        let pool = Pool {
-            token_pair: TokenPair::new(token_a, token_b).unwrap(),
-            reserve0: to_wei(1_000_000).as_u128(),
-            reserve1: to_wei(1_000_000).as_u128(),
-            address: Default::default(),
+        let amm_handler = Arc::new(AmmSettlementHandler::default());
+        let pool = AmmOrder {
+            tokens: (token_a, token_b),
+            reserves: (to_wei(1_000_000).as_u128(), to_wei(1_000_000).as_u128()),
+            fee: Rational::new(3, 1000),
+            settlement_handling: amm_handler,
         };
         let result = solve(orders.into_iter(), &pool);
 
@@ -582,31 +670,32 @@ mod tests {
         let token_a = Address::from_low_u64_be(0);
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
-            OrderCreation {
+            LimitOrder {
                 sell_token: token_a,
                 buy_token: token_b,
                 sell_amount: to_wei(900),
                 buy_amount: to_wei(1000),
                 kind: OrderKind::Sell,
                 partially_fillable: false,
-                ..Default::default()
+                settlement_handling: noop_limit_order_handling(),
             },
-            OrderCreation {
+            LimitOrder {
                 sell_token: token_b,
                 buy_token: token_a,
                 sell_amount: to_wei(900),
                 buy_amount: to_wei(1000),
                 kind: OrderKind::Sell,
                 partially_fillable: false,
-                ..Default::default()
+                settlement_handling: noop_limit_order_handling(),
             },
         ];
 
-        let pool = Pool {
-            token_pair: TokenPair::new(token_a, token_b).unwrap(),
-            reserve0: to_wei(1_000_001).as_u128(),
-            reserve1: to_wei(1_000_000).as_u128(),
-            address: Default::default(),
+        let amm_handler = Arc::new(AmmSettlementHandler::default());
+        let pool = AmmOrder {
+            tokens: (token_a, token_b),
+            reserves: (to_wei(1_000_001).as_u128(), to_wei(1_000_000).as_u128()),
+            fee: Rational::new(3, 1000),
+            settlement_handling: amm_handler,
         };
         let result = solve(orders.into_iter(), &pool);
         assert_eq!(result.trades.len(), 0);
@@ -639,81 +728,86 @@ mod tests {
 
         // Price in the middle is ok
         assert_eq!(
-            is_valid_solution(&SinglePairSettlement {
+            is_valid_solution(&Settlement {
                 clearing_prices: maplit::hashmap! {
                     token_a => to_wei(1),
                     token_b => to_wei(1)
                 },
-                interaction: None,
+                interactions: Vec::new(),
                 trades: orders
                     .clone()
                     .into_iter()
                     .map(Trade::fully_matched)
-                    .collect()
+                    .collect(),
+                ..Default::default()
             }),
             true
         );
 
         // Price at the limit of first order is ok
         assert_eq!(
-            is_valid_solution(&SinglePairSettlement {
+            is_valid_solution(&Settlement {
                 clearing_prices: maplit::hashmap! {
                     token_a => to_wei(8),
                     token_b => to_wei(10)
                 },
-                interaction: None,
+                interactions: Vec::new(),
                 trades: orders
                     .clone()
                     .into_iter()
                     .map(Trade::fully_matched)
-                    .collect()
+                    .collect(),
+                ..Default::default()
             }),
             true
         );
 
         // Price at the limit of second order is ok
         assert_eq!(
-            is_valid_solution(&SinglePairSettlement {
+            is_valid_solution(&Settlement {
                 clearing_prices: maplit::hashmap! {
                     token_a => to_wei(10),
                     token_b => to_wei(9)
                 },
-                interaction: None,
+                interactions: Vec::new(),
                 trades: orders
                     .clone()
                     .into_iter()
                     .map(Trade::fully_matched)
-                    .collect()
+                    .collect(),
+                ..Default::default()
             }),
             true
         );
 
         // Price violating first order is not ok
         assert_eq!(
-            is_valid_solution(&SinglePairSettlement {
+            is_valid_solution(&Settlement {
                 clearing_prices: maplit::hashmap! {
                     token_a => to_wei(7),
                     token_b => to_wei(10)
                 },
-                interaction: None,
+                interactions: Vec::new(),
                 trades: orders
                     .clone()
                     .into_iter()
                     .map(Trade::fully_matched)
-                    .collect()
+                    .collect(),
+                ..Default::default()
             }),
             false
         );
 
         // Price violating second order is not ok
         assert_eq!(
-            is_valid_solution(&SinglePairSettlement {
+            is_valid_solution(&Settlement {
                 clearing_prices: maplit::hashmap! {
                     token_a => to_wei(10),
                     token_b => to_wei(8)
                 },
-                interaction: None,
-                trades: orders.into_iter().map(Trade::fully_matched).collect()
+                interactions: Vec::new(),
+                trades: orders.into_iter().map(Trade::fully_matched).collect(),
+                ..Default::default()
             }),
             false
         );

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -74,7 +74,7 @@ pub fn solve(orders: impl Iterator<Item = LimitOrder> + Clone, pool: &AmmOrder) 
 }
 
 ///
-/// Computes a settlement using orders of a single pair and the direct AMM between those tokens.
+/// Computes a settlement using orders of a single pair and the direct AMM between those tokens.get(.
 /// Panics if orders are not already filtered for a specific token pair, or the reserve information
 /// for that pair is not available.
 ///
@@ -163,9 +163,9 @@ fn fully_matched(
 
 impl AmmOrder {
     fn get_reserve(&self, token: &Address) -> Option<U256> {
-        if &self.tokens.0 == token {
+        if &self.tokens.get().0 == token {
             Some(self.reserves.0.into())
-        } else if &self.tokens.1 == token {
+        } else if &self.tokens.get().1 == token {
             Some(self.reserves.1.into())
         } else {
             None
@@ -287,7 +287,7 @@ mod tests {
     use liquidity::{
         AmmSettlementHandling, LimitOrderSettlementHandling, MockLimitOrderSettlementHandling,
     };
-    use model::order::OrderCreation;
+    use model::{order::OrderCreation, TokenPair};
     use num::Rational;
     use std::sync::{Arc, Mutex};
 
@@ -361,7 +361,7 @@ mod tests {
 
         let amm_handler = Arc::new(AmmSettlementHandler::default());
         let pool = AmmOrder {
-            tokens: (token_a, token_b),
+            tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
             fee: Rational::new(3, 1000),
             settlement_handling: amm_handler.clone(),
@@ -417,7 +417,7 @@ mod tests {
 
         let amm_handler = Arc::new(AmmSettlementHandler::default());
         let pool = AmmOrder {
-            tokens: (token_a, token_b),
+            tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_000).as_u128(), to_wei(1_000_000).as_u128()),
             fee: Rational::new(3, 1000),
             settlement_handling: amm_handler.clone(),
@@ -469,7 +469,7 @@ mod tests {
 
         let amm_handler = Arc::new(AmmSettlementHandler::default());
         let pool = AmmOrder {
-            tokens: (token_a, token_b),
+            tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
             fee: Rational::new(3, 1000),
             settlement_handling: amm_handler.clone(),
@@ -525,7 +525,7 @@ mod tests {
 
         let amm_handler = Arc::new(AmmSettlementHandler::default());
         let pool = AmmOrder {
-            tokens: (token_a, token_b),
+            tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
             fee: Rational::new(3, 1000),
             settlement_handling: amm_handler.clone(),
@@ -585,7 +585,7 @@ mod tests {
 
         let amm_handler = Arc::new(AmmSettlementHandler::default());
         let pool = AmmOrder {
-            tokens: (token_a, token_b),
+            tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_001).as_u128(), to_wei(1_000_000).as_u128()),
             fee: Rational::new(3, 1000),
             settlement_handling: amm_handler.clone(),
@@ -654,7 +654,7 @@ mod tests {
 
         let amm_handler = Arc::new(AmmSettlementHandler::default());
         let pool = AmmOrder {
-            tokens: (token_a, token_b),
+            tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_000).as_u128(), to_wei(1_000_000).as_u128()),
             fee: Rational::new(3, 1000),
             settlement_handling: amm_handler,
@@ -692,7 +692,7 @@ mod tests {
 
         let amm_handler = Arc::new(AmmSettlementHandler::default());
         let pool = AmmOrder {
-            tokens: (token_a, token_b),
+            tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_001).as_u128(), to_wei(1_000_000).as_u128()),
             fee: Rational::new(3, 1000),
             settlement_handling: amm_handler,

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -1,8 +1,7 @@
-use crate::settlement::Settlement;
+use crate::{liquidity::Liquidity, settlement::Settlement};
 use anyhow::Result;
-use model::order::Order;
 
 #[async_trait::async_trait]
 pub trait Solver {
-    async fn solve(&self, orders: Vec<Order>) -> Result<Option<Settlement>>;
+    async fn solve(&self, orders: Vec<Liquidity>) -> Result<Option<Settlement>>;
 }


### PR DESCRIPTION
Part of #194

Changes the solver interface to take a list of abstract liquidity (including all types of orders) instead of only concrete user orders and "adding" the onchain liquidity in the two solvers directly.

Unfortunately this change became quite big, I could split it up on three PRs (changing the interface but commenting out  the solver implementations, adjusting naive solver, adjusting http_solver) if this helps.

The driver is now in charge for creating a full liquidity list (this logic can move into its own "LiquidityFetcher" component as the logic grows) and passes it down to the solvers. This has the nice side effect that solver no longer need to "know" about all the possible onchain sources we support but can instead just "pick" the liquidity they are interested in and that they can handle.

Most of the code changes are just translating between the different data models and a large chunk of lines stems from the updated unittests in the naive solver.

### Test Plan
Unit Tests
