### PR TITLE
Use specialized struct for solver orders

### DIFF
--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -17,6 +17,15 @@ use std::fmt::{self, Display};
 use std::str::FromStr;
 use web3::signing::{self, Key, SecretKeyRef};
 
+/// An order returned by the `solvable_orders` route.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SolverOrder {
+    #[serde(flatten)]
+    pub order_creation: OrderCreation,
+    pub executable_amount: Option<U256>,
+}
+
 /// An order that is returned when querying the orderbook.
 ///
 /// Contains extra fields that are populated by the orderbook.

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -191,9 +191,9 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Trade"
-  /api/v1/solvable_orders:
+  /api/v1/solver_orders:
     get:
-      summary: Get solvable orders.
+      summary: Get orders that should be considered by solvers.
       description: |
         The set of orders that solvers should be solving right now. These orders are determined to
         be valid at the time of the request.
@@ -205,7 +205,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Order"
+                  $ref: "#/components/schemas/SolverOrder"
   /api/v1/fee:
     get:
       description: |
@@ -361,6 +361,16 @@ components:
         invalidated:
           description: Has this order been invalidated?
           type: boolean
+    PartiallyFillable:
+      description: Extra information about partially fillable orders.
+      type: object
+      properties:
+        executableAmount:
+          description: |
+            Amount of the order that can be executed based on user balance and previous executions.
+            Null for fill or kill orders.
+          $ref: "#/components/schemas/TokenAmount"
+          nullable: true
     Order:
       allOf:
         - $ref: "#/components/schemas/OrderCreation"
@@ -373,6 +383,10 @@ components:
         signature:
           description: "OrderCancellation signed by owner"
           $ref: "#/components/schemas/Signature"
+    SolverOrder:
+      allOf:
+        - $ref: "#/components/schemas/OrderCreation"
+        - $ref: "#/components/schemas/PartiallyFillable"
     Trade:
       description: |
         Trade data such as executed amounts, fees, order id and block number.

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -3,7 +3,7 @@ mod create_order;
 mod get_fee_info;
 mod get_order_by_uid;
 mod get_orders;
-mod get_solvable_orders;
+mod get_solver_orders;
 mod get_trades;
 
 use crate::database::Database;
