### PR TITLE
[Easy] make settle interval configurable

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,9 +9,11 @@ RUN cargo build --target x86_64-unknown-linux-musl --release
 FROM alpine:latest
 
 # Handle signal handlers properly
-RUN apk add --no-cache tini
+RUN apk add --no-cache tini postgresql
 COPY --from=cargo-build /usr/src/oba-services/target/x86_64-unknown-linux-musl/release/orderbook /usr/local/bin/orderbook
 COPY --from=cargo-build /usr/src/oba-services/target/x86_64-unknown-linux-musl/release/solver /usr/local/bin/solver
+
+COPY database /usr/database
 
 CMD echo "Specify binary - either solver or orderbook"
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -218,6 +218,7 @@ async fn test_with_ganache() {
         Box::new(solver),
         Box::new(web3),
         Duration::from_secs(1),
+        Duration::from_secs(30),
     );
     driver.single_run().await.unwrap();
 

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -10,8 +10,6 @@ use gas_estimation::GasPriceEstimating;
 use std::time::Duration;
 use tracing::info;
 
-const SETTLE_INTERVAL: Duration = Duration::from_secs(30);
-
 pub struct Driver {
     settlement_contract: GPv2Settlement,
     orderbook: OrderBookApi,
@@ -19,6 +17,7 @@ pub struct Driver {
     solver: Box<dyn Solver>,
     gas_price_estimator: Box<dyn GasPriceEstimating>,
     target_confirm_time: Duration,
+    settle_interval: Duration,
 }
 
 impl Driver {
@@ -29,6 +28,7 @@ impl Driver {
         solver: Box<dyn Solver>,
         gas_price_estimator: Box<dyn GasPriceEstimating>,
         target_confirm_time: Duration,
+        settle_interval: Duration,
     ) -> Self {
         Self {
             settlement_contract,
@@ -37,6 +37,7 @@ impl Driver {
             solver,
             gas_price_estimator,
             target_confirm_time,
+            settle_interval,
         }
     }
 
@@ -46,7 +47,7 @@ impl Driver {
                 Ok(()) => tracing::debug!("single run finished ok"),
                 Err(err) => tracing::error!("single run errored: {:?}", err),
             }
-            tokio::time::delay_for(SETTLE_INTERVAL).await;
+            tokio::time::delay_for(self.settle_interval).await;
         }
     }
 

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -35,6 +35,15 @@ struct Arguments {
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
     target_confirm_time: Duration,
+
+    /// Every how often we should execute the driver's run loop
+    #[structopt(
+        long,
+        env = "SETTLE_INTERVAL",
+        default_value = "30",
+        parse(try_from_str = shared::arguments::duration_from_seconds),
+    )]
+    settle_interval: Duration,
 }
 
 #[tokio::main]
@@ -93,6 +102,7 @@ async fn main() {
         Box::new(solver),
         Box::new(gas_price_estimator),
         args.target_confirm_time,
+        args.settle_interval,
     );
     driver.run_forever().await;
 }


### PR DESCRIPTION
For the internal xDAI challenge it might be nice to configure a larger batch time to increase the chances for coincidence of wants.

This PR makes the settle interval configurable (default to current value).

### Test Plan
Run locally with settle interval of 1s.
