### PR TITLE
Parse http solver response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,6 +2374,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_with",
  "shared",
  "structopt",
  "tokio",

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -28,6 +28,7 @@ primitive-types = { version = "0.8", features = ["fp-conversion"] }
 reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_with = { version = "1.6", default-features = false }
 shared = { path = "../shared" }
 structopt = { version = "0.3" }
 tokio = { version = "0.2", features =["macros", "rt-threaded", "time"] }

--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -1,10 +1,23 @@
-use crate::{liquidity::Liquidity, settlement::Settlement, solver::Solver};
-use anyhow::{Context, Result};
-use model::{order::OrderKind, u256_decimal};
-use primitive_types::{H160, U256};
+mod model;
+mod settlement;
+
+use self::model::*;
+use crate::{
+    liquidity::{AmmOrder, LimitOrder, Liquidity},
+    settlement::Settlement,
+    solver::Solver,
+};
+use ::model::order::OrderKind;
+use anyhow::{ensure, Context, Result};
+use primitive_types::H160;
 use reqwest::{Client, Url};
-use serde::{Deserialize, Serialize, Serializer};
 use std::collections::{HashMap, HashSet};
+
+// TODO: limit trading for tokens that don't have uniswap - fee pool
+// TODO: exclude partially fillable orders
+// TODO: find correct ordering for uniswap trades
+// TODO: special rounding for the prices we get from the solver?
+// TODO: make sure to give the solver disconnected token islands individually
 
 /// The configuration passed as url parameters to the solver.
 #[derive(Debug, Default)]
@@ -52,7 +65,8 @@ impl HttpSolver {
         format!("t{:x}", token)
     }
 
