### PR TITLE
Add new route for solvable orders

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -181,6 +181,21 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Trade"
+  /api/v1/solvable_orders:
+    get:
+      summary: Get solvable orders.
+      description: |
+        The set of orders that solvers should be solving right now. These orders are determined to
+        be valid at the time of the request.
+      responses:
+        200:
+          description: the orders
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Order"
 components:
   schemas:
     Address:

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -2,6 +2,7 @@ mod create_order;
 mod get_fee_info;
 mod get_order_by_uid;
 mod get_orders;
+mod get_solvable_orders;
 
 use crate::{fee::MinFeeCalculator, orderbook::Orderbook};
 use anyhow::Error as anyhowError;
@@ -20,15 +21,17 @@ pub fn handle_all_routes(
     orderbook: Arc<Orderbook>,
     fee_calcuator: Arc<MinFeeCalculator>,
 ) -> impl Filter<Extract = (impl Reply,), Error = warp::Rejection> + Clone {
-    let order_creation = create_order::create_order(orderbook.clone());
-    let order_getter = get_orders::get_orders(orderbook.clone());
+    let create_order = create_order::create_order(orderbook.clone());
+    let get_orders = get_orders::get_orders(orderbook.clone());
     let fee_info = get_fee_info::get_fee_info(fee_calcuator);
-    let order_by_uid = get_order_by_uid::get_order_by_uid(orderbook);
+    let get_order = get_order_by_uid::get_order_by_uid(orderbook.clone());
+    let get_solvable_orders = get_solvable_orders::get_solvable_orders(orderbook);
     warp::path!("api" / "v1" / ..).and(
-        order_creation
-            .or(order_getter)
+        create_order
+            .or(get_orders)
             .or(fee_info)
-            .or(order_by_uid),
+            .or(get_order)
+            .or(get_solvable_orders),
     )
 }
 

--- a/orderbook/src/api/get_solvable_orders.rs
+++ b/orderbook/src/api/get_solvable_orders.rs
@@ -1,0 +1,29 @@
+use crate::api::convert_get_orders_error_to_reply;
+use crate::orderbook::Orderbook;
+use anyhow::Result;
+use model::order::Order;
+use std::{convert::Infallible, sync::Arc};
+use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
+
+fn get_solvable_orders_request() -> impl Filter<Extract = (), Error = Rejection> + Clone {
+    warp::path!("solvable_orders").and(warp::get())
+}
+
+fn get_solvable_orders_response(result: Result<Vec<Order>>) -> impl Reply {
+    match result {
+        Ok(orders) => Ok(reply::with_status(reply::json(&orders), StatusCode::OK)),
+        Err(err) => Ok(convert_get_orders_error_to_reply(err)),
+    }
+}
+
+pub fn get_solvable_orders(
+    orderbook: Arc<Orderbook>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    get_solvable_orders_request().and_then(move || {
+        let orderbook = orderbook.clone();
+        async move {
+            let result = orderbook.get_solvable_orders().await;
+            Result::<_, Infallible>::Ok(get_solvable_orders_response(result))
+        }
+    })
+}

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -9,6 +9,7 @@ use model::{
     order::{Order, OrderCreation, OrderUid},
     DomainSeparator,
 };
+use shared::time::now_in_epoch_seconds;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -88,6 +89,17 @@ impl Orderbook {
             remove_orders_without_sufficient_balance(&mut orders);
         }
         Ok(orders)
+    }
+
+    pub async fn get_solvable_orders(&self) -> Result<Vec<Order>> {
+        let filter = OrderFilter {
+            min_valid_to: now_in_epoch_seconds(),
+            exclude_fully_executed: true,
+            exclude_invalidated: true,
+            exclude_insufficient_balance: true,
+            ..Default::default()
+        };
+        self.get_orders(&filter).await
     }
 
     pub async fn run_maintenance(&self, _settlement_contract: &GPv2Settlement) -> Result<()> {

--- a/solver/src/orderbook.rs
+++ b/solver/src/orderbook.rs
@@ -16,7 +16,7 @@ impl OrderBookApi {
     }
 
     pub async fn get_orders(&self) -> reqwest::Result<Vec<Order>> {
-        const PATH: &str = "/api/v1/orders";
+        const PATH: &str = "/api/v1/solvable_orders";
         let mut url = self.base.clone();
         url.set_path(PATH);
         self.client.get(url).send().await?.json().await


### PR DESCRIPTION
As discussed this is a route that is only intended to be used by
solvers. For now it returns the same order information as get_orders. In
the future we can change this without breaking the frontend.

### Test Plan
e2e test