### PR TITLE
[Baseline 2] Shared helper methods for the Uniswap Baseline Solver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2337,6 +2337,7 @@ dependencies = [
  "futures",
  "gas-estimation",
  "hex-literal",
+ "maplit",
  "model",
  "num",
  "primitive-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,6 +2338,7 @@ dependencies = [
  "gas-estimation",
  "hex-literal",
  "model",
+ "num",
  "primitive-types",
  "reqwest",
  "serde",

--- a/orderbook/src/price_estimate.rs
+++ b/orderbook/src/price_estimate.rs
@@ -68,10 +68,7 @@ mod tests {
     async fn estimate_price_on_direct_pair() {
         let token_a = H160::from_low_u64_be(1);
         let token_b = H160::from_low_u64_be(2);
-        let pool = Pool {
-            tokens: TokenPair::new(token_a, token_b).unwrap(),
-            reserves: (100, 10),
-        };
+        let pool = Pool::uniswap(TokenPair::new(token_a, token_b).unwrap(), (100, 10));
 
         let pool_fetcher = Box::new(FakePoolFetcher(vec![pool]));
         let estimator = UniswapPriceEstimator { pool_fetcher };
@@ -104,10 +101,7 @@ mod tests {
     async fn return_error_if_invalid_reserves() {
         let token_a = H160::from_low_u64_be(1);
         let token_b = H160::from_low_u64_be(2);
-        let pool = Pool {
-            tokens: TokenPair::new(token_a, token_b).unwrap(),
-            reserves: (0, 10),
-        };
+        let pool = Pool::uniswap(TokenPair::new(token_a, token_b).unwrap(), (0, 10));
 
         let pool_fetcher = Box::new(FakePoolFetcher(vec![pool]));
         let estimator = UniswapPriceEstimator { pool_fetcher };

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -12,6 +12,7 @@ ethcontract = { version = "0.11", default-features = false }
 futures = "0.3"
 gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.0", features = ["web3_"] }
 hex-literal = "0.3"
+maplit = "1.0"
 model = { path = "../model" }
 num = "0.3"
 primitive-types = { version = "0.8" }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -13,6 +13,7 @@ futures = "0.3"
 gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.0", features = ["web3_"] }
 hex-literal = "0.3"
 model = { path = "../model" }
+num = "0.3"
 primitive-types = { version = "0.8" }
 reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0" }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -4,3 +4,4 @@ pub mod gas_price_estimation;
 pub mod time;
 pub mod tracing;
 pub mod uniswap_pool;
+pub mod uniswap_solver;

--- a/shared/src/uniswap_pool.rs
+++ b/shared/src/uniswap_pool.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 
 use contracts::{UniswapV2Factory, UniswapV2Pair};
-use ethcontract::{batch::CallBatch, Http, Web3, H160};
+use ethcontract::{batch::CallBatch, Http, Web3, H160, U256};
+use num::rational::Rational;
 use web3::signing::keccak256;
 
 use hex_literal::hex;
@@ -19,10 +20,72 @@ pub trait PoolFetching: Send + Sync {
     async fn fetch(&self, token_pairs: HashSet<TokenPair>) -> Vec<Pool>;
 }
 
-#[derive(Clone)]
+#[derive(Clone, Hash)]
 pub struct Pool {
     pub tokens: TokenPair,
     pub reserves: (u128, u128),
+    pub fee: Rational,
+}
+
+impl Pool {
+    pub fn uniswap(tokens: TokenPair, reserves: (u128, u128)) -> Self {
+        Self {
+            tokens,
+            reserves,
+            fee: Rational::new(3, 1000),
+        }
+    }
+
+    /// Given an input amount and token, returns the maximum output amount and address of the other asset.
+    pub fn get_amount_out(&self, token_in: H160, amount_in: U256) -> (U256, H160) {
+        // https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/libraries/UniswapV2Library.sol#L43
+        let (reserve_in, reserve_out, token_out) = if token_in == self.tokens.get().0 {
+            (
+                U256::from(self.reserves.0),
+                U256::from(self.reserves.1),
+                self.tokens.get().1,
+            )
+        } else {
+            assert!(token_in == self.tokens.get().1, "Token not part of pool");
+            (
+                U256::from(self.reserves.1),
+                U256::from(self.reserves.0),
+                self.tokens.get().0,
+            )
+        };
+
+        let amount_in_with_fee = amount_in * (self.fee.denom() - self.fee.numer());
+        let numerator = amount_in_with_fee * reserve_out;
+        let denominator = reserve_in * self.fee.denom() + amount_in_with_fee;
+        (numerator / denominator, token_out)
+    }
+
+    /// Given an output amount and token, returns a required input amount and address of the other asset. Returns None if out amount is larger than reserve.
+    pub fn get_amount_in(&self, token_out: H160, amount_out: U256) -> Option<(U256, H160)> {
+        // https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/libraries/UniswapV2Library.sol#L53
+        let (reserve_out, reserve_in, token_in) = if token_out == self.tokens.get().0 {
+            (
+                U256::from(self.reserves.0),
+                U256::from(self.reserves.1),
+                self.tokens.get().1,
+            )
+        } else {
+            assert!(token_out == self.tokens.get().1, "Token not part of pool");
+            (
+                U256::from(self.reserves.1),
+                U256::from(self.reserves.0),
+                self.tokens.get().0,
+            )
+        };
+
+        if amount_out >= reserve_out {
+            return None;
+        }
+
+        let numerator = reserve_in * amount_out * self.fee.denom();
+        let denominator = (reserve_out - amount_out) * (self.fee.denom() - self.fee.numer());
+        Some(((numerator / denominator) + 1, token_in))
+    }
 }
 
 pub struct PoolFetcher {
@@ -52,10 +115,7 @@ impl PoolFetching for PoolFetcher {
         let mut results = Vec::with_capacity(futures.len());
         for (pair, future) in futures {
             if let Ok(result) = future.await {
-                results.push(Pool {
-                    tokens: pair,
-                    reserves: (result.0, result.1),
-                })
+                results.push(Pool::uniswap(pair, (result.0, result.1)));
             }
         }
         results
@@ -114,6 +174,94 @@ mod tests {
         assert_eq!(
             pair_address(&pair, mainnet_factory, 100),
             H160::from_slice(&hex!("4505b262dc053998c10685dc5f9098af8ae5c8ad"))
+        );
+    }
+
+    #[test]
+    fn test_get_amounts_out() {
+        let sell_token = H160::from_low_u64_be(1);
+        let buy_token = H160::from_low_u64_be(2);
+
+        // Even Pool
+        let pool = Pool::uniswap(TokenPair::new(sell_token, buy_token).unwrap(), (100, 100));
+        assert_eq!(
+            pool.get_amount_out(sell_token, 10.into()),
+            (9.into(), buy_token)
+        );
+        assert_eq!(
+            pool.get_amount_out(sell_token, 100.into()),
+            (49.into(), buy_token)
+        );
+        assert_eq!(
+            pool.get_amount_out(sell_token, 1000.into()),
+            (90.into(), buy_token)
+        );
+
+        //Uneven Pool
+        let pool = Pool::uniswap(TokenPair::new(sell_token, buy_token).unwrap(), (200, 50));
+        assert_eq!(
+            pool.get_amount_out(sell_token, 10.into()),
+            (2.into(), buy_token)
+        );
+        assert_eq!(
+            pool.get_amount_out(sell_token, 100.into()),
+            (16.into(), buy_token)
+        );
+        assert_eq!(
+            pool.get_amount_out(sell_token, 1000.into()),
+            (41.into(), buy_token)
+        );
+
+        // Large Numbers
+        let pool = Pool::uniswap(
+            TokenPair::new(sell_token, buy_token).unwrap(),
+            (u128::max_value(), u128::max_value()),
+        );
+        assert_eq!(
+            pool.get_amount_out(sell_token, 10u128.pow(20).into()),
+            (99_699_999_999_999_999_970u128.into(), buy_token)
+        );
+    }
+
+    #[test]
+    fn test_get_amounts_in() {
+        let sell_token = H160::from_low_u64_be(1);
+        let buy_token = H160::from_low_u64_be(2);
+
+        // Even Pool
+        let pool = Pool::uniswap(TokenPair::new(sell_token, buy_token).unwrap(), (100, 100));
+        assert_eq!(
+            pool.get_amount_in(buy_token, 10.into()),
+            Some((12.into(), sell_token))
+        );
+        assert_eq!(
+            pool.get_amount_in(buy_token, 99.into()),
+            Some((9930.into(), sell_token))
+        );
+
+        // Buying more than possible
+        assert_eq!(pool.get_amount_in(buy_token, 100.into()), None);
+        assert_eq!(pool.get_amount_in(buy_token, 1000.into()), None);
+
+        //Uneven Pool
+        let pool = Pool::uniswap(TokenPair::new(sell_token, buy_token).unwrap(), (200, 50));
+        assert_eq!(
+            pool.get_amount_in(buy_token, 10.into()),
+            Some((51.into(), sell_token))
+        );
+        assert_eq!(
+            pool.get_amount_in(buy_token, 49.into()),
+            Some((9830.into(), sell_token))
+        );
+
+        // Large Numbers
+        let pool = Pool::uniswap(
+            TokenPair::new(sell_token, buy_token).unwrap(),
+            (u128::max_value(), u128::max_value()),
+        );
+        assert_eq!(
+            pool.get_amount_in(buy_token, 10u128.pow(20).into()),
+            Some((100_300_902_708_124_373_149u128.into(), sell_token))
         );
     }
 }

--- a/shared/src/uniswap_pool.rs
+++ b/shared/src/uniswap_pool.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use contracts::{UniswapV2Factory, UniswapV2Pair};
 use ethcontract::{batch::CallBatch, Http, Web3, H160, U256};
-use num::rational::Rational;
+use num::rational::Ratio;
 use web3::signing::keccak256;
 
 use hex_literal::hex;
@@ -24,7 +24,7 @@ pub trait PoolFetching: Send + Sync {
 pub struct Pool {
     pub tokens: TokenPair,
     pub reserves: (u128, u128),
-    pub fee: Rational,
+    pub fee: Ratio<u32>,
 }
 
 impl Pool {
@@ -32,12 +32,13 @@ impl Pool {
         Self {
             tokens,
             reserves,
-            fee: Rational::new(3, 1000),
+            fee: Ratio::new(3, 1000),
         }
     }
 
     /// Given an input amount and token, returns the maximum output amount and address of the other asset.
-    pub fn get_amount_out(&self, token_in: H160, amount_in: U256) -> (U256, H160) {
+    /// Returns None if operation not possible due to arithmetic issues (e.g. over or underflow)
+    pub fn get_amount_out(&self, token_in: H160, amount_in: U256) -> Option<(U256, H160)> {
         // https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/libraries/UniswapV2Library.sol#L43
         let (reserve_in, reserve_out, token_out) = if token_in == self.tokens.get().0 {
             (
@@ -54,13 +55,14 @@ impl Pool {
             )
         };
 
-        let amount_in_with_fee = amount_in * (self.fee.denom() - self.fee.numer());
-        let numerator = amount_in_with_fee * reserve_out;
-        let denominator = reserve_in * self.fee.denom() + amount_in_with_fee;
-        (numerator / denominator, token_out)
+        Some((
+            self.amount_out(amount_in, reserve_in, reserve_out)?,
+            token_out,
+        ))
     }
 
-    /// Given an output amount and token, returns a required input amount and address of the other asset. Returns None if out amount is larger than reserve.
+    /// Given an output amount and token, returns a required input amount and address of the other asset.
+    /// Returns None if operation not possible due to arithmetic issues (e.g. over or underflow, reserve too small)
     pub fn get_amount_in(&self, token_out: H160, amount_out: U256) -> Option<(U256, H160)> {
         // https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/libraries/UniswapV2Library.sol#L53
         let (reserve_out, reserve_in, token_in) = if token_out == self.tokens.get().0 {
@@ -77,14 +79,38 @@ impl Pool {
                 self.tokens.get().0,
             )
         };
+        Some((
+            self.amount_in(amount_out, reserve_in, reserve_out)?,
+            token_in,
+        ))
+    }
 
-        if amount_out >= reserve_out {
+    fn amount_out(&self, amount_in: U256, reserve_in: U256, reserve_out: U256) -> Option<U256> {
+        if amount_in.is_zero() || reserve_in.is_zero() || reserve_out.is_zero() {
             return None;
         }
 
-        let numerator = reserve_in * amount_out * self.fee.denom();
-        let denominator = (reserve_out - amount_out) * (self.fee.denom() - self.fee.numer());
-        Some(((numerator / denominator) + 1, token_in))
+        let amount_in_with_fee =
+            amount_in.checked_mul(U256::from(self.fee.denom().checked_sub(*self.fee.numer())?))?;
+        let numerator = amount_in_with_fee.checked_mul(reserve_out)?;
+        let denominator = reserve_in
+            .checked_mul(U256::from(*self.fee.denom()))?
+            .checked_add(amount_in_with_fee)?;
+        numerator.checked_div(denominator)
+    }
+
+    fn amount_in(&self, amount_out: U256, reserve_in: U256, reserve_out: U256) -> Option<U256> {
+        if amount_out.is_zero() || reserve_in.is_zero() || reserve_out.is_zero() {
+            return None;
+        }
+
+        let numerator = reserve_in
+            .checked_mul(amount_out)?
+            .checked_mul(U256::from(*self.fee.denom()))?;
+        let denominator = reserve_out
+            .checked_sub(amount_out)?
+            .checked_mul(U256::from(self.fee.denom().checked_sub(*self.fee.numer())?))?;
+        numerator.checked_div(denominator)?.checked_add(1.into())
     }
 }
 
@@ -186,30 +212,30 @@ mod tests {
         let pool = Pool::uniswap(TokenPair::new(sell_token, buy_token).unwrap(), (100, 100));
         assert_eq!(
             pool.get_amount_out(sell_token, 10.into()),
-            (9.into(), buy_token)
+            Some((9.into(), buy_token))
         );
         assert_eq!(
             pool.get_amount_out(sell_token, 100.into()),
-            (49.into(), buy_token)
+            Some((49.into(), buy_token))
         );
         assert_eq!(
             pool.get_amount_out(sell_token, 1000.into()),
-            (90.into(), buy_token)
+            Some((90.into(), buy_token))
         );
 
         //Uneven Pool
         let pool = Pool::uniswap(TokenPair::new(sell_token, buy_token).unwrap(), (200, 50));
         assert_eq!(
             pool.get_amount_out(sell_token, 10.into()),
-            (2.into(), buy_token)
+            Some((2.into(), buy_token))
         );
         assert_eq!(
             pool.get_amount_out(sell_token, 100.into()),
-            (16.into(), buy_token)
+            Some((16.into(), buy_token))
         );
         assert_eq!(
             pool.get_amount_out(sell_token, 1000.into()),
-            (41.into(), buy_token)
+            Some((41.into(), buy_token))
         );
 
         // Large Numbers
@@ -219,8 +245,11 @@ mod tests {
         );
         assert_eq!(
             pool.get_amount_out(sell_token, 10u128.pow(20).into()),
-            (99_699_999_999_999_999_970u128.into(), buy_token)
+            Some((99_699_999_999_999_999_970u128.into(), buy_token))
         );
+
+        // Overflow
+        assert_eq!(pool.get_amount_out(sell_token, U256::max_value()), None);
     }
 
     #[test]

--- a/shared/src/uniswap_solver.rs
+++ b/shared/src/uniswap_solver.rs
@@ -1,0 +1,238 @@
+use ethcontract::{H160, U256};
+use model::TokenPair;
+use std::collections::{HashMap, HashSet};
+
+use crate::uniswap_pool::Pool;
+
+type PathCandidate = Vec<TokenPair>;
+
+pub fn estimate_buy_amount(
+    sell_token: H160,
+    sell_amount: U256,
+    path: &[TokenPair],
+    pools: &HashMap<TokenPair, Pool>,
+) -> Option<U256> {
+    path.iter()
+        .fold(Some((sell_amount, sell_token)), |previous, pair| {
+            let previous = match previous {
+                Some(previous) => previous,
+                None => return None,
+            };
+
+            match pools.get(pair) {
+                Some(pool) => Some(pool.get_amount_out(previous.1, previous.0)),
+                None => None,
+            }
+        })
+        .map(|(amount, _)| amount)
+}
+
+pub fn estimate_sell_amount(
+    buy_token: H160,
+    buy_amount: U256,
+    path: &[TokenPair],
+    pools: &HashMap<TokenPair, Pool>,
+) -> Option<U256> {
+    path.iter()
+        .rev()
+        .fold(Some((buy_amount, buy_token)), |previous, pair| {
+            let previous = match previous {
+                Some(previous) => previous,
+                None => return None,
+            };
+
+            match pools.get(pair) {
+                Some(pool) => pool.get_amount_in(previous.1, previous.0),
+                None => None,
+            }
+        })
+        .map(|(amount, _)| amount)
+}
+
+pub fn path_candidates(
+    sell_token: H160,
+    buy_token: H160,
+    base_tokens: &HashSet<H160>,
+    max_hops: usize,
+) -> HashSet<PathCandidate> {
+    let mut candidates = HashSet::new();
+
+    // Start with just the sell token (yields the direct pair candidate in the 0th iteration)
+    let mut path_prefixes = vec![vec![sell_token]];
+    for _ in 0..(max_hops + 1) {
+        let mut next_round_path_prefixes = vec![];
+        for path_prefix in &path_prefixes {
+            // For this round, add the buy token and path to the candidates
+            let mut full_path = path_prefix.clone();
+            full_path.push(buy_token);
+            candidates.insert(tokens_list_to_path_candidate(&full_path));
+
+            // For the next round, amend current prefix with all base tokens that are not yet on the path
+            for base_token in base_tokens {
+                if base_token != &buy_token && !path_prefix.contains(base_token) {
+                    let mut next_round_path_prefix = path_prefix.clone();
+                    next_round_path_prefix.push(*base_token);
+                    next_round_path_prefixes.push(next_round_path_prefix);
+                }
+            }
+        }
+        path_prefixes = next_round_path_prefixes;
+    }
+    candidates
+}
+
+fn tokens_list_to_path_candidate(token_list: &[H160]) -> PathCandidate {
+    token_list
+        .windows(2)
+        .map(|window| {
+            TokenPair::new(window[0], window[1]).expect("token list contains same token in a row")
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethcontract::H160;
+    use maplit::{hashmap, hashset};
+    use model::TokenPair;
+    use std::iter::FromIterator;
+
+    #[test]
+    fn test_path_candidates() {
+        let base_tokens = vec![
+            H160::from_low_u64_be(0),
+            H160::from_low_u64_be(1),
+            H160::from_low_u64_be(2),
+        ];
+        let base_token_set = &HashSet::from_iter(base_tokens.clone());
+
+        let sell_token = H160::from_low_u64_be(4);
+        let buy_token = H160::from_low_u64_be(5);
+
+        // 0 hops
+        assert_eq!(
+            path_candidates(sell_token, buy_token, base_token_set, 0),
+            hashset! {vec![TokenPair::new(sell_token, buy_token).unwrap()]}
+        );
+
+        // 1 hop with all permutations
+        assert_eq!(
+            path_candidates(sell_token, buy_token, base_token_set, 1),
+            hashset! {
+                vec![TokenPair::new(sell_token, buy_token).unwrap()],
+                vec![TokenPair::new(sell_token, base_tokens[0]).unwrap(), TokenPair::new(base_tokens[0], buy_token).unwrap()],
+                vec![TokenPair::new(sell_token, base_tokens[1]).unwrap(), TokenPair::new(base_tokens[1], buy_token).unwrap()],
+                vec![TokenPair::new(sell_token, base_tokens[2]).unwrap(), TokenPair::new(base_tokens[2], buy_token).unwrap()],
+
+            }
+        );
+
+        // 2 & 3 hops check count
+        assert_eq!(
+            path_candidates(sell_token, buy_token, base_token_set, 2).len(),
+            10
+        );
+        assert_eq!(
+            path_candidates(sell_token, buy_token, base_token_set, 3).len(),
+            16
+        );
+
+        // 4 hops should not yield any more permutations since we used all base tokens
+        assert_eq!(
+            path_candidates(sell_token, buy_token, base_token_set, 4).len(),
+            16
+        );
+
+        // Ignores base token if part of buy or sell
+        assert_eq!(
+            path_candidates(base_tokens[0], buy_token, base_token_set, 1),
+            hashset! {
+                vec![TokenPair::new(base_tokens[0], buy_token).unwrap()],
+                vec![TokenPair::new(base_tokens[0], base_tokens[1]).unwrap(), TokenPair::new(base_tokens[1], buy_token).unwrap()],
+                vec![TokenPair::new(base_tokens[0], base_tokens[2]).unwrap(), TokenPair::new(base_tokens[2], buy_token).unwrap()],
+
+            }
+        );
+        assert_eq!(
+            path_candidates(sell_token, base_tokens[0], base_token_set, 1),
+            hashset! {
+                vec![TokenPair::new(sell_token, base_tokens[0]).unwrap()],
+                vec![TokenPair::new(sell_token, base_tokens[1]).unwrap(), TokenPair::new(base_tokens[1], base_tokens[0]).unwrap()],
+                vec![TokenPair::new(sell_token, base_tokens[2]).unwrap(), TokenPair::new(base_tokens[2], base_tokens[0]).unwrap()],
+
+            }
+        );
+    }
+
+    #[test]
+    fn test_estimate_amount_returns_none_if_it_contains_pair_without_pool() {
+        let sell_token = H160::from_low_u64_be(1);
+        let intermediate = H160::from_low_u64_be(2);
+        let buy_token = H160::from_low_u64_be(3);
+
+        let path = vec![
+            TokenPair::new(sell_token, intermediate).unwrap(),
+            TokenPair::new(intermediate, buy_token).unwrap(),
+        ];
+        let pools = hashmap! {
+            path[0] => Pool::uniswap(path[0], (100, 100)),
+        };
+
+        assert_eq!(
+            estimate_buy_amount(sell_token, 1.into(), &path, &pools),
+            None
+        );
+        assert_eq!(
+            estimate_sell_amount(sell_token, 1.into(), &path, &pools),
+            None
+        );
+    }
+
+    #[test]
+    fn test_estimate_amount() {
+        let sell_token = H160::from_low_u64_be(1);
+        let intermediate = H160::from_low_u64_be(2);
+        let buy_token = H160::from_low_u64_be(3);
+
+        let path = vec![
+            TokenPair::new(sell_token, intermediate).unwrap(),
+            TokenPair::new(intermediate, buy_token).unwrap(),
+        ];
+        let pools = hashmap! {
+            path[0] => Pool::uniswap(path[0],(100, 100)),
+            path[1] => Pool::uniswap(path[1],(200, 50)),
+        };
+
+        assert_eq!(
+            estimate_buy_amount(sell_token, 10.into(), &path, &pools),
+            Some(2.into())
+        );
+
+        assert_eq!(
+            estimate_sell_amount(buy_token, 10.into(), &path, &pools),
+            Some(105.into())
+        );
+    }
+
+    #[test]
+    fn test_estimate_sell_amount_returns_none_buying_too_much() {
+        let sell_token = H160::from_low_u64_be(1);
+        let intermediate = H160::from_low_u64_be(2);
+        let buy_token = H160::from_low_u64_be(3);
+
+        let path = vec![
+            TokenPair::new(sell_token, intermediate).unwrap(),
+            TokenPair::new(intermediate, buy_token).unwrap(),
+        ];
+        let pools = hashmap! {
+            path[0] => Pool::uniswap(path[0],(100, 100)),
+            path[1] => Pool::uniswap(path[1],(200, 50)),
+        };
+
+        assert_eq!(
+            estimate_sell_amount(buy_token, 100.into(), &path, &pools),
+            None
+        );
+    }
+}

--- a/shared/src/uniswap_solver.rs
+++ b/shared/src/uniswap_solver.rs
@@ -20,7 +20,7 @@ pub fn estimate_buy_amount(
             };
 
             match pools.get(pair) {
-                Some(pool) => Some(pool.get_amount_out(previous.1, previous.0)),
+                Some(pool) => pool.get_amount_out(previous.1, previous.0),
                 None => None,
             }
         })

--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -278,7 +278,7 @@ mod tests {
         AmmOrder, LimitOrder, MockAmmSettlementHandling, MockLimitOrderSettlementHandling,
     };
     use ::model::TokenPair;
-    use num::Rational;
+    use num::rational::Ratio;
     use std::sync::Arc;
 
     // cargo test real_solver -- --ignored --nocapture
@@ -314,7 +314,7 @@ mod tests {
             Liquidity::Amm(AmmOrder {
                 tokens: TokenPair::new(H160::zero(), H160::from_low_u64_be(1)).unwrap(),
                 reserves: (base(100), base(100)),
-                fee: Rational::new(0, 1),
+                fee: Ratio::new(0, 1),
                 settlement_handling: Arc::new(MockAmmSettlementHandling::new()),
             }),
         ];

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -1,5 +1,5 @@
 use model::{order::OrderKind, TokenPair};
-use num::rational::Rational;
+use num::rational::Ratio;
 use primitive_types::{H160, U256};
 use settlement::{Interaction, Trade};
 use std::sync::Arc;
@@ -40,7 +40,7 @@ pub trait LimitOrderSettlementHandling: Send + Sync {
 pub struct AmmOrder {
     pub tokens: TokenPair,
     pub reserves: (u128, u128),
-    pub fee: Rational,
+    pub fee: Ratio<u32>,
     pub settlement_handling: Arc<dyn AmmSettlementHandling>,
 }
 

--- a/solver/src/liquidity/uniswap.rs
+++ b/solver/src/liquidity/uniswap.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use contracts::{GPv2Settlement, UniswapV2Factory, UniswapV2Router02, IERC20};
 use ethcontract::{batch::CallBatch, Http, Web3};
 use model::TokenPair;
-use num::rational::Rational;
 use primitive_types::{H160, U256};
 use shared::uniswap_pool::{PoolFetcher, PoolFetching as _};
 use std::collections::{HashMap, HashSet};
@@ -84,7 +83,7 @@ impl UniswapLiquidity {
             result.push(AmmOrder {
                 tokens: pool.tokens,
                 reserves: pool.reserves,
-                fee: Rational::new_raw(3, 1000),
+                fee: pool.fee,
                 settlement_handling: self.inner.clone(),
             })
         }

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -286,7 +286,7 @@ fn bigint_to_u256(input: &BigInt) -> Result<U256> {
 mod tests {
     use liquidity::tests::{CapturingAmmSettlementHandler, CapturingLimitOrderSettlementHandler};
     use model::{order::OrderCreation, TokenPair};
-    use num::Rational;
+    use num::rational::Ratio;
 
     use super::*;
 
@@ -323,7 +323,7 @@ mod tests {
         let pool = AmmOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
-            fee: Rational::new(3, 1000),
+            fee: Ratio::new(3, 1000),
             settlement_handling: amm_handler.clone(),
         };
         let result = solve(orders.clone().into_iter(), &pool);
@@ -379,7 +379,7 @@ mod tests {
         let pool = AmmOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_000).as_u128(), to_wei(1_000_000).as_u128()),
-            fee: Rational::new(3, 1000),
+            fee: Ratio::new(3, 1000),
             settlement_handling: amm_handler.clone(),
         };
         let result = solve(orders.clone().into_iter(), &pool);
@@ -431,7 +431,7 @@ mod tests {
         let pool = AmmOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
-            fee: Rational::new(3, 1000),
+            fee: Ratio::new(3, 1000),
             settlement_handling: amm_handler.clone(),
         };
         let result = solve(orders.clone().into_iter(), &pool);
@@ -487,7 +487,7 @@ mod tests {
         let pool = AmmOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
-            fee: Rational::new(3, 1000),
+            fee: Ratio::new(3, 1000),
             settlement_handling: amm_handler.clone(),
         };
         let result = solve(orders.clone().into_iter(), &pool);
@@ -547,7 +547,7 @@ mod tests {
         let pool = AmmOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_001).as_u128(), to_wei(1_000_000).as_u128()),
-            fee: Rational::new(3, 1000),
+            fee: Ratio::new(3, 1000),
             settlement_handling: amm_handler.clone(),
         };
         let result = solve(orders.into_iter(), &pool);
@@ -616,7 +616,7 @@ mod tests {
         let pool = AmmOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_000).as_u128(), to_wei(1_000_000).as_u128()),
-            fee: Rational::new(3, 1000),
+            fee: Ratio::new(3, 1000),
             settlement_handling: amm_handler,
         };
         let result = solve(orders.into_iter(), &pool);
@@ -654,7 +654,7 @@ mod tests {
         let pool = AmmOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_001).as_u128(), to_wei(1_000_000).as_u128()),
-            fee: Rational::new(3, 1000),
+            fee: Ratio::new(3, 1000),
             settlement_handling: amm_handler,
         };
         let result = solve(orders.into_iter(), &pool);


### PR DESCRIPTION
Depends on #340 

This PR adds common helper methods that the Uniswap baseline solver shares across the driver and orderbook create (the orderbook will use the baseline solver for gas estimates).

These functions are:
- given some base tokens get all possible paths (including intermediate hops)
- given a path estimate the resulting sell_amount (for buy orders)
- given a path estimate the resulting buy_amount (for sell orders)

### Test Plan
Added unit tests
