### PR TITLE
Refactor warp test so that it does not need order book

### DIFF
--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -2,12 +2,16 @@ mod filter;
 mod handler;
 
 use crate::storage::Storage;
+use serde::Serialize;
 use std::sync::Arc;
-use warp::Filter;
+use warp::{
+    reply::{json, Json},
+    Filter, Reply,
+};
 
 pub fn handle_all_routes(
     orderbook: Arc<dyn Storage>,
-) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl Reply,), Error = warp::Rejection> + Clone {
     let order_creation = filter::create_order(orderbook.clone());
     let order_getter = filter::get_orders(orderbook.clone());
     let fee_info = filter::get_fee_info();
@@ -18,4 +22,25 @@ pub fn handle_all_routes(
             .or(fee_info)
             .or(order_by_uid),
     )
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Error<'a> {
+    error_type: &'a str,
+    description: &'a str,
+}
+
+fn error(error_type: &str, description: impl AsRef<str>) -> Json {
+    json(&Error {
+        error_type,
+        description: description.as_ref(),
+    })
+}
+
+fn internal_error() -> Json {
+    json(&Error {
+        error_type: "InternalServerError",
+        description: "",
+    })
 }

--- a/orderbook/src/storage.rs
+++ b/orderbook/src/storage.rs
@@ -30,7 +30,7 @@ pub enum RemoveOrderResult {
 pub trait Storage: Send + Sync {
     async fn add_order(&self, order: OrderCreation) -> Result<AddOrderResult>;
     async fn remove_order(&self, uid: &OrderUid) -> Result<RemoveOrderResult>;
-    async fn get_orders(&self, filter: &OrderFilter<'_>) -> Result<Vec<Order>>;
+    async fn get_orders(&self, filter: &OrderFilter) -> Result<Vec<Order>>;
     async fn run_maintenance(&self, settlement_contract: &GPv2Settlement) -> Result<()>;
 }
 

--- a/orderbook/src/storage/memory.rs
+++ b/orderbook/src/storage/memory.rs
@@ -96,7 +96,7 @@ impl Storage for OrderBook {
         Ok(AddOrderResult::Added(uid))
     }
 
-    async fn get_orders(&self, filter: &OrderFilter<'_>) -> Result<Vec<Order>> {
+    async fn get_orders(&self, filter: &OrderFilter) -> Result<Vec<Order>> {
         Ok(self
             .orders
             .read()
@@ -105,15 +105,15 @@ impl Storage for OrderBook {
             .filter(|order| {
                 filter
                     .owner
-                    .map(|owner| *owner == order.order_meta_data.owner)
+                    .map(|owner| owner == order.order_meta_data.owner)
                     .unwrap_or(true)
                     && filter
                         .sell_token
-                        .map(|token| *token == order.order_creation.sell_token)
+                        .map(|token| token == order.order_creation.sell_token)
                         .unwrap_or(true)
                     && filter
                         .buy_token
-                        .map(|token| *token == order.order_creation.buy_token)
+                        .map(|token| token == order.order_creation.buy_token)
                         .unwrap_or(true)
             })
             .cloned()

--- a/orderbook/src/storage/postgresql.rs
+++ b/orderbook/src/storage/postgresql.rs
@@ -40,7 +40,7 @@ impl Storage for OrderBook {
         todo!()
     }
 
-    async fn get_orders(&self, filter: &OrderFilter<'_>) -> Result<Vec<Order>> {
+    async fn get_orders(&self, filter: &OrderFilter) -> Result<Vec<Order>> {
         self.database.orders(filter).try_collect::<Vec<_>>().await
     }
 


### PR DESCRIPTION
We accomplish this by splitting the filter into three parts:
1. convert request into the arguments for order book method
2. convert result of order book method into a response
3. combine the other parts trivially together

Now we can test 1. 2. individually, neither needing access to an order
book.

This has the advantage that we neither need to mock, nor run a real postgres instance.

I would like to make similar changes to the other filters if this gets positively reviewed. 

### Test Plan
Converted existing tests
