### PR TITLE
Differentiate between sellAmount w & w/o fees

### DIFF
--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -272,7 +272,9 @@ pub struct OrderMetaData {
     #[serde(with = "serde_with::rust::display_fromstr")]
     pub executed_buy_amount: BigUint,
     #[serde(with = "serde_with::rust::display_fromstr")]
-    pub executed_sell_amount: BigUint,
+    pub executed_net_sell_amount: BigUint,
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub executed_gross_sell_amount: BigUint,
     #[serde(with = "serde_with::rust::display_fromstr")]
     pub executed_fee_amount: BigUint,
     pub invalidated: bool,
@@ -286,7 +288,8 @@ impl Default for OrderMetaData {
             uid: Default::default(),
             available_balance: Default::default(),
             executed_buy_amount: Default::default(),
-            executed_sell_amount: Default::default(),
+            executed_net_sell_amount: Default::default(),
+            executed_gross_sell_amount: Default::default(),
             executed_fee_amount: Default::default(),
             invalidated: Default::default(),
         }
@@ -399,8 +402,9 @@ mod tests {
             "uid": "0x1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "availableBalance": "100",
             "executedBuyAmount": "3",
-            "executedSellAmount": "4",
-            "executedFeeAmount": "5",
+            "executedNetSellAmount": "4",
+            "executedGrossSellAmount": "5",
+            "executedFeeAmount": "6",
             "invalidated": true,
             "sellToken": "0x000000000000000000000000000000000000000a",
             "buyToken": "0x0000000000000000000000000000000000000009",
@@ -420,8 +424,9 @@ mod tests {
                 uid: OrderUid([17u8; 56]),
                 available_balance: Some(100.into()),
                 executed_buy_amount: BigUint::from_bytes_be(&[3]),
-                executed_sell_amount: BigUint::from_bytes_be(&[4]),
-                executed_fee_amount: BigUint::from_bytes_be(&[5]),
+                executed_net_sell_amount: BigUint::from_bytes_be(&[4]),
+                executed_gross_sell_amount: BigUint::from_bytes_be(&[5]),
+                executed_fee_amount: BigUint::from_bytes_be(&[6]),
                 invalidated: true,
             },
             order_creation: OrderCreation {

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -272,9 +272,9 @@ pub struct OrderMetaData {
     #[serde(with = "serde_with::rust::display_fromstr")]
     pub executed_buy_amount: BigUint,
     #[serde(with = "serde_with::rust::display_fromstr")]
-    pub executed_net_sell_amount: BigUint,
+    pub executed_sell_amount: BigUint,
     #[serde(with = "serde_with::rust::display_fromstr")]
-    pub executed_gross_sell_amount: BigUint,
+    pub executed_sell_amount_before_fees: BigUint,
     #[serde(with = "serde_with::rust::display_fromstr")]
     pub executed_fee_amount: BigUint,
     pub invalidated: bool,
@@ -288,8 +288,8 @@ impl Default for OrderMetaData {
             uid: Default::default(),
             available_balance: Default::default(),
             executed_buy_amount: Default::default(),
-            executed_net_sell_amount: Default::default(),
-            executed_gross_sell_amount: Default::default(),
+            executed_sell_amount: Default::default(),
+            executed_sell_amount_before_fees: Default::default(),
             executed_fee_amount: Default::default(),
             invalidated: Default::default(),
         }
@@ -402,9 +402,9 @@ mod tests {
             "uid": "0x1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "availableBalance": "100",
             "executedBuyAmount": "3",
-            "executedNetSellAmount": "4",
-            "executedGrossSellAmount": "5",
-            "executedFeeAmount": "6",
+            "executedSellAmount": "5",
+            "executedSellAmountBeforeFees": "4",
+            "executedFeeAmount": "1",
             "invalidated": true,
             "sellToken": "0x000000000000000000000000000000000000000a",
             "buyToken": "0x0000000000000000000000000000000000000009",
@@ -424,9 +424,9 @@ mod tests {
                 uid: OrderUid([17u8; 56]),
                 available_balance: Some(100.into()),
                 executed_buy_amount: BigUint::from_bytes_be(&[3]),
-                executed_net_sell_amount: BigUint::from_bytes_be(&[4]),
-                executed_gross_sell_amount: BigUint::from_bytes_be(&[5]),
-                executed_fee_amount: BigUint::from_bytes_be(&[6]),
+                executed_sell_amount: BigUint::from_bytes_be(&[5]),
+                executed_sell_amount_before_fees: BigUint::from_bytes_be(&[4]),
+                executed_fee_amount: BigUint::from_bytes_be(&[1]),
                 invalidated: true,
             },
             order_creation: OrderCreation {

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -246,8 +246,11 @@ components:
           description: "Amount of sellToken available for the settlement contract to spend on behalf of the owner. Null if API was unable to fetch balance."
           $ref: "#/components/schemas/TokenAmount"
           nullable: true
-        executedSellAmount:
-          description: "The total amount of sellToken that has been executed for this order."
+        executedNetSellAmount:
+          description: "The total amount of sellToken that has been executed for this order including fees."
+          $ref: "#/components/schemas/BigUint"
+        executedGrossSellAmount:
+          description: "The total amount of sellToken that has been executed for this order without fees."
           $ref: "#/components/schemas/BigUint"
         executedBuyAmount:
           description: "The total amount of buyToken that has been executed for this order."

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -246,10 +246,10 @@ components:
           description: "Amount of sellToken available for the settlement contract to spend on behalf of the owner. Null if API was unable to fetch balance."
           $ref: "#/components/schemas/TokenAmount"
           nullable: true
-        executedNetSellAmount:
+        executedSellAmount:
           description: "The total amount of sellToken that has been executed for this order including fees."
           $ref: "#/components/schemas/BigUint"
-        executedGrossSellAmount:
+        executedSellAmountBeforeFees:
           description: "The total amount of sellToken that has been executed for this order without fees."
           $ref: "#/components/schemas/BigUint"
         executedBuyAmount:

--- a/orderbook/src/database/events.rs
+++ b/orderbook/src/database/events.rs
@@ -22,7 +22,7 @@ pub enum Event {
 #[derive(Debug, Default)]
 pub struct Trade {
     pub order_uid: OrderUid,
-    pub sell_amount: U256,
+    pub sell_amount_including_fee: U256,
     pub buy_amount: U256,
     pub fee_amount: U256,
 }
@@ -148,7 +148,7 @@ async fn insert_trade(
                 .bind(index.block_number as i64)
                 .bind(index.log_index as i64)
                 .bind(event.order_uid.0.as_ref())
-                .bind(u256_to_big_decimal(&event.sell_amount))
+                .bind(u256_to_big_decimal(&event.sell_amount_including_fee))
                 .bind(u256_to_big_decimal(&event.buy_amount))
                 .bind(u256_to_big_decimal(&event.fee_amount)),
         )

--- a/orderbook/src/event_updater.rs
+++ b/orderbook/src/event_updater.rs
@@ -145,7 +145,7 @@ fn convert_trade(trade: &ContractTrade, meta: &EventMetadata) -> Result<(DbEvent
     };
     let event = DbTrade {
         order_uid,
-        sell_amount: trade.sell_amount,
+        sell_amount_including_fee: trade.sell_amount,
         buy_amount: trade.buy_amount,
         fee_amount: trade.fee_amount,
     };


### PR DESCRIPTION
Fixes https://github.com/gnosis/gp-v2-contracts/issues/392

We currently display the executed sell amounts as they are emitted by the smart contracts which includes any fees paid in the settle token (thus it's not the gross exchange rate).

This PR make this explicit in the Trade model (without changing existing DB semantics) and adds redundancy to the order metadata, explicitly stating the net and gross sell amount (happy for other naming suggestions)

cc @alfetopito @anxolin 

### Test Plan
CI
