### PR TITLE
Log settlement failure with more details

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -121,7 +121,7 @@ impl Driver {
                     // attempt to settle them again when they are still in the orderbook.
                     break;
                 }
-                Err(err) => tracing::error!("{} Failed to submit settlement: {}", solver, err),
+                Err(err) => tracing::error!("{} Failed to submit settlement: {:?}", solver, err),
             }
         }
         Ok(())


### PR DESCRIPTION
Using debug formatting we should get more info than display formatting.

Might reveal more info in cases like https://github.com/gnosis/gp-v2-services/issues/362 .