### PR TITLE
[API] More expressive fee route

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -160,9 +160,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FeeInformation"
+                $ref: "#/components/schemas/LegacyFeeInformation"
         404:
-          description: sellToken not existent
+          description: sellToken non-existent
   /api/v1/trades:
     get:
       summary: Get existing Trades.
@@ -239,7 +239,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FeeInformation"
         404:
-          description: Token not existent or not connected to native token
+          description: Token non-existent or not connected to native token
 components:
   schemas:
     Address:
@@ -255,6 +255,20 @@ components:
       type: string
       example: "1234567890"
     FeeInformation:
+      description: |
+        Provides the information to calculate the fees.
+      type: object
+      properties:
+        expirationDate:
+          description: |
+            Expiration date of the offered fee. Order service might not accept
+            the fee after this expiration date. Encoded as ISO 8601 UTC.
+          type: string
+          example: "2020-12-03T18:35:18.814523Z"
+        amount:
+          description: Absolute amount of fee charged per order in specified sellToken
+          $ref: "#/components/schemas/TokenAmount"
+    LegacyFeeInformation:
       description: |
         Provides the information to calculate the fees.
       type: object

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -204,6 +204,42 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Order"
+  /api/v1/fee:
+    get:
+      description: |
+        The fee that is charged for placing an order.
+        The fee is described by a minimum fee - in order to cover the gas costs for onchain settling - and
+        a feeRatio charged to the users for using the service.
+      parameters:
+        - name: sellToken
+          in: query
+          schema:
+            $ref: "#/components/schemas/Address"
+          required: true
+        - name: buyToken
+          in: query
+          schema:
+            $ref: "#/components/schemas/Address"
+          required: true
+        - name: amount
+          in: query
+          schema:
+            $ref: "#/components/schemas/TokenAmount"
+          required: true
+        - name: kind
+          in: query
+          schema:
+            $ref: "#/components/schemas/OrderType"
+          required: true
+      responses:
+        200:
+          description: the fee
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeeInformation"
+        404:
+          description: Token not existent or not connected to native token
 components:
   schemas:
     Address:
@@ -381,10 +417,6 @@ components:
       properties:
         errorType:
           type: string
-          enum:
-            [
-                InvalidSignature,
-                InvalidOrderUid,
-            ]
+          enum: [InvalidSignature, InvalidOrderUid]
         description:
           type: string


### PR DESCRIPTION
cc @anxolin @W3stside @alfetopito 

This PR suggests a change to the fee API (technically it's creating a new endpoint so we can keep the old one running for a bit).

The main reason is that we cannot accurately estimate the min fee if just given the sell token. The minimal fee should be equivalent to the "baseline solution" (the simple non COW, non fancy interactions path that is in line with the price estimate we show in the UI). The issue is that this path can be very sensitive in terms of execution costs (e.g. a Uniswap direct pair trade is less than half as expensive in terms of gas as a Uniswap two hop trade).

Therefore I believe we need more information about the order (in particular the buy token and the amount intended to trade).

Looking forward to hearing your thoughts, concerns or alternative suggestions.
