### PR TITLE
Retry transaction sending when gas prices increase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2399,6 +2399,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "transaction-retry",
  "web3",
 ]
 
@@ -2841,6 +2842,15 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "transaction-retry"
+version = "0.1.0"
+source = "git+https://github.com/gnosis/gp-transaction-retry.git?tag=v0.1.0#31b32869dbc773d62c11e91dac4d66aaa691faa2"
+dependencies = [
+ "async-trait",
+ "futures",
 ]
 
 [[package]]

--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -1,4 +1,4 @@
-use contracts::{ERC20Mintable, GPv2Settlement, UniswapV2Factory, UniswapV2Router02};
+use contracts::{ERC20Mintable, UniswapV2Factory, UniswapV2Router02};
 use ethcontract::{
     prelude::{Account, Address, Http, PrivateKey, Web3, U256},
     H160,
@@ -72,7 +72,8 @@ async fn test_with_ganache() {
     let uniswap_router = UniswapV2Router02::deployed(&web3)
         .await
         .expect("Failed to load deployed UniswapFactory");
-    let gp_settlement = GPv2Settlement::deployed(&web3)
+
+    let gp_settlement = solver::get_settlement_contract(&web3, solver.clone())
         .await
         .expect("Failed to load deployed GPv2Settlement");
     let gp_allowance = gp_settlement

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -17,6 +17,7 @@ async-trait = "0.1"
 contracts = { path = "../contracts" }
 ethcontract = { version = "0.11", default-features = false }
 futures = "0.3"
+transaction-retry = { git = "https://github.com/gnosis/gp-transaction-retry.git", tag = "v0.1.0" }
 gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.0", features = ["web3_"] }
 hex = "0.4"
 hex-literal = "0.3"

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -10,6 +10,10 @@ use gas_estimation::GasPriceEstimating;
 use std::time::Duration;
 use tracing::info;
 
+// There is no economic viability calculation yet so we're using an arbitrary very high cap to
+// protect against a gas estimator giving bogus results that would drain all our funds.
+const GAS_PRICE_CAP: f64 = 500e9;
+
 pub struct Driver {
     settlement_contract: GPv2Settlement,
     orderbook: OrderBookApi,
@@ -87,10 +91,11 @@ impl Driver {
         } else {
             // TODO: check if we need to approve spending to uniswap
             settlement_submission::submit(
-                settlement,
                 &self.settlement_contract,
                 self.gas_price_estimator.as_ref(),
                 self.target_confirm_time,
+                GAS_PRICE_CAP,
+                settlement,
             )
             .await
             .context("failed to submit settlement")?;

--- a/solver/src/lib.rs
+++ b/solver/src/lib.rs
@@ -10,16 +10,15 @@ pub mod settlement_submission;
 pub mod solver;
 
 use anyhow::Result;
-use ethcontract::{contract::MethodDefaults, Account, Http, PrivateKey, Web3};
+use ethcontract::{contract::MethodDefaults, Account, Http, Web3};
 
 pub async fn get_settlement_contract(
     web3: &Web3<Http>,
-    chain_id: u64,
-    key: PrivateKey,
+    account: Account,
 ) -> Result<contracts::GPv2Settlement> {
     let mut settlement_contract = contracts::GPv2Settlement::deployed(&web3).await?;
     *settlement_contract.defaults_mut() = MethodDefaults {
-        from: Some(Account::Offline(key, Some(chain_id))),
+        from: Some(account),
         ..Default::default()
     };
     Ok(settlement_contract)

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -1,5 +1,5 @@
 use contracts::WETH9;
-use ethcontract::PrivateKey;
+use ethcontract::{Account, PrivateKey};
 use reqwest::Url;
 use solver::{driver::Driver, liquidity::uniswap::UniswapLiquidity, naive_solver::NaiveSolver};
 use std::time::Duration;
@@ -55,19 +55,20 @@ async fn main() {
     let transport = web3::transports::Http::new(args.shared.node_url.as_str())
         .expect("transport creation failed");
     let web3 = web3::Web3::new(transport);
-    let uniswap_router = contracts::UniswapV2Router02::deployed(&web3)
-        .await
-        .expect("couldn't load deployed uniswap router");
-    let uniswap_factory = contracts::UniswapV2Factory::deployed(&web3)
-        .await
-        .expect("couldn't load deployed uniswap router");
     let chain_id = web3
         .eth()
         .chain_id()
         .await
         .expect("Could not get chainId")
         .as_u64();
-    let settlement_contract = solver::get_settlement_contract(&web3, chain_id, args.private_key)
+    let uniswap_router = contracts::UniswapV2Router02::deployed(&web3)
+        .await
+        .expect("couldn't load deployed uniswap router");
+    let uniswap_factory = contracts::UniswapV2Factory::deployed(&web3)
+        .await
+        .expect("couldn't load deployed uniswap router");
+    let account = Account::Offline(args.private_key, Some(chain_id));
+    let settlement_contract = solver::get_settlement_contract(&web3, account)
         .await
         .expect("couldn't load deployed settlement");
     let native_token = WETH9::deployed(&web3)

--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -1,52 +1,89 @@
-use std::time::Duration;
+mod gas_price_stream;
+mod retry;
 
+use self::retry::{CancelSender, SettlementSender};
 use crate::settlement::Settlement;
 use anyhow::{anyhow, Context, Result};
 use contracts::GPv2Settlement;
-use ethcontract::GasPrice;
 use gas_estimation::GasPriceEstimating;
-use primitive_types::U256;
+use gas_price_stream::gas_price_stream;
+use primitive_types::{H160, U256};
+use std::time::Duration;
+use transaction_retry::RetryResult;
 
 const MAX_GAS: u32 = 8_000_000;
+const GAS_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
 
+// Submit a settlement to the contract, updating the transaction with gas prices if they increase.
 pub async fn submit(
-    settlement: Settlement,
     contract: &GPv2Settlement,
     gas: &dyn GasPriceEstimating,
     target_confirm_time: Duration,
+    gas_price_cap: f64,
+    settlement: Settlement,
 ) -> Result<()> {
-    // TODO: use retry transaction sending crate for updating gas prices
-    let encoded_interactions = settlement
-        .encode_interactions()
-        .context("interaction encoding failed")?;
-    let encoded_trades = settlement
-        .encode_trades()
-        .ok_or_else(|| anyhow!("trade encoding failed"))?;
-    let settle = || {
-        contract
-            .settle(
-                settlement.tokens(),
-                settlement.clearing_prices(),
-                encoded_trades.clone(),
-                encoded_interactions.clone(),
-                Vec::new(),
-            )
-            .gas(MAX_GAS.into())
+    let nonce = transaction_count(contract)
+        .await
+        .context("failed to get transaction_count")?;
+    let settlement = encode_settlement(&settlement)?;
+    // Check that a simulation of the transaction works before submitting it.
+    simulate_settlement(&settlement, contract).await?;
+
+    let settlement_sender = SettlementSender {
+        contract,
+        nonce,
+        settlement,
     };
-    tracing::info!(
-        "Settlement call: {}",
-        hex::encode(settle().tx.data.expect("data").0),
-    );
-    let gas_price = gas
-        .estimate_with_limits(MAX_GAS.into(), target_confirm_time)
-        .await
-        .context("failed to get gas price")?;
-    tracing::info!("Using gas price {}", gas_price);
-    settle().call().await.context("settle simulation failed")?;
-    settle()
-        .gas_price(GasPrice::Value(U256::from_f64_lossy(gas_price)))
-        .send()
-        .await
-        .context("settle execution failed")?;
+    // We never cancel.
+    let cancel_future = std::future::pending::<CancelSender>();
+    let stream = gas_price_stream(target_confirm_time, gas_price_cap, gas);
+
+    match transaction_retry::retry(settlement_sender, cancel_future, stream).await {
+        Some(RetryResult::Submitted(result)) => {
+            tracing::info!("completed settlement submission");
+            result.0.context("settlement transaction failed")
+        }
+        _ => unreachable!(),
+    }
+}
+
+async fn transaction_count(contract: &GPv2Settlement) -> Result<U256> {
+    let defaults = contract.defaults();
+    let address = defaults.from.as_ref().unwrap().address();
+    let web3 = contract.raw_instance().web3();
+    let count = web3.eth().transaction_count(address, None).await?;
+    Ok(count)
+}
+
+#[derive(Clone)]
+pub struct EncodedSettlement {
+    tokens: Vec<H160>,
+    clearing_prices: Vec<U256>,
+    encoded_trades: Vec<u8>,
+    encoded_interactions: Vec<u8>,
+}
+
+fn encode_settlement(settlement: &Settlement) -> Result<EncodedSettlement> {
+    Ok(EncodedSettlement {
+        tokens: settlement.tokens(),
+        clearing_prices: settlement.clearing_prices(),
+        encoded_interactions: settlement
+            .encode_interactions()
+            .context("interaction encoding failed")?,
+        encoded_trades: settlement
+            .encode_trades()
+            .ok_or_else(|| anyhow!("trade encoding failed"))?,
+    })
+}
+
+// Simulate the settlement using a web3 `call`.
+async fn simulate_settlement(
+    settlement: &EncodedSettlement,
+    contract: &GPv2Settlement,
+) -> Result<()> {
+    let method = retry::settle_method_builder(contract, settlement.clone());
+    let data = method.tx.data.as_ref().expect("no data").0.as_slice();
+    tracing::info!("Settlement call: {}", hex::encode(data));
+    method.call().await.context("settle simulation failed")?;
     Ok(())
 }

--- a/solver/src/settlement_submission/gas_price_stream.rs
+++ b/solver/src/settlement_submission/gas_price_stream.rs
@@ -1,0 +1,37 @@
+use super::{GAS_PRICE_REFRESH_INTERVAL, MAX_GAS};
+use futures::{stream, Stream, StreamExt};
+use gas_estimation::GasPriceEstimating;
+use std::time::Duration;
+
+// TODO: use a real gas estimation instead of MAX_GAS.
+
+// Create a never ending stream of gas prices based on checking the estimator in fixed intervals
+// and enforcing the minimum increase. Errors are ignored.
+pub fn gas_price_stream(
+    target_confirm_time: Duration,
+    gas_price_cap: f64,
+    estimator: &dyn GasPriceEstimating,
+) -> impl Stream<Item = f64> + '_ {
+    let stream = stream::unfold(true, move |first_call| async move {
+        if !first_call {
+            tokio::time::delay_for(GAS_PRICE_REFRESH_INTERVAL).await;
+        }
+        let estimate = estimator
+            .estimate_with_limits(MAX_GAS as f64, target_confirm_time)
+            .await;
+        Some((estimate, false))
+    })
+    .filter_map(|gas_price_result| async move {
+        match gas_price_result {
+            Ok(gas_price) => {
+                tracing::debug!("estimated gas price {}", gas_price);
+                Some(gas_price)
+            }
+            Err(err) => {
+                tracing::error!("gas price estimation failed: {:?}", err);
+                None
+            }
+        }
+    });
+    transaction_retry::gas_price_increase::enforce_minimum_increase_and_cap(gas_price_cap, stream)
+}

--- a/solver/src/settlement_submission/retry.rs
+++ b/solver/src/settlement_submission/retry.rs
@@ -1,0 +1,109 @@
+use super::EncodedSettlement;
+use anyhow::Result;
+use contracts::GPv2Settlement;
+use ethcontract::{
+    dyns::DynMethodBuilder,
+    errors::{ExecutionError, MethodError},
+    jsonrpc::types::Error as RpcError,
+    transaction::{confirm::ConfirmParams, ResolveCondition},
+    web3::error::Error as Web3Error,
+    GasPrice, Void,
+};
+use primitive_types::U256;
+use transaction_retry::{TransactionResult, TransactionSending};
+
+fn is_transaction_error(error: &ExecutionError) -> bool {
+    // This is the error as we've seen it on openethereum nodes. The code and error messages can
+    // be found in openethereum's source code in `rpc/src/v1/helpers/errors.rs`.
+    // TODO: check how this looks on geth and infura. Not recognizing the error is not a serious
+    // problem but it will make us sometimes log an error when there actually was no problem.
+    matches!(error, ExecutionError::Web3(Web3Error::Rpc(RpcError { code, .. })) if code.code() == -32010)
+}
+
+pub struct SettleResult(pub Result<(), MethodError>);
+impl TransactionResult for SettleResult {
+    fn was_mined(&self) -> bool {
+        if let Err(err) = &self.0 {
+            !is_transaction_error(&err.inner)
+        } else {
+            true
+        }
+    }
+}
+
+pub struct SettlementSender<'a> {
+    pub contract: &'a GPv2Settlement,
+    pub nonce: U256,
+    pub settlement: EncodedSettlement,
+}
+#[async_trait::async_trait]
+impl<'a> TransactionSending for SettlementSender<'a> {
+    type Output = SettleResult;
+    async fn send(&self, gas_price: f64) -> Self::Output {
+        tracing::info!("submitting solution transaction at gas price {}", gas_price);
+        let mut method = settle_method_builder(self.contract, self.settlement.clone())
+            .nonce(self.nonce)
+            .gas_price(GasPrice::Value(U256::from_f64_lossy(gas_price)));
+        method.tx.resolve = Some(ResolveCondition::Confirmed(ConfirmParams::mined()));
+        let result = method.send().await.map(|_| ());
+        SettleResult(result)
+    }
+}
+
+pub fn settle_method_builder(
+    contract: &GPv2Settlement,
+    settlement: EncodedSettlement,
+) -> DynMethodBuilder<Void> {
+    contract
+        .settle(
+            settlement.tokens,
+            settlement.clearing_prices,
+            settlement.encoded_trades,
+            settlement.encoded_interactions,
+            Vec::new(),
+        )
+        .gas(super::MAX_GAS.into())
+}
+
+// We never send cancellations but we still need to have types that implement the traits.
+pub struct CancelResult;
+impl TransactionResult for CancelResult {
+    fn was_mined(&self) -> bool {
+        unreachable!()
+    }
+}
+
+pub struct CancelSender;
+#[async_trait::async_trait]
+impl TransactionSending for CancelSender {
+    type Output = CancelResult;
+    async fn send(&self, _gas_price: f64) -> Self::Output {
+        unreachable!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonrpc_core::ErrorCode;
+
+    #[test]
+    fn test_submission_result_was_mined() {
+        let transaction_error = ExecutionError::Web3(Web3Error::Rpc(RpcError {
+            code: ErrorCode::from(-32010),
+            message: "".into(),
+            data: None,
+        }));
+        let result = SettleResult(Ok(()));
+        assert!(result.was_mined());
+
+        let result = SettleResult(Err(MethodError::from_parts(
+            "".into(),
+            ExecutionError::StreamEndedUnexpectedly,
+        )));
+        assert!(result.was_mined());
+
+        let result = SettleResult(Err(MethodError::from_parts("".into(), transaction_error)));
+        assert!(!result.was_mined());
+    }
+}


### PR DESCRIPTION
Using the retry crate from gpv1.

A lot of the code is similar to solution_submission.rs in gp-v1 but adapted to the rest of the gpv2 code. `is_transaction_error` and `GasPriceStream` are exactly the same. It wasn't worth to factor those into individual crates because they are small and the stream relies on a sleep trait which is project specific.

### Test Plan
CI e2e test.
