### PR TITLE
Makes all AMM pools mandatory for now.

### DIFF
--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -151,7 +151,7 @@ impl HttpSolver {
                         amount: 0,
                         token: self.token_to_string(&self.native_token),
                     },
-                    mandatory: false,
+                    mandatory: true,
                 };
                 (index.clone(), uniswap)
             })


### PR DESCRIPTION
The current version of the http solver requires all pools to be mandatory for correct price finding.

Closes #399.