### PR TITLE
[Trivial] Actually skip empty settlement

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -82,16 +82,17 @@ impl Driver {
         info!("Computed {:?}", settlement);
         if settlement.trades.is_empty() {
             info!("Skipping empty settlement");
+        } else {
+            // TODO: check if we need to approve spending to uniswap
+            settlement_submission::submit(
+                settlement,
+                &self.settlement_contract,
+                self.gas_price_estimator.as_ref(),
+                self.target_confirm_time,
+            )
+            .await
+            .context("failed to submit settlement")?;
         }
-        // TODO: check if we need to approve spending to uniswap
-        settlement_submission::submit(
-            settlement,
-            &self.settlement_contract,
-            self.gas_price_estimator.as_ref(),
-            self.target_confirm_time,
-        )
-        .await
-        .context("failed to submit settlement")?;
         Ok(())
     }
 }


### PR DESCRIPTION
🤡 review of #273 didn't make me catch that we are not actually doing anything except for printing we will skip settlement. This PR makes it so we actually don't submit in this case

### Test Plan
Test we don't see `solver::settlement_submission: Settlement call` and `Skipping empty settlement` in the same runloop
