### PR TITLE
Extend get_orders with more filters and exlclude invalid by default

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -44,9 +44,9 @@ paths:
     get:
       summary: Get existing orders.
       description: |
-        The orders are optionally filtered by the owner, sell token, buy token. Each filter can be
-        specified individually and is optional. So not specifying any returns all orders in the
-        system.
+        By default all currently valid orders are returned. The set of returned orders can be
+        reduced by setting owner, sell token, buy token filters. It can be increased by disabling
+        different order validity exclusion criteria.
       parameters:
         - name: owner
           in: query
@@ -63,6 +63,31 @@ paths:
           schema:
             $ref: "#/components/schemas/Address"
           required: false
+        - name: includeFullyExecuted
+          in: query
+          description: Should fully executed orders be returned?
+          schema:
+            type: boolean
+            default: false
+        - name: includeInvalidated
+          in: query
+          description: Should orders that have been invalidated in the smart contract be returned?
+          schema:
+            type: boolean
+            default: false
+        - name: includeInsufficientBalance
+          in: query
+          description: Should fill or kill orders that are not sufficiently funded be included?
+          schema:
+            type: boolean
+            default: false
+        - name: minValidTo
+          in: query
+          description: |
+            Minimum valid_to timestamp for included orders.
+            The default is the current time.
+          schema:
+            type: integer
       responses:
         200:
           description: existing orders

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -4,32 +4,48 @@ use crate::orderbook::Orderbook;
 use anyhow::Result;
 use model::order::Order;
 use serde::Deserialize;
+use shared::time::now_in_epoch_seconds;
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
 
+// The default values create a filter that only includes valid orders.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct Query {
+    #[serde(default = "now_in_epoch_seconds")]
+    min_valid_to: u32,
     owner: Option<H160Wrapper>,
     sell_token: Option<H160Wrapper>,
     buy_token: Option<H160Wrapper>,
+    #[serde(default)]
+    include_fully_executed: bool,
+    #[serde(default)]
+    include_invalidated: bool,
+    #[serde(default)]
+    include_insufficient_balance: bool,
+}
+
+impl Query {
+    fn order_filter(&self) -> OrderFilter {
+        let to_h160 = |option: Option<&H160Wrapper>| option.map(|wrapper| wrapper.0);
+        OrderFilter {
+            min_valid_to: self.min_valid_to,
+            owner: to_h160(self.owner.as_ref()),
+            sell_token: to_h160(self.sell_token.as_ref()),
+            buy_token: to_h160(self.buy_token.as_ref()),
+            exclude_fully_executed: !self.include_fully_executed,
+            exclude_invalidated: !self.include_invalidated,
+            exclude_insufficient_balance: !self.include_insufficient_balance,
+            uid: None,
+        }
+    }
 }
 
 pub fn get_orders_request() -> impl Filter<Extract = (OrderFilter,), Error = Rejection> + Clone {
-    let to_h160 = |option: Option<H160Wrapper>| option.map(|wrapper| wrapper.0);
-
     warp::path!("orders")
         .and(warp::get())
         .and(warp::query::<Query>())
-        .map(move |query: Query| OrderFilter {
-            owner: to_h160(query.owner),
-            sell_token: to_h160(query.sell_token),
-            buy_token: to_h160(query.buy_token),
-            exclude_fully_executed: true,
-            exclude_invalidated: true,
-            exclude_insufficient_balance: true,
-            ..Default::default()
-        })
+        .map(|query: Query| query.order_filter())
 }
 
 pub fn get_orders_response(result: Result<Vec<Order>>) -> impl Reply {
@@ -82,7 +98,7 @@ mod tests {
         let sell = H160::from_slice(&hex!("0000000000000000000000000000000000000002"));
         let buy = H160::from_slice(&hex!("0000000000000000000000000000000000000003"));
         let path = format!(
-            "/orders?owner=0x{:x}&sellToken=0x{:x}&buyToken=0x{:x}",
+            "/orders?owner=0x{:x}&sellToken=0x{:x}&buyToken=0x{:x}&minValidTo=2&includeFullyExecuted=true&includeInvalidated=true&includeInsufficientBalance=true",
             owner, sell, buy
         );
         let request = request().path(path.as_str());
@@ -90,6 +106,10 @@ mod tests {
         assert_eq!(result.owner, Some(owner));
         assert_eq!(result.buy_token, Some(buy));
         assert_eq!(result.sell_token, Some(sell));
+        assert_eq!(result.min_valid_to, 2);
+        assert_eq!(result.exclude_fully_executed, false);
+        assert_eq!(result.exclude_invalidated, false);
+        assert_eq!(result.exclude_insufficient_balance, false);
     }
 
     #[tokio::test]

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -1,9 +1,6 @@
-use std::time::SystemTime;
-
-use anyhow::Result;
-
 use crate::storage::{AddOrderResult, RemoveOrderResult, Storage};
 use crate::{account_balances::BalanceFetching, database::OrderFilter};
+use anyhow::Result;
 use contracts::GPv2Settlement;
 use futures::join;
 use model::{
@@ -31,7 +28,7 @@ impl Orderbook {
     }
 
     pub async fn add_order(&self, order: OrderCreation) -> Result<AddOrderResult> {
-        if !has_future_valid_to(now_in_epoch_seconds(), &order) {
+        if !has_future_valid_to(shared::time::now_in_epoch_seconds(), &order) {
             return Ok(AddOrderResult::PastValidTo);
         }
         let order = match Order::from_order_creation(order, &self.domain_separator) {
@@ -92,15 +89,8 @@ impl Orderbook {
     }
 }
 
-pub fn now_in_epoch_seconds() -> u64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("now earlier than epoch")
-        .as_secs()
-}
-
-pub fn has_future_valid_to(now_in_epoch_seconds: u64, order: &OrderCreation) -> bool {
-    order.valid_to as u64 > now_in_epoch_seconds
+pub fn has_future_valid_to(now_in_epoch_seconds: u32, order: &OrderCreation) -> bool {
+    order.valid_to > now_in_epoch_seconds
 }
 
 #[cfg(test)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod arguments;
+pub mod time;
 pub mod tracing;

--- a/shared/src/time.rs
+++ b/shared/src/time.rs
@@ -1,0 +1,11 @@
+use std::{convert::TryInto, time::SystemTime};
+
+/// The current time in the same unit as `valid_to` for orders in the smart contract.
+pub fn now_in_epoch_seconds() -> u32 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("now earlier than epoch")
+        .as_secs()
+        .try_into()
+        .expect("epoch seconds larger than max u32")
+}


### PR DESCRIPTION
This allows users of the api to make use of the full available filters.
It also fixes a bug where by default we were not setting min_valid_to
which would return old orders in the postgres orderbook.

### Test Plan
CI
