### PR TITLE
Adding an orderbook component between API handler and storage

### DIFF
--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -5,7 +5,7 @@ use model::{
     order::{OrderBuilder, OrderKind},
     DomainSeparator,
 };
-use orderbook::storage::{InMemoryOrderBook, Storage};
+use orderbook::{orderbook::Orderbook, storage::InMemoryOrderBook};
 use secp256k1::SecretKey;
 use serde_json::json;
 use std::{str::FromStr, sync::Arc};
@@ -115,7 +115,10 @@ async fn test_with_ganache() {
             .await
             .expect("Couldn't query domain separator"),
     );
-    let orderbook = Arc::new(InMemoryOrderBook::new(domain_separator));
+    let orderbook = Arc::new(Orderbook::new(
+        DomainSeparator::default(),
+        Box::new(InMemoryOrderBook::default()),
+    ));
     orderbook::serve_task(
         orderbook.clone(),
         API_HOST[7..].parse().expect("Couldn't parse API address"),

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -37,4 +37,3 @@ web3 = { version = "0.15", default-features = false, features = ["http-tls"] }
 [dev-dependencies]
 hex-literal = "0.3"
 secp256k1 = "0.20"
-web3 = { version = "0.15", default-features = false, features = ["test"] }

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -37,3 +37,4 @@ web3 = { version = "0.15", default-features = false, features = ["http-tls"] }
 [dev-dependencies]
 hex-literal = "0.3"
 secp256k1 = "0.20"
+web3 = { version = "0.15", default-features = false, features = ["test"] }

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -3,7 +3,7 @@ mod get_fee_info;
 mod get_order_by_uid;
 mod get_orders;
 
-use crate::storage::Storage;
+use crate::orderbook::Orderbook;
 use hex::{FromHex, FromHexError};
 use model::h160_hexadecimal;
 use primitive_types::H160;
@@ -15,7 +15,7 @@ use warp::{
 };
 
 pub fn handle_all_routes(
-    orderbook: Arc<dyn Storage>,
+    orderbook: Arc<Orderbook>,
 ) -> impl Filter<Extract = (impl Reply,), Error = warp::Rejection> + Clone {
     let order_creation = create_order::create_order(orderbook.clone());
     let order_getter = get_orders::get_orders(orderbook.clone());

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -1,4 +1,6 @@
-use crate::storage::{AddOrderResult, Storage};
+use crate::orderbook::Orderbook;
+use crate::storage::AddOrderResult;
+
 use anyhow::Result;
 use model::order::OrderCreation;
 use std::{convert::Infallible, sync::Arc};
@@ -57,7 +59,7 @@ pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
 }
 
 pub fn create_order(
-    orderbook: Arc<dyn Storage>,
+    orderbook: Arc<Orderbook>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     create_order_request().and_then(move |order| {
         let orderbook = orderbook.clone();

--- a/orderbook/src/api/filter.rs
+++ b/orderbook/src/api/filter.rs
@@ -1,0 +1,274 @@
+use super::handler;
+use crate::{database::OrderFilter, orderbook::Orderbook};
+use anyhow::Result;
+use hex::{FromHex, FromHexError};
+use model::{
+    h160_hexadecimal,
+    order::{Order, OrderCreation, OrderUid},
+};
+use primitive_types::H160;
+use serde::Deserialize;
+use std::{convert::Infallible, str::FromStr, sync::Arc};
+use warp::{
+    http::StatusCode,
+    reply::{json, with_status},
+    Filter, Rejection, Reply,
+};
+
+const MAX_JSON_BODY_PAYLOAD: u64 = 1024 * 16;
+
+fn with_orderbook(
+    orderbook: Arc<Orderbook>,
+) -> impl Filter<Extract = (Arc<Orderbook>,), Error = std::convert::Infallible> + Clone {
+    warp::any().map(move || orderbook.clone())
+}
+
+fn extract_user_order() -> impl Filter<Extract = (OrderCreation,), Error = Rejection> + Clone {
+    // (rejecting huge payloads)...
+    warp::body::content_length_limit(MAX_JSON_BODY_PAYLOAD).and(warp::body::json())
+}
+
+pub fn create_order(
+    orderbook: Arc<Orderbook>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    warp::path!("orders")
+        .and(warp::post())
+        .and(with_orderbook(orderbook))
+        .and(extract_user_order())
+        .and_then(handler::add_order)
+}
+
+pub fn get_orders_request() -> impl Filter<Extract = (OrderFilter,), Error = Rejection> + Clone {
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Query {
+        owner: Option<H160Wrapper>,
+        sell_token: Option<H160Wrapper>,
+        buy_token: Option<H160Wrapper>,
+    }
+
+    let to_h160 = |option: Option<H160Wrapper>| option.map(|wrapper| wrapper.0);
+
+    warp::path!("orders")
+        .and(warp::get())
+        .and(warp::query::<Query>())
+        .map(move |query: Query| OrderFilter {
+            owner: to_h160(query.owner),
+            sell_token: to_h160(query.sell_token),
+            buy_token: to_h160(query.buy_token),
+            exclude_fully_executed: true,
+            exclude_invalidated: true,
+            ..Default::default()
+        })
+}
+
+pub fn get_orders_response(result: Result<Vec<Order>>) -> impl Reply {
+    let orders = match result {
+        Ok(orders) => orders,
+        Err(err) => {
+            tracing::error!(?err, "get_orders error");
+            return Ok(with_status(
+                super::internal_error(),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ));
+        }
+    };
+    Ok(with_status(json(&orders), StatusCode::OK))
+}
+
+pub fn get_orders(
+    orderbook: Arc<Orderbook>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    get_orders_request().and_then(move |order_filter| {
+        let orderbook = orderbook.clone();
+        async move {
+            let result = orderbook.get_orders(&order_filter).await;
+            Result::<_, Infallible>::Ok(get_orders_response(result))
+        }
+    })
+}
+
+pub fn get_order_by_uid(
+    orderbook: Arc<Orderbook>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    warp::path!("orders" / OrderUid)
+        .and(warp::get())
+        .and(with_orderbook(orderbook))
+        .and_then(handler::get_order_by_uid)
+}
+
+/// Wraps H160 with FromStr and Deserialize that can handle a `0x` prefix.
+#[derive(Deserialize)]
+#[serde(transparent)]
+struct H160Wrapper(#[serde(with = "h160_hexadecimal")] H160);
+impl FromStr for H160Wrapper {
+    type Err = FromHexError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.strip_prefix("0x").unwrap_or(s);
+        Ok(H160Wrapper(H160(FromHex::from_hex(s)?)))
+    }
+}
+
+pub fn get_fee_info() -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    warp::path!("tokens" / H160Wrapper / "fee")
+        .and(warp::get())
+        .map(|token: H160Wrapper| token.0)
+        .and_then(handler::get_fee_info)
+}
+
+#[cfg(test)]
+pub mod test_util {
+    use super::*;
+    use crate::{
+        database::OrderFilter,
+        storage::{AddOrderResult, InMemoryOrderBook as OrderBook},
+    };
+    use futures::StreamExt;
+    use hex_literal::hex;
+    use model::{order::Order, DomainSeparator};
+    use primitive_types::U256;
+    use serde_json::json;
+    use warp::{
+        http::StatusCode,
+        hyper::{Body, Response},
+        test::{request, RequestBuilder},
+    };
+
+    async fn response_body(response: Response<Body>) -> Vec<u8> {
+        let mut body = response.into_body();
+        let mut result = Vec::new();
+        while let Some(bytes) = body.next().await {
+            result.extend_from_slice(bytes.unwrap().as_ref());
+        }
+        result
+    }
+
+    #[tokio::test]
+    async fn get_orders_request_ok() {
+        let order_filter = |request: RequestBuilder| async move {
+            let filter = get_orders_request();
+            request.method("GET").filter(&filter).await
+        };
+
+        let result = order_filter(request().path("/orders")).await.unwrap();
+        assert_eq!(result.owner, None);
+        assert_eq!(result.buy_token, None);
+        assert_eq!(result.sell_token, None);
+
+        let owner = H160::from_slice(&hex!("0000000000000000000000000000000000000001"));
+        let sell = H160::from_slice(&hex!("0000000000000000000000000000000000000002"));
+        let buy = H160::from_slice(&hex!("0000000000000000000000000000000000000003"));
+        let path = format!(
+            "/orders?owner=0x{:x}&sellToken=0x{:x}&buyToken=0x{:x}",
+            owner, sell, buy
+        );
+        let request = request().path(path.as_str());
+        let result = order_filter(request).await.unwrap();
+        assert_eq!(result.owner, Some(owner));
+        assert_eq!(result.buy_token, Some(buy));
+        assert_eq!(result.sell_token, Some(sell));
+    }
+
+    #[tokio::test]
+    async fn get_orders_response_ok() {
+        let orders = vec![Order::default()];
+        let response = get_orders_response(Ok(orders.clone())).into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body(response).await;
+        let response_orders: Vec<Order> = serde_json::from_slice(body.as_slice()).unwrap();
+        assert_eq!(response_orders, orders);
+    }
+
+    #[tokio::test]
+    async fn get_order_by_uid_() {
+        let orderbook = Arc::new(Orderbook::new(
+            DomainSeparator::default(),
+            Box::new(OrderBook::default()),
+        ));
+        let filter = get_order_by_uid(orderbook.clone());
+        let order_creation = OrderCreation::default();
+        let uid = match orderbook.add_order(order_creation).await.unwrap() {
+            AddOrderResult::Added(uid) => uid,
+            _ => panic!("unexpected result"),
+        };
+        let response = request()
+            .path(&format!("/orders/{:}", uid))
+            .method("GET")
+            .reply(&filter)
+            .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let response_orders: Order = serde_json::from_slice(response.body()).unwrap();
+        let orderbook_orders = orderbook.get_orders(&OrderFilter::default()).await.unwrap();
+        assert_eq!(response_orders, orderbook_orders[0]);
+    }
+    #[tokio::test]
+    async fn get_order_by_uid_for_non_existent_order_() {
+        let orderbook = Arc::new(Orderbook::new(
+            DomainSeparator::default(),
+            Box::new(OrderBook::default()),
+        ));
+        let filter = get_order_by_uid(orderbook.clone());
+        let uid = OrderUid([0u8; 56]);
+        let response = request()
+            .path(&format!("/orders/{:}", uid))
+            .method("GET")
+            .reply(&filter)
+            .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn get_fee_info_() {
+        let filter = get_fee_info();
+        let sell_token = String::from("0x000000000000000000000000000000000000000a");
+        let path_string = format!("/tokens/{}/fee", sell_token);
+        let post = || async {
+            request()
+                .path(&path_string)
+                .method("GET")
+                .reply(&filter)
+                .await
+        };
+        let response = post().await;
+        let body: handler::FeeInfo = serde_json::from_slice(response.body()).unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body.minimal_fee, U256::zero());
+        assert_eq!(body.fee_ratio, 0);
+        assert!(body.expiration_date.gt(&chrono::offset::Utc::now()))
+    }
+
+    #[tokio::test]
+    async fn create_order_route() {
+        let orderbook = Arc::new(Orderbook::new(
+            DomainSeparator::default(),
+            Box::new(OrderBook::default()),
+        ));
+        let filter = create_order(orderbook.clone());
+        let order = OrderCreation::default();
+        let expected_uid = json!(
+            "0xbd185ee633752c56b3eabec61259e8a65c765943665a2c17ad8b74a119e5f1ca7e5f4552091a69125d5dfcb7b8c2659029395bdfffffffff"
+        );
+        let post = || async {
+            request()
+                .path("/orders")
+                .method("POST")
+                .header("content-type", "application/json")
+                .json(&order)
+                .reply(&filter)
+                .await
+        };
+        let response = post().await;
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body: serde_json::Value = serde_json::from_slice(response.body()).unwrap();
+
+        assert_eq!(body, expected_uid);
+        // Posting again should fail because order already exists.
+        let response = post().await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body: serde_json::Value = serde_json::from_slice(response.body()).unwrap();
+        let expected_error =
+            json!({"errorType": "DuplicatedOrder", "description": "order already exists"});
+        assert_eq!(body, expected_error);
+    }
+}

--- a/orderbook/src/api/get_order_by_uid.rs
+++ b/orderbook/src/api/get_order_by_uid.rs
@@ -1,4 +1,5 @@
-use crate::{database::OrderFilter, storage::Storage};
+use crate::database::OrderFilter;
+use crate::orderbook::Orderbook;
 use anyhow::Result;
 use model::order::{Order, OrderUid};
 use std::{convert::Infallible, sync::Arc};
@@ -35,7 +36,7 @@ pub fn get_order_by_uid_response(result: Result<Vec<Order>>) -> impl Reply {
 }
 
 pub fn get_order_by_uid(
-    orderbook: Arc<dyn Storage>,
+    orderbook: Arc<Orderbook>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     get_order_by_uid_request().and_then(move |order_filter| {
         let orderbook = orderbook.clone();

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -1,5 +1,6 @@
 use super::H160Wrapper;
-use crate::{database::OrderFilter, storage::Storage};
+use crate::database::OrderFilter;
+use crate::orderbook::Orderbook;
 use anyhow::Result;
 use model::order::Order;
 use serde::Deserialize;
@@ -45,7 +46,7 @@ pub fn get_orders_response(result: Result<Vec<Order>>) -> impl Reply {
 }
 
 pub fn get_orders(
-    orderbook: Arc<dyn Storage>,
+    orderbook: Arc<Orderbook>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     get_orders_request().and_then(move |order_filter| {
         let orderbook = orderbook.clone();

--- a/orderbook/src/api/handler.rs
+++ b/orderbook/src/api/handler.rs
@@ -1,0 +1,110 @@
+use super::{error, internal_error};
+use crate::{database::OrderFilter, orderbook::Orderbook, storage::AddOrderResult};
+use anyhow::Result;
+use chrono::prelude::{DateTime, FixedOffset, Utc};
+use model::{
+    order::{OrderCreation, OrderUid},
+    u256_decimal,
+};
+use primitive_types::{H160, U256};
+use serde::{Deserialize, Serialize};
+use std::{convert::Infallible, sync::Arc};
+use warp::{
+    http::StatusCode,
+    reply::{json, with_status},
+    Reply,
+};
+
+const STANDARD_VALIDITY_FOR_FEE_IN_SEC: i32 = 3600;
+
+/// Fee struct being returned on fee API requests
+#[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeeInfo {
+    pub expiration_date: DateTime<Utc>,
+    #[serde(with = "u256_decimal")]
+    pub minimal_fee: U256,
+    pub fee_ratio: u32,
+}
+
+pub async fn add_order(
+    storage: Arc<Orderbook>,
+    order: OrderCreation,
+) -> Result<impl Reply, Infallible> {
+    let (body, status_code) = match storage.add_order(order).await {
+        Ok(AddOrderResult::Added(uid)) => (warp::reply::json(&uid), StatusCode::CREATED),
+        Ok(AddOrderResult::DuplicatedOrder) => (
+            error("DuplicatedOrder", "order already exists"),
+            StatusCode::BAD_REQUEST,
+        ),
+        Ok(AddOrderResult::InvalidSignature) => (
+            error("InvalidSignature", "invalid signature"),
+            StatusCode::BAD_REQUEST,
+        ),
+        Ok(AddOrderResult::Forbidden) => (
+            error("Forbidden", "Forbidden, your account is deny-listed"),
+            StatusCode::FORBIDDEN,
+        ),
+        Ok(AddOrderResult::PastValidTo) => (
+            error("PastValidTo", "validTo is in the past"),
+            StatusCode::BAD_REQUEST,
+        ),
+        Ok(AddOrderResult::MissingOrderData) => (
+            error(
+                "MissingOrderData",
+                "at least 1 field of orderCreation is missing, please check the field",
+            ),
+            StatusCode::BAD_REQUEST,
+        ),
+        Ok(AddOrderResult::InsufficientFunds) => (
+            error(
+                "InsufficientFunds",
+                "order owner must have funds worth at least x in his account",
+            ),
+            StatusCode::BAD_REQUEST,
+        ),
+        Err(err) => {
+            tracing::error!(?err, ?order, "add_order error");
+            (internal_error(), StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    };
+    Ok(with_status(body, status_code))
+}
+
+pub async fn get_order_by_uid(
+    uid: OrderUid,
+    orderbook: Arc<Orderbook>,
+) -> Result<impl Reply, Infallible> {
+    let filter = OrderFilter {
+        uid: Some(uid),
+        ..Default::default()
+    };
+    let orders = match orderbook.get_orders(&filter).await {
+        Ok(orders) => orders,
+        Err(err) => {
+            tracing::error!(?err, ?uid, "get_order error");
+            return Ok(with_status(
+                internal_error(),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ));
+        }
+    };
+    Ok(match orders.first() {
+        Some(order) => with_status(json(&order), StatusCode::OK),
+        None => with_status(
+            error("NotFound", "Order was not found"),
+            StatusCode::NOT_FOUND,
+        ),
+    })
+}
+
+#[allow(unused_variables)]
+pub async fn get_fee_info(sell_token: H160) -> Result<impl Reply, Infallible> {
+    let fee_info = FeeInfo {
+        expiration_date: chrono::offset::Utc::now()
+            + FixedOffset::east(STANDARD_VALIDITY_FOR_FEE_IN_SEC),
+        minimal_fee: U256::zero(),
+        fee_ratio: 0u32,
+    };
+    Ok(with_status(warp::reply::json(&fee_info), StatusCode::OK))
+}

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -2,9 +2,10 @@ pub mod api;
 pub mod database;
 pub mod event_updater;
 pub mod integer_conversions;
+pub mod orderbook;
 pub mod storage;
 
-use crate::storage::Storage;
+use crate::orderbook::Orderbook;
 use anyhow::{anyhow, Context as _, Result};
 use contracts::GPv2Settlement;
 use model::DomainSeparator;
@@ -12,12 +13,12 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::{task, task::JoinHandle};
 use warp::Filter;
 
-pub fn serve_task(storage: Arc<dyn Storage>, address: SocketAddr) -> JoinHandle<()> {
+pub fn serve_task(orderbook: Arc<Orderbook>, address: SocketAddr) -> JoinHandle<()> {
     let cors = warp::cors()
         .allow_any_origin()
         .allow_methods(vec!["GET", "POST", "DELETE", "OPTIONS", "PUT", "PATCH"])
         .allow_headers(vec!["Origin", "Content-Type", "X-Auth-Token", "X-AppId"]);
-    let filter = api::handle_all_routes(storage).with(cors);
+    let filter = api::handle_all_routes(orderbook).with(cors);
     tracing::info!(%address, "serving order book");
     task::spawn(warp::serve(filter).bind(address))
 }

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -1,0 +1,59 @@
+use std::time::SystemTime;
+
+use anyhow::Result;
+
+use crate::database::OrderFilter;
+use crate::storage::{AddOrderResult, RemoveOrderResult, Storage};
+use contracts::GPv2Settlement;
+use model::{
+    order::{Order, OrderCreation, OrderUid},
+    DomainSeparator,
+};
+
+pub struct Orderbook {
+    domain_separator: DomainSeparator,
+    storage: Box<dyn Storage>,
+}
+
+impl Orderbook {
+    pub fn new(domain_separator: DomainSeparator, storage: Box<dyn Storage>) -> Self {
+        Self {
+            domain_separator,
+            storage,
+        }
+    }
+
+    pub async fn add_order(&self, order: OrderCreation) -> Result<AddOrderResult> {
+        if !has_future_valid_to(now_in_epoch_seconds(), &order) {
+            return Ok(AddOrderResult::PastValidTo);
+        }
+        let order = match Order::from_order_creation(order, &self.domain_separator) {
+            Some(order) => order,
+            None => return Ok(AddOrderResult::InvalidSignature),
+        };
+        self.storage.add_order(order).await
+    }
+
+    pub async fn remove_order(&self, uid: &OrderUid) -> Result<RemoveOrderResult> {
+        self.storage.remove_order(uid).await
+    }
+
+    pub async fn get_orders(&self, filter: &OrderFilter) -> Result<Vec<Order>> {
+        self.storage.get_orders(filter).await
+    }
+
+    pub async fn run_maintenance(&self, settlement_contract: &GPv2Settlement) -> Result<()> {
+        self.storage.run_maintenance(settlement_contract).await
+    }
+}
+
+pub fn now_in_epoch_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("now earlier than epoch")
+        .as_secs()
+}
+
+pub fn has_future_valid_to(now_in_epoch_seconds: u64, order: &OrderCreation) -> bool {
+    order.valid_to as u64 > now_in_epoch_seconds
+}

--- a/orderbook/src/storage.rs
+++ b/orderbook/src/storage.rs
@@ -4,8 +4,7 @@ mod postgresql;
 use crate::database::OrderFilter;
 use anyhow::Result;
 use contracts::GPv2Settlement;
-use model::order::{Order, OrderCreation, OrderUid};
-use std::time::SystemTime;
+use model::order::{Order, OrderUid};
 
 pub use memory::OrderBook as InMemoryOrderBook;
 
@@ -28,19 +27,8 @@ pub enum RemoveOrderResult {
 
 #[async_trait::async_trait]
 pub trait Storage: Send + Sync {
-    async fn add_order(&self, order: OrderCreation) -> Result<AddOrderResult>;
+    async fn add_order(&self, order: Order) -> Result<AddOrderResult>;
     async fn remove_order(&self, uid: &OrderUid) -> Result<RemoveOrderResult>;
     async fn get_orders(&self, filter: &OrderFilter) -> Result<Vec<Order>>;
     async fn run_maintenance(&self, settlement_contract: &GPv2Settlement) -> Result<()>;
-}
-
-fn now_in_epoch_seconds() -> u64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("now earlier than epoch")
-        .as_secs()
-}
-
-fn has_future_valid_to(now_in_epoch_seconds: u64, order: &OrderCreation) -> bool {
-    order.valid_to as u64 > now_in_epoch_seconds
 }

--- a/orderbook/src/storage/memory.rs
+++ b/orderbook/src/storage/memory.rs
@@ -98,6 +98,10 @@ impl Storage for OrderBook {
                         .buy_token
                         .map(|token| token == order.order_creation.buy_token)
                         .unwrap_or(true)
+                    && filter
+                        .uid
+                        .map(|uid| uid == order.order_meta_data.uid)
+                        .unwrap_or(true)
             })
             .cloned()
             .collect())
@@ -117,6 +121,7 @@ impl Storage for OrderBook {
         let remove_order_future = self.remove_expired_orders(now_in_epoch_seconds());
         let remove_settled_orders_future = self.remove_settled_orders(settlement_contract);
         futures::join!(remove_order_future, remove_settled_orders_future);
+        println!("maintained");
         Ok(())
     }
 }

--- a/orderbook/src/storage/memory.rs
+++ b/orderbook/src/storage/memory.rs
@@ -1,11 +1,9 @@
 use super::*;
+use crate::orderbook::{has_future_valid_to, now_in_epoch_seconds};
 use anyhow::Result;
 use contracts::GPv2Settlement;
 use futures::future;
-use model::{
-    order::{Order, OrderCreation, OrderUid},
-    DomainSeparator,
-};
+use model::order::{Order, OrderUid};
 use primitive_types::U256;
 use std::collections::{hash_map::Entry, HashMap};
 use tokio::sync::RwLock;
@@ -13,19 +11,11 @@ use tracing::info;
 
 #[derive(Debug, Default)]
 pub struct OrderBook {
-    domain_separator: DomainSeparator,
     // TODO: Store more efficiently (for example HashMap) depending on functionality we need.
     orders: RwLock<HashMap<OrderUid, Order>>,
 }
 
 impl OrderBook {
-    pub fn new(domain_separator: DomainSeparator) -> Self {
-        Self {
-            domain_separator,
-            orders: RwLock::new(HashMap::new()),
-        }
-    }
-
     async fn remove_expired_orders(&self, now_in_epoch_seconds: u64) {
         // TODO: use the timestamp from the most recent block instead?
         let mut orders = self.orders.write().await;
@@ -77,14 +67,7 @@ impl OrderBook {
 
 #[async_trait::async_trait]
 impl Storage for OrderBook {
-    async fn add_order(&self, order: OrderCreation) -> Result<AddOrderResult> {
-        if !has_future_valid_to(now_in_epoch_seconds(), &order) {
-            return Ok(AddOrderResult::PastValidTo);
-        }
-        let order = match Order::from_order_creation(order, &self.domain_separator) {
-            Some(order) => order,
-            None => return Ok(AddOrderResult::InvalidSignature),
-        };
+    async fn add_order(&self, order: Order) -> Result<AddOrderResult> {
         let uid = order.order_meta_data.uid;
         let mut orders = self.orders.write().await;
         match orders.entry(uid) {
@@ -140,13 +123,15 @@ impl Storage for OrderBook {
 
 #[cfg(test)]
 pub mod test_util {
+    use model::order::OrderCreation;
+
     use super::*;
 
     #[tokio::test]
     async fn cannot_add_order_twice() {
         let orderbook = OrderBook::default();
-        let order = OrderCreation::default();
-        orderbook.add_order(order).await.unwrap();
+        let order = Order::default();
+        orderbook.add_order(order.clone()).await.unwrap();
         assert_eq!(
             orderbook
                 .get_orders(&OrderFilter::default())
@@ -164,7 +149,7 @@ pub mod test_util {
     #[tokio::test]
     async fn test_simple_removing_order() {
         let orderbook = OrderBook::default();
-        let order = OrderCreation::default();
+        let order = Order::default();
         let uid = match orderbook.add_order(order).await.unwrap() {
             AddOrderResult::Added(uid) => uid,
             _ => panic!("unexpected result"),
@@ -191,8 +176,11 @@ pub mod test_util {
     #[tokio::test]
     async fn removes_expired_orders() {
         let orderbook = OrderBook::default();
-        let order = OrderCreation {
-            valid_to: u32::MAX - 10,
+        let order = Order {
+            order_creation: OrderCreation {
+                valid_to: u32::MAX - 10,
+                ..Default::default()
+            },
             ..Default::default()
         };
         orderbook.add_order(order).await.unwrap();


### PR DESCRIPTION
Part of #40 

This PR adds another layer in between API handler and storage (happy for better naming suggestion) which for now simply combines the common logic between in-memory and postgres storage when it comes to adding orders.

In the next PR I'm planning to also make it aware of the AccountBalanceFetching component. It will then create the appropriate subscriptions to watch allowance/balance changes as well as filter orders for which there is not enough balance.

### Test Plan
CI
