### PR TITLE
More expressive fee 2

### DIFF
--- a/database/sql/V005__extend_fee_measurements_with_order_details.sql
+++ b/database/sql/V005__extend_fee_measurements_with_order_details.sql
@@ -1,0 +1,5 @@
+ALTER TABLE min_fee_measurements RENAME COLUMN token TO sell_token;
+
+ALTER TABLE min_fee_measurements
+  ADD COLUMN buy_token bytea,
+  ADD COLUMN sell_amount  numeric(78,0);

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -26,6 +26,7 @@ pub fn handle_all_routes(
 ) -> impl Filter<Extract = (impl Reply,), Error = warp::Rejection> + Clone {
     let create_order = create_order::create_order(orderbook.clone());
     let get_orders = get_orders::get_orders(orderbook.clone());
+    let legacy_fee_info = get_fee_info::legacy_get_fee_info(fee_calculator.clone());
     let fee_info = get_fee_info::get_fee_info(fee_calculator);
     let get_order = get_order_by_uid::get_order_by_uid(orderbook.clone());
     let get_solvable_orders = get_solvable_orders::get_solvable_orders(orderbook);
@@ -34,6 +35,7 @@ pub fn handle_all_routes(
         create_order
             .or(get_orders)
             .or(fee_info)
+            .or(legacy_fee_info)
             .or(get_order)
             .or(get_solvable_orders)
             .or(get_trades),

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -55,7 +55,9 @@ pub fn get_fee_info(
     get_fee_info_request().and_then(move |token| {
         let fee_calculator = fee_calculator.clone();
         async move {
-            Result::<_, Infallible>::Ok(get_fee_info_response(fee_calculator.min_fee(token).await))
+            Result::<_, Infallible>::Ok(get_fee_info_response(
+                fee_calculator.min_fee(token, None, None).await,
+            ))
         }
     })
 }

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -3,7 +3,7 @@ use crate::fee::MinFeeCalculator;
 use super::H160Wrapper;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use model::u256_decimal;
+use model::{order::OrderKind, u256_decimal};
 use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
@@ -15,23 +15,31 @@ use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
 struct FeeInfo {
     pub expiration_date: DateTime<Utc>,
     #[serde(with = "u256_decimal")]
-    pub minimal_fee: U256,
-    pub fee_ratio: u32,
+    pub amount: U256,
 }
 
-pub fn get_fee_info_request() -> impl Filter<Extract = (H160,), Error = Rejection> + Clone {
-    warp::path!("tokens" / H160Wrapper / "fee")
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Query {
+    sell_token: H160Wrapper,
+    buy_token: H160Wrapper,
+    #[serde(with = "u256_decimal")]
+    amount: U256,
+    kind: OrderKind,
+}
+
+fn get_fee_info_request() -> impl Filter<Extract = (Query,), Error = Rejection> + Clone {
+    warp::path!("fee")
         .and(warp::get())
-        .map(|token: H160Wrapper| token.0)
+        .and(warp::query::<Query>())
 }
 
 pub fn get_fee_info_response(result: Result<Option<(U256, DateTime<Utc>)>>) -> impl Reply {
     match result {
-        Ok(Some((minimal_fee, expiration_date))) => {
+        Ok(Some((amount, expiration_date))) => {
             let fee_info = FeeInfo {
                 expiration_date,
-                minimal_fee,
-                fee_ratio: 0u32,
+                amount,
             };
             Ok(reply::with_status(reply::json(&fee_info), StatusCode::OK))
         }
@@ -52,11 +60,72 @@ pub fn get_fee_info_response(result: Result<Option<(U256, DateTime<Utc>)>>) -> i
 pub fn get_fee_info(
     fee_calculator: Arc<MinFeeCalculator>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    get_fee_info_request().and_then(move |token| {
+    get_fee_info_request().and_then(move |query: Query| {
         let fee_calculator = fee_calculator.clone();
         async move {
             Result::<_, Infallible>::Ok(get_fee_info_response(
-                fee_calculator.min_fee(token, None, None).await,
+                fee_calculator
+                    .min_fee(
+                        query.sell_token.0,
+                        Some(query.buy_token.0),
+                        Some(query.amount),
+                        Some(query.kind),
+                    )
+                    .await,
+            ))
+        }
+    })
+}
+
+// TODO remove legacy fee endpoint once frontend is updated
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LegacyFeeInfo {
+    pub expiration_date: DateTime<Utc>,
+    #[serde(with = "u256_decimal")]
+    pub minimal_fee: U256,
+    pub fee_ratio: u32,
+}
+
+pub fn legacy_get_fee_info_request() -> impl Filter<Extract = (H160,), Error = Rejection> + Clone {
+    warp::path!("tokens" / H160Wrapper / "fee")
+        .and(warp::get())
+        .map(|token: H160Wrapper| token.0)
+}
+
+pub fn legacy_get_fee_info_response(result: Result<Option<(U256, DateTime<Utc>)>>) -> impl Reply {
+    match result {
+        Ok(Some((minimal_fee, expiration_date))) => {
+            let fee_info = LegacyFeeInfo {
+                expiration_date,
+                minimal_fee,
+                fee_ratio: 0u32,
+            };
+            Ok(reply::with_status(reply::json(&fee_info), StatusCode::OK))
+        }
+        Ok(None) => Ok(reply::with_status(
+            super::error("NotFound", "Token was not found"),
+            StatusCode::NOT_FOUND,
+        )),
+        Err(err) => {
+            tracing::error!(?err, "get_fee error");
+            Ok(reply::with_status(
+                super::internal_error(),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ))
+        }
+    }
+}
+
+pub fn legacy_get_fee_info(
+    fee_calculator: Arc<MinFeeCalculator>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    legacy_get_fee_info_request().and_then(move |token| {
+        let fee_calculator = fee_calculator.clone();
+        async move {
+            Result::<_, Infallible>::Ok(legacy_get_fee_info_response(
+                fee_calculator.min_fee(token, None, None, None).await,
             ))
         }
     })
@@ -72,11 +141,20 @@ mod tests {
     #[tokio::test]
     async fn get_fee_info_request_ok() {
         let filter = get_fee_info_request();
-        let token = String::from("0x0000000000000000000000000000000000000001");
-        let path_string = format!("/tokens/{}/fee", token);
+        let sell_token = String::from("0x0000000000000000000000000000000000000001");
+        let buy_token = String::from("0x0000000000000000000000000000000000000002");
+        let path_string = format!(
+            "/fee?sellToken={}&buyToken={}&amount={}&kind=buy",
+            sell_token,
+            buy_token,
+            U256::exp10(18)
+        );
         let request = request().path(&path_string).method("GET");
         let result = request.filter(&filter).await.unwrap();
-        assert_eq!(result, H160::from_low_u64_be(1));
+        assert_eq!(result.sell_token.0, H160::from_low_u64_be(1));
+        assert_eq!(result.buy_token.0, H160::from_low_u64_be(2));
+        assert_eq!(result.amount, U256::exp10(18));
+        assert_eq!(result.kind, OrderKind::Buy);
     }
 
     #[tokio::test]
@@ -87,6 +165,30 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = response_body(response).await;
         let body: FeeInfo = serde_json::from_slice(body.as_slice()).unwrap();
+        assert_eq!(body.amount, U256::zero());
+        assert!(body.expiration_date.gt(&chrono::offset::Utc::now()))
+    }
+
+    #[tokio::test]
+    async fn legacy_get_fee_info_request_ok() {
+        let filter = legacy_get_fee_info_request();
+        let token = String::from("0x0000000000000000000000000000000000000001");
+        let path_string = format!("/tokens/{}/fee", token);
+        let request = request().path(&path_string).method("GET");
+        let result = request.filter(&filter).await.unwrap();
+        assert_eq!(result, H160::from_low_u64_be(1));
+    }
+
+    #[tokio::test]
+    async fn legacy_get_fee_info_response_() {
+        let response = legacy_get_fee_info_response(Ok(Some((
+            U256::zero(),
+            Utc::now() + FixedOffset::east(10),
+        ))))
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body(response).await;
+        let body: LegacyFeeInfo = serde_json::from_slice(body.as_slice()).unwrap();
         assert_eq!(body.minimal_fee, U256::zero());
         assert_eq!(body.fee_ratio, 0);
         assert!(body.expiration_date.gt(&chrono::offset::Utc::now()))

--- a/orderbook/src/database/fees.rs
+++ b/orderbook/src/database/fees.rs
@@ -11,14 +11,18 @@ use ethcontract::{H160, U256};
 impl MinFeeStoring for Database {
     async fn save_fee_measurement(
         &self,
-        token: H160,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        sell_amount: Option<U256>,
         expiry: DateTime<Utc>,
         min_fee: U256,
     ) -> Result<()> {
         const QUERY: &str =
-            "INSERT INTO min_fee_measurements (token, expiration_timestamp, min_fee) VALUES ($1, $2, $3);";
+            "INSERT INTO min_fee_measurements (sell_token, buy_token, sell_amount, expiration_timestamp, min_fee) VALUES ($1, $2, $3, $4, $5);";
         sqlx::query(QUERY)
-            .bind(token.as_bytes())
+            .bind(sell_token.as_bytes())
+            .bind(buy_token.map(|t| t.as_bytes().to_owned()))
+            .bind(sell_amount.map(|a| u256_to_big_decimal(&a)))
             .bind(expiry)
             .bind(u256_to_big_decimal(&min_fee))
             .execute(&self.pool)
@@ -27,14 +31,25 @@ impl MinFeeStoring for Database {
             .map(|_| ())
     }
 
-    async fn get_min_fee(&self, token: H160, min_expiry: DateTime<Utc>) -> Result<Option<U256>> {
+    async fn get_min_fee(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        sell_amount: Option<U256>,
+        min_expiry: DateTime<Utc>,
+    ) -> Result<Option<U256>> {
         const QUERY: &str = "\
             SELECT MIN(min_fee) FROM min_fee_measurements \
-            WHERE token = $1 AND expiration_timestamp >= $2
+            WHERE sell_token = $1 \
+            AND ($2 IS NULL OR buy_token = $2) \
+            AND ($3 IS NULL OR sell_amount = $3) \
+            AND expiration_timestamp >= $4
             ";
 
         let result: Option<BigDecimal> = sqlx::query_scalar(QUERY)
-            .bind(token.as_bytes())
+            .bind(sell_token.as_bytes())
+            .bind(buy_token.map(|t| t.as_bytes().to_owned()))
+            .bind(sell_amount.map(|a| u256_to_big_decimal(&a)))
             .bind(min_expiry)
             .fetch_one(&self.pool)
             .await
@@ -78,34 +93,73 @@ mod tests {
         let token_a = H160::from_low_u64_be(1);
         let token_b = H160::from_low_u64_be(2);
 
-        db.save_fee_measurement(token_a, now, 100u32.into())
+        // Save two measurements for token_a
+        db.save_fee_measurement(token_a, None, None, now, 100u32.into())
             .await
             .unwrap();
-        db.save_fee_measurement(token_a, now + Duration::seconds(60), 200u32.into())
-            .await
-            .unwrap();
-        db.save_fee_measurement(token_b, now, 10u32.into())
+        db.save_fee_measurement(
+            token_a,
+            None,
+            None,
+            now + Duration::seconds(60),
+            200u32.into(),
+        )
+        .await
+        .unwrap();
+
+        // Save one measurement for token_b
+        db.save_fee_measurement(token_b, Some(token_a), Some(100.into()), now, 10u32.into())
             .await
             .unwrap();
 
+        // Token A has readings valid until now and in 30s
         assert_eq!(
-            db.get_min_fee(token_a, now).await.unwrap().unwrap(),
+            db.get_min_fee(token_a, None, None, now)
+                .await
+                .unwrap()
+                .unwrap(),
             100_u32.into()
         );
         assert_eq!(
-            db.get_min_fee(token_a, now + Duration::seconds(30))
+            db.get_min_fee(token_a, None, None, now + Duration::seconds(30))
                 .await
                 .unwrap()
                 .unwrap(),
             200u32.into()
         );
 
+        // Token B only has readings valid until now
         assert_eq!(
-            db.get_min_fee(token_b, now).await.unwrap().unwrap(),
+            db.get_min_fee(token_b, None, None, now)
+                .await
+                .unwrap()
+                .unwrap(),
             10u32.into()
         );
         assert_eq!(
-            db.get_min_fee(token_b, now + Duration::seconds(30))
+            db.get_min_fee(token_b, None, None, now + Duration::seconds(30))
+                .await
+                .unwrap(),
+            None
+        );
+
+        // Token B has readings for right filters
+        assert_eq!(
+            db.get_min_fee(token_b, Some(token_a), None, now)
+                .await
+                .unwrap()
+                .unwrap(),
+            10u32.into()
+        );
+        assert_eq!(
+            db.get_min_fee(token_b, None, Some(100.into()), now)
+                .await
+                .unwrap()
+                .unwrap(),
+            10u32.into()
+        );
+        assert_eq!(
+            db.get_min_fee(token_b, None, Some(U256::zero()), now)
                 .await
                 .unwrap(),
             None
@@ -114,6 +168,9 @@ mod tests {
         db.remove_expired_fee_measurements(now + Duration::seconds(120))
             .await
             .unwrap();
-        assert_eq!(db.get_min_fee(token_b, now).await.unwrap(), None);
+        assert_eq!(
+            db.get_min_fee(token_b, None, None, now).await.unwrap(),
+            None
+        );
     }
 }

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -23,13 +23,22 @@ pub trait MinFeeStoring: Send + Sync {
     // Stores the given measurement. Returns an error if this fails
     async fn save_fee_measurement(
         &self,
-        token: H160,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        sell_amount: Option<U256>,
         expiry: DateTime<Utc>,
         min_fee: U256,
     ) -> Result<()>;
 
     // Return a vector of previously stored measurements for the given token that have an expiry >= min expiry
-    async fn get_min_fee(&self, token: H160, min_expiry: DateTime<Utc>) -> Result<Option<U256>>;
+    // If buy_token or sell_amount is not specified, it will return the lowest estimate matching the values provided.
+    async fn get_min_fee(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        sell_amount: Option<U256>,
+        min_expiry: DateTime<Utc>,
+    ) -> Result<Option<U256>>;
 }
 
 const GAS_PER_ORDER: f64 = 100_000.0;
@@ -61,27 +70,38 @@ impl MinFeeCalculator {
     // and an expiry date for the estimate.
     // Returns an error if there is some estimation error and Ok(None) if no information about the given
     // token exists
-    pub async fn min_fee(&self, token: H160) -> Result<Option<Measurement>> {
+    pub async fn min_fee(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        sell_amount: Option<U256>,
+    ) -> Result<Option<Measurement>> {
         let now = (self.now)();
         let official_valid_until = now + Duration::seconds(STANDARD_VALIDITY_FOR_FEE_IN_SEC);
         let internal_valid_until = now + Duration::seconds(PERSISTED_VALIDITY_FOR_FEE_IN_SEC);
 
         if let Ok(Some(past_fee)) = self
             .measurements
-            .get_min_fee(token, official_valid_until)
+            .get_min_fee(sell_token, buy_token, sell_amount, official_valid_until)
             .await
         {
             return Ok(Some((past_fee, official_valid_until)));
         }
 
-        let min_fee = match self.compute_min_fee(token).await? {
+        let min_fee = match self.compute_min_fee(sell_token).await? {
             Some(fee) => fee,
             None => return Ok(None),
         };
 
         let _ = self
             .measurements
-            .save_fee_measurement(token, internal_valid_until, min_fee)
+            .save_fee_measurement(
+                sell_token,
+                buy_token,
+                sell_amount,
+                internal_valid_until,
+                min_fee,
+            )
             .await;
         Ok(Some((min_fee, official_valid_until)))
     }
@@ -103,20 +123,29 @@ impl MinFeeCalculator {
     }
 
     // Returns true if the fee satisfies a previous not yet expired estimate, or the fee is high enough given the current estimate.
-    pub async fn is_valid_fee(&self, token: H160, fee: U256) -> bool {
-        if let Ok(Some(past_fee)) = self.measurements.get_min_fee(token, (self.now)()).await {
+    pub async fn is_valid_fee(&self, sell_token: H160, fee: U256) -> bool {
+        if let Ok(Some(past_fee)) = self
+            .measurements
+            .get_min_fee(sell_token, None, None, (self.now)())
+            .await
+        {
             if fee >= past_fee {
                 return true;
             }
         }
-        if let Ok(Some(current_fee)) = self.compute_min_fee(token).await {
+        if let Ok(Some(current_fee)) = self.compute_min_fee(sell_token).await {
             return fee >= current_fee;
         }
         false
     }
 }
 
-type FeeMeasurement = (DateTime<Utc>, U256);
+struct FeeMeasurement {
+    buy_token: Option<H160>,
+    sell_amount: Option<U256>,
+    expiry: DateTime<Utc>,
+    min_fee: U256,
+}
 
 #[derive(Default)]
 struct InMemoryFeeStore(Mutex<HashMap<H160, Vec<FeeMeasurement>>>);
@@ -124,24 +153,48 @@ struct InMemoryFeeStore(Mutex<HashMap<H160, Vec<FeeMeasurement>>>);
 impl MinFeeStoring for InMemoryFeeStore {
     async fn save_fee_measurement(
         &self,
-        token: H160,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        sell_amount: Option<U256>,
         expiry: DateTime<Utc>,
         min_fee: U256,
     ) -> Result<()> {
         self.0
             .lock()
             .expect("Thread holding Mutex panicked")
-            .entry(token)
+            .entry(sell_token)
             .or_default()
-            .push((expiry, min_fee));
+            .push(FeeMeasurement {
+                buy_token,
+                sell_amount,
+                expiry,
+                min_fee,
+            });
         Ok(())
     }
 
-    async fn get_min_fee(&self, token: H160, min_expiry: DateTime<Utc>) -> Result<Option<U256>> {
+    async fn get_min_fee(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        sell_amount: Option<U256>,
+        min_expiry: DateTime<Utc>,
+    ) -> Result<Option<U256>> {
         let mut guard = self.0.lock().expect("Thread holding Mutex panicked");
-        let measurements = guard.entry(token).or_default();
-        measurements.retain(|(expiry, _)| expiry >= &min_expiry);
-        Ok(measurements.iter().map(|(_, fee)| *fee).min())
+        let measurements = guard.entry(sell_token).or_default();
+        measurements.retain(|measurement| {
+            if buy_token.is_some() && buy_token != measurement.buy_token {
+                return false;
+            }
+            if sell_amount.is_some() && sell_amount != measurement.sell_amount {
+                return false;
+            }
+            measurement.expiry >= min_expiry
+        });
+        Ok(measurements
+            .iter()
+            .map(|measurement| measurement.min_fee)
+            .min())
     }
 }
 
@@ -198,7 +251,11 @@ mod tests {
             MinFeeCalculator::new_for_test(gas_estimator, price_estimator, Box::new(now));
 
         let token = H160::from_low_u64_be(1);
-        let (fee, expiry) = fee_estimator.min_fee(token).await.unwrap().unwrap();
+        let (fee, expiry) = fee_estimator
+            .min_fee(token, None, None)
+            .await
+            .unwrap()
+            .unwrap();
 
         // Gas price increase after measurement
         *gas_price.lock().unwrap() *= 2.0;
@@ -223,7 +280,11 @@ mod tests {
             MinFeeCalculator::new_for_test(gas_estimator, price_estimator, Box::new(Utc::now));
 
         let token = H160::from_low_u64_be(1);
-        let (fee, _) = fee_estimator.min_fee(token).await.unwrap().unwrap();
+        let (fee, _) = fee_estimator
+            .min_fee(token, None, None)
+            .await
+            .unwrap()
+            .unwrap();
 
         let lower_fee = fee - U256::one();
 


### PR DESCRIPTION
We are currently unable to estimate fees for e.g. USDC: https://protocol-mainnet.dev.gnosisdev.com/api/v1/tokens/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/fee

The reason is that #348 introduced a more sophisticated fee estimation that tries to compute the amount of sell token required to purchase the amount of native token required for the gas (via a buy order).

In our buy order logic we sort the possible uniswap paths by their required sell amount in reverse order (the less you have to sell the better). However, since this method returns an Option<U256> `Reverse` considers None to be the smaller (as such best) path. None however means no path exists. This leads to the effect that as long as there is one invalid path candidate (e.g. with a missing pool), we cannot estimate the fee. 

### Test Plan
Added a regression test and made sure the above request now returns a valid fee again.
