### PR TITLE
[Easy] Better error message when order already exists

### DIFF
--- a/orderbook/src/database.rs
+++ b/orderbook/src/database.rs
@@ -20,6 +20,18 @@ pub struct Database {
     pool: PgPool,
 }
 
+#[derive(Debug)]
+pub enum InsertionError {
+    DuplicatedRecord,
+    DbError(sqlx::Error),
+}
+
+impl From<sqlx::Error> for InsertionError {
+    fn from(err: sqlx::Error) -> Self {
+        Self::DbError(err)
+    }
+}
+
 // The implementation is split up into several modules which contain more public methods.
 
 impl Database {

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -50,8 +50,6 @@ impl DbOrderKind {
 }
 
 impl Database {
-    // TODO: Errors if order uid already exists. We might want to have different behavior like
-    // indicating this in the return value or simply allowing it to happen.
     pub async fn insert_order(&self, order: &Order) -> Result<(), InsertionError> {
         const FETCH: &str = "SELECT uid FROM orders WHERE uid = $1";
         const INSERT: &str = "\


### PR DESCRIPTION
Related [discussion on slack](https://gnosisinc.slack.com/archives/CPZA1AGKY/p1615464592060700)

At the moment we return a 500 internal server error when someone tries to place the same order twice. Internally we run into a primary key violation error in the DB which we swallow behind a general purpose internal error. This PR makes it so that we return the proper error reason.

### Test Plan
Place order once via the UI, copy the cURL request from dev tools, run again in shell and observe:

> {"errorType":"DuplicatedOrder","description":"order already exists"}
