### PR TITLE
Allow for Uniswap Spot price estimation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,6 +2342,7 @@ name = "shared"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_approx_eq",
  "async-trait",
  "atty",
  "contracts",

--- a/orderbook/src/price_estimate.rs
+++ b/orderbook/src/price_estimate.rs
@@ -2,9 +2,11 @@ use anyhow::{anyhow, Result};
 use ethcontract::{H160, U256};
 use model::{order::OrderKind, TokenPair};
 use shared::{
+    conversions::big_rational_to_float,
     uniswap_pool::{Pool, PoolFetching},
     uniswap_solver::{
-        estimate_buy_amount, estimate_sell_amount, path_candidates, token_path_to_pair_path,
+        estimate_buy_amount, estimate_sell_amount, estimate_spot_price, path_candidates,
+        token_path_to_pair_path,
     },
 };
 use std::{
@@ -44,6 +46,7 @@ impl UniswapPriceEstimator {
 impl PriceEstimating for UniswapPriceEstimator {
     // Estimates the price between sell and buy token denominated in |sell token| per buy token.
     // Returns an error if no path exists between sell and buy token.
+    // Incorporates uniswap fee unless amount is 0 in which case it returns the best spot price.
     async fn estimate_price(
         &self,
         sell_token: H160,
@@ -54,7 +57,12 @@ impl PriceEstimating for UniswapPriceEstimator {
         if sell_token == buy_token {
             return Ok(1.0);
         }
-        let amount = U256::max(amount, U256::one());
+        if amount.is_zero() {
+            return self
+                .best_execution_spot_price(sell_token, buy_token)
+                .await
+                .map(|(_, price)| price);
+        }
 
         match kind {
             OrderKind::Buy => {
@@ -108,16 +116,38 @@ impl UniswapPriceEstimator {
         .await
     }
 
-    async fn best_execution<AmountFn, CompareFn, O>(
+    pub async fn best_execution_spot_price(
+        &self,
+        sell_token: H160,
+        buy_token: H160,
+    ) -> Result<(Vec<H160>, f64)> {
+        self.best_execution(
+            sell_token,
+            buy_token,
+            U256::zero(),
+            |_, path, pools| estimate_spot_price(path, pools),
+            |_, path, pools| estimate_spot_price(path, pools),
+        )
+        .await
+        .and_then(|(path, price)| {
+            Ok((
+                path,
+                big_rational_to_float(price)
+                    .ok_or_else(|| anyhow!("Cannot convert price ratio to float"))?,
+            ))
+        })
+    }
+
+    async fn best_execution<AmountFn, CompareFn, O, Amount>(
         &self,
         sell_token: H160,
         buy_token: H160,
         amount: U256,
         comparison: CompareFn,
         resulting_amount: AmountFn,
-    ) -> Result<(Vec<H160>, U256)>
+    ) -> Result<(Vec<H160>, Amount)>
     where
-        AmountFn: Fn(U256, &[H160], &HashMap<TokenPair, Pool>) -> Option<U256>,
+        AmountFn: Fn(U256, &[H160], &HashMap<TokenPair, Pool>) -> Option<Amount>,
         CompareFn: Fn(U256, &[H160], &HashMap<TokenPair, Pool>) -> O,
         O: Ord,
     {

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+assert_approx_eq = "1.1"
 async-trait = "0.1"
 atty = "0.2"
 contracts = { path = "../contracts" }

--- a/shared/src/conversions.rs
+++ b/shared/src/conversions.rs
@@ -1,0 +1,5 @@
+use num::{BigRational, ToPrimitive as _};
+
+pub fn big_rational_to_float(ratio: BigRational) -> Option<f64> {
+    Some(ratio.numer().to_f64()? / ratio.denom().to_f64()?)
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod arguments;
+pub mod conversions;
 pub mod current_block;
 pub mod gas_price_estimation;
 pub mod time;


### PR DESCRIPTION
In #348 I handled the case when amount is 0 by just rounding it up to 1 (the smallest amount to buy/sell). While this leads to arithmetically valid results they are not very useful in practice because of integer division rounding errors for such small amounts (e.g if token B is worth more than token A, selling 1 of token A gives you 0 token B).

This PR adds functionality to the Pool struct, the uniswap shared methods and the price estimator to compute the spot price (relation of reserves) for a given path. This allows more accurate price estimation for 0 amounts which might also be useful when estimating the current value of a certain token (e.g. for display in the block explorer)

### Test Plan
Added unit tests for this case.
