### PR TITLE
[Easy] convert get orders error to reply

### DIFF
--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -54,7 +54,7 @@ fn internal_error() -> Json {
 
 pub fn convert_get_orders_error_to_reply(err: anyhowError) -> WithStatus<Json> {
     tracing::error!(?err, "get_orders error");
-    return with_status(internal_error(), StatusCode::INTERNAL_SERVER_ERROR);
+    with_status(internal_error(), StatusCode::INTERNAL_SERVER_ERROR)
 }
 
 /// Wraps H160 with FromStr and Deserialize that can handle a `0x` prefix.

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -1,3 +1,4 @@
+mod common;
 mod create_order;
 mod get_fee_info;
 mod get_order_by_uid;

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -1,17 +1,18 @@
-mod common;
 mod create_order;
 mod get_fee_info;
 mod get_order_by_uid;
 mod get_orders;
 
 use crate::orderbook::Orderbook;
+use anyhow::Error as anyhowError;
 use hex::{FromHex, FromHexError};
 use model::h160_hexadecimal;
 use primitive_types::H160;
 use serde::{Deserialize, Serialize};
 use std::{str::FromStr, sync::Arc};
 use warp::{
-    reply::{json, Json},
+    hyper::StatusCode,
+    reply::{json, with_status, Json, WithStatus},
     Filter, Reply,
 };
 
@@ -49,6 +50,11 @@ fn internal_error() -> Json {
         error_type: "InternalServerError",
         description: "",
     })
+}
+
+pub fn convert_get_orders_error_to_reply(err: anyhowError) -> WithStatus<Json> {
+    tracing::error!(?err, "get_orders error");
+    return with_status(internal_error(), StatusCode::INTERNAL_SERVER_ERROR);
 }
 
 /// Wraps H160 with FromStr and Deserialize that can handle a `0x` prefix.

--- a/orderbook/src/api/common.rs
+++ b/orderbook/src/api/common.rs
@@ -3,8 +3,5 @@ use warp::{hyper::StatusCode, reply};
 
 pub fn convert_get_orders_error_to_reply(err: Error) -> reply::WithStatus<reply::Json> {
     tracing::error!(?err, "get_orders error");
-    return reply::with_status(
-        super::internal_error(),
-        StatusCode::INTERNAL_SERVER_ERROR,
-    );
+    return reply::with_status(super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR);
 }

