### PR TITLE
Cached Pool Fetcher

### DIFF
--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -1,5 +1,8 @@
 use contracts::{ERC20Mintable, UniswapV2Factory, UniswapV2Router02};
-use ethcontract::prelude::{Account, Address, Http, PrivateKey, Web3, U256};
+use ethcontract::{
+    futures::StreamExt,
+    prelude::{Account, Address, Http, PrivateKey, Web3, U256},
+};
 use hex_literal::hex;
 use model::{
     order::{OrderBuilder, OrderKind},

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -1,6 +1,5 @@
 use chrono::offset::Utc;
 use contracts::{GPv2Settlement, UniswapV2Factory, WETH9};
-use futures::StreamExt;
 use model::{order::OrderUid, DomainSeparator};
 use orderbook::{
     account_balances::Web3BalanceFetcher,
@@ -10,7 +9,11 @@ use orderbook::{
     orderbook::Orderbook,
     serve_task, verify_deployed_contract_constants,
 };
-use shared::{price_estimate::UniswapPriceEstimator, uniswap_pool::PoolFetcher};
+use shared::{
+    current_block::current_block_stream,
+    price_estimate::UniswapPriceEstimator,
+    uniswap_pool::{CachedPoolFetcher, PoolFetcher},
+};
 use std::{
     collections::HashSet, iter::FromIterator as _, net::SocketAddr, sync::Arc, time::Duration,
 };
@@ -117,12 +120,18 @@ async fn main() {
     let mut base_tokens = HashSet::from_iter(args.shared.base_tokens);
     // We should always use the native token as a base token.
     base_tokens.insert(native_token.address());
-    let price_estimator = Arc::new(UniswapPriceEstimator::new(
+
+    let current_block_stream = current_block_stream(web3.clone()).await.unwrap();
+    let pool_fetcher = CachedPoolFetcher::new(
         Box::new(PoolFetcher {
             factory: uniswap_factory,
             web3,
             chain_id,
         }),
+        current_block_stream,
+    );
+    let price_estimator = Arc::new(UniswapPriceEstimator::new(
+        Box::new(pool_fetcher),
         base_tokens,
     ));
     let fee_calculator = Arc::new(MinFeeCalculator::new(

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -1,5 +1,6 @@
 use chrono::offset::Utc;
 use contracts::{GPv2Settlement, UniswapV2Factory, WETH9};
+use futures::StreamExt;
 use model::{order::OrderUid, DomainSeparator};
 use orderbook::{
     account_balances::Web3BalanceFetcher,


### PR DESCRIPTION
Now that we are using the uniswap pools in a lot of places (price estimate, fee estimate, base line solver, objective value computation), it might make sense to cache pool information as least until a new block arrives.

This PR introduces a CachedPoolFetcher which does exactly that. It uses the current_block_stream to invalidate its cache and otherwise performs a read_through logic with its inner fetcher.

I had to change current_block_stream to take a concrete Transport instead of a DynTransport. If there is value in having DynTransport we should probably change it everywhere in the codebase where we are passing Web3.

### Test Plan
Unit tests for the new component.