@@ -31,7 +31,7 @@ pub fn handle_all_routes(
     let legacy_fee_info = get_fee_info::legacy_get_fee_info(fee_calculator.clone());
     let fee_info = get_fee_info::get_fee_info(fee_calculator);
     let get_order = get_order_by_uid::get_order_by_uid(orderbook.clone());
-    let get_solvable_orders = get_solvable_orders::get_solvable_orders(orderbook.clone());
+    let get_solvable_orders = get_solver_orders::get_solver_orders(orderbook.clone());
     let get_trades = get_trades::get_trades(database);
     let cancel_order = cancel_order::cancel_order(orderbook);
     warp::path!("api" / "v1" / ..).and(

--- a/orderbook/src/api/get_solver_orders.rs
+++ b/orderbook/src/api/get_solver_orders.rs
@@ -1,29 +1,29 @@
 use crate::api::convert_get_orders_error_to_reply;
 use crate::orderbook::Orderbook;
 use anyhow::Result;
-use model::order::Order;
+use model::order::SolverOrder;
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
 
-fn get_solvable_orders_request() -> impl Filter<Extract = (), Error = Rejection> + Clone {
-    warp::path!("solvable_orders").and(warp::get())
+fn get_solver_orders_request() -> impl Filter<Extract = (), Error = Rejection> + Clone {
+    warp::path!("solver_orders").and(warp::get())
 }
 
-fn get_solvable_orders_response(result: Result<Vec<Order>>) -> impl Reply {
+fn get_solver_orders_response(result: Result<Vec<SolverOrder>>) -> impl Reply {
     match result {
         Ok(orders) => Ok(reply::with_status(reply::json(&orders), StatusCode::OK)),
         Err(err) => Ok(convert_get_orders_error_to_reply(err)),
     }
 }
 
-pub fn get_solvable_orders(
+pub fn get_solver_orders(
     orderbook: Arc<Orderbook>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    get_solvable_orders_request().and_then(move || {
+    get_solver_orders_request().and_then(move || {
         let orderbook = orderbook.clone();
         async move {
             let result = orderbook.get_solvable_orders().await;
-            Result::<_, Infallible>::Ok(get_solvable_orders_response(result))
+            Result::<_, Infallible>::Ok(get_solver_orders_response(result))
         }
     })
 }

--- a/orderbook/src/database.rs
+++ b/orderbook/src/database.rs
@@ -1,10 +1,13 @@
 mod events;
 mod fees;
 mod orders;
+mod solver_orders;
 mod trades;
 
 use anyhow::Result;
+use model::order::OrderKind;
 use sqlx::PgPool;
+use std::convert::TryInto;
 
 pub use events::*;
 pub use orders::OrderFilter;
@@ -53,5 +56,29 @@ impl Database {
             .execute(sqlx::query("TRUNCATE min_fee_measurements;"))
             .await?;
         Ok(())
+    }
+}
+
+#[derive(sqlx::Type)]
+#[sqlx(rename = "OrderKind")]
+#[sqlx(rename_all = "lowercase")]
+enum DbOrderKind {
+    Buy,
+    Sell,
+}
+
+impl DbOrderKind {
+    fn from(order_kind: OrderKind) -> Self {
+        match order_kind {
+            OrderKind::Buy => Self::Buy,
+            OrderKind::Sell => Self::Sell,
+        }
+    }
+
+    fn into(self) -> OrderKind {
+        match self {
+            Self::Buy => OrderKind::Buy,
+            Self::Sell => OrderKind::Sell,
+        }
     }
 }

--- a/orderbook/src/database/fees.rs
+++ b/orderbook/src/database/fees.rs
@@ -1,4 +1,4 @@
-use super::{orders::DbOrderKind, Database};
+use super::{Database, DbOrderKind};
 use crate::conversions::*;
 use crate::fee::MinFeeStoring;
 

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -5,7 +5,7 @@ use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
 use futures::{stream::TryStreamExt, Stream};
 use model::{
-    order::{Order, OrderCreation, OrderKind, OrderMetaData, OrderUid},
+    order::{Order, OrderCreation, OrderMetaData, OrderUid},
     Signature,
 };
 use primitive_types::H160;
@@ -22,30 +22,6 @@ pub struct OrderFilter {
     pub exclude_invalidated: bool,
     pub exclude_insufficient_balance: bool,
     pub uid: Option<OrderUid>,
-}
-
-#[derive(sqlx::Type)]
-#[sqlx(rename = "OrderKind")]
-#[sqlx(rename_all = "lowercase")]
-pub enum DbOrderKind {
-    Buy,
-    Sell,
-}
-
-impl DbOrderKind {
-    pub fn from(order_kind: OrderKind) -> Self {
-        match order_kind {
-            OrderKind::Buy => Self::Buy,
-            OrderKind::Sell => Self::Sell,
-        }
-    }
-
-    fn into(self) -> OrderKind {
-        match self {
-            Self::Buy => OrderKind::Buy,
-            Self::Sell => OrderKind::Sell,
-        }
-    }
 }
 
 impl Database {

--- a/orderbook/src/database/solver_orders.rs
+++ b/orderbook/src/database/solver_orders.rs
@@ -1,0 +1,110 @@
+use super::*;
+use crate::conversions::*;
+use anyhow::{anyhow, Context, Result};
+use bigdecimal::BigDecimal;
+use futures::{stream::TryStreamExt, Stream};
+use model::{
+    order::{OrderCreation, OrderKind, SolverOrder},
+    Signature,
+};
+
+impl Database {
+    pub fn solver_orders(&self, min_valid_to: u32) -> impl Stream<Item = Result<SolverOrder>> + '_ {
+        const QUERY: &str = "\
+        SELECT * FROM ( \
+            SELECT \
+                o.owner, o.sell_token, o.buy_token, o.sell_amount, o.buy_amount, o.valid_to, \
+                o.app_data, o.fee_amount, o.kind, o.partially_fillable, o.signature, \
+                COALESCE(SUM(CASE o.kind \
+                    WHEN 'sell' THEN t.sell_amount - t.fee_amount \
+                    WHEN 'buy' THEN t.buy_amount \
+                END), 0) AS executed_amount \
+            FROM orders o \
+            WHERE o.cancellation_timestasmp IS NULL
+            LEFT OUTER JOIN trades t ON o.uid = t.order_uid \
+            LEFT OUTER JOIN invalidations ON o.uid = invalidations.order_uid \
+            GROUP BY o.uid \
+            HAVING COUNT(invalidations.*) = 0
+        ) AS temp \
+        WHERE executed_amount < (CASE kind
+            WHEN 'sell' THEN sell_amount \
+            WHEN 'buy' THEN buy_amount \
+        END) \
+        ;";
+        sqlx::query_as(QUERY)
+            .bind(min_valid_to)
+            .fetch(&self.pool)
+            .err_into()
+            .and_then(|row: OrdersQueryRow| async move { row.into_order() })
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct OrdersQueryRow {
+    sell_token: Vec<u8>,
+    buy_token: Vec<u8>,
+    sell_amount: BigDecimal,
+    buy_amount: BigDecimal,
+    valid_to: i64,
+    app_data: i64,
+    fee_amount: BigDecimal,
+    kind: DbOrderKind,
+    partially_fillable: bool,
+    signature: Vec<u8>,
+    executed_amount: BigDecimal,
+}
+
+impl OrdersQueryRow {
+    fn into_order(self) -> Result<SolverOrder> {
+        let order_creation = OrderCreation {
+            sell_token: h160_from_vec(self.sell_token)?,
+            buy_token: h160_from_vec(self.buy_token)?,
+            sell_amount: big_decimal_to_u256(&self.sell_amount)
+                .ok_or_else(|| anyhow!("sell_amount is not U256"))?,
+            buy_amount: big_decimal_to_u256(&self.buy_amount)
+                .ok_or_else(|| anyhow!("buy_amount is not U256"))?,
+            valid_to: self.valid_to.try_into().context("valid_to is not u32")?,
+            app_data: self.app_data.try_into().context("app_data is not u32")?,
+            fee_amount: big_decimal_to_u256(&self.fee_amount)
+                .ok_or_else(|| anyhow!("buy_amount is not U256"))?,
+            kind: self.kind.into(),
+            partially_fillable: self.partially_fillable,
+            signature: Signature::from_bytes(
+                &self
+                    .signature
+                    .try_into()
+                    .map_err(|_| anyhow!("signature has wrong length"))?,
+            ),
+        };
+        let executable_amount = if self.partially_fillable {
+            Some(
+                match order_creation.kind {
+                    OrderKind::Buy => order_creation.buy_amount,
+                    OrderKind::Sell => order_creation.sell_amount,
+                } - big_decimal_to_u256(&self.executed_amount)
+                    .ok_or_else(|| anyhow!("executed_amount is not U256"))?,
+            )
+        } else {
+            None
+        };
+        Ok(SolverOrder {
+            order_creation,
+            executable_amount,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_solver_orders_query_works() {
+        let db = Database::new("postgresql://").unwrap();
+        db.clear().await.unwrap();
+        db.solver_orders(0).try_collect::<Vec<_>>().await.unwrap();
+    }
+
+    // TODO: more tests
+}

--- a/solver/src/orderbook.rs
+++ b/solver/src/orderbook.rs
@@ -1,4 +1,4 @@
-use model::order::Order;
+use model::order::SolverOrder;
 use reqwest::{Client, Url};
 use std::time::Duration;
 
@@ -15,8 +15,8 @@ impl OrderBookApi {
         Self { base, client }
     }
 
-    pub async fn get_orders(&self) -> reqwest::Result<Vec<Order>> {
-        const PATH: &str = "/api/v1/solvable_orders";
+    pub async fn get_orders(&self) -> reqwest::Result<Vec<SolverOrder>> {
+        const PATH: &str = "/api/v1/solver_orders";
         let mut url = self.base.clone();
         url.set_path(PATH);
         self.client.get(url).send().await?.json().await


### PR DESCRIPTION
There is no need to carry around the extra information for the front end facing orders endpoint so we use a smaller struct for the solver facing endpoint. Likewise querying these orders from the db can be done with a specialized query.
This is good to have before #323 . In this PR the balance filtering for solver orders is temporarily removed. Will add it back in that PR.
Before writing more tests for the db query I want to see if this PR gets positive feedback. If so I will add more tests before merging into main.

### Test Plan
e2e test
