### PR TITLE
Make CurrentBlockStream able to return most recently seen block

### DIFF
--- a/shared/src/current_block.rs
+++ b/shared/src/current_block.rs
@@ -5,6 +5,7 @@ use primitive_types::H256;
 use std::{
     future::Future,
     pin::Pin,
+    sync::{Arc, Mutex},
     task::{Context, Poll},
     time::Duration,
 };
@@ -28,11 +29,17 @@ const POLL_INTERVAL: Duration = Duration::from_secs(1);
 /// The stream is clonable so that we only have to poll the node once while being able to share the
 /// result with several consumers. Calling this function again would create a new poller so it is
 /// preferable to clone an existing stream instead.
-pub fn current_block_stream(web3: Web3<DynTransport>) -> CurrentBlockStream {
-    let (sender, receiver) = watch::channel(None);
+pub async fn current_block_stream(web3: Web3<DynTransport>) -> Result<CurrentBlockStream> {
+    let first_block = current_block(&web3).await?;
+    let first_hash = first_block.hash.ok_or_else(|| anyhow!("missing hash"))?;
+
+    let (sender, receiver) = watch::channel(first_block.clone());
+
+    let most_recent = Arc::new(Mutex::new(first_block));
+    let stream = CurrentBlockStream::new(receiver, most_recent.clone());
 
     let update_future = async move {
-        let mut previous_hash = H256::default();
+        let mut previous_hash = first_hash;
         loop {
             tokio::time::delay_for(POLL_INTERVAL).await;
             let block = match current_block(&web3).await {
@@ -52,45 +59,46 @@ pub fn current_block_stream(web3: Web3<DynTransport>) -> CurrentBlockStream {
             if hash == previous_hash {
                 continue;
             }
-            if sender.broadcast(Some(block)).is_err() {
+            if sender.broadcast(block.clone()).is_err() {
                 break;
             }
+            *most_recent.lock().unwrap() = block;
             previous_hash = hash;
         }
     };
 
     tokio::task::spawn(update_future);
-    CurrentBlockStream::new(receiver)
+    Ok(stream)
 }
 
 #[derive(Clone)]
 pub struct CurrentBlockStream {
-    receiver: watch::Receiver<Option<Block>>,
+    receiver: watch::Receiver<Block>,
+    most_recent: Arc<Mutex<Block>>,
     is_terminated: bool,
 }
 
 impl CurrentBlockStream {
-    fn new(receiver: watch::Receiver<Option<Block>>) -> Self {
+    fn new(receiver: watch::Receiver<Block>, most_recent: Arc<Mutex<Block>>) -> Self {
         Self {
             receiver,
+            most_recent,
             is_terminated: false,
         }
     }
 
     async fn next(&mut self) -> Option<Block> {
-        loop {
-            // recv returns Option<Option<Block>>. If the outer option is None then the sender has
-            // been dropped in which case the stream ends. If the inner option is None then this is
-            // because we have fetched the initial default value so we loop and try again.
-            match self.receiver.recv().await {
-                Some(None) => (),
-                Some(Some(block)) => return Some(block),
-                None => {
-                    self.is_terminated = true;
-                    return None;
-                }
-            }
+        if let Some(block) = self.receiver.recv().await {
+            Some(block)
+        } else {
+            self.is_terminated = true;
+            None
         }
+    }
+
+    /// The most recent block. Cached in the struct so it is always ready and up to date.
+    pub fn current_block(&self) -> Block {
+        self.most_recent.lock().unwrap().clone()
     }
 }
 
@@ -121,16 +129,29 @@ async fn current_block(web3: &Web3<DynTransport>) -> Result<Block> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::FutureExt;
+    use primitive_types::H256;
 
     #[tokio::test]
     async fn stream_works() {
-        let (sender, receiver) = watch::channel(None);
-        let block = Block::default();
-        sender.broadcast(Some(block)).unwrap();
-        let mut stream = CurrentBlockStream::new(receiver);
+        let mut block = Block {
+            hash: Some(H256::from_low_u64_be(0)),
+            ..Default::default()
+        };
+        let (sender, receiver) = watch::channel(block.clone());
+        let mut stream = CurrentBlockStream::new(receiver, Default::default());
+
         assert!(!stream.is_terminated());
-        assert_eq!(stream.next().await, Some(Block::default()));
+        assert_eq!(stream.next().await, Some(block.clone()));
+
+        block.hash = Some(H256::from_low_u64_be(1));
+        sender.broadcast(block.clone()).unwrap();
         assert!(!stream.is_terminated());
+        assert_eq!(stream.next().await, Some(block.clone()));
+
+        assert!(stream.next().now_or_never().is_none());
+        assert!(!stream.is_terminated());
+
         std::mem::drop(sender);
         assert_eq!(stream.next().await, None);
         assert!(stream.is_terminated());
@@ -143,7 +164,7 @@ mod tests {
         let node = "https://dev-openethereum.mainnet.gnosisdev.com";
         let transport = web3::transports::Http::new(node).unwrap();
         let web3 = Web3::new(DynTransport::new(transport));
-        let mut stream = current_block_stream(web3);
+        let mut stream = current_block_stream(web3).await.unwrap();
         for _ in 0..3 {
             let block = stream.next().await.unwrap();
             println!("new block number {}", block.number.unwrap().as_u64());


### PR DESCRIPTION
This is useful for users of the struct that do not need to react to the
stream in realtime but only poll whether the block has changed some
times.

As part of this the initialization function has become async so that it can fetch the initial block immediately. This also plays nicely with the channel because we no longer need a `None` default value.

### Test Plan
adjusted test