### PR TITLE
Add log splitter binary for kubernetes alerts

### DIFF
--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -5,11 +5,18 @@ WORKDIR /usr/src/oba-services
 COPY . .
 RUN cargo build --target x86_64-unknown-linux-musl --release
 
+RUN \
+    cd .. && \
+    git clone https://github.com/gnosis/regex-stream-split.git && \
+    cd regex-stream-split && \
+    cargo build --target x86_64-unknown-linux-musl --release
+
 # Extract Binary
 FROM alpine:latest
 
 # Handle signal handlers properly
 RUN apk add --no-cache tini
+COPY --from=cargo-build /usr/src/regex-stream-split/target/x86_64-unknown-linux-musl/release/regex-stream-split /usr/local/bin/regex-stream-split
 COPY --from=cargo-build /usr/src/oba-services/target/x86_64-unknown-linux-musl/release/orderbook /usr/local/bin/orderbook
 COPY --from=cargo-build /usr/src/oba-services/target/x86_64-unknown-linux-musl/release/solver /usr/local/bin/solver
 

--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -9,6 +9,7 @@ RUN \
     cd .. && \
     git clone https://github.com/gnosis/regex-stream-split.git && \
     cd regex-stream-split && \
+    git checkout edc88224612b9e151c334fa6d3a7d20575d83836 && \
     cargo build --target x86_64-unknown-linux-musl --release
 
 # Extract Binary


### PR DESCRIPTION
After some discussion with devops we want to make this part of the
docker image instead of inserting it through configmap later.
Reimplemented in rust because we're a rust code base.

Once this is merged the plan is to change the kubernetes command to `sh -c "orderbook | log-splitter"`.

### Test Plan
new unit test