### PR TITLE
Redo price vector estimation

### DIFF
--- a/shared/src/conversions.rs
+++ b/shared/src/conversions.rs
@@ -1,5 +1,35 @@
+use num::bigint::Sign;
+use num::BigInt;
 use num::{BigRational, ToPrimitive as _};
+use primitive_types::U256;
 
-pub fn big_rational_to_float(ratio: BigRational) -> Option<f64> {
+pub fn big_rational_to_float(ratio: &BigRational) -> Option<f64> {
     Some(ratio.numer().to_f64()? / ratio.denom().to_f64()?)
+}
+
+pub fn u256_to_big_int(input: &U256) -> BigInt {
+    let mut bytes = [0; 32];
+    input.to_big_endian(&mut bytes);
+    BigInt::from_bytes_be(Sign::Plus, &bytes)
+}
+
+pub fn u256_to_big_rational(input: &U256) -> BigRational {
+    let as_bigint = u256_to_big_int(input);
+    BigRational::new(as_bigint, 1.into())
+}
+
+// Convenience:
+
+trait U256Ext {
+    fn to_big_int(&self) -> BigInt;
+    fn to_big_rational(&self) -> BigRational;
+}
+
+impl U256Ext for U256 {
+    fn to_big_int(&self) -> BigInt {
+        u256_to_big_int(self)
+    }
+    fn to_big_rational(&self) -> BigRational {
+        u256_to_big_rational(self)
+    }
 }

--- a/shared/src/conversions.rs
+++ b/shared/src/conversions.rs
@@ -20,7 +20,7 @@ pub fn u256_to_big_rational(input: &U256) -> BigRational {
 
 // Convenience:
 
-trait U256Ext {
+pub trait U256Ext {
     fn to_big_int(&self) -> BigInt;
     fn to_big_rational(&self) -> BigRational;
 }

--- a/shared/src/uniswap_pool.rs
+++ b/shared/src/uniswap_pool.rs
@@ -328,11 +328,11 @@ mod tests {
 
         let pool = Pool::uniswap(TokenPair::new(token_a, token_b).unwrap(), (100, 125));
         assert_approx_eq!(
-            big_rational_to_float(pool.get_spot_price(token_a).unwrap().0).unwrap(),
+            big_rational_to_float(&pool.get_spot_price(token_a).unwrap().0).unwrap(),
             1.25
         );
         assert_approx_eq!(
-            big_rational_to_float(pool.get_spot_price(token_b).unwrap().0).unwrap(),
+            big_rational_to_float(&pool.get_spot_price(token_b).unwrap().0).unwrap(),
             0.8
         );
 

--- a/shared/src/uniswap_solver.rs
+++ b/shared/src/uniswap_solver.rs
@@ -275,7 +275,7 @@ mod tests {
         };
 
         assert_eq!(
-            big_rational_to_float(estimate_spot_price(&path, &pools).unwrap()),
+            big_rational_to_float(&estimate_spot_price(&path, &pools).unwrap()),
             Some(0.25)
         );
     }


### PR DESCRIPTION
* Changes estimate_price to return a BigRational.
* Moves estimate_prices to PriceEstimating.

Left estimate_price_as_f64 since it has a bit of boilerplate that needs to be repeated in several places.