### PR TITLE
Enable tokio threaded runtime

### DIFF
--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = "1.0"
 shared-arguments = { path = "../shared-arguments" }
 sqlx = { version = "0.4", default-features = false, features = ["bigdecimal", "chrono", "macros", "runtime-tokio-native-tls", "postgres"] }
 structopt = { version = "0.3" }
-tokio = { version = "0.2", features =[ "macros", "time"] }
+tokio = { version = "0.2", features =["macros", "rt-threaded", "time"] }
 tracing = "0.1"
 tracing-setup = { path = "../tracing-setup" }
 warp = "0.2"

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shared-arguments = { path = "../shared-arguments" }
 structopt = { version = "0.3" }
-tokio = { version = "0.2", features =[ "macros", "time"] }
+tokio = { version = "0.2", features =["macros", "rt-threaded", "time"] }
 tracing = "0.1"
 tracing-setup = { path = "../tracing-setup" }
 web3 = { version = "0.15", default-features = false, features = ["http-tls"] }


### PR DESCRIPTION
Based on Cargo.lock not changing this feature was transitively enabled
anyway but we should still explicitly specify that we want the threaded
runtime.

Closes #15 

### Test Plan
CI