### PR TITLE
[FeeRefactor] Prepare fee measurements for buy token and amount

### DIFF
--- a/database/sql/V005__extend_fee_measurements_with_order_details.sql
+++ b/database/sql/V005__extend_fee_measurements_with_order_details.sql
@@ -1,0 +1,5 @@
+ALTER TABLE min_fee_measurements RENAME COLUMN token TO sell_token;
+
+ALTER TABLE min_fee_measurements
+  ADD COLUMN buy_token bytea,
+  ADD COLUMN sell_amount  numeric(78,0);

--- a/database/sql/V005__extend_fee_measurements_with_order_details.sql
+++ b/database/sql/V005__extend_fee_measurements_with_order_details.sql
@@ -2,4 +2,5 @@ ALTER TABLE min_fee_measurements RENAME COLUMN token TO sell_token;
 
 ALTER TABLE min_fee_measurements
   ADD COLUMN buy_token bytea,
-  ADD COLUMN sell_amount  numeric(78,0);
+  ADD COLUMN amount  numeric(78,0),
+  ADD COLUMN order_kind OrderKind;

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -55,7 +55,9 @@ pub fn get_fee_info(
     get_fee_info_request().and_then(move |token| {
         let fee_calculator = fee_calculator.clone();
         async move {
-            Result::<_, Infallible>::Ok(get_fee_info_response(fee_calculator.min_fee(token).await))
+            Result::<_, Infallible>::Ok(get_fee_info_response(
+                fee_calculator.min_fee(token, None, None).await,
+            ))
         }
     })
 }

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -56,7 +56,7 @@ pub fn get_fee_info(
         let fee_calculator = fee_calculator.clone();
         async move {
             Result::<_, Infallible>::Ok(get_fee_info_response(
-                fee_calculator.min_fee(token, None, None).await,
+                fee_calculator.min_fee(token, None, None, None).await,
             ))
         }
     })

