### PR TITLE
Enable event updater

### DIFF
--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -70,7 +70,7 @@ async fn main() {
     let storage: Box<dyn Storage> = match args.db_url {
         None => Box::new(InMemoryOrderBook::default()),
         Some(url) => Box::new(
-            storage::postgres_orderbook(url)
+            storage::postgres_orderbook(settlement_contract.clone(), url)
                 .await
                 .expect("failed to connect to postgres"),
         ),

--- a/orderbook/src/storage.rs
+++ b/orderbook/src/storage.rs
@@ -9,9 +9,9 @@ use url::Url;
 
 pub use memory::OrderBook as InMemoryOrderBook;
 
-pub async fn postgres_orderbook(url: Url) -> Result<impl Storage> {
-    let db = Database::new(url.as_str())?;
-    let order_book = postgresql::OrderBook::_new(db);
+pub async fn postgres_orderbook(contract: GPv2Settlement, db_url: Url) -> Result<impl Storage> {
+    let db = Database::new(db_url.as_str())?;
+    let order_book = postgresql::OrderBook::new(contract, db);
     // Perform one operation on the database to ensure that the connection works.
     order_book
         .get_orders(&OrderFilter {


### PR DESCRIPTION
Silly mistake on my part. I wrote the whole EventUpdater code but never integrated it as part of the maintenance function.
I tested locally that this works with mainnet. Note that the first event update is going to take a really long time because it has to start at block 0.  This wasn't  the case in v1 because there we had information about the deployment transaction hash available in the artifact which ethcontract knows how to use in order to set a lower bound for the block of the first event. I am working on a PR to ethcontract to allow us to use that there too.

### Test Plan
CI
