### PR TITLE
[Baseline 5] Integrate new Baseline solver

### DIFF
--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -207,11 +207,7 @@ async fn test_with_ganache() {
         web3.clone(),
         1,
     );
-    let solver = solver::naive_solver::NaiveSolver {
-        uniswap_router,
-        uniswap_factory,
-        gpv2_settlement: gp_settlement.clone(),
-    };
+    let solver = solver::naive_solver::NaiveSolver {};
     let mut driver = solver::driver::Driver::new(
         gp_settlement.clone(),
         uniswap_liquidity,

--- a/solver/src/naive_solver.rs
+++ b/solver/src/naive_solver.rs
@@ -6,15 +6,10 @@ use crate::{
     solver::Solver,
 };
 use anyhow::Result;
-use contracts::{GPv2Settlement, UniswapV2Factory, UniswapV2Router02};
 use model::TokenPair;
 use std::collections::HashMap;
 
-pub struct NaiveSolver {
-    pub uniswap_router: UniswapV2Router02,
-    pub uniswap_factory: UniswapV2Factory,
-    pub gpv2_settlement: GPv2Settlement,
-}
+pub struct NaiveSolver;
 
 #[async_trait::async_trait]
 impl Solver for NaiveSolver {

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -1,7 +1,29 @@
-use crate::{liquidity::Liquidity, settlement::Settlement};
+use std::collections::HashSet;
+
+use crate::{
+    liquidity::Liquidity, naive_solver::NaiveSolver, settlement::Settlement,
+    uniswap_solver::UniswapSolver,
+};
 use anyhow::Result;
+use ethcontract::H160;
+use structopt::clap::arg_enum;
 
 #[async_trait::async_trait]
 pub trait Solver {
     async fn solve(&self, orders: Vec<Liquidity>) -> Result<Option<Settlement>>;
+}
+
+arg_enum! {
+    #[derive(Debug)]
+    pub enum SolverType {
+        Naive,
+        UniswapBaseline,
+    }
+}
+
+pub fn create(solver_type: SolverType, base_tokens: HashSet<H160>) -> Box<dyn Solver> {
+    match solver_type {
+        SolverType::Naive => Box::new(NaiveSolver {}),
+        SolverType::UniswapBaseline => Box::new(UniswapSolver::new(base_tokens)),
+    }
 }


### PR DESCRIPTION
Depends on #343 

Last PR of this stack integrating the solver we created in the last couple of PRs. For now only one solver can be configured via the command line (defaulting to the previous NaiveSolver). I plan to build support for internal solver competition next. I noticed the Naive solver still had some state which it no longer required which I removed as I was touching it anyways.

### Test Plan
Running the solver with `--solver-type UniswapBaseline`. Placing an order which is requiring an intermediate hop (STAKE <> USDC on xDAI) and seeing it settle for [sell orders](https://blockscout.com/poa/xdai/tx/0xd2dbc5e3da71ca7aacc435b0e2d638c5957aec818aa40ad0602a07a1a555d579/token-transfers) and [buy orders](https://blockscout.com/poa/xdai/tx/0x766e735c66baac87d8b89800904c43b8b21b07ff328610546fd491148dd89d77/token-transfers).
