### PR TITLE
Use UniswapSolver for fee estimation (sellToken -> ETH)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,6 +1667,7 @@ dependencies = [
  "gas-estimation",
  "hex",
  "hex-literal",
+ "maplit",
  "mockall",
  "model",
  "num-bigint 0.3.2",

--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -129,11 +129,14 @@ async fn test_with_ganache() {
     db.clear().await.unwrap();
     let event_updater = EventUpdater::new(gp_settlement.clone(), db.clone());
 
-    let price_estimator = UniswapPriceEstimator::new(Box::new(PoolFetcher {
-        factory: uniswap_factory.clone(),
-        web3: web3.clone(),
-        chain_id,
-    }));
+    let price_estimator = UniswapPriceEstimator::new(
+        Box::new(PoolFetcher {
+            factory: uniswap_factory.clone(),
+            web3: web3.clone(),
+            chain_id,
+        }),
+        HashSet::new(),
+    );
     let fee_calculator = Arc::new(MinFeeCalculator::new(
         Box::new(price_estimator),
         Box::new(web3.clone()),

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -22,6 +22,7 @@ ethcontract = { version = "0.11", default-features = false }
 futures = "0.3.13"
 gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.0", features = ["web3_"] }
 hex = { version = "0.4", default-features = false }
+maplit = "1.0"
 model = { path = "../model" }
 num-bigint = "0.3"
 primitive-types = { version = "0.8", features = ["fp-conversion"] }

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -90,7 +90,12 @@ impl MinFeeCalculator {
         let gas_price = self.gas_estimator.estimate().await?;
         let token_price = match self
             .price_estimator
-            .estimate_price(token, self.native_token)
+            .estimate_price(
+                token,
+                self.native_token,
+                U256::from_f64_lossy(gas_price * GAS_PER_ORDER),
+                model::order::OrderKind::Buy,
+            )
             .await
         {
             Ok(price) => price,
@@ -148,6 +153,7 @@ impl MinFeeStoring for InMemoryFeeStore {
 #[cfg(test)]
 mod tests {
     use chrono::Duration;
+    use model::order::OrderKind;
     use std::sync::Arc;
 
     use super::*;
@@ -155,7 +161,7 @@ mod tests {
     struct FakePriceEstimator(f64);
     #[async_trait::async_trait]
     impl PriceEstimating for FakePriceEstimator {
-        async fn estimate_price(&self, _: H160, _: H160) -> Result<f64> {
+        async fn estimate_price(&self, _: H160, _: H160, _: U256, _: OrderKind) -> Result<f64> {
             Ok(self.0)
         }
     }

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -100,7 +100,10 @@ impl MinFeeCalculator {
             .await
         {
             Ok(price) => price,
-            Err(_) => return Ok(None),
+            Err(err) => {
+                tracing::warn!("Failed to estimate sell token price: {}", err);
+                return Ok(None);
+            }
         };
 
         Ok(Some(U256::from_f64_lossy(fee_in_eth * token_price)))

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -88,12 +88,13 @@ impl MinFeeCalculator {
 
     async fn compute_min_fee(&self, token: H160) -> Result<Option<U256>> {
         let gas_price = self.gas_estimator.estimate().await?;
+        let fee_in_eth = gas_price * GAS_PER_ORDER;
         let token_price = match self
             .price_estimator
             .estimate_price(
                 token,
                 self.native_token,
-                U256::from_f64_lossy(gas_price * GAS_PER_ORDER),
+                U256::from_f64_lossy(fee_in_eth),
                 model::order::OrderKind::Buy,
             )
             .await
@@ -102,9 +103,7 @@ impl MinFeeCalculator {
             Err(_) => return Ok(None),
         };
 
-        Ok(Some(U256::from_f64_lossy(
-            gas_price * token_price * GAS_PER_ORDER,
-        )))
+        Ok(Some(U256::from_f64_lossy(fee_in_eth * token_price)))
     }
 
     // Returns true if the fee satisfies a previous not yet expired estimate, or the fee is high enough given the current estimate.

--- a/orderbook/src/price_estimate.rs
+++ b/orderbook/src/price_estimate.rs
@@ -106,17 +106,17 @@ impl UniswapPriceEstimator {
         .await
     }
 
-    async fn best_execution<A, C, O>(
+    async fn best_execution<AmountFn, CompareFn, O>(
         &self,
         sell_token: H160,
         buy_token: H160,
         amount: U256,
-        comparison: C,
-        resulting_amount: A,
+        comparison: CompareFn,
+        resulting_amount: AmountFn,
     ) -> Result<(Vec<H160>, U256)>
     where
-        A: Fn(U256, &[H160], &HashMap<TokenPair, Pool>) -> Option<U256>,
-        C: Fn(U256, &[H160], &HashMap<TokenPair, Pool>) -> O,
+        AmountFn: Fn(U256, &[H160], &HashMap<TokenPair, Pool>) -> Option<U256>,
+        CompareFn: Fn(U256, &[H160], &HashMap<TokenPair, Pool>) -> O,
         O: Ord,
     {
         let path_candidates = path_candidates(sell_token, buy_token, &self.base_tokens, MAX_HOPS);

--- a/orderbook/src/price_estimate.rs
+++ b/orderbook/src/price_estimate.rs
@@ -42,8 +42,8 @@ impl UniswapPriceEstimator {
 
 #[async_trait::async_trait]
 impl PriceEstimating for UniswapPriceEstimator {
-    // Estimates the price using the direct pool between sell and buy token.
-    // Returns an error if no pool exists between sell and buy token.
+    // Estimates the price between sell and buy token denominated in |sell token| per buy token.
+    // Returns an error if no path exists between sell and buy token.
     async fn estimate_price(
         &self,
         sell_token: H160,

--- a/orderbook/src/price_estimate.rs
+++ b/orderbook/src/price_estimate.rs
@@ -1,56 +1,154 @@
-use anyhow::{anyhow, ensure, Result};
-use ethcontract::H160;
-use model::TokenPair;
-use shared::uniswap_pool::PoolFetching;
-use std::iter::once;
+use anyhow::{anyhow, Result};
+use ethcontract::{H160, U256};
+use model::{order::OrderKind, TokenPair};
+use shared::{
+    uniswap_pool::{Pool, PoolFetching},
+    uniswap_solver::{
+        estimate_buy_amount, estimate_sell_amount, path_candidates, token_path_to_pair_path,
+    },
+};
+use std::{
+    cmp::Reverse,
+    collections::{HashMap, HashSet},
+};
+
+const MAX_HOPS: usize = 2;
 
 #[async_trait::async_trait]
 pub trait PriceEstimating: Send + Sync {
-    async fn estimate_price(&self, sell_token: H160, buy_token: H160) -> Result<f64>;
+    // Price is given in how much of sell_token needs to be sold for one buy_token.
+    async fn estimate_price(
+        &self,
+        sell_token: H160,
+        buy_token: H160,
+        amount: U256,
+        kind: OrderKind,
+    ) -> Result<f64>;
 }
 
 pub struct UniswapPriceEstimator {
     pool_fetcher: Box<dyn PoolFetching>,
+    base_tokens: HashSet<H160>,
 }
 
 impl UniswapPriceEstimator {
-    pub fn new(pool_fetcher: Box<dyn PoolFetching>) -> Self {
-        Self { pool_fetcher }
+    pub fn new(pool_fetcher: Box<dyn PoolFetching>, base_tokens: HashSet<H160>) -> Self {
+        Self {
+            pool_fetcher,
+            base_tokens,
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl PriceEstimating for UniswapPriceEstimator {
-    // Estimates the price using the direct pool between sell and buy token. Price is given in
-    // how much of sell_token needs to be sold for one buy_token.
+    // Estimates the price using the direct pool between sell and buy token.
     // Returns an error if no pool exists between sell and buy token.
-    async fn estimate_price(&self, sell_token: H160, buy_token: H160) -> Result<f64> {
-        let pair = match TokenPair::new(sell_token, buy_token) {
-            Some(pair) => pair,
-            None => return Ok(1.0),
-        };
-        let pool = self
+    async fn estimate_price(
+        &self,
+        sell_token: H160,
+        buy_token: H160,
+        amount: U256,
+        kind: OrderKind,
+    ) -> Result<f64> {
+        if sell_token == buy_token {
+            return Ok(1.0);
+        }
+
+        match kind {
+            OrderKind::Buy => {
+                let (_, sell_amount) = self
+                    .best_execution_buy_order(sell_token, buy_token, amount)
+                    .await?;
+                Ok(sell_amount.to_f64_lossy() / amount.to_f64_lossy())
+            }
+            OrderKind::Sell => {
+                let (_, buy_amount) = self
+                    .best_execution_sell_order(sell_token, buy_token, amount)
+                    .await?;
+                Ok(amount.to_f64_lossy() / buy_amount.to_f64_lossy())
+            }
+        }
+    }
+}
+
+impl UniswapPriceEstimator {
+    pub async fn best_execution_sell_order(
+        &self,
+        sell_token: H160,
+        buy_token: H160,
+        sell_amount: U256,
+    ) -> Result<(Vec<H160>, U256)> {
+        self.best_execution(
+            sell_token,
+            buy_token,
+            sell_amount,
+            estimate_buy_amount,
+            estimate_buy_amount,
+        )
+        .await
+    }
+
+    pub async fn best_execution_buy_order(
+        &self,
+        sell_token: H160,
+        buy_token: H160,
+        buy_amount: U256,
+    ) -> Result<(Vec<H160>, U256)> {
+        self.best_execution(
+            sell_token,
+            buy_token,
+            buy_amount,
+            |amount, path, pools| Reverse(estimate_sell_amount(amount, path, pools)),
+            estimate_sell_amount,
+        )
+        .await
+    }
+
+    async fn best_execution<A, C, O>(
+        &self,
+        sell_token: H160,
+        buy_token: H160,
+        amount: U256,
+        comparison: C,
+        resulting_amount: A,
+    ) -> Result<(Vec<H160>, U256)>
+    where
+        A: Fn(U256, &[H160], &HashMap<TokenPair, Pool>) -> Option<U256>,
+        C: Fn(U256, &[H160], &HashMap<TokenPair, Pool>) -> O,
+        O: Ord,
+    {
+        let path_candidates = path_candidates(sell_token, buy_token, &self.base_tokens, MAX_HOPS);
+        let all_pairs = path_candidates
+            .iter()
+            .flat_map(|candidate| token_path_to_pair_path(candidate).into_iter())
+            .collect();
+        let pools: HashMap<_, _> = self
             .pool_fetcher
-            .fetch(once(pair).collect())
+            .fetch(all_pairs)
             .await
-            .pop()
-            .ok_or_else(|| anyhow!("Uniswap pool does not exist"))?;
-        let (sell_reserve, buy_reserve) = if pool.tokens.get().0 == sell_token {
-            (pool.reserves.0, pool.reserves.1)
-        } else {
-            (pool.reserves.1, pool.reserves.0)
-        };
-        ensure!(
-            sell_reserve != 0 && buy_reserve != 0,
-            "Pools with empty reserve"
-        );
-        Ok((sell_reserve as f64) / (buy_reserve as f64))
+            .into_iter()
+            .map(|pool| (pool.tokens, pool))
+            .collect();
+        let best_path = path_candidates
+            .iter()
+            .max_by_key(|path| comparison(amount, path, &pools))
+            .ok_or(anyhow!(format!(
+                "No Uniswap path found between {:x} and {:x}",
+                sell_token, buy_token
+            )))?;
+        Ok((
+            best_path.clone(),
+            resulting_amount(amount, best_path, &pools)
+                .ok_or_else(|| anyhow!("no valid path found"))?,
+        ))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use assert_approx_eq::assert_approx_eq;
+    use maplit::hashset;
     use std::collections::HashSet;
 
     use super::*;
@@ -68,22 +166,59 @@ mod tests {
     async fn estimate_price_on_direct_pair() {
         let token_a = H160::from_low_u64_be(1);
         let token_b = H160::from_low_u64_be(2);
-        let pool = Pool::uniswap(TokenPair::new(token_a, token_b).unwrap(), (100, 10));
+        let pool = Pool::uniswap(
+            TokenPair::new(token_a, token_b).unwrap(),
+            (10u128.pow(30), 10u128.pow(29)),
+        );
 
         let pool_fetcher = Box::new(FakePoolFetcher(vec![pool]));
-        let estimator = UniswapPriceEstimator { pool_fetcher };
+        let estimator = UniswapPriceEstimator::new(pool_fetcher, hashset!());
 
         assert_approx_eq!(
-            estimator.estimate_price(token_a, token_a).await.unwrap(),
+            estimator
+                .estimate_price(token_a, token_a, U256::exp10(18), OrderKind::Buy)
+                .await
+                .unwrap(),
             1.0
         );
         assert_approx_eq!(
-            estimator.estimate_price(token_a, token_b).await.unwrap(),
-            10.0
+            estimator
+                .estimate_price(token_a, token_a, U256::exp10(18), OrderKind::Sell)
+                .await
+                .unwrap(),
+            1.0
         );
         assert_approx_eq!(
-            estimator.estimate_price(token_b, token_a).await.unwrap(),
-            0.1
+            estimator
+                .estimate_price(token_a, token_b, U256::exp10(18), OrderKind::Buy)
+                .await
+                .unwrap(),
+            10.03,
+            1.0e-4
+        );
+        assert_approx_eq!(
+            estimator
+                .estimate_price(token_a, token_b, U256::exp10(18), OrderKind::Sell)
+                .await
+                .unwrap(),
+            10.03,
+            1.0e-4
+        );
+        assert_approx_eq!(
+            estimator
+                .estimate_price(token_b, token_a, U256::exp10(18), OrderKind::Buy)
+                .await
+                .unwrap(),
+            0.1003,
+            1.0e-4
+        );
+        assert_approx_eq!(
+            estimator
+                .estimate_price(token_b, token_a, U256::exp10(18), OrderKind::Sell)
+                .await
+                .unwrap(),
+            0.1003,
+            1.0e-4
         );
     }
 
@@ -92,9 +227,12 @@ mod tests {
         let token_a = H160::from_low_u64_be(1);
         let token_b = H160::from_low_u64_be(2);
         let pool_fetcher = Box::new(FakePoolFetcher(vec![]));
-        let estimator = UniswapPriceEstimator { pool_fetcher };
+        let estimator = UniswapPriceEstimator::new(pool_fetcher, hashset!());
 
-        assert!(estimator.estimate_price(token_a, token_b).await.is_err());
+        assert!(estimator
+            .estimate_price(token_a, token_b, 1.into(), OrderKind::Buy)
+            .await
+            .is_err());
     }
 
     #[tokio::test]
@@ -104,8 +242,11 @@ mod tests {
         let pool = Pool::uniswap(TokenPair::new(token_a, token_b).unwrap(), (0, 10));
 
         let pool_fetcher = Box::new(FakePoolFetcher(vec![pool]));
-        let estimator = UniswapPriceEstimator { pool_fetcher };
+        let estimator = UniswapPriceEstimator::new(pool_fetcher, hashset!());
 
-        assert!(estimator.estimate_price(token_a, token_b).await.is_err());
+        assert!(estimator
+            .estimate_price(token_a, token_b, 1.into(), OrderKind::Buy)
+            .await
+            .is_err());
     }
 }


### PR DESCRIPTION
This PR changes the price estimation trait to also take an amount and order type (buy vs sell). This is important to account for more accurate fee estimations of our baseline solution (e.g. large trades might make it worthwhile going over multiple hops, but would cost more gas to execute).

While that particular benefit requires a change in the fee endpoint (we need to pass buy token, amount and order type as well), it can immediately benefit the estimation of how much sell token we need to convert for ETH by pricing an ETH buy order from the sell token with the amount of ETH needed for the settlement (gas_price * GAS_PER_ORDER).

The PR is using the shared baseline Uniswap solver logic and as such also enabling sell tokens which don't have a direct pool to the native token.

This should make the component ready to be used for a general price estimation endpoint (cc @alfetopito)

### Test Plan
Unit tests