-    fn tokens(&self, orders: &[Liquidity]) -> HashMap<String, TokenInfoModel> {
+    // Maps string based token index from solver api
+    fn tokens(&self, orders: &[Liquidity]) -> HashMap<String, H160> {
         orders
             .iter()
             .flat_map(|liquidity| match liquidity {
@@ -65,15 +79,21 @@ impl HttpSolver {
             })
             .collect::<HashSet<_>>()
             .into_iter()
-            .map(|token| {
-                // TODO: gather real decimals and store them in a cache
-                let token_model = TokenInfoModel { decimals: 18 };
-                (self.token_to_string(&token), token_model)
-            })
+            .map(|token| (self.token_to_string(&token), token))
             .collect()
     }
 
-    fn orders(&self, orders: &[Liquidity]) -> HashMap<String, OrderModel> {
+    // Maps string based token index from solver api
+    fn token_models(&self, tokens: &HashMap<String, H160>) -> HashMap<String, TokenInfoModel> {
+        // TODO: gather real decimals and store them in a cache
+        tokens
+            .iter()
+            .map(|(index, _)| (index.clone(), TokenInfoModel { decimals: 18 }))
+            .collect()
+    }
+
+    // Maps string based order index from solver api
+    fn orders<'a>(&self, orders: &'a [Liquidity]) -> HashMap<String, &'a LimitOrder> {
         orders
             .iter()
             .filter_map(|liquidity| match liquidity {
@@ -81,6 +101,17 @@ impl HttpSolver {
                 Liquidity::Amm(_) => None,
             })
             .enumerate()
+            .map(|(index, order)| (index.to_string(), order))
+            .collect()
+    }
+
+    // Maps string based order index from solver api
+    fn order_models<'a>(
+        &self,
+        orders: &HashMap<String, &'a LimitOrder>,
+    ) -> HashMap<String, OrderModel> {
+        orders
+            .iter()
             .map(|(index, order)| {
                 let order = OrderModel {
                     sell_token: self.token_to_string(&order.sell_token),
@@ -90,20 +121,30 @@ impl HttpSolver {
                     allow_partial_fill: order.partially_fillable,
                     is_sell_order: matches!(order.kind, OrderKind::Sell),
                 };
-                (index.to_string(), order)
+                (index.clone(), order)
             })
             .collect()
     }
 
-    async fn uniswaps(&self, orders: &[Liquidity]) -> Result<HashMap<String, UniswapModel>> {
-        // TODO: use a cache
-        Ok(orders
+    // Maps string based amm index from solver api
+    fn amms<'a>(&self, orders: &'a [Liquidity]) -> HashMap<String, &'a AmmOrder> {
+        orders
             .iter()
             .filter_map(|liquidity| match liquidity {
                 Liquidity::Limit(_) => None,
                 Liquidity::Amm(amm) => Some(amm),
             })
             .enumerate()
+            .map(|(index, amm)| (index.to_string(), amm))
+            .collect()
+    }
+
+    // Maps string based amm index from solver api
+    fn amm_models<'a>(
+        &self,
+        amms: &HashMap<String, &'a AmmOrder>,
+    ) -> HashMap<String, UniswapModel> {
+        amms.iter()
             .map(|(index, amm)| {
                 let uniswap = UniswapModel {
                     token1: self.token_to_string(&amm.tokens.get().0),
@@ -114,140 +155,111 @@ impl HttpSolver {
                     fee: 0.003,
                     mandatory: false,
                 };
-                (index.to_string(), uniswap)
+                (index.clone(), uniswap)
             })
-            .collect())
+            .collect()
     }
 
-    async fn create_body(&self, orders: &[Liquidity]) -> Result<BatchAuctionModel> {
-        Ok(BatchAuctionModel {
-            tokens: self.tokens(orders),
-            orders: self.orders(orders),
-            uniswaps: self.uniswaps(orders).await?,
-            ref_token: self.token_to_string(&H160::zero()),
-            default_fee: 0.0,
-        })
+    async fn send(&self, model: &BatchAuctionModel) -> Result<SettledBatchAuctionModel> {
+        let mut url = self.base.clone();
+        url.set_path("/solve");
+        self.config.add_to_query(&mut url);
+        let query = url.query().map(ToString::to_string).unwrap_or_default();
+        let mut request = self.client.post(url);
+        if let Some(api_key) = &self.api_key {
+            request = request.header("X-API-KEY", api_key);
+        }
+        let body = serde_json::to_string(&model).context("failed to encode body")?;
+        tracing::debug!("request query {} body {}", query, body);
+        let request = request.body(body);
+
+        let response = request.send().await.context("failed to send request")?;
+        let status = response.status();
+        let body_bytes = response
+            .bytes()
+            .await
+            .context("failed to get response body")?;
+        let body_str =
+            std::str::from_utf8(body_bytes.as_ref()).context("failed to decode response body")?;
+        tracing::debug!("response body {}", body_str);
+        ensure!(
+            status.is_success(),
+            "solver response is not success: status: {}",
+            status
+        );
+        serde_json::from_str(body_str).context("failed to decode response json")
     }
 }
 
 #[async_trait::async_trait]
 impl Solver for HttpSolver {
-    async fn solve(&self, orders: Vec<Liquidity>) -> Result<Option<Settlement>> {
-        let mut url = self.base.clone();
-        url.set_path("/solve");
-        self.config.add_to_query(&mut url);
-        let body = self.create_body(orders.as_slice()).await?;
-        let mut request = self.client.post(url);
-        if let Some(api_key) = &self.api_key {
-            request = request.header("X-API-KEY", api_key);
-        }
-        let request = request.json(&body);
-
-        let response = request
-            .send()
-            .await
-            .context("failed to send solver request")?
-            .error_for_status()
-            .context("solver response was unsuccessful")?;
-        let body = response
-            .bytes()
-            .await
-            .context("failed to get response body")?;
-        let _decoded: Solution =
-            serde_json::from_slice(&body).with_context(|| match std::str::from_utf8(&body) {
-                Ok(body) => format!("failed to decode response body: {}", body),
-                Err(_) => format!("failed to decode response body: {:?}", body),
-            })?;
-        Ok(None)
+    async fn solve(&self, liquidity: Vec<Liquidity>) -> Result<Option<Settlement>> {
+        let tokens = self.tokens(liquidity.as_slice());
+        let orders = self.orders(liquidity.as_slice());
+        let amms = self.amms(liquidity.as_slice());
+        let ref_token = match tokens.keys().next() {
+            Some(token) => token.clone(),
+            None => return Ok(None),
+        };
+        let model = BatchAuctionModel {
+            tokens: self.token_models(&tokens),
+            orders: self.order_models(&orders),
+            uniswaps: self.amm_models(&amms),
+            ref_token,
+            default_fee: 0.0,
+        };
+        let settled = self.send(&model).await?;
+        tracing::debug!("optimizer response {:?}", settled);
+        settlement::convert_settlement(&settled, &tokens, &orders, &amms).map(Some)
     }
-}
-
-// types used in the solver http api
-
-#[derive(Debug, Default, Serialize)]
-struct BatchAuctionModel {
-    tokens: HashMap<String, TokenInfoModel>,
-    orders: HashMap<String, OrderModel>,
-    uniswaps: HashMap<String, UniswapModel>,
-    ref_token: String,
-    #[serde(serialize_with = "serialize_as_string")]
-    default_fee: f32,
-}
-
-#[derive(Debug, Deserialize)]
-struct Solution {
-    // TODO: wait for solution format to be documented
-}
-
-#[derive(Debug, Serialize)]
-struct OrderModel {
-    sell_token: String,
-    buy_token: String,
-    #[serde(with = "u256_decimal")]
-    sell_amount: U256,
-    #[serde(with = "u256_decimal")]
-    buy_amount: U256,
-    allow_partial_fill: bool,
-    is_sell_order: bool,
-}
-
-#[derive(Debug, Serialize)]
-struct UniswapModel {
-    token1: String,
-    token2: String,
-    #[serde(serialize_with = "serialize_as_string")]
-    balance1: u128,
-    #[serde(serialize_with = "serialize_as_string")]
-    balance2: u128,
-    #[serde(serialize_with = "serialize_as_string")]
-    fee: f32,
-    mandatory: bool,
-}
-
-#[derive(Debug, Serialize)]
-struct TokenInfoModel {
-    #[serde(serialize_with = "serialize_as_string")]
-    decimals: u32,
-}
-
-fn serialize_as_string<S>(t: &impl ToString, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_str(t.to_string().as_str())
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::liquidity::{LimitOrder, MockLimitOrderSettlementHandling};
+    use super::*;
+    use crate::liquidity::{
+        AmmOrder, LimitOrder, MockAmmSettlementHandling, MockLimitOrderSettlementHandling,
+    };
+    use ::model::TokenPair;
+    use num::Rational;
     use std::sync::Arc;
 
-    use super::*;
-
     // cargo test real_solver -- --ignored --nocapture
+    // set the env variable GP_V2_OPTIMIZER_URL to use a non localhost optimizer
     #[tokio::test]
     #[ignore]
     async fn real_solver() {
         tracing_subscriber::fmt::fmt()
-            .with_env_filter("debug")
+            .with_env_filter("solver=debug")
             .init();
+        let url = std::env::var("GP_V2_OPTIMIZER_URL")
+            .unwrap_or_else(|_| "http://localhost:8000".to_string());
         let solver = HttpSolver::new(
-            "http://localhost:8000".parse().unwrap(),
+            url.parse().unwrap(),
             None,
             SolverConfig {
                 max_nr_exec_orders: 100,
                 time_limit: 100,
             },
         );
-        let orders = vec![Liquidity::Limit(LimitOrder {
-            buy_token: H160::zero(),
-            sell_token: H160::from_low_u64_be(1),
-            buy_amount: 1.into(),
-            sell_amount: 1.into(),
-            kind: OrderKind::Sell,
-            partially_fillable: false,
-            settlement_handling: Arc::new(MockLimitOrderSettlementHandling::new()),
-        })];
-        solver.solve(orders).await.unwrap();
+        let orders = vec![
+            Liquidity::Limit(LimitOrder {
+                buy_token: H160::zero(),
+                sell_token: H160::from_low_u64_be(1),
+                buy_amount: 1.into(),
+                sell_amount: 2.into(),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                settlement_handling: Arc::new(MockLimitOrderSettlementHandling::new()),
+            }),
+            Liquidity::Amm(AmmOrder {
+                tokens: TokenPair::new(H160::zero(), H160::from_low_u64_be(1)).unwrap(),
+                reserves: (100, 100),
+                fee: Rational::new(1, 1),
+                settlement_handling: Arc::new(MockAmmSettlementHandling::new()),
+            }),
+        ];
+        let settlement = solver.solve(orders).await.unwrap().unwrap();
+        dbg!(settlement);
     }
 }

--- a/solver/src/http_solver/model.rs
+++ b/solver/src/http_solver/model.rs
@@ -1,0 +1,71 @@
+use model::u256_decimal;
+use primitive_types::U256;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Default, Serialize)]
+pub struct BatchAuctionModel {
+    pub tokens: HashMap<String, TokenInfoModel>,
+    pub orders: HashMap<String, OrderModel>,
+    pub uniswaps: HashMap<String, UniswapModel>,
+    pub ref_token: String,
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub default_fee: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OrderModel {
+    pub sell_token: String,
+    pub buy_token: String,
+    #[serde(with = "u256_decimal")]
+    pub sell_amount: U256,
+    #[serde(with = "u256_decimal")]
+    pub buy_amount: U256,
+    pub allow_partial_fill: bool,
+    pub is_sell_order: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UniswapModel {
+    pub token1: String,
+    pub token2: String,
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub balance1: u128,
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub balance2: u128,
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub fee: f64,
+    pub mandatory: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TokenInfoModel {
+    pub decimals: u32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SettledBatchAuctionModel {
+    pub orders: HashMap<String, ExecutedOrderModel>,
+    pub uniswaps: HashMap<String, UpdatedUniswapModel>,
+    pub ref_token: String,
+    pub prices: HashMap<String, Price>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Price(#[serde(with = "serde_with::rust::display_fromstr")] pub f64);
+
+#[derive(Debug, Deserialize)]
+pub struct ExecutedOrderModel {
+    #[serde(with = "u256_decimal")]
+    pub exec_sell_amount: U256,
+    #[serde(with = "u256_decimal")]
+    pub exec_buy_amount: U256,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdatedUniswapModel {
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub balance_update_1: i128,
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub balance_update_2: i128,
+}

--- a/solver/src/http_solver/settlement.rs
+++ b/solver/src/http_solver/settlement.rs
@@ -1,0 +1,204 @@
+use super::model::{Price, SettledBatchAuctionModel};
+use crate::{
+    liquidity::{AmmOrder, LimitOrder},
+    settlement::Settlement,
+};
+use anyhow::{anyhow, ensure, Result};
+use model::order::OrderKind;
+use primitive_types::{H160, U256};
+use std::collections::HashMap;
+
+pub fn convert_settlement(
+    model: &SettledBatchAuctionModel,
+    tokens: &HashMap<String, H160>,
+    orders: &HashMap<String, &LimitOrder>,
+    amms: &HashMap<String, &AmmOrder>,
+) -> Result<Settlement> {
+    let mut settlement = Settlement::default();
+    set_orders(model, orders, &mut settlement)?;
+    set_amms(model, amms, &mut settlement)?;
+    set_prices(model, tokens, &mut settlement)?;
+    Ok(settlement)
+}
+
+fn set_orders(
+    model: &SettledBatchAuctionModel,
+    orders: &HashMap<String, &LimitOrder>,
+    settlement: &mut Settlement,
+) -> Result<()> {
+    for (index, model) in model.orders.iter() {
+        let order = orders
+            .get(index.as_str())
+            .ok_or_else(|| anyhow!("invalid order {}", index))?;
+        let executed_amount = match order.kind {
+            OrderKind::Buy => model.exec_buy_amount,
+            OrderKind::Sell => model.exec_sell_amount,
+        };
+        if executed_amount.is_zero() {
+            continue;
+        }
+        let (trade, interactions) = order.settlement_handling.settle(executed_amount);
+        if let Some(trade) = trade {
+            settlement.trades.push(trade);
+        }
+        settlement.interactions.extend(interactions);
+    }
+    Ok(())
+}
+
+fn set_amms(
+    model: &SettledBatchAuctionModel,
+    amms: &HashMap<String, &AmmOrder>,
+    settlement: &mut Settlement,
+) -> Result<()> {
+    for (index, model) in model.uniswaps.iter() {
+        let amm = amms
+            .get(index.as_str())
+            .ok_or_else(|| anyhow!("invalid amm {}", index))?;
+        let (input, output) =
+            if model.balance_update_1.is_positive() && model.balance_update_2.is_negative() {
+                (
+                    (amm.tokens.get().0, i128_abs_to_u256(model.balance_update_1)),
+                    (amm.tokens.get().1, i128_abs_to_u256(model.balance_update_2)),
+                )
+            } else if model.balance_update_2.is_positive() && model.balance_update_1.is_negative() {
+                (
+                    (amm.tokens.get().1, i128_abs_to_u256(model.balance_update_2)),
+                    (amm.tokens.get().0, i128_abs_to_u256(model.balance_update_1)),
+                )
+            } else if model.balance_update_1 == 0 && model.balance_update_2 == 0 {
+                continue;
+            } else {
+                return Err(anyhow!("invalid uniswap update {:?}", model));
+            };
+        let interactions = amm.settlement_handling.settle(input, output);
+        settlement.interactions.extend(interactions);
+    }
+    Ok(())
+}
+
+fn set_prices(
+    model: &SettledBatchAuctionModel,
+    tokens: &HashMap<String, H160>,
+    settlement: &mut Settlement,
+) -> Result<()> {
+    for (index, &Price(price)) in model.prices.iter() {
+        let token = tokens
+            .get(index.as_str())
+            .ok_or_else(|| anyhow!("invalid token {}", index))?;
+        let token_used_in_trade = settlement
+            .trades
+            .iter()
+            .any(|trade| *token == trade.order.sell_token || *token == trade.order.buy_token);
+        dbg!(token, token_used_in_trade);
+        if token_used_in_trade {
+            ensure!(price.is_finite() && price > 0.0, "invalid price {}", price);
+            let price = U256::from_f64_lossy(price);
+            settlement.clearing_prices.insert(*token, price);
+        }
+    }
+    Ok(())
+}
+
+fn i128_abs_to_u256(i: i128) -> U256 {
+    // TODO: use `unsigned_abs` once it is stable in next compiler version
+    // until then we need this check because the most negative value can not be `abs`ed because it
+    // it the most positive value plus 1.
+    if i == i128::MIN {
+        (i128::MAX as u128 + 1).into()
+    } else {
+        (i.abs() as u128).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        http_solver::model::{ExecutedOrderModel, UpdatedUniswapModel},
+        liquidity::{MockAmmSettlementHandling, MockLimitOrderSettlementHandling},
+        settlement::{Interaction, Trade},
+    };
+    use maplit::hashmap;
+    use mockall::predicate::eq;
+    use model::{order::OrderCreation, TokenPair};
+    use std::sync::Arc;
+
+    #[derive(Debug)]
+    struct NoopInteraction;
+    impl Interaction for NoopInteraction {
+        fn encode(&self, _writer: &mut dyn std::io::Write) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn convert_settlement_() {
+        let t0 = H160::from_low_u64_be(0);
+        let t1 = H160::from_low_u64_be(1);
+        let tokens = hashmap! { "t0".to_string() => t0, "t1".to_string() => t1 };
+
+        let mut limit_handling = MockLimitOrderSettlementHandling::new();
+        limit_handling.expect_settle().returning(move |_| {
+            (
+                Some(Trade {
+                    order: OrderCreation {
+                        sell_token: t0,
+                        buy_token: t1,
+                        sell_amount: 1.into(),
+                        buy_amount: 2.into(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+                vec![],
+            )
+        });
+        let limit_order = LimitOrder {
+            sell_token: t0,
+            buy_token: t1,
+            sell_amount: 1.into(),
+            buy_amount: 2.into(),
+            kind: OrderKind::Sell,
+            partially_fillable: false,
+            settlement_handling: Arc::new(limit_handling),
+        };
+        let orders = hashmap! { "lo0".to_string() => &limit_order };
+
+        let mut amm_handling = MockAmmSettlementHandling::new();
+        amm_handling
+            .expect_settle()
+            .with(eq((t0, 8.into())), eq((t1, 9.into())))
+            .returning(|_, _| vec![Box::new(NoopInteraction)]);
+        let amm_order = AmmOrder {
+            tokens: TokenPair::new(t0, t1).unwrap(),
+            reserves: (3, 4),
+            fee: 5.into(),
+            settlement_handling: Arc::new(amm_handling),
+        };
+        let amms = hashmap! { "amm0".to_string() => &amm_order };
+
+        let executed_order = ExecutedOrderModel {
+            exec_buy_amount: 6.into(),
+            exec_sell_amount: 7.into(),
+        };
+        let updated_uniswap = UpdatedUniswapModel {
+            balance_update_1: 8,
+            balance_update_2: -9,
+        };
+        let model = SettledBatchAuctionModel {
+            orders: hashmap! { "lo0".to_string() => executed_order },
+            uniswaps: hashmap! { "amm0".to_string() => updated_uniswap },
+            ref_token: "t0".to_string(),
+            prices: hashmap! { "t0".to_string() => Price(10.0), "t1".to_string() => Price(11.0) },
+        };
+
+        let settlement = convert_settlement(&model, &tokens, &orders, &amms).unwrap();
+        assert_eq!(
+            settlement.clearing_prices,
+            hashmap! { t0 => 10.into(), t1 => 11.into() }
+        );
+        assert_eq!(settlement.trades.len(), 1);
+        assert_eq!(settlement.interactions.len(), 1);
+    }
+}


### PR DESCRIPTION
Edit: will split this up into smaller PRs

First step in updating the http solver. Previously we were not parsing the response.
Change is smaller than it looks because some structs moved to new place and test takes a lot of lines to set up.

### Test Plan
New unit test but cannot test with the staging deployed solver atm because it is running an older version with some bugs and needs a new release.