### PR TITLE
Specify gas limit with a buffer

### DIFF
--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use transaction_retry::RetryResult;
 
 const GAS_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
+const ESTIMATE_GAS_LIMIT_FACTOR: f64 = 1.2;
 
 // Submit a settlement to the contract, updating the transaction with gas prices if they increase.
 pub async fn submit(
@@ -28,14 +29,23 @@ pub async fn submit(
     // Check that a simulation of the transaction works before submitting it.
     simulate_settlement(&settlement, contract).await?;
 
+    let gas_limit = retry::settle_method_builder(contract, settlement.clone())
+        .tx
+        .estimate_gas()
+        .await
+        .context("failed to estimate gas")?
+        .to_f64_lossy()
+        * ESTIMATE_GAS_LIMIT_FACTOR;
+
     let settlement_sender = SettlementSender {
         contract,
         nonce,
+        gas_limit,
         settlement,
     };
     // We never cancel.
     let cancel_future = std::future::pending::<CancelSender>();
-    let stream = gas_price_stream(target_confirm_time, gas_price_cap, gas);
+    let stream = gas_price_stream(target_confirm_time, gas_price_cap, gas_limit, gas);
 
     match transaction_retry::retry(settlement_sender, cancel_future, stream).await {
         Some(RetryResult::Submitted(result)) => {

--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -29,6 +29,7 @@ pub async fn submit(
     // Check that a simulation of the transaction works before submitting it.
     simulate_settlement(&settlement, contract).await?;
 
+    // Account for some buffer in the gas limit in case racing state changes result in slightly more heavy computation at execution time
     let gas_limit = retry::settle_method_builder(contract, settlement.clone())
         .tx
         .estimate_gas()

--- a/solver/src/settlement_submission/gas_price_stream.rs
+++ b/solver/src/settlement_submission/gas_price_stream.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 pub fn gas_price_stream(
     target_confirm_time: Duration,
     gas_price_cap: f64,
+    gas_limit: f64,
     estimator: &dyn GasPriceEstimating,
 ) -> impl Stream<Item = f64> + '_ {
     let stream = stream::unfold(true, move |first_call| async move {
@@ -16,7 +17,7 @@ pub fn gas_price_stream(
         }
         // TODO: once we have gas limit size aware estimators, use a real estimation.
         let estimate = estimator
-            .estimate_with_limits(1_000_000.0, target_confirm_time)
+            .estimate_with_limits(gas_limit, target_confirm_time)
             .await;
         Some((estimate, false))
     })

--- a/solver/src/settlement_submission/gas_price_stream.rs
+++ b/solver/src/settlement_submission/gas_price_stream.rs
@@ -15,7 +15,6 @@ pub fn gas_price_stream(
         if !first_call {
             tokio::time::delay_for(GAS_PRICE_REFRESH_INTERVAL).await;
         }
-        // TODO: once we have gas limit size aware estimators, use a real estimation.
         let estimate = estimator
             .estimate_with_limits(gas_limit, target_confirm_time)
             .await;

--- a/solver/src/settlement_submission/retry.rs
+++ b/solver/src/settlement_submission/retry.rs
@@ -34,6 +34,7 @@ impl TransactionResult for SettleResult {
 pub struct SettlementSender<'a> {
     pub contract: &'a GPv2Settlement,
     pub nonce: U256,
+    pub gas_limit: f64,
     pub settlement: EncodedSettlement,
 }
 #[async_trait::async_trait]
@@ -43,7 +44,8 @@ impl<'a> TransactionSending for SettlementSender<'a> {
         tracing::info!("submitting solution transaction at gas price {}", gas_price);
         let mut method = settle_method_builder(self.contract, self.settlement.clone())
             .nonce(self.nonce)
-            .gas_price(GasPrice::Value(U256::from_f64_lossy(gas_price)));
+            .gas_price(GasPrice::Value(U256::from_f64_lossy(gas_price)))
+            .gas(U256::from_f64_lossy(self.gas_limit));
         method.tx.resolve = Some(ResolveCondition::Confirmed(ConfirmParams::mined()));
         let result = method.send().await.map(|_| ());
         SettleResult(result)


### PR DESCRIPTION
Fixes #354

We are seeing in practice that the gas estimate can be too tight. Therefore we should perform the estimate ourselves and multiply it with a factor to allow for a buffer (e.g. in case some state changes making the execution slightly more gas heavy at runtime).

This has the nice side effect of fixing a TODO for the gas estimation.

### Test Plan
Unit tests, observe no more out of gas failures.
