### PR TITLE
Component to estimate & validate min viable fee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,6 +1656,7 @@ dependencies = [
  "contracts",
  "ethcontract",
  "futures",
+ "gas-estimation",
  "hex",
  "hex-literal",
  "mockall",

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -20,10 +20,11 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 contracts = { path = "../contracts" }
 ethcontract = { version = "0.11", default-features = false }
 futures = "0.3.12"
+gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.0", features = ["web3_"] }
 hex = { version = "0.4", default-features = false }
 model = { path = "../model" }
 num-bigint = "0.3"
-primitive-types = "0.8"
+primitive-types = { version = "0.8", features = ["fp-conversion"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shared= { path = "../shared" }

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -1,6 +1,6 @@
 use super::H160Wrapper;
 use anyhow::Result;
-use chrono::{DateTime, FixedOffset, Utc};
+use chrono::{DateTime, Duration, Utc};
 use model::u256_decimal;
 use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
@@ -23,9 +23,9 @@ pub fn get_fee_info_request() -> impl Filter<Extract = (H160,), Error = Rejectio
 }
 
 pub fn get_fee_info_response() -> impl Reply {
-    const STANDARD_VALIDITY_FOR_FEE_IN_SEC: i32 = 3600;
+    const STANDARD_VALIDITY_FOR_FEE_IN_SEC: i64 = 3600;
     let fee_info = FeeInfo {
-        expiration_date: Utc::now() + FixedOffset::east(STANDARD_VALIDITY_FOR_FEE_IN_SEC),
+        expiration_date: Utc::now() + Duration::seconds(STANDARD_VALIDITY_FOR_FEE_IN_SEC),
         minimal_fee: U256::zero(),
         fee_ratio: 0u32,
     };

--- a/orderbook/src/api/handler.rs
+++ b/orderbook/src/api/handler.rs
@@ -102,7 +102,7 @@ pub async fn get_order_by_uid(
 pub async fn get_fee_info(sell_token: H160) -> Result<impl Reply, Infallible> {
     let fee_info = FeeInfo {
         expiration_date: chrono::offset::Utc::now()
-            + FixedOffset::east(STANDARD_VALIDITY_FOR_FEE_IN_SEC),
+            + Duration::seconds(STANDARD_VALIDITY_FOR_FEE_IN_SEC),
         minimal_fee: U256::zero(),
         fee_ratio: 0u32,
     };

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -1,0 +1,180 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use chrono::{DateTime, FixedOffset, Utc};
+use primitive_types::{H160, U256};
+use std::sync::Mutex;
+
+use crate::price_estimate::PriceEstimating;
+use gas_estimation::GasPriceEstimating;
+
+type Measurement = (U256, DateTime<Utc>);
+
+pub struct MinFeeCalculator {
+    price_estimator: Box<dyn PriceEstimating>,
+    gas_estimator: Box<dyn GasPriceEstimating>,
+    native_token: H160,
+    // TODO persist past measurements to shared storage
+    measurements: Mutex<HashMap<H160, Vec<Measurement>>>,
+    now: Box<dyn Fn() -> DateTime<Utc>>,
+}
+
+const GAS_PER_ORDER: f64 = 100_000.0;
+const STANDARD_VALIDITY_FOR_FEE_IN_SEC: i32 = 60;
+
+impl MinFeeCalculator {
+    pub fn new(
+        price_estimator: Box<dyn PriceEstimating>,
+        gas_estimator: Box<dyn GasPriceEstimating>,
+        native_token: H160,
+    ) -> Self {
+        Self {
+            price_estimator,
+            gas_estimator,
+            native_token,
+            measurements: Default::default(),
+            now: Box::new(Utc::now),
+        }
+    }
+}
+
+impl MinFeeCalculator {
+    // Returns the minimum amount of fee required to accept an order selling the specified token
+    // and an expiry date for the estimate.
+    pub async fn min_fee(&self, token: H160) -> Result<Measurement> {
+        let gas_price = self.gas_estimator.estimate().await?;
+        let token_price = self
+            .price_estimator
+            .estimate_price(token, self.native_token)
+            .await?;
+
+        let min_fee = U256::from_f64_lossy(gas_price * token_price * GAS_PER_ORDER);
+        let valid_until = (self.now)() + FixedOffset::east(STANDARD_VALIDITY_FOR_FEE_IN_SEC);
+        let result = (min_fee, valid_until);
+
+        self.measurements
+            .lock()
+            .expect("Thread holding mutex panicked")
+            .entry(token)
+            .or_default()
+            .push(result);
+        Ok(result)
+    }
+
+    // Returns true if the fee satisfies a previous not yet expired estimate, or the fee is high enough given the current estimate.
+    pub async fn is_valid_fee(&self, token: H160, fee: U256) -> bool {
+        if let Some(measurements) = self
+            .measurements
+            .lock()
+            .expect("Thread holding mutex panicked")
+            .get(&token)
+        {
+            // Previous measurements are ordered ascending by expiry data
+            for (suggested_fee, expiry_date) in measurements.iter().rev() {
+                if expiry_date < &(self.now)() {
+                    break;
+                }
+                if &fee >= suggested_fee {
+                    return true;
+                }
+            }
+        }
+        if let Ok((current_fee, _)) = self.min_fee(token).await {
+            return fee >= current_fee;
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use super::*;
+
+    struct FakePriceEstimator(f64);
+    #[async_trait::async_trait]
+    impl PriceEstimating for FakePriceEstimator {
+        async fn estimate_price(&self, _: H160, _: H160) -> Result<f64> {
+            Ok(self.0)
+        }
+    }
+
+    struct FakeGasEstimator(Arc<Mutex<f64>>);
+    #[async_trait::async_trait]
+    impl GasPriceEstimating for FakeGasEstimator {
+        async fn estimate_with_limits(&self, _: f64, _: Duration) -> Result<f64> {
+            Ok(*self.0.lock().unwrap())
+        }
+    }
+
+    impl MinFeeCalculator {
+        fn new_for_test(
+            gas_estimator: Box<dyn GasPriceEstimating>,
+            price_estimator: Box<dyn PriceEstimating>,
+            now: Box<dyn Fn() -> DateTime<Utc>>,
+        ) -> Self {
+            Self {
+                gas_estimator,
+                price_estimator,
+                native_token: Default::default(),
+                measurements: Default::default(),
+                now,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn accepts_min_fee_if_validated_before_expiry() {
+        let gas_price = Arc::new(Mutex::new(100.0));
+        let time = Rc::new(RefCell::new(Utc::now()));
+
+        let gas_estimator = Box::new(FakeGasEstimator(gas_price.clone()));
+        let price_estimator = Box::new(FakePriceEstimator(1.0));
+        let time_copy = time.clone();
+        let now = move || *time_copy.borrow();
+
+        let fee_estimator =
+            MinFeeCalculator::new_for_test(gas_estimator, price_estimator, Box::new(now));
+
+        let token = H160::from_low_u64_be(1);
+        let (fee, expiry) = fee_estimator.min_fee(token).await.unwrap();
+
+        // Gas price increase after measurement
+        *gas_price.lock().unwrap() *= 2.0;
+
+        // fee is valid before expiry
+        time.replace(expiry - FixedOffset::east(10));
+        assert!(fee_estimator.is_valid_fee(token, fee).await);
+
+        // fee is invalid after expiry
+        time.replace(expiry - FixedOffset::west(10));
+        assert_eq!(fee_estimator.is_valid_fee(token, fee).await, false);
+    }
+
+    #[tokio::test]
+    async fn accepts_fee_if_higher_than_current_min_fee() {
+        let gas_price = Arc::new(Mutex::new(100.0));
+
+        let gas_estimator = Box::new(FakeGasEstimator(gas_price.clone()));
+        let price_estimator = Box::new(FakePriceEstimator(1.0));
+
+        let fee_estimator =
+            MinFeeCalculator::new_for_test(gas_estimator, price_estimator, Box::new(Utc::now));
+
+        let token = H160::from_low_u64_be(1);
+        let (fee, _) = fee_estimator.min_fee(token).await.unwrap();
+
+        let lower_fee = fee - U256::one();
+
+        // slightly lower fee is not valid
+        assert_eq!(fee_estimator.is_valid_fee(token, lower_fee).await, false);
+
+        // Gas price reduces, and slightly lower fee is now valid
+        *gas_price.lock().unwrap() /= 2.0;
+        assert!(fee_estimator.is_valid_fee(token, lower_fee).await);
+    }
+}

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -2,6 +2,7 @@ pub mod account_balances;
 pub mod api;
 pub mod database;
 pub mod event_updater;
+pub mod fee;
 pub mod integer_conversions;
 pub mod orderbook;
 pub mod price_estimate;

--- a/orderbook/src/price_estimate.rs
+++ b/orderbook/src/price_estimate.rs
@@ -4,17 +4,21 @@ use model::TokenPair;
 use shared::uniswap_pool::PoolFetching;
 use std::iter::once;
 
-#[allow(dead_code)]
-struct UniswapPriceEstimator {
+#[async_trait::async_trait]
+pub trait PriceEstimating {
+    async fn estimate_price(&self, sell_token: H160, buy_token: H160) -> Result<f64>;
+}
+
+pub struct UniswapPriceEstimator {
     pool_fetcher: Box<dyn PoolFetching>,
 }
 
-impl UniswapPriceEstimator {
+#[async_trait::async_trait]
+impl PriceEstimating for UniswapPriceEstimator {
     // Estimates the price using the direct pool between sell and buy token. Price is given in
     // how much of sell_token needs to be sold for one buy_token.
     // Returns an error if no pool exists between sell and buy token.
-    #[allow(dead_code)]
-    pub async fn estimate_price(&self, sell_token: H160, buy_token: H160) -> Result<f64> {
+    async fn estimate_price(&self, sell_token: H160, buy_token: H160) -> Result<f64> {
         let pair = match TokenPair::new(sell_token, buy_token) {
             Some(pair) => pair,
             None => return Ok(1.0),

--- a/shared/src/uniswap_pool.rs
+++ b/shared/src/uniswap_pool.rs
@@ -15,7 +15,7 @@ const HONEYSWAP_PAIR_INIT_CODE: [u8; 32] =
 const MAX_BATCH_SIZE: usize = 100;
 
 #[async_trait::async_trait]
-pub trait PoolFetching {
+pub trait PoolFetching: Send + Sync {
     async fn fetch(&self, token_pairs: HashSet<TokenPair>) -> Vec<Pool>;
 }
 


### PR DESCRIPTION
This PR adds a component that allows estimating a min viable fee and validate if a fee is considered viable. For the latter, we store previous estimates in memory for now and upon validation check if we have given a fee estimate that satisfies the provided fee in the past.

We probably need to store these value in the database as otherwise we might run into issues as soon as we add HPA to our API or if fees are fetched before a cold start and the order is only submitted afterwards.

I will tackle this in a future PR.

Min fee is estimated by using a constant gas amount estimate (100k which is roughly what a Uniswap settlement costs), and dynamic gas as well as sell token price estimates.

### Test Plan
Unit tests
