### PR TITLE
Http solver fixes after testing with updated real solver

### DIFF
--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -1,7 +1,7 @@
 mod model;
 mod settlement;
 
-use self::model::*;
+use self::{model::*, settlement::PreparedModel};
 use crate::{
     liquidity::{AmmOrder, LimitOrder, Liquidity},
     settlement::Settlement,
@@ -93,23 +93,16 @@ impl HttpSolver {
     }
 
     // Maps string based order index from solver api
-    fn orders<'a>(&self, orders: &'a [Liquidity]) -> HashMap<String, &'a LimitOrder> {
+    fn orders(&self, orders: Vec<LimitOrder>) -> HashMap<String, LimitOrder> {
         orders
-            .iter()
-            .filter_map(|liquidity| match liquidity {
-                Liquidity::Limit(order) => Some(order),
-                Liquidity::Amm(_) => None,
-            })
+            .into_iter()
             .enumerate()
             .map(|(index, order)| (index.to_string(), order))
             .collect()
     }
 
     // Maps string based order index from solver api
-    fn order_models<'a>(
-        &self,
-        orders: &HashMap<String, &'a LimitOrder>,
-    ) -> HashMap<String, OrderModel> {
+    fn order_models(&self, orders: &HashMap<String, LimitOrder>) -> HashMap<String, OrderModel> {
         orders
             .iter()
             .map(|(index, order)| {
@@ -127,23 +120,16 @@ impl HttpSolver {
     }
 
     // Maps string based amm index from solver api
-    fn amms<'a>(&self, orders: &'a [Liquidity]) -> HashMap<String, &'a AmmOrder> {
+    fn amms(&self, orders: Vec<AmmOrder>) -> HashMap<String, AmmOrder> {
         orders
-            .iter()
-            .filter_map(|liquidity| match liquidity {
-                Liquidity::Limit(_) => None,
-                Liquidity::Amm(amm) => Some(amm),
-            })
+            .into_iter()
             .enumerate()
             .map(|(index, amm)| (index.to_string(), amm))
             .collect()
     }
 
     // Maps string based amm index from solver api
-    fn amm_models<'a>(
-        &self,
-        amms: &HashMap<String, &'a AmmOrder>,
-    ) -> HashMap<String, UniswapModel> {
+    fn amm_models(&self, amms: &HashMap<String, AmmOrder>) -> HashMap<String, UniswapModel> {
         amms.iter()
             .map(|(index, amm)| {
                 let uniswap = UniswapModel {
@@ -151,13 +137,31 @@ impl HttpSolver {
                     token2: self.token_to_string(&amm.tokens.get().1),
                     balance1: amm.reserves.0,
                     balance2: amm.reserves.1,
-                    // TODO use AMM fee
-                    fee: 0.003,
+                    fee: *amm.fee.numer() as f64 / *amm.fee.denom() as f64,
                     mandatory: false,
                 };
                 (index.clone(), uniswap)
             })
             .collect()
+    }
+
+    fn prepare_model(&self, liquidity: Vec<Liquidity>) -> PreparedModel {
+        let tokens = self.tokens(liquidity.as_slice());
+        let orders = split_liquidity(liquidity);
+        let limit_orders = self.orders(orders.0);
+        let amm_orders = self.amms(orders.1);
+        let model = BatchAuctionModel {
+            tokens: self.token_models(&tokens),
+            orders: self.order_models(&limit_orders),
+            uniswaps: self.amm_models(&amm_orders),
+            default_fee: 0.0,
+        };
+        PreparedModel {
+            model,
+            tokens,
+            limit_orders,
+            amm_orders,
+        }
     }
 
     async fn send(&self, model: &BatchAuctionModel) -> Result<SettledBatchAuctionModel> {
@@ -172,6 +176,7 @@ impl HttpSolver {
             request = request.header("X-API-KEY", header);
         }
         let body = serde_json::to_string(&model).context("failed to encode body")?;
+        tracing::trace!("request {}", body);
         let request = request.body(body.clone());
         let response = request.send().await.context("failed to send request")?;
         let status = response.status();
@@ -179,6 +184,7 @@ impl HttpSolver {
             .text()
             .await
             .context("failed to decode response body")?;
+        tracing::trace!("response {}", text);
         let context = || {
             format!(
                 "request query {}, request body {}, response body {}",
@@ -196,25 +202,25 @@ impl HttpSolver {
     }
 }
 
+fn split_liquidity(liquidity: Vec<Liquidity>) -> (Vec<LimitOrder>, Vec<AmmOrder>) {
+    let mut limit_orders = Vec::new();
+    let mut amm_orders = Vec::new();
+    for order in liquidity {
+        match order {
+            Liquidity::Limit(order) => limit_orders.push(order),
+            Liquidity::Amm(order) => amm_orders.push(order),
+        }
+    }
+    (limit_orders, amm_orders)
+}
+
 #[async_trait::async_trait]
 impl Solver for HttpSolver {
     async fn solve(&self, liquidity: Vec<Liquidity>) -> Result<Option<Settlement>> {
-        let tokens = self.tokens(liquidity.as_slice());
-        let orders = self.orders(liquidity.as_slice());
-        let amms = self.amms(liquidity.as_slice());
-        let ref_token = match tokens.keys().next() {
-            Some(token) => token.clone(),
-            None => return Ok(None),
-        };
-        let model = BatchAuctionModel {
-            tokens: self.token_models(&tokens),
-            orders: self.order_models(&orders),
-            uniswaps: self.amm_models(&amms),
-            ref_token,
-            default_fee: 0.0,
-        };
-        let settled = self.send(&model).await?;
-        settlement::convert_settlement(&settled, &tokens, &orders, &amms).map(Some)
+        let prepared = self.prepare_model(liquidity);
+        let settled = self.send(&prepared.model).await?;
+        tracing::trace!(?settled);
+        settlement::convert_settlement(&settled, &prepared).map(Some)
     }
 }
 
@@ -246,24 +252,36 @@ mod tests {
                 time_limit: 100,
             },
         );
+        let base = |x: u128| x * 10u128.pow(18);
         let orders = vec![
             Liquidity::Limit(LimitOrder {
                 buy_token: H160::zero(),
                 sell_token: H160::from_low_u64_be(1),
-                buy_amount: 1.into(),
-                sell_amount: 2.into(),
+                buy_amount: base(1).into(),
+                sell_amount: base(2).into(),
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 settlement_handling: Arc::new(MockLimitOrderSettlementHandling::new()),
             }),
             Liquidity::Amm(AmmOrder {
                 tokens: TokenPair::new(H160::zero(), H160::from_low_u64_be(1)).unwrap(),
-                reserves: (100, 100),
-                fee: Rational::new(1, 1),
+                reserves: (base(100), base(100)),
+                fee: Rational::new(0, 1),
                 settlement_handling: Arc::new(MockAmmSettlementHandling::new()),
             }),
         ];
-        let settlement = solver.solve(orders).await.unwrap().unwrap();
-        dbg!(settlement);
+        let prepared = solver.prepare_model(orders);
+        let settled = solver.send(&prepared.model).await.unwrap();
+        dbg!(&settled);
+
+        let exec_order = settled.orders.values().next().unwrap();
+        assert_eq!(exec_order.exec_sell_amount.as_u128(), base(2));
+        assert!(exec_order.exec_buy_amount.as_u128() > 0);
+
+        let uniswap = settled.uniswaps.values().next().unwrap();
+        assert!(uniswap.balance_update1 < 0);
+        assert_eq!(uniswap.balance_update2 as u128, base(2));
+
+        assert_eq!(settled.prices.len(), 2);
     }
 }

--- a/solver/src/http_solver/model.rs
+++ b/solver/src/http_solver/model.rs
@@ -8,7 +8,6 @@ pub struct BatchAuctionModel {
     pub tokens: HashMap<String, TokenInfoModel>,
     pub orders: HashMap<String, OrderModel>,
     pub uniswaps: HashMap<String, UniswapModel>,
-    pub ref_token: String,
     #[serde(with = "serde_with::rust::display_fromstr")]
     pub default_fee: f64,
 }
@@ -65,7 +64,7 @@ pub struct ExecutedOrderModel {
 #[derive(Debug, Deserialize)]
 pub struct UpdatedUniswapModel {
     #[serde(with = "serde_with::rust::display_fromstr")]
-    pub balance_update_1: i128,
+    pub balance_update1: i128,
     #[serde(with = "serde_with::rust::display_fromstr")]
-    pub balance_update_2: i128,
+    pub balance_update2: i128,
 }

--- a/solver/src/http_solver/settlement.rs
+++ b/solver/src/http_solver/settlement.rs
@@ -1,4 +1,4 @@
-use super::model::{Price, SettledBatchAuctionModel};
+use super::model::{BatchAuctionModel, Price, SettledBatchAuctionModel};
 use crate::{
     liquidity::{AmmOrder, LimitOrder},
     settlement::Settlement,
@@ -8,22 +8,29 @@ use model::order::OrderKind;
 use primitive_types::{H160, U256};
 use std::collections::HashMap;
 
+// To send an instance to the solver we need to identify tokens and orders through strings. This
+// struct combines the created model and a mapping of those identifiers to their original value.
+pub struct PreparedModel {
+    pub model: BatchAuctionModel,
+    pub tokens: HashMap<String, H160>,
+    pub limit_orders: HashMap<String, LimitOrder>,
+    pub amm_orders: HashMap<String, AmmOrder>,
+}
+
 pub fn convert_settlement(
-    model: &SettledBatchAuctionModel,
-    tokens: &HashMap<String, H160>,
-    orders: &HashMap<String, &LimitOrder>,
-    amms: &HashMap<String, &AmmOrder>,
+    settled: &SettledBatchAuctionModel,
+    prepared: &PreparedModel,
 ) -> Result<Settlement> {
     let mut settlement = Settlement::default();
-    set_orders(model, orders, &mut settlement)?;
-    set_amms(model, amms, &mut settlement)?;
-    set_prices(model, tokens, &mut settlement)?;
+    set_orders(settled, &prepared.limit_orders, &mut settlement)?;
+    set_amms(settled, &prepared.amm_orders, &mut settlement)?;
+    set_prices(settled, &prepared.tokens, &mut settlement)?;
     Ok(settlement)
 }
 
 fn set_orders(
     model: &SettledBatchAuctionModel,
-    orders: &HashMap<String, &LimitOrder>,
+    orders: &HashMap<String, LimitOrder>,
     settlement: &mut Settlement,
 ) -> Result<()> {
     for (index, model) in model.orders.iter() {
@@ -48,7 +55,7 @@ fn set_orders(
 
 fn set_amms(
     model: &SettledBatchAuctionModel,
-    amms: &HashMap<String, &AmmOrder>,
+    amms: &HashMap<String, AmmOrder>,
     settlement: &mut Settlement,
 ) -> Result<()> {
     for (index, model) in model.uniswaps.iter() {
@@ -56,17 +63,17 @@ fn set_amms(
             .get(index.as_str())
             .ok_or_else(|| anyhow!("invalid amm {}", index))?;
         let (input, output) =
-            if model.balance_update_1.is_positive() && model.balance_update_2.is_negative() {
+            if model.balance_update1.is_positive() && model.balance_update2.is_negative() {
                 (
-                    (amm.tokens.get().0, i128_abs_to_u256(model.balance_update_1)),
-                    (amm.tokens.get().1, i128_abs_to_u256(model.balance_update_2)),
+                    (amm.tokens.get().0, i128_abs_to_u256(model.balance_update1)),
+                    (amm.tokens.get().1, i128_abs_to_u256(model.balance_update2)),
                 )
-            } else if model.balance_update_2.is_positive() && model.balance_update_1.is_negative() {
+            } else if model.balance_update2.is_positive() && model.balance_update1.is_negative() {
                 (
-                    (amm.tokens.get().1, i128_abs_to_u256(model.balance_update_2)),
-                    (amm.tokens.get().0, i128_abs_to_u256(model.balance_update_1)),
+                    (amm.tokens.get().1, i128_abs_to_u256(model.balance_update2)),
+                    (amm.tokens.get().0, i128_abs_to_u256(model.balance_update1)),
                 )
-            } else if model.balance_update_1 == 0 && model.balance_update_2 == 0 {
+            } else if model.balance_update1 == 0 && model.balance_update2 == 0 {
                 continue;
             } else {
                 return Err(anyhow!("invalid uniswap update {:?}", model));
@@ -162,7 +169,7 @@ mod tests {
             partially_fillable: false,
             settlement_handling: Arc::new(limit_handling),
         };
-        let orders = hashmap! { "lo0".to_string() => &limit_order };
+        let orders = hashmap! { "lo0".to_string() => limit_order };
 
         let mut amm_handling = MockAmmSettlementHandling::new();
         amm_handling
@@ -175,24 +182,30 @@ mod tests {
             fee: 5.into(),
             settlement_handling: Arc::new(amm_handling),
         };
-        let amms = hashmap! { "amm0".to_string() => &amm_order };
+        let amms = hashmap! { "amm0".to_string() => amm_order };
 
         let executed_order = ExecutedOrderModel {
             exec_buy_amount: 6.into(),
             exec_sell_amount: 7.into(),
         };
         let updated_uniswap = UpdatedUniswapModel {
-            balance_update_1: 8,
-            balance_update_2: -9,
+            balance_update1: 8,
+            balance_update2: -9,
         };
-        let model = SettledBatchAuctionModel {
+        let settled = SettledBatchAuctionModel {
             orders: hashmap! { "lo0".to_string() => executed_order },
             uniswaps: hashmap! { "amm0".to_string() => updated_uniswap },
             ref_token: "t0".to_string(),
             prices: hashmap! { "t0".to_string() => Price(10.0), "t1".to_string() => Price(11.0) },
         };
 
-        let settlement = convert_settlement(&model, &tokens, &orders, &amms).unwrap();
+        let prepared = PreparedModel {
+            model: Default::default(),
+            tokens,
+            limit_orders: orders,
+            amm_orders: amms,
+        };
+        let settlement = convert_settlement(&settled, &prepared).unwrap();
         assert_eq!(
             settlement.clearing_prices,
             hashmap! { t0 => 10.into(), t1 => 11.into() }

--- a/solver/src/http_solver/settlement.rs
+++ b/solver/src/http_solver/settlement.rs
@@ -1,4 +1,4 @@
-use super::model::{BatchAuctionModel, Price, SettledBatchAuctionModel};
+use super::model::{Price, SettledBatchAuctionModel};
 use crate::{
     liquidity::{AmmOrder, LimitOrder},
     settlement::Settlement,
@@ -10,8 +10,7 @@ use std::collections::HashMap;
 
 // To send an instance to the solver we need to identify tokens and orders through strings. This
 // struct combines the created model and a mapping of those identifiers to their original value.
-pub struct PreparedModel {
-    pub model: BatchAuctionModel,
+pub struct SettlementContext {
     pub tokens: HashMap<String, H160>,
     pub limit_orders: HashMap<String, LimitOrder>,
     pub amm_orders: HashMap<String, AmmOrder>,
@@ -19,7 +18,7 @@ pub struct PreparedModel {
 
 pub fn convert_settlement(
     settled: &SettledBatchAuctionModel,
-    prepared: &PreparedModel,
+    prepared: &SettlementContext,
 ) -> Result<Settlement> {
     let mut settlement = Settlement::default();
     set_orders(settled, &prepared.limit_orders, &mut settlement)?;
@@ -199,8 +198,7 @@ mod tests {
             prices: hashmap! { "t0".to_string() => Price(10.0), "t1".to_string() => Price(11.0) },
         };
 
-        let prepared = PreparedModel {
-            model: Default::default(),
+        let prepared = SettlementContext {
             tokens,
             limit_orders: orders,
             amm_orders: amms,


### PR DESCRIPTION
Sorry for combining several small changes into one PR. This was all motivated by testing with the real solver and several of these changes are just a couple of lines so I didn't want to have the overhead of creating that many PRs.

* introduce a PreparedModel struct for combing the model sent to the
solver with the data it references.
* get rid of references in the model data to remove lifetimes
* use that struct to simplify `solve` so that the real solver test can
skip the `convert_settlement` step so that it does not have to set up
mocks on the order handling.
* fix two fields that were changed in the solver api
* re-add trace log because it was useful during testing
* use real amm fees

### Test Plan
Test with real solver works and prints response
