### PR TITLE
[API] Define Price Estimation Endpoint

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -240,6 +240,41 @@ paths:
                 $ref: "#/components/schemas/FeeInformation"
         404:
           description: Token non-existent or not connected to native token
+  /api/v1/price/{baseToken}/{quoteToken}:
+    get:
+      description: |
+        The estimated price for selling an optionally specified amount of baseToken or buying that amount of quote token. Price is denominated in quote token.
+        E.g. the price for WETH/USDC (0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48) might be around 1800 USDC.
+      parameters:
+        - name: baseToken
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Address"
+        - name: quoteToken
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Address"
+        - name: amount
+          in: query
+          schema:
+            $ref: "#/components/schemas/TokenAmount"
+            default: "0"
+        - name: kind
+          in: query
+          schema:
+            $ref: "#/components/schemas/OrderType"
+            default: sell
+      responses:
+        200:
+          description: the price denominated in quote token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PriceEstimate"
+        404:
+          description: Token non-existent or no valid price found
 components:
   schemas:
     Address:
@@ -371,6 +406,18 @@ components:
         signature:
           description: "OrderCancellation signed by owner"
           $ref: "#/components/schemas/Signature"
+    PriceEstimate:
+      description: |
+        Provides the information about an estimated price.
+      type: object
+      properties:
+        price:
+          description: The estimated price
+          type: number
+          format: double
+        currency:
+          description: "The currency in which the price is given"
+          $ref: "#/components/schemas/Address"
     Trade:
       description: |
         Trade data such as executed amounts, fees, order id and block number.
@@ -431,11 +478,6 @@ components:
       properties:
         errorType:
           type: string
-          enum:
-            [
-                InvalidSignature,
-                WrongOwner,
-                OrderNotFound,
-            ]
+          enum: [InvalidSignature, WrongOwner, OrderNotFound]
         description:
           type: string

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -240,11 +240,10 @@ paths:
                 $ref: "#/components/schemas/FeeInformation"
         404:
           description: Token non-existent or not connected to native token
-  /api/v1/markets/{baseToken}-{quoteToken}/price:
+  /api/v1/markets/{baseToken}-{quoteToken}/{kind}/{amount}:
     get:
       description: |
-        The estimated price for selling an optionally specified amount of baseToken or buying that amount of quote token. Price is denominated in quote token.
-        E.g. the price for WETH-USDC (0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48) might be around 1800 USDC.
+        The estimated amount received for selling a specified amount of baseToken or the estimate amount require to sell for buying that amount of quote token.
       parameters:
         - name: baseToken
           in: path
@@ -257,22 +256,22 @@ paths:
           schema:
             $ref: "#/components/schemas/Address"
         - name: amount
-          in: query
+          in: path
+          required: true
           schema:
             $ref: "#/components/schemas/TokenAmount"
-            default: "0"
         - name: kind
-          in: query
+          in: path
+          required: true
           schema:
             $ref: "#/components/schemas/OrderType"
-            default: sell
       responses:
         200:
           description: the price denominated in quote token
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PriceEstimate"
+                $ref: "#/components/schemas/AmountEstimate"
         404:
           description: Token non-existent or no valid price found
 components:
@@ -406,15 +405,14 @@ components:
         signature:
           description: "OrderCancellation signed by owner"
           $ref: "#/components/schemas/Signature"
-    PriceEstimate:
+    AmountEstimate:
       description: |
         Provides the information about an estimated price.
       type: object
       properties:
-        price:
-          description: The estimated price
-          type: number
-          format: double
+        amount:
+          description: The estimated amount
+          $ref: "#/components/schemas/TokenAmount"
         currency:
           description: "The currency in which the price is given"
           $ref: "#/components/schemas/Address"

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -240,11 +240,11 @@ paths:
                 $ref: "#/components/schemas/FeeInformation"
         404:
           description: Token non-existent or not connected to native token
-  /api/v1/price/{baseToken}/{quoteToken}:
+  /api/v1/markets/{baseToken}-{quoteToken}/price:
     get:
       description: |
         The estimated price for selling an optionally specified amount of baseToken or buying that amount of quote token. Price is denominated in quote token.
-        E.g. the price for WETH/USDC (0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48) might be around 1800 USDC.
+        E.g. the price for WETH-USDC (0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48) might be around 1800 USDC.
       parameters:
         - name: baseToken
           in: path

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -243,7 +243,7 @@ paths:
   /api/v1/markets/{baseToken}-{quoteToken}/{kind}/{amount}:
     get:
       description: |
-        The estimated amount received for selling a specified amount of baseToken or the estimate amount require to sell for buying that amount of quote token.
+        The estimated amount received for selling a `amount` of baseToken or the amount required to spend for buying `amount` of quote token.
       parameters:
         - name: baseToken
           in: path
@@ -413,8 +413,8 @@ components:
         amount:
           description: The estimated amount
           $ref: "#/components/schemas/TokenAmount"
-        currency:
-          description: "The currency in which the price is given"
+        token:
+          description: "The token in which the amount is given"
           $ref: "#/components/schemas/Address"
     Trade:
       description: |


### PR DESCRIPTION
This PR suggests a new price estimation endpoint that can be consumed by clients instead of doing their own estimation (as e.g. currently in the frontend).

I'm planning to use this endpoint when setting up the testing bots that will place random orders every once in a while. A similar endpoint was also already requested by Andrey and Dima when they built their iOS prototype and Leandro was planning to use this endpoint to estimate the value of surplus and other token units in the explorer.

The implementation will follow...

### Test Plan
OpenAPI format is valid.
