### PR TITLE
[Uniswap] Only set allowance if necessary

### DIFF
--- a/solver/src/liquidity/uniswap.rs
+++ b/solver/src/liquidity/uniswap.rs
@@ -141,14 +141,11 @@ impl UniswapLiquidity {
             token_and_allowance.push((pair, allowance.await.unwrap_or_default()));
         }
 
-        let mut guard = self
-            .inner
+        self.inner
             .allowances
             .lock()
-            .expect("Thread holding mutex panicked");
-        for (pair, allowance) in token_and_allowance {
-            guard.insert(pair, allowance);
-        }
+            .expect("Thread holding mutex panicked")
+            .extend(token_and_allowance);
     }
 }
 

--- a/solver/src/liquidity/uniswap.rs
+++ b/solver/src/liquidity/uniswap.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
-use contracts::{GPv2Settlement, UniswapV2Factory, UniswapV2Pair, UniswapV2Router02};
+use contracts::{GPv2Settlement, UniswapV2Factory, UniswapV2Pair, UniswapV2Router02, IERC20};
 use ethcontract::{batch::CallBatch, Http, Web3};
 use hex_literal::hex;
 use model::TokenPair;
 use num::rational::Rational;
 use primitive_types::{H160, U256};
-use std::collections::{hash_map::Entry, HashMap};
-use std::sync::Arc;
+use std::collections::{hash_map::Entry, HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 use web3::signing::keccak256;
 
 const UNISWAP_PAIR_INIT_CODE: [u8; 32] =
@@ -33,6 +33,8 @@ struct Inner {
     factory: UniswapV2Factory,
     router: UniswapV2Router02,
     gpv2_settlement: GPv2Settlement,
+    // Mapping of how much allowance the router has per token to spend on behalf of the settlement contract
+    allowances: Mutex<HashMap<H160, U256>>,
 }
 
 impl UniswapLiquidity {
@@ -49,6 +51,7 @@ impl UniswapLiquidity {
                 factory,
                 router,
                 gpv2_settlement,
+                allowances: Mutex::new(HashMap::new()),
             }),
             web3,
             chain_id,
@@ -62,6 +65,7 @@ impl UniswapLiquidity {
         offchain_orders: impl Iterator<Item = &LimitOrder> + Send + Sync,
     ) -> Result<Vec<AmmOrder>> {
         let mut pools = HashMap::new();
+        let mut tokens = HashSet::new();
         let mut batch = CallBatch::new(self.web3.transport());
 
         // Helper closure that enqueues the call to fetch the reserves for the token pair if it hasn't been fetched already
@@ -99,6 +103,9 @@ impl UniswapLiquidity {
         let mut result = Vec::new();
         for (pair, future) in pools {
             if let Ok(reserves) = future.await {
+                tokens.insert(pair.get().0);
+                tokens.insert(pair.get().1);
+
                 result.push(AmmOrder {
                     tokens: pair,
                     reserves: (reserves.0, reserves.1),
@@ -107,22 +114,70 @@ impl UniswapLiquidity {
                 })
             };
         }
+        self.cache_allowances(tokens.into_iter()).await;
         Ok(result)
+    }
+
+    async fn cache_allowances(&self, tokens: impl Iterator<Item = H160>) {
+        let mut batch = CallBatch::new(self.web3.transport());
+        let results: Vec<_> = tokens
+            .map(|token| {
+                let allowance = IERC20::at(&self.web3, token)
+                    .allowance(
+                        self.inner.gpv2_settlement.address(),
+                        self.inner.router.address(),
+                    )
+                    .view()
+                    .batch_call(&mut batch);
+                (token, allowance)
+            })
+            .collect();
+
+        let _ = batch.execute_all(MAX_BATCH_SIZE).await;
+
+        // await before acquiring lock so we can use std::sync::mutex (async::mutex wouldn't allow AmmSettlementHandling to be non-blocking)
+        let mut token_and_allowance = Vec::with_capacity(results.len());
+        for (pair, allowance) in results {
+            token_and_allowance.push((pair, allowance.await.unwrap_or_default()));
+        }
+
+        let mut guard = self
+            .inner
+            .allowances
+            .lock()
+            .expect("Thread holding mutex panicked");
+        for (pair, allowance) in token_and_allowance {
+            guard.insert(pair, allowance);
+        }
+    }
+}
+
+impl Inner {
+    fn _settle(&self, input: (H160, U256), output: (H160, U256)) -> UniswapInteraction {
+        let set_allowance = self
+            .allowances
+            .lock()
+            .expect("Thread holding mutex panicked")
+            .get(&input.0)
+            .cloned()
+            .unwrap_or_default()
+            < input.1;
+
+        UniswapInteraction {
+            contract: self.router.clone(),
+            settlement: self.gpv2_settlement.clone(),
+            set_allowance,
+            amount_in: input.1,
+            amount_out_min: output.1,
+            token_in: input.0,
+            token_out: output.0,
+        }
     }
 }
 
 impl AmmSettlementHandling for Inner {
     fn settle(&self, input: (H160, U256), output: (H160, U256)) -> Vec<Box<dyn Interaction>> {
-        vec![Box::new(UniswapInteraction {
-            contract: self.router.clone(),
-            settlement: self.gpv2_settlement.clone(),
-            // TODO(fleupold) Only set allowance if we need to
-            set_allowance: true,
-            amount_in: input.1,
-            amount_out_min: output.1,
-            token_in: input.0,
-            token_out: output.0,
-        })]
+        vec![Box::new(self._settle(input, output))]
     }
 }
 
@@ -149,6 +204,8 @@ fn create2(address: H160, salt: &[u8; 32], init_hash: &[u8; 32]) -> H160 {
 
 #[cfg(test)]
 mod tests {
+    use crate::interactions::dummy_web3;
+
     use super::*;
 
     #[test]
@@ -179,5 +236,54 @@ mod tests {
             pair_address(&pair, mainnet_factory, 100),
             H160::from_slice(&hex!("4505b262dc053998c10685dc5f9098af8ae5c8ad"))
         );
+    }
+
+    impl Inner {
+        fn new(allowances: HashMap<H160, U256>) -> Self {
+            let web3 = dummy_web3::dummy_web3();
+            Self {
+                factory: UniswapV2Factory::at(&web3, H160::zero()),
+                router: UniswapV2Router02::at(&web3, H160::zero()),
+                gpv2_settlement: GPv2Settlement::at(&web3, H160::zero()),
+                allowances: Mutex::new(allowances),
+            }
+        }
+    }
+
+    #[test]
+    fn test_should_set_allowance() {
+        let token_a = H160::from_low_u64_be(1);
+        let token_b = H160::from_low_u64_be(2);
+        let allowances = maplit::hashmap! {
+            token_a => 100.into(),
+            token_b => 200.into(),
+        };
+
+        let inner = Inner::new(allowances);
+
+        // Token A below, equal, above
+        let interaction = inner._settle((token_a, 50.into()), (token_b, 100.into()));
+        assert_eq!(interaction.set_allowance, false);
+
+        let interaction = inner._settle((token_a, 100.into()), (token_b, 100.into()));
+        assert_eq!(interaction.set_allowance, false);
+
+        let interaction = inner._settle((token_a, 150.into()), (token_b, 100.into()));
+        assert_eq!(interaction.set_allowance, true);
+
+        // Token B below, equal, above
+        let interaction = inner._settle((token_b, 150.into()), (token_a, 100.into()));
+        assert_eq!(interaction.set_allowance, false);
+
+        let interaction = inner._settle((token_b, 200.into()), (token_a, 100.into()));
+        assert_eq!(interaction.set_allowance, false);
+
+        let interaction = inner._settle((token_b, 250.into()), (token_a, 100.into()));
+        assert_eq!(interaction.set_allowance, true);
+
+        // Untracked token
+        let interaction =
+            inner._settle((H160::from_low_u64_be(3), 1.into()), (token_a, 100.into()));
+        assert_eq!(interaction.set_allowance, true);
     }
 }


### PR DESCRIPTION
This PR makes it so that we only add an `approve` call to the Uniswap interaction if the `in_token` has not yet been approved before. This saves gas, but not doing it was also causing problems with the MiniMe token template (e.g. HNY on xDAI) where an allowance has to be set to 0 before it can be set to a non-zero value again (cf. [their code](https://github.com/Giveth/minime/blob/ea04d950eea153a04c51fa510b068b9dded390cb/contracts/MiniMeToken.sol#L225)).

This is achieved by caching the allowance for all tokens for which AMMs are fetched on the liquidity read path (in order to make the submit solution path non blocking and fast). It uses a second batch call (so we can filter out all token pairs for which there are no pools beforehand) and stores the allowances in a Map available for the settlement logic.

### Test Plan
Run solver locally and make sure we can now [sell HNY e.g. for wxDAI](https://blockscout.com/poa/xdai/tx/0xa21c3a72c1a73a86783c5b9ca90c3df1b55cebdf875fb8c208d7eb943ea361a7/token-transfers) again: 

Before it was failing:


![image](https://user-images.githubusercontent.com/1200333/106918173-41b9e300-6709-11eb-8853-bd9806afcc2c.png)
