### PR TITLE
Move http solver types to own module and add response structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,6 +2374,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_with",
  "shared",
  "structopt",
  "tokio",

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -28,6 +28,7 @@ primitive-types = { version = "0.8", features = ["fp-conversion"] }
 reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_with = { version = "1.6", default-features = false }
 shared = { path = "../shared" }
 structopt = { version = "0.3" }
 tokio = { version = "0.2", features =["macros", "rt-threaded", "time"] }

--- a/solver/src/http_solver/model.rs
+++ b/solver/src/http_solver/model.rs
@@ -1,0 +1,71 @@
+use model::u256_decimal;
+use primitive_types::U256;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Default, Serialize)]
+pub struct BatchAuctionModel {
+    pub tokens: HashMap<String, TokenInfoModel>,
+    pub orders: HashMap<String, OrderModel>,
+    pub uniswaps: HashMap<String, UniswapModel>,
+    pub ref_token: String,
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub default_fee: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OrderModel {
+    pub sell_token: String,
+    pub buy_token: String,
+    #[serde(with = "u256_decimal")]
+    pub sell_amount: U256,
+    #[serde(with = "u256_decimal")]
+    pub buy_amount: U256,
+    pub allow_partial_fill: bool,
+    pub is_sell_order: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UniswapModel {
+    pub token1: String,
+    pub token2: String,
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub balance1: u128,
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub balance2: u128,
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub fee: f64,
+    pub mandatory: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TokenInfoModel {
+    pub decimals: u32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SettledBatchAuctionModel {
+    pub orders: HashMap<String, ExecutedOrderModel>,
+    pub uniswaps: HashMap<String, UpdatedUniswapModel>,
+    pub ref_token: String,
+    pub prices: HashMap<String, Price>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Price(#[serde(with = "serde_with::rust::display_fromstr")] pub f64);
+
+#[derive(Debug, Deserialize)]
+pub struct ExecutedOrderModel {
+    #[serde(with = "u256_decimal")]
+    pub exec_sell_amount: U256,
+    #[serde(with = "u256_decimal")]
+    pub exec_buy_amount: U256,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdatedUniswapModel {
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub balance_update_1: i128,
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub balance_update_2: i128,
+}


### PR DESCRIPTION
Moved to new module because it got too big.

### Test Plan
Can't test response structs yet because solver has a bug that makes it return wrong type.