### PR TITLE
Query smaller event range when possible

### DIFF
--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -31,7 +31,7 @@ shared= { path = "../shared" }
 sqlx = { version = "0.4", default-features = false, features = ["bigdecimal", "chrono", "macros", "runtime-tokio-native-tls", "postgres"] }
 structopt = { version = "0.3" }
 reqwest = { version = "0.10", features = ["json"] }
-tokio = { version = "0.2", features =["macros", "rt-threaded", "time"] }
+tokio = { version = "0.2", features =["macros", "rt-threaded", "sync", "time"] }
 tracing = "0.1"
 url = "2.2"
 warp = "0.2"


### PR DESCRIPTION
Instead of using only the most recent event block from the db we also store the last
handled block in self so that during long times of no events we do not query needlessly
large block ranges.

related #305 


### Test Plan
Run locally and observe block range is small after initial update