### PR TITLE
Make event sync optional

### DIFF
--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -127,7 +127,7 @@ async fn test_with_ganache() {
     );
     let db = Database::new("postgresql://").unwrap();
     db.clear().await.unwrap();
-    let event_updater = EventUpdater::new(gp_settlement.clone(), db.clone());
+    let event_updater = EventUpdater::new(gp_settlement.clone(), db.clone(), None);
 
     let price_estimator = UniswapPriceEstimator::new(
         Box::new(PoolFetcher {

--- a/orderbook/src/event_updater.rs
+++ b/orderbook/src/event_updater.rs
@@ -25,11 +25,11 @@ pub struct EventUpdater {
 }
 
 impl EventUpdater {
-    pub fn new(contract: GPv2Settlement, db: Database) -> Self {
+    pub fn new(contract: GPv2Settlement, db: Database, start_sync_at_block: Option<u64>) -> Self {
         Self {
             contract,
             db,
-            last_handled_block: None,
+            last_handled_block: start_sync_at_block,
         }
     }
 


### PR DESCRIPTION
When restarting the database from scratch (e.g. to test migrations or switch between networks) it takes a significant time for the Event Updater to catch up (>10 minutes on my local machine). In the meantime running the e2e integration locally can lead to weird effects as e.g. trade events that come from recent test trades are only picked up after the event updater has caught up (until then the solver tries to submit the orders over and over again).

This PR adds an optional flag to the orderbook which makes it skip all past events. For local development where we only care about orders that we create once the orderbook/solver have been running this is fine and much faster

### Test Plan
Run orderbook with and without `--skip-event-sync`
