### PR TITLE
Remove in memory orderbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,41 @@ Several pieces of functionality are shared between the order book and the solver
 
 ## Testing
 
-Run unit tests with `cargo test`.
-Some (by default ignored) tests require a locally running Postgres instance as seen on [CI](.github/workflows/pull-request.yaml).
-More extensive end to end tests can be run with `cargo test -p e2e`.
-These require a locally running instance of ganache.
+Run unit tests: `cargo test`.
 
-A more extensive e2e test using ganache
+Some unit tests and the e2e tests require a local postgres setup. For some ways on how to start postgres see the next section. e2e tests additionally require ganache to be running.
+
+Run postgres unit tests: `cargo test --jobs 1 postgres -- --ignored --test-threads 1`
+
+Run e2e tests: `cargo test -p e2e -- --test-threads 1`.
+
+### Postgres
+
+The tests that require postgres connect to the default database of locally running postgres instance on the default port. There are several ways to set up postgres:
+
+```sh
+# Docker
+docker run -d -e POSTGRES_HOST_AUTH_METHOD=trust -e POSTGRES_USER=`whoami` -p 5432:5432 postgres
+
+# Service
+sudo systemctl start postgresql.service
+sudo -u postgres createuser $USER
+sudo -u postgres createdb $USER
+
+# Manual setup in local folder
+mkdir postgres && cd postgres
+initdb data # Arbitrary directory that stores the database
+# In data/postgresql.conf set unix_socket_directories to the absolute path to an arbitrary existing
+# and writable directory that postgres creates a temporary file in.
+# Run postgres
+postgres -D data
+# In another terminal, only for first time setup
+createdb -h localhost $USER
+
+# Finally for all methods to test that the server is reachable and to set the schema for the tests.
+psql -h localhost -f database/schema.sql
+```
+
 
 ## Running
 

--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -120,9 +120,9 @@ async fn test_with_ganache() {
     );
     let db = Database::new("postgresql://").unwrap();
     db.clear().await.unwrap();
-    let storage = storage::postgresql::OrderBook::new(db);
+    let storage = storage::postgresql::OrderBook::new(gp_settlement.clone(), db);
     let orderbook = Arc::new(Orderbook::new(
-        DomainSeparator::default(),
+        domain_separator,
         Box::new(storage),
         Box::new(Web3BalanceFetcher::new(web3.clone(), gp_allowance)),
     ));

--- a/orderbook/src/database.rs
+++ b/orderbook/src/database.rs
@@ -26,9 +26,8 @@ impl Database {
         })
     }
 
-    #[cfg(test)]
-    /// Delete all data in the database.
-    async fn clear(&self) -> Result<()> {
+    /// Delete all data in the database. Only used by tests.
+    pub async fn clear(&self) -> Result<()> {
         use sqlx::Executor;
         self.pool.execute(sqlx::query("TRUNCATE orders;")).await?;
         self.pool.execute(sqlx::query("TRUNCATE trades;")).await?;

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -64,7 +64,7 @@ async fn main() {
         .expect("Deployed contract constants don't match the ones in this binary");
     let domain_separator =
         DomainSeparator::get_domain_separator(chain_id, settlement_contract.address());
-    let storage = storage::postgres_orderbook(args.db_url)
+    let storage = storage::postgres_orderbook(settlement_contract.clone(), args.db_url)
         .await
         .expect("failed to connect to postgres");
     let balance_fetcher = Web3BalanceFetcher::new(web3.clone(), gp_allowance);

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -95,27 +95,33 @@ pub fn has_future_valid_to(now_in_epoch_seconds: u32, order: &OrderCreation) -> 
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::{account_balances::MockBalanceFetching, storage::MockStorage};
     use ethcontract::H160;
     use mockall::{
         predicate::{always, eq},
         Sequence,
     };
-    use model::{order::OrderCreation, DomainSeparator};
-
-    use super::*;
-    use crate::account_balances::MockBalanceFetching;
-    use crate::storage::{InMemoryOrderBook, MockStorage};
+    use model::{
+        order::{OrderBuilder, OrderCreation},
+        DomainSeparator,
+    };
 
     #[tokio::test]
     async fn watches_owners_sell_token_balance_for_added_orders() {
-        let storage = Box::new(InMemoryOrderBook::default());
+        let mut storage = MockStorage::new();
         let mut balance_fetcher = MockBalanceFetching::new();
 
         let sell_token = H160::from_low_u64_be(2);
-        let order = OrderCreation {
-            sell_token,
-            ..Default::default()
-        };
+        let order = OrderBuilder::default().with_sell_token(sell_token).build();
+
+        storage
+            .expect_add_order()
+            .returning(|_| Ok(AddOrderResult::Added(OrderUid::default())));
+        storage.expect_get_orders().return_once({
+            let order = order.clone();
+            move |_| Ok(vec![order])
+        });
 
         balance_fetcher
             .expect_register()
@@ -124,10 +130,10 @@ mod tests {
 
         let orderbook = Orderbook::new(
             DomainSeparator::default(),
-            storage,
+            Box::new(storage),
             Box::new(balance_fetcher),
         );
-        orderbook.add_order(order).await.unwrap();
+        orderbook.add_order(order.order_creation).await.unwrap();
     }
 
     #[tokio::test]

--- a/orderbook/src/storage.rs
+++ b/orderbook/src/storage.rs
@@ -1,13 +1,10 @@
-mod memory;
-mod postgresql;
+pub mod postgresql;
 
 use crate::database::{Database, OrderFilter};
 use anyhow::Result;
 use contracts::GPv2Settlement;
 use model::order::{Order, OrderUid};
 use url::Url;
-
-pub use memory::OrderBook as InMemoryOrderBook;
 
 pub async fn postgres_orderbook(contract: GPv2Settlement, db_url: Url) -> Result<impl Storage> {
     let db = Database::new(db_url.as_str())?;


### PR DESCRIPTION
Staging is working with postgres now so the in memory order book can be
removed.

I would also like to remove the whole storage module in the next PR, moving those functions directly to `struct OrderBook`.

### Test Plan
e2e test works on CI
