### PR TITLE
Put startup script that uses correct log regex into image

### DIFF
--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -20,6 +20,7 @@ RUN apk add --no-cache tini
 COPY --from=cargo-build /usr/src/regex-stream-split/target/x86_64-unknown-linux-musl/release/regex-stream-split /usr/local/bin/regex-stream-split
 COPY --from=cargo-build /usr/src/oba-services/target/x86_64-unknown-linux-musl/release/orderbook /usr/local/bin/orderbook
 COPY --from=cargo-build /usr/src/oba-services/target/x86_64-unknown-linux-musl/release/solver /usr/local/bin/solver
+COPY docker/startup.sh /usr/local/bin/startup.sh
 
 CMD echo "Specify binary - either solver or orderbook"
-ENTRYPOINT ["/sbin/tini", "--"]
+ENTRYPOINT ["/sbin/tini", "--", "startup.sh"]

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# The purpose of this script is to set a log regex to forward error logs to stderr and other logs to
+# stdout. This allows us to easily configure alerts when any message goes to stderr.
+"$@" | regex-stream-split "^\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z\s+(TRACE|DEBUG|INFO|WARN)" "^\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z\s+ERROR"


### PR DESCRIPTION
Since we have the binary itself in the container it makes to also have
the regex so that we can update it directly if we ever change the log
message format.

### Test Plan
Ran the image manually to make sure it still works