### PR TITLE
Move order signing logic into a trait for reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,7 +1436,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "ethabi",
- "ethcontract",
  "hex",
  "hex-literal",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,6 +1436,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "ethabi",
+ "ethcontract",
  "hex",
  "hex-literal",
  "lazy_static",

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 ethabi = "13.0"
+ethcontract = { version = "0.11",  default-features = false }
 hex = { version = "0.4", default-features = false }
 hex-literal = "0.3"
 lazy_static = "1.4"
@@ -14,7 +15,7 @@ primitive-types = { version = "0.8" }
 secp256k1 = "0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = { version = "1.6", default-features = false, features = ["macros"] }
-web3 = { version = "0.15", default-features = false }
+web3 = { version = "0.15", default-features = false, features = ["signing"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 ethabi = "13.0"
-ethcontract = { version = "0.11",  default-features = false }
 hex = { version = "0.4", default-features = false }
 hex-literal = "0.3"
 lazy_static = "1.4"

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -94,7 +94,6 @@ impl Signature {
 
     pub fn validate(&self, domain_separator: &DomainSeparator, digest: &[u8; 32]) -> Option<H160> {
         let v = self.v & 0x1f;
-        // Does it make sense to include just order_uid here?
         let message = self.signing_digest(domain_separator, digest);
         let recovery = Recovery::new(message, v as u64, self.r, self.s);
         let (signature, recovery_id) = recovery.as_signature()?;

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -12,12 +12,34 @@ use primitive_types::{H160, H256};
 use serde::{de, Deserialize, Serialize};
 use std::fmt;
 use web3::signing;
+use web3::signing::{Key, SecretKeyRef};
+use web3::types::Recovery;
 
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Default, Hash)]
 pub struct Signature {
     pub r: H256,
     pub s: H256,
     pub v: u8,
+}
+
+pub trait EIP712Signing {
+    fn digest(&self) -> [u8; 32];
+    fn signature(&self) -> Signature;
+
+    fn sign_self_with(&self, domain_separator: &DomainSeparator, key: &SecretKeyRef) -> Signature {
+        let message = Signature::signing_digest_message(domain_separator, &self.digest());
+        // Unwrap because the only error is for invalid messages which we don't create.
+        let signature = Key::sign(key, &message, None).unwrap();
+        Signature {
+            v: signature.v as u8 | 0x80,
+            r: signature.r,
+            s: signature.s,
+        }
+    }
+
+    fn validate_signature(&self, domain_separator: &DomainSeparator) -> Option<H160> {
+        self.signature().validate(domain_separator, &self.digest())
+    }
 }
 
 impl Signature {
@@ -36,6 +58,46 @@ impl Signature {
             s: H256::from_slice(&bytes[32..64]),
             v: bytes[64],
         }
+    }
+
+    fn signing_digest_typed_data(
+        domain_separator: &DomainSeparator,
+        digest: &[u8; 32],
+    ) -> [u8; 32] {
+        let mut hash_data = [0u8; 66];
+        hash_data[0..2].copy_from_slice(&[0x19, 0x01]);
+        hash_data[2..34].copy_from_slice(&domain_separator.0);
+        hash_data[34..66].copy_from_slice(digest);
+        signing::keccak256(&hash_data)
+    }
+
+    pub fn signing_digest_message(
+        domain_separator: &DomainSeparator,
+        digest: &[u8; 32],
+    ) -> [u8; 32] {
+        let mut hash_data = [0u8; 92];
+        hash_data[0..28].copy_from_slice(b"\x19Ethereum Signed Message:\n64");
+        hash_data[28..60].copy_from_slice(&domain_separator.0);
+        hash_data[60..92].copy_from_slice(digest);
+        signing::keccak256(&hash_data)
+    }
+
+    fn signing_digest(&self, domain_separator: &DomainSeparator, digest: &[u8; 32]) -> [u8; 32] {
+        // This is fallback for wallets that don't support EIP712
+        if self.v & 0x80 == 0 {
+            Signature::signing_digest_typed_data(domain_separator, digest)
+        } else {
+            Signature::signing_digest_message(domain_separator, digest)
+        }
+    }
+
+    pub fn validate(&self, domain_separator: &DomainSeparator, digest: &[u8; 32]) -> Option<H160> {
+        let v = self.v & 0x1f;
+        // Does it make sense to include just order_uid here?
+        let message = self.signing_digest(domain_separator, digest);
+        let recovery = Recovery::new(message, v as u64, self.r, self.s);
+        let (signature, recovery_id) = recovery.as_signature()?;
+        signing::recover(&message, &signature, recovery_id).ok()
     }
 }
 
@@ -189,6 +251,7 @@ impl DomainSeparator {
 mod tests {
     use super::*;
     use hex_literal::hex;
+    use secp256k1::key::ONE_KEY;
 
     #[test]
     fn domain_separator_rinkeby() {
@@ -235,5 +298,40 @@ mod tests {
         assert_eq!(iter.next(), Some(token_a));
         assert_eq!(iter.next(), Some(token_b));
         assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn self_sign_with() {
+        struct TestEIP712Structure {
+            signature: Signature,
+        }
+        impl Default for TestEIP712Structure {
+            fn default() -> Self {
+                let mut result = Self {
+                    signature: Default::default(),
+                };
+                result.signature = result
+                    .sign_self_with(&DomainSeparator::default(), &SecretKeyRef::new(&ONE_KEY));
+                result
+            }
+        }
+
+        impl EIP712Signing for TestEIP712Structure {
+            fn digest(&self) -> [u8; 32] {
+                [0u8; 32]
+            }
+
+            fn signature(&self) -> Signature {
+                self.signature
+            }
+        }
+
+        let test_struct = TestEIP712Structure::default();
+        let key = SecretKeyRef::from(&ONE_KEY);
+        test_struct.sign_self_with(&DomainSeparator::default(), &key);
+        assert_eq!(
+            test_struct.validate_signature(&DomainSeparator::default()),
+            Some(key.address())
+        );
     }
 }

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -37,6 +37,7 @@ pub trait EIP712Signing {
         }
     }
 
+    // Returns public key (as an ethereum address - H160) if the signature is well-formed
     fn validate_signature(&self, domain_separator: &DomainSeparator) -> Option<H160> {
         self.signature().validate(domain_separator, &self.digest())
     }

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -110,7 +110,7 @@ impl OrderBuilder {
     pub fn sign_with(mut self, domain_separator: &DomainSeparator, key: SecretKeyRef) -> Self {
         self.0.order_meta_data.owner = key.address();
         self.0.order_meta_data.uid = self.0.order_creation.uid(&key.address());
-        self.0.order_creation.sign_self_with(domain_separator, &key);
+        self.0.order_creation.signature = self.0.order_creation.sign_self_with(domain_separator, &key);
         self
     }
 

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -3,7 +3,7 @@
 use crate::{
     h160_hexadecimal,
     u256_decimal::{self, DecimalU256},
-    DomainSeparator, Signature, TokenPair,
+    DomainSeparator, EIP712Signing, Signature, TokenPair,
 };
 use chrono::{offset::Utc, DateTime, NaiveDateTime};
 use hex_literal::hex;
@@ -15,10 +15,7 @@ use serde::{Deserializer, Serializer};
 use serde_with::serde_as;
 use std::fmt::{self, Display};
 use std::str::FromStr;
-use web3::{
-    signing::{self, Key, SecretKeyRef},
-    types::Recovery,
-};
+use web3::signing::{self, Key, SecretKeyRef};
 /// An order that is returned when querying the orderbook.
 ///
 /// Contains extra fields that are populated by the orderbook.
@@ -159,7 +156,8 @@ impl Default for OrderCreation {
             partially_fillable: Default::default(),
             signature: Default::default(),
         };
-        result.sign_self_with(&DomainSeparator::default(), &SecretKeyRef::new(&ONE_KEY));
+        result.signature =
+            result.sign_self_with(&DomainSeparator::default(), &SecretKeyRef::new(&ONE_KEY));
         result
     }
 }
@@ -169,30 +167,9 @@ impl OrderCreation {
         TokenPair::new(self.buy_token, self.sell_token)
     }
 
-    // If signature is valid returns the owner.
-    pub fn validate_signature(&self, domain_separator: &DomainSeparator) -> Option<H160> {
-        // The signature related functionality is defined by the smart contract:
-        // https://github.com/gnosis/gp-v2-contracts/blob/main/src/contracts/libraries/GPv2Encoding.sol
-
-        let v = self.signature.v & 0x1f;
-        let message = self.signing_digest(domain_separator);
-        let recovery = Recovery::new(message, v as u64, self.signature.r, self.signature.s);
-        let (signature, recovery_id) = recovery.as_signature()?;
-        signing::recover(&message, &signature, recovery_id).ok()
-    }
-
-    fn sign_self_with(&mut self, domain_separator: &DomainSeparator, key: &SecretKeyRef) {
-        let message = self.signing_digest_message(domain_separator);
-        // Unwrap because the only error is for invalid messages which we don't create.
-        let signature = Key::sign(key, &message, None).unwrap();
-        self.signature.v = signature.v as u8 | 0x80;
-        self.signature.r = signature.r;
-        self.signature.s = signature.s;
-    }
-
     pub fn uid(&self, owner: &H160) -> OrderUid {
         let mut uid = OrderUid([0u8; 56]);
-        uid.0[0..32].copy_from_slice(&self.order_digest());
+        uid.0[0..32].copy_from_slice(&self.digest());
         uid.0[32..52].copy_from_slice(owner.as_fixed_bytes());
         uid.0[52..56].copy_from_slice(&self.valid_to.to_be_bytes());
         uid
@@ -213,8 +190,10 @@ impl OrderCreation {
     // keccak256("buy")
     const ORDER_KIND_BUY: [u8; 32] =
         hex!("6ed88e868af0a1983e3886d5f3e95a2fafbd6c3450bc229e27342283dc429ccc");
+}
 
-    fn order_digest(&self) -> [u8; 32] {
+impl EIP712Signing for OrderCreation {
+    fn digest(&self) -> [u8; 32] {
         let mut hash_data = [0u8; 320];
         hash_data[0..32].copy_from_slice(&Self::ORDER_TYPE_HASH);
         // Some slots are not assigned (stay 0) because all values are extended to 256 bits.
@@ -233,28 +212,8 @@ impl OrderCreation {
         signing::keccak256(&hash_data)
     }
 
-    fn signing_digest_typed_data(&self, domain_separator: &DomainSeparator) -> [u8; 32] {
-        let mut hash_data = [0u8; 66];
-        hash_data[0..2].copy_from_slice(&[0x19, 0x01]);
-        hash_data[2..34].copy_from_slice(&domain_separator.0);
-        hash_data[34..66].copy_from_slice(&self.order_digest());
-        signing::keccak256(&hash_data)
-    }
-
-    fn signing_digest_message(&self, domain_separator: &DomainSeparator) -> [u8; 32] {
-        let mut hash_data = [0u8; 92];
-        hash_data[0..28].copy_from_slice(b"\x19Ethereum Signed Message:\n64");
-        hash_data[28..60].copy_from_slice(&domain_separator.0);
-        hash_data[60..92].copy_from_slice(&self.order_digest());
-        signing::keccak256(&hash_data)
-    }
-
-    fn signing_digest(&self, domain_separator: &DomainSeparator) -> [u8; 32] {
-        if self.signature.v & 0x80 == 0 {
-            self.signing_digest_typed_data(domain_separator)
-        } else {
-            self.signing_digest_message(domain_separator)
-        }
+    fn signature(&self) -> Signature {
+        self.signature
     }
 }
 
@@ -389,8 +348,11 @@ impl Default for OrderKind {
 mod tests {
     use super::*;
     use chrono::NaiveDateTime;
+    use ethcontract::prelude::Account;
+    use ethcontract::PrivateKey;
     use hex_literal::hex;
     use primitive_types::H256;
+    use secp256k1::SecretKey;
     use serde_json::json;
 
     #[test]
@@ -515,17 +477,6 @@ mod tests {
     }
 
     #[test]
-    fn sign_self() {
-        let mut order = OrderCreation::default();
-        let key = SecretKeyRef::from(&ONE_KEY);
-        order.sign_self_with(&DomainSeparator::default(), &key);
-        assert_eq!(
-            order.validate_signature(&DomainSeparator::default()),
-            Some(key.address())
-        );
-    }
-
-    #[test]
     fn domain_separator_does_not_panic_in_debug() {
         println!("{:?}", DomainSeparator::default());
     }
@@ -538,5 +489,30 @@ mod tests {
         let expected = "0x01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff";
         assert_eq!(uid.to_string(), expected);
         assert_eq!(format!("{}", uid), expected);
+    }
+
+    #[test]
+    fn order_signature_recovery() {
+        const PRIVATE_KEY: [u8; 32] =
+            hex!("0000000000000000000000000000000000000000000000000000000000000001");
+        let public_key = Account::Offline(PrivateKey::from_raw(PRIVATE_KEY).unwrap(), None);
+        let order = OrderBuilder::default()
+            .with_sell_token(H160::zero())
+            .with_sell_amount(100.into())
+            .with_buy_token(H160::zero())
+            .with_buy_amount(80.into())
+            .with_valid_to(u32::max_value())
+            .with_kind(OrderKind::Sell)
+            .sign_with(
+                &DomainSeparator::default(),
+                SecretKeyRef::from(&SecretKey::from_slice(&PRIVATE_KEY).unwrap()),
+            )
+            .build();
+
+        let owner = order
+            .order_creation
+            .validate_signature(&DomainSeparator::default())
+            .unwrap();
+        assert_eq!(owner, public_key.address());
     }
 }

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -492,9 +492,7 @@ mod tests {
     }
 
     pub fn h160_from_public_key(key: PublicKey) -> H160 {
-        let hash = keccak256(
-            &key.serialize_uncompressed()[1..], /* cut '04' */
-        );
+        let hash = keccak256(&key.serialize_uncompressed()[1..] /* cut '04' */);
         H160::from_slice(&hash[12..])
     }
 

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -499,7 +499,7 @@ mod tests {
     }
 
     #[test]
-    fn order_signature_recovery() {
+    fn order_builder_signature_recovery() {
         const PRIVATE_KEY: [u8; 32] =
             hex!("0000000000000000000000000000000000000000000000000000000000000001");
         let sk = SecretKey::from_slice(&PRIVATE_KEY).unwrap();

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -110,7 +110,8 @@ impl OrderBuilder {
     pub fn sign_with(mut self, domain_separator: &DomainSeparator, key: SecretKeyRef) -> Self {
         self.0.order_meta_data.owner = key.address();
         self.0.order_meta_data.uid = self.0.order_creation.uid(&key.address());
-        self.0.order_creation.signature = self.0.order_creation.sign_self_with(domain_separator, &key);
+        self.0.order_creation.signature =
+            self.0.order_creation.sign_self_with(domain_separator, &key);
         self
     }
 

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -349,12 +349,11 @@ impl Default for OrderKind {
 mod tests {
     use super::*;
     use chrono::NaiveDateTime;
-    use ethcontract::prelude::Account;
-    use ethcontract::PrivateKey;
     use hex_literal::hex;
     use primitive_types::H256;
-    use secp256k1::SecretKey;
+    use secp256k1::{PublicKey, Secp256k1, SecretKey};
     use serde_json::json;
+    use web3::signing::keccak256;
 
     #[test]
     fn deserialization_and_back() {
@@ -492,11 +491,19 @@ mod tests {
         assert_eq!(format!("{}", uid), expected);
     }
 
+    pub fn h160_from_public_key(key: PublicKey) -> H160 {
+        let hash = keccak256(
+            &key.serialize_uncompressed()[1..], /* cut '04' */
+        );
+        H160::from_slice(&hash[12..])
+    }
+
     #[test]
     fn order_signature_recovery() {
         const PRIVATE_KEY: [u8; 32] =
             hex!("0000000000000000000000000000000000000000000000000000000000000001");
-        let public_key = Account::Offline(PrivateKey::from_raw(PRIVATE_KEY).unwrap(), None);
+        let sk = SecretKey::from_slice(&PRIVATE_KEY).unwrap();
+        let public_key = PublicKey::from_secret_key(&Secp256k1::signing_only(), &sk);
         let order = OrderBuilder::default()
             .with_sell_token(H160::zero())
             .with_sell_amount(100.into())
@@ -504,16 +511,14 @@ mod tests {
             .with_buy_amount(80.into())
             .with_valid_to(u32::max_value())
             .with_kind(OrderKind::Sell)
-            .sign_with(
-                &DomainSeparator::default(),
-                SecretKeyRef::from(&SecretKey::from_slice(&PRIVATE_KEY).unwrap()),
-            )
+            .sign_with(&DomainSeparator::default(), SecretKeyRef::from(&sk))
             .build();
 
         let owner = order
             .order_creation
             .validate_signature(&DomainSeparator::default())
             .unwrap();
-        assert_eq!(owner, public_key.address());
+
+        assert_eq!(owner, h160_from_public_key(public_key));
     }
 }


### PR DESCRIPTION
Because we plan to sign `OrderCancellation`, it will be important to refactor the order signing logic in a way that generalizes the common methods into a trait (`EIP712Signing`). This PR performs the refactor for `OrderCreation`so that less work needs to be done when introducing Order Cancellation.

I am not entirely sure it is appropriate to include this new unit test since it requires an ethcontract import into models. Perhaps now that the bug has been uncovered, we should really test `OrderBuilder.sign_with`