### PR TITLE
Introduce BalanceFetcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b4cc7775cded7a186ed4a8f76e23e893dfb60430de947c958e964d4603a211"
+checksum = "12a626563659af43e55b407dac9e79b9d3c322337d64c162bab26777ce07e63a"
 dependencies = [
  "ethcontract-common",
  "futures",
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-common"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075fb9804a2767e448d5026decc6c550b9e3e9130a3c4d4b3f1bb4e473553d33"
+checksum = "ec2f873eada6906c9b51b2a15ea2127d48bcf7be5430f755ac14d37e39379983"
 dependencies = [
  "ethabi",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,6 +1651,7 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal",
+ "mockall",
  "model",
  "num-bigint",
  "primitive-types",

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -37,3 +37,4 @@ web3 = { version = "0.15", default-features = false, features = ["http-tls"] }
 [dev-dependencies]
 hex-literal = "0.3"
 secp256k1 = "0.20"
+mockall = "0.9"

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod account_balances;
 pub mod api;
 pub mod database;
 pub mod event_updater;


### PR DESCRIPTION
Part of #40

This component defines an interface for balance/allowance fetching and a concrete implementation that registers `(account, token)` pairs by fetching their balance and allowance for the Allowance manager contract. 
Updates can be triggered periodically, which refetch all subscribed balances and allowances using the new Batch Call feature of ethcontracts (will likely happen inside orderbook maintenance).

In the future we probably also want a way to unsubscribe token pairs that are no longer part of the active orderbook. 

### Test Plan
Unfortunately testing ethcontract related code at the moment is painful. I added an e2e test that require ganache, but would much prefer if we could make it easier to test these type of interactions as a unit test. There is https://github.com/gnosis/ethcontract-rs/issues/424 to track part of this effort. Maybe for now the easiest solution would be to expose [TestTransport](https://github.com/gnosis/ethcontract-rs/blob/5c677d10bfa37da073c1c80bb4f3c562bb2dc9c8/ethcontract/src/test/transport.rs#L24) behind a feature so that we can use it to mock web3 responses.