### PR TITLE
Filter insufficient balance

### DIFF
--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -119,7 +119,7 @@ async fn test_with_ganache() {
             .expect("Couldn't query domain separator"),
     );
     let orderbook = Arc::new(Orderbook::new(
-        DomainSeparator::default(),
+        domain_separator,
         Box::new(InMemoryOrderBook::default()),
         Box::new(Web3BalanceFetcher::new(web3.clone(), gp_allowance)),
     ));

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -27,6 +27,7 @@ pub fn get_orders_request() -> impl Filter<Extract = (OrderFilter,), Error = Rej
             buy_token: to_h160(query.buy_token),
             exclude_fully_executed: true,
             exclude_invalidated: true,
+            exclude_insufficient_balance: true,
             ..Default::default()
         })
 }

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -20,6 +20,7 @@ pub struct OrderFilter {
     pub buy_token: Option<H160>,
     pub exclude_fully_executed: bool,
     pub exclude_invalidated: bool,
+    pub exclude_insufficient_balance: bool,
     pub uid: Option<OrderUid>,
 }
 


### PR DESCRIPTION
Closes #40 (for now)

Adding a new boolean to OrderFilter and enabling it for the default order requests, making sure we only return orders that are valid.

### Test Plan
Added a unit test. Also tested on Rinkeby with frontend pointing to localhost that when i create an order with max balance and then do a small transfer from that balance the order disappears from the orderbook.