### PR TITLE
Fix musl image to prevent deploy stet from failing

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:nightly-2021-02-01 as cargo-build
+FROM clux/muslrust:stable as cargo-build
 WORKDIR /usr/src/oba-services
 
 # Copy and Build Code

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust as cargo-build
+FROM clux/muslrust:nightly-2021-02-01 as cargo-build
 WORKDIR /usr/src/oba-services
 
 # Copy and Build Code


### PR DESCRIPTION
The deploy step on master is [failing](https://github.com/gnosis/gp-v2-services/runs/1818274604) because of a compilation error in the musl target.

It looks like it's related to the latest musl image which was published yesterday (none of the failing dependencies changed during that time): https://hub.docker.com/r/clux/muslrust

It seems like the latest image is based on a daily nightly release. A simple fix for now is to fix the musl image we use to the last know working one.

### Test Plan
Tested locally that `clux/muslrust:nightly-2021-02-02` fails compilation, but `clux/muslrust:nightly-2021-02-01` passes.
