### PR TITLE
Price Estimator for Orderbook API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "assert_approx_eq"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
+
+[[package]]
 name = "async-trait"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +1649,7 @@ name = "orderbook"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_approx_eq",
  "async-trait",
  "bigdecimal",
  "chrono",
@@ -2323,6 +2330,7 @@ dependencies = [
 name = "shared"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "atty",
  "contracts",
  "ethcontract",

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+assert_approx_eq = "1.1"
 bigdecimal = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 contracts = { path = "../contracts" }

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -4,6 +4,7 @@ pub mod database;
 pub mod event_updater;
 pub mod integer_conversions;
 pub mod orderbook;
+pub mod price_estimate;
 
 use crate::orderbook::Orderbook;
 use anyhow::{anyhow, Context as _, Result};

--- a/orderbook/src/price_estimate.rs
+++ b/orderbook/src/price_estimate.rs
@@ -1,0 +1,88 @@
+use anyhow::{anyhow, Result};
+use ethcontract::H160;
+use model::TokenPair;
+use shared::uniswap_pool::PoolFetching;
+use std::iter::once;
+
+#[allow(dead_code)]
+struct UniswapPriceEstimator {
+    pool_fetcher: Box<dyn PoolFetching>,
+}
+
+impl UniswapPriceEstimator {
+    // Estimates the price using the direct pool between sell and buy token. Price is given in
+    // how much of sell_token needs to be sold for one buy_token.
+    // Returns an error if no pool exists between sell and buy token.
+    #[allow(dead_code)]
+    pub async fn estimate_price(&self, sell_token: H160, buy_token: H160) -> Result<f64> {
+        let pair = match TokenPair::new(sell_token, buy_token) {
+            Some(pair) => pair,
+            None => return Ok(1.0),
+        };
+        let pool = self
+            .pool_fetcher
+            .fetch(once(pair).collect())
+            .await
+            .pop()
+            .ok_or_else(|| anyhow!("Uniswap pool does not exist"))?;
+        let (sell_reserve, buy_reserve) = if pool.tokens.get().0 == sell_token {
+            (pool.reserves.0, pool.reserves.1)
+        } else {
+            (pool.reserves.1, pool.reserves.0)
+        };
+        Ok((sell_reserve as f64) / (buy_reserve as f64))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_approx_eq::assert_approx_eq;
+    use std::collections::HashSet;
+
+    use super::*;
+    use shared::uniswap_pool::{Pool, PoolFetching};
+
+    struct FakePoolFetcher(Vec<Pool>);
+    #[async_trait::async_trait]
+    impl PoolFetching for FakePoolFetcher {
+        async fn fetch(&self, _: HashSet<TokenPair>) -> Vec<Pool> {
+            self.0.clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn estimate_price_on_direct_pair() {
+        let token_a = H160::from_low_u64_be(1);
+        let token_b = H160::from_low_u64_be(2);
+        let pool = Pool {
+            tokens: TokenPair::new(token_a, token_b).unwrap(),
+            reserves: (100, 10),
+        };
+
+        let pool_fetcher = Box::new(FakePoolFetcher(vec![pool]));
+        let estimator = UniswapPriceEstimator { pool_fetcher };
+
+        assert_approx_eq!(
+            estimator.estimate_price(token_a, token_a).await.unwrap(),
+            1.0
+        );
+        assert_approx_eq!(
+            estimator.estimate_price(token_a, token_b).await.unwrap(),
+            10.0
+        );
+        assert_approx_eq!(
+            estimator.estimate_price(token_b, token_a).await.unwrap(),
+            0.1
+        );
+    }
+
+    #[tokio::test]
+    async fn return_error_if_no_token_found() {
+        let token_a = H160::from_low_u64_be(1);
+        let token_b = H160::from_low_u64_be(2);
+        let pool_fetcher = Box::new(FakePoolFetcher(vec![]));
+        let estimator = UniswapPriceEstimator { pool_fetcher };
+
+        assert!(estimator.estimate_price(token_a, token_b).await.is_err());
+    }
+}

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [dependencies]
 atty = "0.2"
+async-trait = "0.1"
 contracts = { path = "../contracts" }
 ethcontract = { version = "0.11", default-features = false }
 hex-literal = "0.3"

--- a/solver/src/liquidity/uniswap.rs
+++ b/solver/src/liquidity/uniswap.rs
@@ -4,7 +4,7 @@ use ethcontract::{batch::CallBatch, Http, Web3};
 use model::TokenPair;
 use num::rational::Rational;
 use primitive_types::{H160, U256};
-use shared::uniswap_pool::PoolFetcher;
+use shared::uniswap_pool::{PoolFetcher, PoolFetching as _};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
@@ -77,7 +77,7 @@ impl UniswapLiquidity {
 
         let mut tokens = HashSet::new();
         let mut result = Vec::new();
-        for pool in self.pool_fetcher.fetch(pools.into_iter()).await {
+        for pool in self.pool_fetcher.fetch(pools).await {
             tokens.insert(pool.tokens.get().0);
             tokens.insert(pool.tokens.get().1);
 


### PR DESCRIPTION
Part of computing reasonable fees.

This PR introduces a component that can compute a price estimate between two tokens based on the direct Uniswap pair. In the future, we can make the logic more sophisticated by considering multiple likely "base tokens" as intermediate hops. This is how the Uniswap SDK is implementing their price estimate (cf. [gp-v2-swap](https://github.com/gnosis/gp-v2-swap/blob/c53137bed99a9037800b67dd4468a4e4b2d4435b/src/constants/index.ts#L64))

### Test Plan
Added a unit test