--- a/orderbook/src/database/fees.rs
+++ b/orderbook/src/database/fees.rs
@@ -21,7 +21,7 @@ impl MinFeeStoring for Database {
             "INSERT INTO min_fee_measurements (sell_token, buy_token, sell_amount, expiration_timestamp, min_fee) VALUES ($1, $2, $3, $4, $5);";
         sqlx::query(QUERY)
             .bind(sell_token.as_bytes())
-            .bind(buy_token.map(|t| t.as_bytes().to_owned()))
+            .bind(buy_token.as_ref().map(|t| t.as_bytes()))
             .bind(sell_amount.map(|a| u256_to_big_decimal(&a)))
             .bind(expiry)
             .bind(u256_to_big_decimal(&min_fee))
@@ -48,7 +48,7 @@ impl MinFeeStoring for Database {
 
         let result: Option<BigDecimal> = sqlx::query_scalar(QUERY)
             .bind(sell_token.as_bytes())
-            .bind(buy_token.map(|t| t.as_bytes().to_owned()))
+            .bind(buy_token.as_ref().map(|t| t.as_bytes()))
             .bind(sell_amount.map(|a| u256_to_big_decimal(&a)))
             .bind(min_expiry)
             .fetch_one(&self.pool)

--- a/orderbook/src/database/fees.rs
+++ b/orderbook/src/database/fees.rs
@@ -1,4 +1,4 @@
-use super::Database;
+use super::{orders::DbOrderKind, Database};
 use crate::conversions::*;
 use crate::fee::MinFeeStoring;
 
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Context, Result};
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
 use ethcontract::{H160, U256};
+use model::order::OrderKind;
 
 #[async_trait::async_trait]
 impl MinFeeStoring for Database {
@@ -13,16 +14,18 @@ impl MinFeeStoring for Database {
         &self,
         sell_token: H160,
         buy_token: Option<H160>,
-        sell_amount: Option<U256>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
         expiry: DateTime<Utc>,
         min_fee: U256,
     ) -> Result<()> {
         const QUERY: &str =
-            "INSERT INTO min_fee_measurements (sell_token, buy_token, sell_amount, expiration_timestamp, min_fee) VALUES ($1, $2, $3, $4, $5);";
+            "INSERT INTO min_fee_measurements (sell_token, buy_token, amount, order_kind, expiration_timestamp, min_fee) VALUES ($1, $2, $3, $4, $5, $6);";
         sqlx::query(QUERY)
             .bind(sell_token.as_bytes())
             .bind(buy_token.as_ref().map(|t| t.as_bytes()))
-            .bind(sell_amount.map(|a| u256_to_big_decimal(&a)))
+            .bind(amount.map(|a| u256_to_big_decimal(&a)))
+            .bind(kind.map(DbOrderKind::from))
             .bind(expiry)
             .bind(u256_to_big_decimal(&min_fee))
             .execute(&self.pool)
@@ -35,21 +38,24 @@ impl MinFeeStoring for Database {
         &self,
         sell_token: H160,
         buy_token: Option<H160>,
-        sell_amount: Option<U256>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
         min_expiry: DateTime<Utc>,
     ) -> Result<Option<U256>> {
         const QUERY: &str = "\
             SELECT MIN(min_fee) FROM min_fee_measurements \
             WHERE sell_token = $1 \
             AND ($2 IS NULL OR buy_token = $2) \
-            AND ($3 IS NULL OR sell_amount = $3) \
-            AND expiration_timestamp >= $4
+            AND ($3 IS NULL OR amount = $3) \
+            AND ($4 IS NULL OR order_kind = $4) \
+            AND expiration_timestamp >= $5
             ";
 
         let result: Option<BigDecimal> = sqlx::query_scalar(QUERY)
             .bind(sell_token.as_bytes())
             .bind(buy_token.as_ref().map(|t| t.as_bytes()))
-            .bind(sell_amount.map(|a| u256_to_big_decimal(&a)))
+            .bind(amount.map(|a| u256_to_big_decimal(&a)))
+            .bind(kind.map(DbOrderKind::from))
             .bind(min_expiry)
             .fetch_one(&self.pool)
             .await
@@ -94,11 +100,12 @@ mod tests {
         let token_b = H160::from_low_u64_be(2);
 
         // Save two measurements for token_a
-        db.save_fee_measurement(token_a, None, None, now, 100u32.into())
+        db.save_fee_measurement(token_a, None, None, None, now, 100u32.into())
             .await
             .unwrap();
         db.save_fee_measurement(
             token_a,
+            None,
             None,
             None,
             now + Duration::seconds(60),
@@ -108,20 +115,27 @@ mod tests {
         .unwrap();
 
         // Save one measurement for token_b
-        db.save_fee_measurement(token_b, Some(token_a), Some(100.into()), now, 10u32.into())
-            .await
-            .unwrap();
+        db.save_fee_measurement(
+            token_b,
+            Some(token_a),
+            Some(100.into()),
+            Some(OrderKind::Buy),
+            now,
+            10u32.into(),
+        )
+        .await
+        .unwrap();
 
         // Token A has readings valid until now and in 30s
         assert_eq!(
-            db.get_min_fee(token_a, None, None, now)
+            db.get_min_fee(token_a, None, None, None, now)
                 .await
                 .unwrap()
                 .unwrap(),
             100_u32.into()
         );
         assert_eq!(
-            db.get_min_fee(token_a, None, None, now + Duration::seconds(30))
+            db.get_min_fee(token_a, None, None, None, now + Duration::seconds(30))
                 .await
                 .unwrap()
                 .unwrap(),
@@ -130,14 +144,14 @@ mod tests {
 
         // Token B only has readings valid until now
         assert_eq!(
-            db.get_min_fee(token_b, None, None, now)
+            db.get_min_fee(token_b, None, None, None, now)
                 .await
                 .unwrap()
                 .unwrap(),
             10u32.into()
         );
         assert_eq!(
-            db.get_min_fee(token_b, None, None, now + Duration::seconds(30))
+            db.get_min_fee(token_b, None, None, None, now + Duration::seconds(30))
                 .await
                 .unwrap(),
             None
@@ -145,21 +159,28 @@ mod tests {
 
         // Token B has readings for right filters
         assert_eq!(
-            db.get_min_fee(token_b, Some(token_a), None, now)
+            db.get_min_fee(token_b, Some(token_a), None, None, now)
                 .await
                 .unwrap()
                 .unwrap(),
             10u32.into()
         );
         assert_eq!(
-            db.get_min_fee(token_b, None, Some(100.into()), now)
+            db.get_min_fee(token_b, None, Some(100.into()), None, now)
                 .await
                 .unwrap()
                 .unwrap(),
             10u32.into()
         );
         assert_eq!(
-            db.get_min_fee(token_b, None, Some(U256::zero()), now)
+            db.get_min_fee(token_b, None, None, Some(OrderKind::Buy), now)
+                .await
+                .unwrap()
+                .unwrap(),
+            10u32.into()
+        );
+        assert_eq!(
+            db.get_min_fee(token_b, None, Some(U256::zero()), None, now)
                 .await
                 .unwrap(),
             None
@@ -169,7 +190,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            db.get_min_fee(token_b, None, None, now).await.unwrap(),
+            db.get_min_fee(token_b, None, None, None, now)
+                .await
+                .unwrap(),
             None
         );
     }

--- a/orderbook/src/database/fees.rs
+++ b/orderbook/src/database/fees.rs
@@ -11,14 +11,18 @@ use ethcontract::{H160, U256};
 impl MinFeeStoring for Database {
     async fn save_fee_measurement(
         &self,
-        token: H160,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        sell_amount: Option<U256>,
         expiry: DateTime<Utc>,
         min_fee: U256,
     ) -> Result<()> {
         const QUERY: &str =
-            "INSERT INTO min_fee_measurements (token, expiration_timestamp, min_fee) VALUES ($1, $2, $3);";
+            "INSERT INTO min_fee_measurements (sell_token, buy_token, sell_amount, expiration_timestamp, min_fee) VALUES ($1, $2, $3, $4, $5);";
         sqlx::query(QUERY)
-            .bind(token.as_bytes())
+            .bind(sell_token.as_bytes())
+            .bind(buy_token.map(|t| t.as_bytes().to_owned()))
+            .bind(sell_amount.map(|a| u256_to_big_decimal(&a)))
             .bind(expiry)
             .bind(u256_to_big_decimal(&min_fee))
             .execute(&self.pool)
@@ -27,14 +31,25 @@ impl MinFeeStoring for Database {
             .map(|_| ())
     }
 
-    async fn get_min_fee(&self, token: H160, min_expiry: DateTime<Utc>) -> Result<Option<U256>> {
+    async fn get_min_fee(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        sell_amount: Option<U256>,
+        min_expiry: DateTime<Utc>,
+    ) -> Result<Option<U256>> {
         const QUERY: &str = "\
             SELECT MIN(min_fee) FROM min_fee_measurements \
-            WHERE token = $1 AND expiration_timestamp >= $2
+            WHERE sell_token = $1 \
+            AND ($2 IS NULL OR buy_token = $2) \
+            AND ($3 IS NULL OR sell_amount = $3) \
+            AND expiration_timestamp >= $4
             ";
 
         let result: Option<BigDecimal> = sqlx::query_scalar(QUERY)
-            .bind(token.as_bytes())
+            .bind(sell_token.as_bytes())
+            .bind(buy_token.map(|t| t.as_bytes().to_owned()))
+            .bind(sell_amount.map(|a| u256_to_big_decimal(&a)))
             .bind(min_expiry)
             .fetch_one(&self.pool)
             .await
@@ -78,34 +93,73 @@ mod tests {
         let token_a = H160::from_low_u64_be(1);
         let token_b = H160::from_low_u64_be(2);
 
-        db.save_fee_measurement(token_a, now, 100u32.into())
+        // Save two measurements for token_a
+        db.save_fee_measurement(token_a, None, None, now, 100u32.into())
             .await
             .unwrap();
-        db.save_fee_measurement(token_a, now + Duration::seconds(60), 200u32.into())
-            .await
-            .unwrap();
-        db.save_fee_measurement(token_b, now, 10u32.into())
+        db.save_fee_measurement(
+            token_a,
+            None,
+            None,
+            now + Duration::seconds(60),
+            200u32.into(),
+        )
+        .await
+        .unwrap();
+
+        // Save one measurement for token_b
+        db.save_fee_measurement(token_b, Some(token_a), Some(100.into()), now, 10u32.into())
             .await
             .unwrap();
 
+        // Token A has readings valid until now and in 30s
         assert_eq!(
-            db.get_min_fee(token_a, now).await.unwrap().unwrap(),
+            db.get_min_fee(token_a, None, None, now)
+                .await
+                .unwrap()
+                .unwrap(),
             100_u32.into()
         );
         assert_eq!(
-            db.get_min_fee(token_a, now + Duration::seconds(30))
+            db.get_min_fee(token_a, None, None, now + Duration::seconds(30))
                 .await
                 .unwrap()
                 .unwrap(),
             200u32.into()
         );
 
+        // Token B only has readings valid until now
         assert_eq!(
-            db.get_min_fee(token_b, now).await.unwrap().unwrap(),
+            db.get_min_fee(token_b, None, None, now)
+                .await
+                .unwrap()
+                .unwrap(),
             10u32.into()
         );
         assert_eq!(
-            db.get_min_fee(token_b, now + Duration::seconds(30))
+            db.get_min_fee(token_b, None, None, now + Duration::seconds(30))
+                .await
+                .unwrap(),
+            None
+        );
+
+        // Token B has readings for right filters
+        assert_eq!(
+            db.get_min_fee(token_b, Some(token_a), None, now)
+                .await
+                .unwrap()
+                .unwrap(),
+            10u32.into()
+        );
+        assert_eq!(
+            db.get_min_fee(token_b, None, Some(100.into()), now)
+                .await
+                .unwrap()
+                .unwrap(),
+            10u32.into()
+        );
+        assert_eq!(
+            db.get_min_fee(token_b, None, Some(U256::zero()), now)
                 .await
                 .unwrap(),
             None
@@ -114,6 +168,9 @@ mod tests {
         db.remove_expired_fee_measurements(now + Duration::seconds(120))
             .await
             .unwrap();
-        assert_eq!(db.get_min_fee(token_b, now).await.unwrap(), None);
+        assert_eq!(
+            db.get_min_fee(token_b, None, None, now).await.unwrap(),
+            None
+        );
     }
 }

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -27,13 +27,13 @@ pub struct OrderFilter {
 #[derive(sqlx::Type)]
 #[sqlx(rename = "OrderKind")]
 #[sqlx(rename_all = "lowercase")]
-enum DbOrderKind {
+pub enum DbOrderKind {
     Buy,
     Sell,
 }
 
 impl DbOrderKind {
-    fn from(order_kind: OrderKind) -> Self {
+    pub fn from(order_kind: OrderKind) -> Self {
         match order_kind {
             OrderKind::Buy => Self::Buy,
             OrderKind::Sell => Self::Sell,

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -23,13 +23,22 @@ pub trait MinFeeStoring: Send + Sync {
     // Stores the given measurement. Returns an error if this fails
     async fn save_fee_measurement(
         &self,
-        token: H160,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        sell_amount: Option<U256>,
         expiry: DateTime<Utc>,
         min_fee: U256,
     ) -> Result<()>;
 
     // Return a vector of previously stored measurements for the given token that have an expiry >= min expiry
-    async fn get_min_fee(&self, token: H160, min_expiry: DateTime<Utc>) -> Result<Option<U256>>;
+    // If buy_token or sell_amount is not specified, it will return the lowest estimate matching the values provided.
+    async fn get_min_fee(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        sell_amount: Option<U256>,
+        min_expiry: DateTime<Utc>,
+    ) -> Result<Option<U256>>;
 }
 
 const GAS_PER_ORDER: f64 = 100_000.0;
@@ -61,27 +70,38 @@ impl MinFeeCalculator {
     // and an expiry date for the estimate.
     // Returns an error if there is some estimation error and Ok(None) if no information about the given
     // token exists
-    pub async fn min_fee(&self, token: H160) -> Result<Option<Measurement>> {
+    pub async fn min_fee(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        sell_amount: Option<U256>,
+    ) -> Result<Option<Measurement>> {
         let now = (self.now)();
         let official_valid_until = now + Duration::seconds(STANDARD_VALIDITY_FOR_FEE_IN_SEC);
         let internal_valid_until = now + Duration::seconds(PERSISTED_VALIDITY_FOR_FEE_IN_SEC);
 
         if let Ok(Some(past_fee)) = self
             .measurements
-            .get_min_fee(token, official_valid_until)
+            .get_min_fee(sell_token, buy_token, sell_amount, official_valid_until)
             .await
         {
             return Ok(Some((past_fee, official_valid_until)));
         }
 
-        let min_fee = match self.compute_min_fee(token).await? {
+        let min_fee = match self.compute_min_fee(sell_token).await? {
             Some(fee) => fee,
             None => return Ok(None),
         };
 
         let _ = self
             .measurements
-            .save_fee_measurement(token, internal_valid_until, min_fee)
+            .save_fee_measurement(
+                sell_token,
+                buy_token,
+                sell_amount,
+                internal_valid_until,
+                min_fee,
+            )
             .await;
         Ok(Some((min_fee, official_valid_until)))
     }
@@ -110,20 +130,29 @@ impl MinFeeCalculator {
     }
 
     // Returns true if the fee satisfies a previous not yet expired estimate, or the fee is high enough given the current estimate.
-    pub async fn is_valid_fee(&self, token: H160, fee: U256) -> bool {
-        if let Ok(Some(past_fee)) = self.measurements.get_min_fee(token, (self.now)()).await {
+    pub async fn is_valid_fee(&self, sell_token: H160, fee: U256) -> bool {
+        if let Ok(Some(past_fee)) = self
+            .measurements
+            .get_min_fee(sell_token, None, None, (self.now)())
+            .await
+        {
             if fee >= past_fee {
                 return true;
             }
         }
-        if let Ok(Some(current_fee)) = self.compute_min_fee(token).await {
+        if let Ok(Some(current_fee)) = self.compute_min_fee(sell_token).await {
             return fee >= current_fee;
         }
         false
     }
 }
 
-type FeeMeasurement = (DateTime<Utc>, U256);
+struct FeeMeasurement {
+    buy_token: Option<H160>,
+    sell_amount: Option<U256>,
+    expiry: DateTime<Utc>,
+    min_fee: U256,
+}
 
 #[derive(Default)]
 struct InMemoryFeeStore(Mutex<HashMap<H160, Vec<FeeMeasurement>>>);
@@ -131,24 +160,48 @@ struct InMemoryFeeStore(Mutex<HashMap<H160, Vec<FeeMeasurement>>>);
 impl MinFeeStoring for InMemoryFeeStore {
     async fn save_fee_measurement(
         &self,
-        token: H160,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        sell_amount: Option<U256>,
         expiry: DateTime<Utc>,
         min_fee: U256,
     ) -> Result<()> {
         self.0
             .lock()
             .expect("Thread holding Mutex panicked")
-            .entry(token)
+            .entry(sell_token)
             .or_default()
-            .push((expiry, min_fee));
+            .push(FeeMeasurement {
+                buy_token,
+                sell_amount,
+                expiry,
+                min_fee,
+            });
         Ok(())
     }
 
-    async fn get_min_fee(&self, token: H160, min_expiry: DateTime<Utc>) -> Result<Option<U256>> {
+    async fn get_min_fee(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        sell_amount: Option<U256>,
+        min_expiry: DateTime<Utc>,
+    ) -> Result<Option<U256>> {
         let mut guard = self.0.lock().expect("Thread holding Mutex panicked");
-        let measurements = guard.entry(token).or_default();
-        measurements.retain(|(expiry, _)| expiry >= &min_expiry);
-        Ok(measurements.iter().map(|(_, fee)| *fee).min())
+        let measurements = guard.entry(sell_token).or_default();
+        measurements.retain(|measurement| {
+            if buy_token.is_some() && buy_token != measurement.buy_token {
+                return false;
+            }
+            if sell_amount.is_some() && sell_amount != measurement.sell_amount {
+                return false;
+            }
+            measurement.expiry >= min_expiry
+        });
+        Ok(measurements
+            .iter()
+            .map(|measurement| measurement.min_fee)
+            .min())
     }
 }
 
@@ -206,7 +259,11 @@ mod tests {
             MinFeeCalculator::new_for_test(gas_estimator, price_estimator, Box::new(now));
 
         let token = H160::from_low_u64_be(1);
-        let (fee, expiry) = fee_estimator.min_fee(token).await.unwrap().unwrap();
+        let (fee, expiry) = fee_estimator
+            .min_fee(token, None, None)
+            .await
+            .unwrap()
+            .unwrap();
 
         // Gas price increase after measurement
         *gas_price.lock().unwrap() *= 2.0;
@@ -231,7 +288,11 @@ mod tests {
             MinFeeCalculator::new_for_test(gas_estimator, price_estimator, Box::new(Utc::now));
 
         let token = H160::from_low_u64_be(1);
-        let (fee, _) = fee_estimator.min_fee(token).await.unwrap().unwrap();
+        let (fee, _) = fee_estimator
+            .min_fee(token, None, None)
+            .await
+            .unwrap()
+            .unwrap();
 
         let lower_fee = fee - U256::one();
 


### PR DESCRIPTION
First step towards implementing the change in #350

The database needs to be able to store fee measurements based on buy token and sell_amount (I assume buy order's amounts will be converted to sell amounts before performing fee estimation - this will allow reusing cache hits from sell orders).

For the moment all those fields are still nullable as long as we are maintaining the old endpoint (until the frontend has switched). In this PR the logic doesn't change and we fill the extra fields with `None`.

In the next PR I will implement the new route which will populate non None values. Note, that as long as the validation doesn't use buyToken and amount to verify the min fee, it has still not affect on whether a fee accepted when the order is created.

### Test Plan
Adjusted Unit Tests