--- a/orderbook/src/api/common.rs
+++ b/orderbook/src/api/common.rs
@@ -1,0 +1,10 @@
+use anyhow::Error;
+use warp::{hyper::StatusCode, reply};
+
+pub fn convert_get_orders_error_to_reply(err: Error) -> reply::WithStatus<reply::Json> {
+    tracing::error!(?err, "get_orders error");
+    return reply::with_status(
+        super::internal_error(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+    );
+}

--- a/orderbook/src/api/common.rs
+++ b/orderbook/src/api/common.rs
@@ -1,7 +1,0 @@
-use anyhow::Error;
-use warp::{hyper::StatusCode, reply};
-
-pub fn convert_get_orders_error_to_reply(err: Error) -> reply::WithStatus<reply::Json> {
-    tracing::error!(?err, "get_orders error");
-    return reply::with_status(super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR);
-}

--- a/orderbook/src/api/get_order_by_uid.rs
+++ b/orderbook/src/api/get_order_by_uid.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use model::order::{Order, OrderUid};
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
+use crate::api::common::convert_get_orders_error_to_reply;
 
 pub fn get_order_by_uid_request() -> impl Filter<Extract = (OrderFilter,), Error = Rejection> + Clone
 {
@@ -19,11 +20,7 @@ pub fn get_order_by_uid_response(result: Result<Vec<Order>>) -> impl Reply {
     let orders = match result {
         Ok(orders) => orders,
         Err(err) => {
-            tracing::error!(?err, "get_orders error");
-            return Ok(reply::with_status(
-                super::internal_error(),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ));
+            return Ok(convert_get_orders_error_to_reply(err));
         }
     };
     Ok(match orders.first() {

--- a/orderbook/src/api/get_order_by_uid.rs
+++ b/orderbook/src/api/get_order_by_uid.rs
@@ -1,10 +1,10 @@
+use crate::api::common::convert_get_orders_error_to_reply;
 use crate::database::OrderFilter;
 use crate::orderbook::Orderbook;
 use anyhow::Result;
 use model::order::{Order, OrderUid};
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
-use crate::api::common::convert_get_orders_error_to_reply;
 
 pub fn get_order_by_uid_request() -> impl Filter<Extract = (OrderFilter,), Error = Rejection> + Clone
 {

--- a/orderbook/src/api/get_order_by_uid.rs
+++ b/orderbook/src/api/get_order_by_uid.rs
@@ -1,4 +1,4 @@
-use crate::api::common::convert_get_orders_error_to_reply;
+use crate::api::convert_get_orders_error_to_reply;
 use crate::database::OrderFilter;
 use crate::orderbook::Orderbook;
 use anyhow::Result;

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -1,4 +1,5 @@
 use super::H160Wrapper;
+use crate::api::common::convert_get_orders_error_to_reply;
 use crate::database::OrderFilter;
 use crate::orderbook::Orderbook;
 use anyhow::Result;
@@ -7,7 +8,6 @@ use serde::Deserialize;
 use shared::time::now_in_epoch_seconds;
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
-use crate::api::common::convert_get_orders_error_to_reply;
 
 // The default values create a filter that only includes valid orders.
 #[derive(Deserialize)]
@@ -52,9 +52,7 @@ pub fn get_orders_request() -> impl Filter<Extract = (OrderFilter,), Error = Rej
 pub fn get_orders_response(result: Result<Vec<Order>>) -> impl Reply {
     match result {
         Ok(orders) => Ok(reply::with_status(reply::json(&orders), StatusCode::OK)),
-        Err(err) => {
-            Ok(convert_get_orders_error_to_reply(err))
-        }
+        Err(err) => Ok(convert_get_orders_error_to_reply(err)),
     }
 }
 

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -1,5 +1,5 @@
 use super::H160Wrapper;
-use crate::api::common::convert_get_orders_error_to_reply;
+use crate::api::convert_get_orders_error_to_reply;
 use crate::database::OrderFilter;
 use crate::orderbook::Orderbook;
 use anyhow::Result;

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use shared::time::now_in_epoch_seconds;
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
+use crate::api::common::convert_get_orders_error_to_reply;
 
 // The default values create a filter that only includes valid orders.
 #[derive(Deserialize)]
@@ -49,17 +50,12 @@ pub fn get_orders_request() -> impl Filter<Extract = (OrderFilter,), Error = Rej
 }
 
 pub fn get_orders_response(result: Result<Vec<Order>>) -> impl Reply {
-    let orders = match result {
-        Ok(orders) => orders,
+    match result {
+        Ok(orders) => Ok(reply::with_status(reply::json(&orders), StatusCode::OK)),
         Err(err) => {
-            tracing::error!(?err, "get_orders error");
-            return Ok(reply::with_status(
-                super::internal_error(),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ));
+            Ok(convert_get_orders_error_to_reply(err))
         }
-    };
-    Ok(reply::with_status(reply::json(&orders), StatusCode::OK))
+    }
 }
 
 pub fn get_orders(


### PR DESCRIPTION
A simple PR that eliminates duplication of the following match statement over two different files:

```js
    match result {
        Ok(orders) => Ok(reply::with_status(reply::json(&orders), StatusCode::OK)),
        Err(err) => {
            tracing::error!(?err, "get_orders error");
            return Ok(reply::with_status(
                super::internal_error(),
                StatusCode::INTERNAL_SERVER_ERROR,
            ));
        }
    }
```

We introduce `common.rs` with shared method `convert_get_orders_error_to_reply` that is used in two places.

### Test Plan
Existing unit tests.
