### PR TITLE
Introduce fee discount

### DIFF
--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -142,6 +142,7 @@ async fn test_with_ganache() {
         Box::new(web3.clone()),
         token_a.address(),
         db.clone(),
+        1.0,
     ));
     let orderbook = Arc::new(Orderbook::new(
         domain_separator,

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -32,6 +32,9 @@ struct Arguments {
     /// Skip syncing past events (useful for local deployments)
     #[structopt(long)]
     skip_event_sync: bool,
+
+    #[structopt(long, env = "FEE_DISCOUNT_FACTOR", default_value = "1")]
+    fee_discount_factor: f64,
 }
 
 const MAINTENANCE_INTERVAL: Duration = Duration::from_secs(10);
@@ -126,6 +129,7 @@ async fn main() {
         Box::new(gas_price_estimator),
         native_token.address(),
         database.clone(),
+        args.fee_discount_factor,
     ));
 
     let orderbook = Arc::new(Orderbook::new(


### PR DESCRIPTION
Now that we can estimate the gas cost for a trade quite accurately, we add an extra config param the the API binary that allows giving a dedicated discount. In the future, this might have to be more dynamic (e.g. if we want to introduce something like a happy hour) but for now a static factor will do.

### Test Plan
Run binary once with 1.0 and again with 0.5 factor (make sure to etiher reset the DB, wait for previous estimate to be expired or use slightly different value). See difference in fee by around 1/2
