### PR TITLE
Remove MAX_GAS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a00ffbfb6e29fd828f12dd00c1dcc31f3c4a0912cc8d5f87b8242addaf315c9"
+checksum = "7aec86e4d70b134c61e75476c8a02ed25fcda11f7f9f390d985848b66e281fd8"
 dependencies = [
  "ethcontract-common",
  "futures",
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-common"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20addff5b356ce614996ceb5c217bc4d95f50f21bbddca32e91579978f0ef316"
+checksum = "6aea28defb2be6bb75c77919c0dabbc4d88e251dde9c122a387b2e5e17df9cea"
 dependencies = [
  "ethabi",
  "hex",

--- a/contracts/src/bin/deploy.rs
+++ b/contracts/src/bin/deploy.rs
@@ -42,7 +42,6 @@ async fn run() -> Result<()> {
 
                 log::debug!("deploying {}...", NAME);
                 let instance = $contract::builder(&web3 $(, $param)*)
-                    .gas(8_000_000_u32.into())
                     .deploy()
                     .await
                     .with_context(|| format!("failed to deploy {}", NAME))?;

--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -44,7 +44,6 @@ async fn test_with_ganache() {
 
     let deploy_mintable_token = || async {
         ERC20Mintable::builder(&web3)
-            .gas(8_000_000u32.into())
             .deploy()
             .await
             .expect("MintableERC20 deployment failed")
@@ -55,7 +54,6 @@ async fn test_with_ganache() {
             const NAME: &str = stringify!($call);
             $call
                 .from($acc.clone())
-                .gas(8_000_000u32.into())
                 .send()
                 .await
                 .expect(&format!("{} failed", NAME))

--- a/orderbook/src/account_balances.rs
+++ b/orderbook/src/account_balances.rs
@@ -164,7 +164,6 @@ mod tests {
         let allowance_target = Account::Local(accounts[1], None);
 
         let token = ERC20Mintable::builder(&web3)
-            .gas(8_000_000u32.into())
             .deploy()
             .await
             .expect("MintableERC20 deployment failed");

--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -11,7 +11,6 @@ use primitive_types::{H160, U256};
 use std::time::Duration;
 use transaction_retry::RetryResult;
 
-const MAX_GAS: u32 = 8_000_000;
 const GAS_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
 
 // Submit a settlement to the contract, updating the transaction with gas prices if they increase.

--- a/solver/src/settlement_submission/gas_price_stream.rs
+++ b/solver/src/settlement_submission/gas_price_stream.rs
@@ -1,9 +1,7 @@
-use super::{GAS_PRICE_REFRESH_INTERVAL, MAX_GAS};
+use super::GAS_PRICE_REFRESH_INTERVAL;
 use futures::{stream, Stream, StreamExt};
 use gas_estimation::GasPriceEstimating;
 use std::time::Duration;
-
-// TODO: use a real gas estimation instead of MAX_GAS.
 
 // Create a never ending stream of gas prices based on checking the estimator in fixed intervals
 // and enforcing the minimum increase. Errors are ignored.
@@ -16,8 +14,9 @@ pub fn gas_price_stream(
         if !first_call {
             tokio::time::delay_for(GAS_PRICE_REFRESH_INTERVAL).await;
         }
+        // TODO: once we have gas limit size aware estimators, use a real estimation.
         let estimate = estimator
-            .estimate_with_limits(MAX_GAS as f64, target_confirm_time)
+            .estimate_with_limits(1_000_000.0, target_confirm_time)
             .await;
         Some((estimate, false))
     })

--- a/solver/src/settlement_submission/retry.rs
+++ b/solver/src/settlement_submission/retry.rs
@@ -54,15 +54,13 @@ pub fn settle_method_builder(
     contract: &GPv2Settlement,
     settlement: EncodedSettlement,
 ) -> DynMethodBuilder<Void> {
-    contract
-        .settle(
-            settlement.tokens,
-            settlement.clearing_prices,
-            settlement.encoded_trades,
-            settlement.encoded_interactions,
-            Vec::new(),
-        )
-        .gas(super::MAX_GAS.into())
+    contract.settle(
+        settlement.tokens,
+        settlement.clearing_prices,
+        settlement.encoded_trades,
+        settlement.encoded_interactions,
+        Vec::new(),
+    )
 }
 
 // We never send cancellations but we still need to have types that implement the traits.


### PR DESCRIPTION
We currently send every transaction with a very large gas limit. This is quite dangerous as it could cause massive settlement costs if e.g. an interaction started failing with a revert that uses all remaining gas (due to a race condition that wasn't called at simulation time). Moreover, it is plausible that this increases the time our transaction spends in the mem-pool as miners might not consider transactions whose limit is larger than the remaining size in the block (I didn't verify this).

This requires ethcontract-rs 11.2 which fixes a bug in the transaction logic which was causing issues for the e2e tests.

### Test Plan
e2e still pass. Also made sure that gas estimates on xDAI and mainnet are large enough to execute the tx but still much smaller than now (around 200k gas).
