### PR TITLE
[MultiSovler 2] Allow driver to work with multiple solvers

### DIFF
--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -212,7 +212,7 @@ async fn test_with_ganache() {
         gp_settlement.clone(),
         uniswap_liquidity,
         create_orderbook_api(),
-        Box::new(solver),
+        vec![Box::new(solver)],
         Box::new(web3),
         Duration::from_secs(1),
         Duration::from_secs(30),

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use contracts::GPv2Settlement;
 use futures::future::join_all;
 use gas_estimation::GasPriceEstimating;
-use std::time::Duration;
+use std::{cmp::Reverse, time::Duration};
 use tracing::info;
 
 // There is no economic viability calculation yet so we're using an arbitrary very high cap to
@@ -97,9 +97,9 @@ impl Driver {
             })
             .collect();
 
-        // Sort by key yields ascending order, but we want to start with the highest objective value, so reverse iterator in loop
-        settlements.sort_by_key(|(_, settlement)| settlement.objective_value());
-        for (solver, settlement) in settlements.into_iter().rev() {
+        // Sort by key in descending order
+        settlements.sort_by_key(|(_, settlement)| Reverse(settlement.objective_value()));
+        for (solver, settlement) in settlements {
             info!("{} computed {:?}", solver, settlement);
             if settlement.trades.is_empty() {
                 info!("Skipping empty settlement");

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -1,11 +1,13 @@
 use crate::{
     liquidity::{uniswap::UniswapLiquidity, Liquidity},
     orderbook::OrderBookApi,
+    settlement::Settlement,
     settlement_submission,
     solver::Solver,
 };
 use anyhow::{Context, Result};
 use contracts::GPv2Settlement;
+use futures::future::join_all;
 use gas_estimation::GasPriceEstimating;
 use std::time::Duration;
 use tracing::info;
@@ -18,7 +20,7 @@ pub struct Driver {
     settlement_contract: GPv2Settlement,
     orderbook: OrderBookApi,
     uniswap_liquidity: UniswapLiquidity,
-    solver: Box<dyn Solver>,
+    solver: Vec<Box<dyn Solver>>,
     gas_price_estimator: Box<dyn GasPriceEstimating>,
     target_confirm_time: Duration,
     settle_interval: Duration,
@@ -29,7 +31,7 @@ impl Driver {
         settlement_contract: GPv2Settlement,
         uniswap_liquidity: UniswapLiquidity,
         orderbook: OrderBookApi,
-        solver: Box<dyn Solver>,
+        solver: Vec<Box<dyn Solver>>,
         gas_price_estimator: Box<dyn GasPriceEstimating>,
         target_confirm_time: Duration,
         settle_interval: Duration,
@@ -71,26 +73,39 @@ impl Driver {
             .context("failed to get uniswap pools")?;
         tracing::debug!("got {} AMMs", amms.len());
 
-        let liquidity = limit_orders
+        let liquidity: Vec<Liquidity> = limit_orders
             .into_iter()
             .map(Liquidity::Limit)
             .chain(amms.into_iter().map(Liquidity::Amm))
             .collect();
 
-        // TODO: order validity checks
-        // Decide what is handled by orderbook service and what by us.
-        // We likely want to at least mark orders we know we have settled so that we don't
-        // attempt to settle them again when they are still in the orderbook.
-        let settlement = match self.solver.solve(liquidity).await? {
-            None => return Ok(()),
-            Some(settlement) => settlement,
-        };
-        info!("Computed {:?}", settlement);
-        if settlement.trades.is_empty() {
-            info!("Skipping empty settlement");
-        } else {
-            // TODO: check if we need to approve spending to uniswap
-            settlement_submission::submit(
+        let mut settlements: Vec<(&Box<dyn Solver>, Settlement)> =
+            join_all(self.solver.iter().map(|solver| {
+                let liquidity = liquidity.clone();
+                async move { (solver, solver.solve(liquidity).await) }
+            }))
+            .await
+            .into_iter()
+            .filter_map(|(solver, settlement)| {
+                let settlement = settlement.ok()??;
+                info!(
+                    "{} found solution with objective value: {}",
+                    solver,
+                    settlement.objective_value()
+                );
+                Some((solver, settlement))
+            })
+            .collect();
+
+        // Sort by key yields ascending order, but we want to start with the highest objective value, so reverse iterator in loop
+        settlements.sort_by_key(|(_, settlement)| settlement.objective_value());
+        for (solver, settlement) in settlements.into_iter().rev() {
+            info!("{} computed {:?}", solver, settlement);
+            if settlement.trades.is_empty() {
+                info!("Skipping empty settlement");
+                continue;
+            }
+            match settlement_submission::submit(
                 &self.settlement_contract,
                 self.gas_price_estimator.as_ref(),
                 self.target_confirm_time,
@@ -98,7 +113,16 @@ impl Driver {
                 settlement,
             )
             .await
-            .context("failed to submit settlement")?;
+            {
+                Ok(_) => {
+                    // TODO: order validity checks
+                    // Decide what is handled by orderbook service and what by us.
+                    // We likely want to at least mark orders we know we have settled so that we don't
+                    // attempt to settle them again when they are still in the orderbook.
+                    break;
+                }
+                Err(err) => tracing::error!("{} Failed to submit settlement: {}", solver, err),
+            }
         }
         Ok(())
     }

--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -11,7 +11,10 @@ use ::model::order::OrderKind;
 use anyhow::{ensure, Context, Result};
 use primitive_types::H160;
 use reqwest::{header::HeaderValue, Client, Url};
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+};
 
 // TODO: exclude partially fillable orders
 // TODO: set settlement.fee_factor
@@ -268,6 +271,12 @@ impl Solver for HttpSolver {
         let settled = self.send(&model).await?;
         tracing::trace!(?settled);
         settlement::convert_settlement(settled, context).map(Some)
+    }
+}
+
+impl fmt::Display for HttpSolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "HTTPSolver")
     }
 }
 

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -13,6 +13,7 @@ pub mod offchain_orderbook;
 pub mod uniswap;
 
 /// Defines the different types of liquidity our solvers support
+#[derive(Clone)]
 pub enum Liquidity {
     Limit(LimitOrder),
     Amm(AmmOrder),

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -53,8 +53,9 @@ struct Arguments {
         default_value = "Naive",
         possible_values = &SolverType::variants(),
         case_insensitive = true,
+        use_delimiter = true,
     )]
-    solver_type: SolverType,
+    solvers: Vec<SolverType>,
 }
 
 #[tokio::main]
@@ -98,7 +99,7 @@ async fn main() {
         web3.clone(),
         chain_id,
     );
-    let solver = solver::solver::create(args.solver_type, base_tokens);
+    let solver = solver::solver::create(args.solvers, base_tokens);
     let gas_price_estimator = shared::gas_price_estimation::create_priority_estimator(
         &reqwest::Client::new(),
         &web3,

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -50,7 +50,7 @@ struct Arguments {
     #[structopt(
         long,
         env = "SOLVER_TYPE",
-        default_value = "Naive",
+        default_value = "Naive,UniswapBaseline",
         possible_values = &SolverType::variants(),
         case_insensitive = true,
         use_delimiter = true,

--- a/solver/src/naive_solver.rs
+++ b/solver/src/naive_solver.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use anyhow::Result;
 use model::TokenPair;
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt};
 
 pub struct NaiveSolver;
 
@@ -29,6 +29,12 @@ impl Solver for NaiveSolver {
             }
         }
         Ok(settle(limit_orders.into_iter(), uniswaps).await)
+    }
+}
+
+impl fmt::Display for NaiveSolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NaiveSolver")
     }
 }
 

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, fmt::Display};
 
 use crate::{
     liquidity::Liquidity, naive_solver::NaiveSolver, settlement::Settlement,
@@ -9,7 +9,7 @@ use ethcontract::H160;
 use structopt::clap::arg_enum;
 
 #[async_trait::async_trait]
-pub trait Solver {
+pub trait Solver: Display {
     async fn solve(&self, orders: Vec<Liquidity>) -> Result<Option<Settlement>>;
 }
 
@@ -21,9 +21,12 @@ arg_enum! {
     }
 }
 
-pub fn create(solver_type: SolverType, base_tokens: HashSet<H160>) -> Box<dyn Solver> {
-    match solver_type {
-        SolverType::Naive => Box::new(NaiveSolver {}),
-        SolverType::UniswapBaseline => Box::new(UniswapSolver::new(base_tokens)),
-    }
+pub fn create(solvers: Vec<SolverType>, base_tokens: HashSet<H160>) -> Vec<Box<dyn Solver>> {
+    solvers
+        .into_iter()
+        .map(|solver_type| match solver_type {
+            SolverType::Naive => Box::new(NaiveSolver {}) as Box<dyn Solver>,
+            SolverType::UniswapBaseline => Box::new(UniswapSolver::new(base_tokens.clone())),
+        })
+        .collect()
 }

--- a/solver/src/uniswap_solver.rs
+++ b/solver/src/uniswap_solver.rs
@@ -8,7 +8,10 @@ use shared::{
         estimate_buy_amount, estimate_sell_amount, path_candidates, token_path_to_pair_path,
     },
 };
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+};
 
 use crate::{
     liquidity::{uniswap::MAX_HOPS, AmmOrder, LimitOrder, Liquidity},
@@ -23,6 +26,12 @@ pub struct UniswapSolver {
 impl Solver for UniswapSolver {
     async fn solve(&self, liquidity: Vec<Liquidity>) -> Result<Option<Settlement>> {
         Ok(self.solve(liquidity))
+    }
+}
+
+impl fmt::Display for UniswapSolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "UniswapSolver")
     }
 }
 


### PR DESCRIPTION
Depends on #346. Now that we can rank different settlements, we can have multiple solver "compete" internally for the best solution. This PR makes the driver take a vector of solvers and execute each one of them in parallel, afterwards sorting the resulting solutions by objective value and submitting the best one.

### Test Plan
Ran the binary locally and saw that we can both handle a multi-hop uniswap trade (UniswapBaseline) and a direct pair COW trade (NaiveSolver) in the same process.
