### PR TITLE
Specify deployment transaction hash for settlement contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract"
-version = "0.10.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a626563659af43e55b407dac9e79b9d3c322337d64c162bab26777ce07e63a"
+checksum = "4a00ffbfb6e29fd828f12dd00c1dcc31f3c4a0912cc8d5f87b8242addaf315c9"
 dependencies = [
  "ethcontract-common",
  "futures",
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-common"
-version = "0.10.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2f873eada6906c9b51b2a15ea2127d48bcf7be5430f755ac14d37e39379983"
+checksum = "20addff5b356ce614996ceb5c217bc4d95f50f21bbddca32e91579978f0ef316"
 dependencies = [
  "ethabi",
  "hex",
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-generate"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c8f75df99d9d13b70fea71ce278d90113a3fe5130a8225b9b6e07e1ca725e9"
+checksum = "aa9bc413a324ad98a80a70bfe8b7dea0d3e85f1921fe4a0c3497bc21cf0f393b"
 dependencies = [
  "Inflector",
  "anyhow",

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -25,18 +25,18 @@ bin = [
 ]
 
 [dependencies]
-ethcontract = { version = "0.10",  default-features = false, features = ["http"] }
+ethcontract = { version = "0.11",  default-features = false, features = ["http"] }
 serde = "1.0"
 
 # [bin-dependencies]
 anyhow = { version = "1.0", optional = true }
 env_logger = { version = "0.8", optional = true }
-ethcontract-generate = { version = "0.10", optional = true}
+ethcontract-generate = { version = "0.11", optional = true}
 filetime = { version = "0.2.14", optional = true }
 log = { version = "0.4", optional = true }
 serde_json = { version = "1.0", optional = true }
 tokio = { version = "0.2", optional = true, features = ["macros"] }
 
 [build-dependencies]
-ethcontract-generate = "0.10"
+ethcontract-generate = "0.11"
 maplit = "1.0"

--- a/contracts/build.rs
+++ b/contracts/build.rs
@@ -1,4 +1,4 @@
-use ethcontract_generate::{Address, Builder};
+use ethcontract_generate::{Address, Builder, TransactionHash};
 use maplit::hashmap;
 use std::{collections::HashMap, env, fs, path::Path, str::FromStr};
 
@@ -20,32 +20,35 @@ fn main() {
     generate_contract(
         "UniswapV2Router02",
         hashmap! {
-            1 => Address::from_str("7a250d5630B4cF539739dF2C5dAcb4c659F2488D").unwrap(),
-            4 => Address::from_str("7a250d5630B4cF539739dF2C5dAcb4c659F2488D").unwrap(),
-            100 => Address::from_str("1C232F01118CB8B424793ae03F870aa7D0ac7f77").unwrap(),
+            1 => (Address::from_str("7a250d5630B4cF539739dF2C5dAcb4c659F2488D").unwrap(), None),
+            4 => (Address::from_str("7a250d5630B4cF539739dF2C5dAcb4c659F2488D").unwrap(), None),
+            100 => (Address::from_str("1C232F01118CB8B424793ae03F870aa7D0ac7f77").unwrap(), None),
         },
     );
     generate_contract(
         "UniswapV2Factory",
         hashmap! {
-            1 => Address::from_str("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f").unwrap(),
-            4 => Address::from_str("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f").unwrap(),
-            100 => Address::from_str("A818b4F111Ccac7AA31D0BCc0806d64F2E0737D7").unwrap(),
+            1 => (Address::from_str("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f").unwrap(), None),
+            4 => (Address::from_str("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f").unwrap(), None),
+            100 => (Address::from_str("A818b4F111Ccac7AA31D0BCc0806d64F2E0737D7").unwrap(), None),
         },
     );
     generate_contract("UniswapV2Pair", hashmap! {});
     generate_contract(
         "GPv2Settlement",
         hashmap! {
-            1 => Address::from_str("4E608b7Da83f8E9213F554BDAA77C72e125529d0").unwrap(),
-            4 => Address::from_str("4E608b7Da83f8E9213F554BDAA77C72e125529d0").unwrap(),
-            100 => Address::from_str("4E608b7Da83f8E9213F554BDAA77C72e125529d0").unwrap(),
+            1 => (Address::from_str("4E608b7Da83f8E9213F554BDAA77C72e125529d0").unwrap(), Some("4e20d94594f7ae340dadb18a9b7fa10e80f0a8dae2c72c27442cb015b9b205cf".parse().unwrap())),
+            4 => (Address::from_str("4E608b7Da83f8E9213F554BDAA77C72e125529d0").unwrap(), Some("0xd1030e85508042a6762598935751d38c4acd537401e2f2980c8fba5261022691".parse().unwrap())),
+            100 => (Address::from_str("4E608b7Da83f8E9213F554BDAA77C72e125529d0").unwrap(), Some("0xa1f149073825dc0ea99ce00656a54b038b739a70309193e43c2e64935828fdaa".parse().unwrap())),
         },
     );
     generate_contract("GPv2AllowListAuthentication", hashmap! {});
 }
 
-fn generate_contract(name: &str, deployment_overrides: HashMap<u32, Address>) {
+fn generate_contract(
+    name: &str,
+    deployment_overrides: HashMap<u32, (Address, Option<TransactionHash>)>,
+) {
     let artifact = paths::contract_artifacts_dir().join(format!("{}.json", name));
     let address_file = paths::contract_address_file(name);
     let dest = env::var("OUT_DIR").unwrap();
@@ -62,8 +65,8 @@ fn generate_contract(name: &str, deployment_overrides: HashMap<u32, Address>) {
         builder = builder.add_deployment_str(5777, address.trim());
     }
 
-    for (network_id, address) in deployment_overrides.into_iter() {
-        builder = builder.add_deployment(network_id, address);
+    for (network_id, (address, transaction_hash)) in deployment_overrides.into_iter() {
+        builder = builder.add_deployment(network_id, address, transaction_hash);
     }
 
     builder

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dev-dependencies]
 contracts = { path = "../contracts" }
-ethcontract = { version = "0.10",  default-features = false, features = ["http"] }
+ethcontract = { version = "0.11",  default-features = false, features = ["http"] }
 hex-literal = "0.3"
 model = { path = "../model" }
 orderbook = { path = "../orderbook" }

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -17,7 +17,7 @@ async-trait = "0.1"
 bigdecimal = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 contracts = { path = "../contracts" }
-ethcontract = { version = "0.10", default-features = false }
+ethcontract = { version = "0.11", default-features = false }
 futures = "0.3.12"
 hex = { version = "0.4", default-features = false }
 model = { path = "../model" }

--- a/orderbook/src/account_balances.rs
+++ b/orderbook/src/account_balances.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use ethcontract::{batch::CallBatch, Http, Web3};
 use futures::future::{join3, join_all};
 use std::collections::HashMap;
@@ -89,10 +89,7 @@ impl Web3BalanceFetcher {
             })
             .collect::<Vec<_>>();
 
-        batch
-            .execute_all()
-            .await
-            .context("Batch call to fetch balances failed")?;
+        batch.execute_all(usize::MAX).await;
 
         let call_results = join_all(calls).await;
         let mut guard = self.balances.lock().expect("thread holding mutex panicked");

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 anyhow = "1.0"
 async-trait = "0.1"
 contracts = { path = "../contracts" }
-ethcontract = { version = "0.10", default-features = false }
+ethcontract = { version = "0.11", default-features = false }
 futures = "0.3"
 gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.0", features = ["web3_"] }
 hex = "0.4"


### PR DESCRIPTION
This makes event fetching in ethcontract more efficient because it lower
bounds the block of the first event.
I got the transaction hashes from looking up the contract addresses in
each network's respective block explorer.

### Test Plan
Still compiles