### PR TITLE
Use gas price estimation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -425,6 +425,41 @@ dependencies = [
  "pkg-config",
  "vcpkg",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.9.3",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -823,6 +858,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gas-estimation"
+version = "0.1.0"
+source = "git+https://github.com/gnosis/gp-gas-estimation.git?tag=v0.1.0#dfae4041e37009698cfbefdf778f26b08dd20808"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "log",
+ "primitive-types",
+ "serde",
+ "serde_with",
+ "web3",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1108,12 @@ dependencies = [
  "tokio",
  "tokio-tls",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2189,6 +2244,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15f6201e064705553ece353a736a64be975680bd244908cf63e8fa71e478a51a"
 dependencies = [
  "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1197ff7de45494f290c1e3e1a6f80e108974681984c87a3e480991ef3d0f1950"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2290,6 +2358,7 @@ dependencies = [
  "contracts",
  "ethcontract",
  "futures",
+ "gas-estimation",
  "hex",
  "hex-literal",
  "jsonrpc-core",
@@ -2297,7 +2366,6 @@ dependencies = [
  "mockall",
  "model",
  "num",
- "num-rational",
  "primitive-types",
  "reqwest",
  "serde",
@@ -2432,6 +2500,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"

--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -9,7 +9,7 @@ use orderbook::{orderbook::Orderbook, storage::InMemoryOrderBook};
 use secp256k1::SecretKey;
 use serde_json::json;
 use solver::liquidity::uniswap::UniswapLiquidity;
-use std::{str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc, time::Duration};
 use web3::signing::SecretKeyRef;
 
 const TRADER_A_PK: [u8; 32] =
@@ -187,6 +187,7 @@ async fn test_with_ganache() {
         orderbook_api,
         Box::new(solver),
         Box::new(web3),
+        Duration::from_secs(1),
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -186,6 +186,7 @@ async fn test_with_ganache() {
         uniswap_liquidity,
         orderbook_api,
         Box::new(solver),
+        Box::new(web3),
     );
     driver.single_run().await.unwrap();
 

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -17,14 +17,14 @@ async-trait = "0.1"
 contracts = { path = "../contracts" }
 ethcontract = { version = "0.10", default-features = false }
 futures = "0.3"
+gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.0", features = ["web3_"] }
 hex = "0.4"
 hex-literal = "0.3"
 jsonrpc-core = "16.0"
 maplit = "1.0"
 model = { path = "../model" }
 num = "0.3"
-num-rational = "0.3"
-primitive-types = "0.8"
+primitive-types = { version = "0.8", features = ["fp-conversion"] }
 reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -1,7 +1,12 @@
-use crate::liquidity::{uniswap::UniswapLiquidity, Liquidity};
-use crate::{orderbook::OrderBookApi, solver::Solver};
-use anyhow::{anyhow, Context, Result};
+use crate::{
+    liquidity::{uniswap::UniswapLiquidity, Liquidity},
+    orderbook::OrderBookApi,
+    settlement_submission,
+    solver::Solver,
+};
+use anyhow::{Context, Result};
 use contracts::GPv2Settlement;
+use gas_estimation::GasPriceEstimating;
 use std::time::Duration;
 use tracing::info;
 
@@ -12,6 +17,7 @@ pub struct Driver {
     orderbook: OrderBookApi,
     uniswap_liquidity: UniswapLiquidity,
     solver: Box<dyn Solver>,
+    gas_price_estimator: Box<dyn GasPriceEstimating>,
 }
 
 impl Driver {
@@ -20,12 +26,14 @@ impl Driver {
         uniswap_liquidity: UniswapLiquidity,
         orderbook: OrderBookApi,
         solver: Box<dyn Solver>,
+        gas_price_estimator: Box<dyn GasPriceEstimating>,
     ) -> Self {
         Self {
             settlement_contract,
-            solver,
             orderbook,
             uniswap_liquidity,
+            solver,
+            gas_price_estimator,
         }
     }
 
@@ -70,30 +78,13 @@ impl Driver {
         };
         info!("Computed {:?}", settlement);
         // TODO: check if we need to approve spending to uniswap
-        // TODO: use retry transaction sending crate for updating gas prices
-        let encoded_interactions = settlement
-            .encode_interactions()
-            .context("interaction encoding failed")?;
-        let encoded_trades = settlement
-            .encode_trades()
-            .ok_or_else(|| anyhow!("trade encoding failed"))?;
-        let settle = || {
-            self.settlement_contract
-                .settle(
-                    settlement.tokens(),
-                    settlement.clearing_prices(),
-                    encoded_trades.clone(),
-                    encoded_interactions.clone(),
-                    Vec::new(),
-                )
-                .gas(8_000_000u32.into())
-        };
-        tracing::info!(
-            "Settlement call: {}",
-            hex::encode(settle().tx.data.expect("data").0),
-        );
-        settle().call().await.context("settle simulation failed")?;
-        settle().send().await.context("settle execution failed")?;
+        settlement_submission::submit(
+            settlement,
+            &self.settlement_contract,
+            self.gas_price_estimator.as_ref(),
+        )
+        .await
+        .context("failed to submit settlement")?;
         Ok(())
     }
 }

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -18,6 +18,7 @@ pub struct Driver {
     uniswap_liquidity: UniswapLiquidity,
     solver: Box<dyn Solver>,
     gas_price_estimator: Box<dyn GasPriceEstimating>,
+    target_confirm_time: Duration,
 }
 
 impl Driver {
@@ -27,6 +28,7 @@ impl Driver {
         orderbook: OrderBookApi,
         solver: Box<dyn Solver>,
         gas_price_estimator: Box<dyn GasPriceEstimating>,
+        target_confirm_time: Duration,
     ) -> Self {
         Self {
             settlement_contract,
@@ -34,6 +36,7 @@ impl Driver {
             uniswap_liquidity,
             solver,
             gas_price_estimator,
+            target_confirm_time,
         }
     }
 
@@ -82,6 +85,7 @@ impl Driver {
             settlement,
             &self.settlement_contract,
             self.gas_price_estimator.as_ref(),
+            self.target_confirm_time,
         )
         .await
         .context("failed to submit settlement")?;

--- a/solver/src/gas_price_estimation.rs
+++ b/solver/src/gas_price_estimation.rs
@@ -1,0 +1,72 @@
+use anyhow::{anyhow, Context, Result};
+use gas_estimation::{
+    EthGasStation, GasNowGasStation, GasPriceEstimating, GnosisSafeGasStation,
+    PriorityGasPriceEstimating, Transport,
+};
+use serde::de::DeserializeOwned;
+use structopt::clap::arg_enum;
+use web3::Web3;
+
+arg_enum! {
+    #[derive(Debug)]
+    pub enum GasEstimatorType {
+        EthGasStation,
+        GasNow,
+        GnosisSafe,
+        Web3,
+    }
+}
+
+#[derive(Clone)]
+struct Client(reqwest::Client);
+
+#[async_trait::async_trait]
+impl Transport for Client {
+    async fn get_json<'a, T: DeserializeOwned>(&self, url: &'a str) -> Result<T> {
+        self.0
+            .get(url)
+            .send()
+            .await
+            .context("failed to make request")?
+            .error_for_status()
+            .context("response status is not success")?
+            .json()
+            .await
+            .context("failed to decode response")
+    }
+}
+
+pub async fn create_priority_estimator(
+    client: &reqwest::Client,
+    web3: &Web3<web3::transports::Http>,
+    estimator_types: &[GasEstimatorType],
+) -> Result<impl GasPriceEstimating> {
+    let client = Client(client.clone());
+    let network_id = web3.net().version().await?;
+    let mut estimators = Vec::<Box<dyn GasPriceEstimating>>::new();
+    for estimator_type in estimator_types {
+        match estimator_type {
+            GasEstimatorType::EthGasStation => {
+                if !is_mainnet(&network_id) {
+                    return Err(anyhow!("EthGasStation only supports mainnet"));
+                }
+                estimators.push(Box::new(EthGasStation::new(client.clone())))
+            }
+            GasEstimatorType::GasNow => {
+                if !is_mainnet(&network_id) {
+                    return Err(anyhow!("GasNow only supports mainnet"));
+                }
+                estimators.push(Box::new(GasNowGasStation::new(client.clone())))
+            }
+            GasEstimatorType::GnosisSafe => estimators.push(Box::new(
+                GnosisSafeGasStation::with_network_id(&network_id, client.clone())?,
+            )),
+            GasEstimatorType::Web3 => estimators.push(Box::new(web3.clone())),
+        }
+    }
+    Ok(PriorityGasPriceEstimating::new(estimators))
+}
+
+fn is_mainnet(network_id: &str) -> bool {
+    network_id == "1"
+}

--- a/solver/src/lib.rs
+++ b/solver/src/lib.rs
@@ -1,28 +1,28 @@
 pub mod driver;
 pub mod encoding;
+pub mod gas_price_estimation;
 pub mod http_solver;
 pub mod interactions;
 pub mod liquidity;
 pub mod naive_solver;
 pub mod orderbook;
 pub mod settlement;
+pub mod settlement_submission;
 pub mod solver;
 pub mod uniswap;
 
 use anyhow::Result;
-use ethcontract::{contract::MethodDefaults, Account, GasPrice, Http, PrivateKey, Web3};
+use ethcontract::{contract::MethodDefaults, Account, Http, PrivateKey, Web3};
 
 pub async fn get_settlement_contract(
     web3: &Web3<Http>,
     chain_id: u64,
     key: PrivateKey,
-    gas_price_factor: f64,
 ) -> Result<contracts::GPv2Settlement> {
     let mut settlement_contract = contracts::GPv2Settlement::deployed(&web3).await?;
     *settlement_contract.defaults_mut() = MethodDefaults {
         from: Some(Account::Offline(key, Some(chain_id))),
-        gas: None,
-        gas_price: Some(GasPrice::Scaled(gas_price_factor)),
+        ..Default::default()
     };
     Ok(settlement_contract)
 }

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -1,5 +1,5 @@
 use model::{order::OrderKind, TokenPair};
-use num_rational::Rational;
+use num::rational::Rational;
 use primitive_types::{H160, U256};
 use settlement::{Interaction, Trade};
 use std::sync::Arc;

--- a/solver/src/liquidity/uniswap.rs
+++ b/solver/src/liquidity/uniswap.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use contracts::{GPv2Settlement, UniswapV2Factory, UniswapV2Router02};
 use model::TokenPair;
-use num_rational::Rational;
+use num::rational::Rational;
 use primitive_types::{H160, U256};
 use std::collections::{hash_map::Entry, HashMap};
 use std::sync::Arc;

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -1,8 +1,12 @@
 use ethcontract::PrivateKey;
 use reqwest::Url;
-use solver::{driver::Driver, liquidity::uniswap::UniswapLiquidity, naive_solver::NaiveSolver};
+use solver::{
+    driver::Driver, gas_price_estimation::GasEstimatorType, liquidity::uniswap::UniswapLiquidity,
+    naive_solver::NaiveSolver,
+};
 use std::time::Duration;
 use structopt::StructOpt;
+
 #[derive(Debug, StructOpt)]
 struct Arguments {
     #[structopt(flatten)]
@@ -25,9 +29,21 @@ struct Arguments {
     #[structopt(short = "k", long, env = "PRIVATE_KEY", hide_env_values = true)]
     private_key: PrivateKey,
 
-    /// The factor by which the gas price estimate is multiplied (to ensure fast settlement)
-    #[structopt(long, env = "GAS_PRICE_FACTOR", default_value = "1.0")]
-    gas_price_factor: f64,
+    /// Which gas estimators to use. Multiple estimators are used in sequence if a previous one
+    /// fails. Individual estimators support different networks.
+    /// `EthGasStation`: supports mainnet.
+    /// `GasNow`: supports mainnet.
+    /// `GnosisSafe`: supports mainnet and rinkeby.
+    /// `Web3`: supports every network.
+    #[structopt(
+        long,
+        env = "GAS_ESTIMATORS",
+        default_value = "Web3",
+        possible_values = &GasEstimatorType::variants(),
+        case_insensitive = true,
+        use_delimiter = true
+    )]
+    gas_estimators: Vec<GasEstimatorType>,
 }
 
 #[tokio::main]
@@ -51,10 +67,9 @@ async fn main() {
         .await
         .expect("Could not get chainId")
         .as_u64();
-    let settlement_contract =
-        solver::get_settlement_contract(&web3, chain_id, args.private_key, args.gas_price_factor)
-            .await
-            .expect("couldn't load deployed settlement");
+    let settlement_contract = solver::get_settlement_contract(&web3, chain_id, args.private_key)
+        .await
+        .expect("couldn't load deployed settlement");
     let orderbook_api =
         solver::orderbook::OrderBookApi::new(args.orderbook_url, args.orderbook_timeout);
     let uniswap_liquidity = UniswapLiquidity::new(
@@ -67,11 +82,19 @@ async fn main() {
         uniswap_factory,
         gpv2_settlement: settlement_contract.clone(),
     };
+    let gas_price_estimator = solver::gas_price_estimation::create_priority_estimator(
+        &reqwest::Client::new(),
+        &web3,
+        args.gas_estimators.as_slice(),
+    )
+    .await
+    .expect("failed to create gas price estimator");
     let mut driver = Driver::new(
         settlement_contract,
         uniswap_liquidity,
         orderbook_api,
         Box::new(solver),
+        Box::new(gas_price_estimator),
     );
     driver.run_forever().await;
 }

--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -1,0 +1,50 @@
+use std::time::Duration;
+
+use crate::settlement::Settlement;
+use anyhow::{anyhow, Context, Result};
+use contracts::GPv2Settlement;
+use ethcontract::GasPrice;
+use gas_estimation::GasPriceEstimating;
+use primitive_types::U256;
+
+const MAX_GAS: u32 = 8_000_000;
+
+pub async fn submit(
+    settlement: Settlement,
+    contract: &GPv2Settlement,
+    gas: &dyn GasPriceEstimating,
+) -> Result<()> {
+    // TODO: use retry transaction sending crate for updating gas prices
+    let encoded_interactions = settlement
+        .encode_interactions()
+        .context("interaction encoding failed")?;
+    let encoded_trades = settlement
+        .encode_trades()
+        .ok_or_else(|| anyhow!("trade encoding failed"))?;
+    let settle = || {
+        contract
+            .settle(
+                settlement.tokens(),
+                settlement.clearing_prices(),
+                encoded_trades.clone(),
+                encoded_interactions.clone(),
+                Vec::new(),
+            )
+            .gas(MAX_GAS.into())
+    };
+    tracing::info!(
+        "Settlement call: {}",
+        hex::encode(settle().tx.data.expect("data").0),
+    );
+    let gas_price = gas
+        .estimate_with_limits(MAX_GAS.into(), Duration::from_secs(60))
+        .await
+        .context("failed to get gas price")?;
+    settle().call().await.context("settle simulation failed")?;
+    settle()
+        .gas_price(GasPrice::Value(U256::from_f64_lossy(gas_price)))
+        .send()
+        .await
+        .context("settle execution failed")?;
+    Ok(())
+}

--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -13,6 +13,7 @@ pub async fn submit(
     settlement: Settlement,
     contract: &GPv2Settlement,
     gas: &dyn GasPriceEstimating,
+    target_confirm_time: Duration,
 ) -> Result<()> {
     // TODO: use retry transaction sending crate for updating gas prices
     let encoded_interactions = settlement
@@ -37,9 +38,10 @@ pub async fn submit(
         hex::encode(settle().tx.data.expect("data").0),
     );
     let gas_price = gas
-        .estimate_with_limits(MAX_GAS.into(), Duration::from_secs(60))
+        .estimate_with_limits(MAX_GAS.into(), target_confirm_time)
         .await
         .context("failed to get gas price")?;
+    tracing::info!("Using gas price {}", gas_price);
     settle().call().await.context("settle simulation failed")?;
     settle()
         .gas_price(GasPrice::Value(U256::from_f64_lossy(gas_price)))


### PR DESCRIPTION
like in gpv1 we have several estimators that are selected in the command
line argument.

Does not yet retry with higher gas prices, just uses the gas price for the one transaction.

`gas_price_estimation.rs` has mostly been copied from gpv1. While adapting it I noticed that we do not yet have an http client abstraction and don't define a crate wide `web3` type that uses that http client so I resused the exact types we already had. Will add those in a separate PR.

Note to self: Should update staging so that as in gpv1 we use better gas estimators than just web3.

### Test Plan
e2e test still works
