### PR TITLE
Specify full docker registry url for images

### DIFF
--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -1,4 +1,4 @@
-FROM clux/muslrust:stable as cargo-build
+FROM docker.io/clux/muslrust:stable as cargo-build
 WORKDIR /usr/src/oba-services
 
 # Copy and Build Code
@@ -13,7 +13,7 @@ RUN \
     cargo build --target x86_64-unknown-linux-musl --release
 
 # Extract Binary
-FROM alpine:latest
+FROM docker.io/alpine:latest
 
 # Handle signal handlers properly
 RUN apk add --no-cache tini

--- a/docker/Dockerfile.migration
+++ b/docker/Dockerfile.migration
@@ -1,4 +1,4 @@
-FROM flyway/flyway:7.5.3
+FROM docker.io/flyway/flyway:7.5.3
 
 COPY database/sql sql/
 COPY database/flyway.conf conf/


### PR DESCRIPTION
This is good form to make it clear where the images come from (in our
case the default docker registry). I encountered this when trying to use
the docker alternative podman which forces users to be explicit about this.


### Test Plan
image still builds
