### PR TITLE
Refactor solver result to settlement conversion

### DIFF
--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -15,6 +15,7 @@ use std::collections::{HashMap, HashSet};
 
 // TODO: limit trading for tokens that don't have uniswap - fee pool
 // TODO: exclude partially fillable orders
+// TODO: set settlement.fee_factor
 // TODO: find correct ordering for uniswap trades
 // TODO: gather real token decimals and store them in a cache
 // TODO: special rounding for the prices we get from the solver?
@@ -217,7 +218,7 @@ impl Solver for HttpSolver {
         let (model, context) = self.prepare_model(liquidity);
         let settled = self.send(&model).await?;
         tracing::trace!(?settled);
-        settlement::convert_settlement(&settled, &context).map(Some)
+        settlement::convert_settlement(settled, context).map(Some)
     }
 }
 


### PR DESCRIPTION
While working on finding the correct ordering of uniswap uses we get
from the solver I found that this code is a lot easier to work with if
we first convert it to something more convenient to use than the raw
data we get from the solver.
We put error handling and association of the string identifiers up front
before doing more work with the data.
I also changed the implementation of new_prices to
be more efficient by only going through all orders once instead of once
for every price.

Test Plan:
existing test. but could make more fine grained test in the future as this has become easier with this refactor.