### PR TITLE
Do not submit empty settlement

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -80,6 +80,9 @@ impl Driver {
             Some(settlement) => settlement,
         };
         info!("Computed {:?}", settlement);
+        if settlement.trades.is_empty() {
+            info!("Skipping empty settlement");
+        }
         // TODO: check if we need to approve spending to uniswap
         settlement_submission::submit(
             settlement,


### PR DESCRIPTION
Noticed in kibana that were are submitting empty solutions on xdai. Not sure if this is a bug in the naive solver but anyway it is probably a good idea to have this check.

### Test Plan
still compiles