### PR TITLE
Suppress no valid path found alert

### DIFF
--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -66,13 +66,9 @@ fn error(error_type: &str, description: impl AsRef<str>) -> Json {
 }
 
 fn internal_error() -> Json {
-    internal_error_with_description("")
-}
-
-fn internal_error_with_description(description: &str) -> Json {
     json(&Error {
         error_type: "InternalServerError",
-        description,
+        description: "",
     })
 }
 

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -66,9 +66,13 @@ fn error(error_type: &str, description: impl AsRef<str>) -> Json {
 }
 
 fn internal_error() -> Json {
+    internal_error_with_description("")
+}
+
+fn internal_error_with_description(description: &str) -> Json {
     json(&Error {
         error_type: "InternalServerError",
-        description: "",
+        description,
     })
 }
 

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -44,13 +44,13 @@ pub fn get_fee_info_response(result: Result<Option<(U256, DateTime<Utc>)>>) -> i
             Ok(reply::with_status(reply::json(&fee_info), StatusCode::OK))
         }
         Ok(None) => Ok(reply::with_status(
-            super::error("NotFound", "Token was not found"),
+            super::error("NotFound", "Fee path for given Token pair was not found"),
             StatusCode::NOT_FOUND,
         )),
         Err(err) => {
             tracing::warn!(?err, "get_fee error");
             Ok(reply::with_status(
-                super::internal_error_with_description(&err.to_string()),
+                super::internal_error(),
                 StatusCode::INTERNAL_SERVER_ERROR,
             ))
         }
@@ -111,7 +111,7 @@ pub fn legacy_get_fee_info_response(result: Result<Option<(U256, DateTime<Utc>)>
         Err(err) => {
             tracing::warn!(?err, "get_fee error");
             Ok(reply::with_status(
-                super::internal_error_with_description(&err.to_string()),
+                super::internal_error(),
                 StatusCode::INTERNAL_SERVER_ERROR,
             ))
         }

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -48,9 +48,9 @@ pub fn get_fee_info_response(result: Result<Option<(U256, DateTime<Utc>)>>) -> i
             StatusCode::NOT_FOUND,
         )),
         Err(err) => {
-            tracing::error!(?err, "get_fee error");
+            tracing::warn!(?err, "get_fee error");
             Ok(reply::with_status(
-                super::internal_error(),
+                super::internal_error_with_description(&err.to_string()),
                 StatusCode::INTERNAL_SERVER_ERROR,
             ))
         }
@@ -109,9 +109,9 @@ pub fn legacy_get_fee_info_response(result: Result<Option<(U256, DateTime<Utc>)>
             StatusCode::NOT_FOUND,
         )),
         Err(err) => {
-            tracing::error!(?err, "get_fee error");
+            tracing::warn!(?err, "get_fee error");
             Ok(reply::with_status(
-                super::internal_error(),
+                super::internal_error_with_description(&err.to_string()),
                 StatusCode::INTERNAL_SERVER_ERROR,
             ))
         }

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -48,7 +48,7 @@ pub fn get_fee_info_response(result: Result<Option<(U256, DateTime<Utc>)>>) -> i
             StatusCode::NOT_FOUND,
         )),
         Err(err) => {
-            tracing::warn!(?err, "get_fee error");
+            tracing::error!(?err, "get_fee error");
             Ok(reply::with_status(
                 super::internal_error(),
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -109,7 +109,7 @@ pub fn legacy_get_fee_info_response(result: Result<Option<(U256, DateTime<Utc>)>
             StatusCode::NOT_FOUND,
         )),
         Err(err) => {
-            tracing::warn!(?err, "get_fee error");
+            tracing::error!(?err, "get_fee error");
             Ok(reply::with_status(
                 super::internal_error(),
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/shared/src/price_estimate.rs
+++ b/shared/src/price_estimate.rs
@@ -242,13 +242,17 @@ impl UniswapPriceEstimator {
             .iter()
             .max_by_key(|path| comparison(amount, path, &pools))
             .ok_or(anyhow!(format!(
-                "No Uniswap path found between {:x} and {:x}",
+                "No Uniswap path found between {:#x} and {:#x}",
                 sell_token, buy_token
             )))?;
         Ok((
             best_path.clone(),
-            resulting_amount(amount, best_path, &pools)
-                .ok_or_else(|| anyhow!("no valid path found"))?,
+            resulting_amount(amount, best_path, &pools).ok_or_else(|| {
+                anyhow!(format!(
+                    "No valid path found between {:#x} and {:#x}",
+                    sell_token, buy_token
+                ))
+            })?,
         ))
     }
 }


### PR DESCRIPTION
This PR suppresses the 'No valid path found alert', which we have seen from time to time last week in our alert channel. This happens if someone tries to trade tokens for which no baseline route to the fee native token exists.

We are already catching the case when no baseline between the two tokens exist (and map the Err into a None). However, e.g. when using very illiquid or non existent tokens there is also no path to the native token, we propagate up an error leading to a 500 response.

This PR makes it so that we also catch this case and turn the Err into a None, leading to a 404 resut.

### Test Plan
Local instance against xDAI:

http://localhost:8080/api/v1/fee?sellToken=0x1a5f9352af8af974bfc03399e3767df6370d82e4&buyToken=0x6810e776880c02933d47db1b9fc05908e5386b96&amount=100000000000000000000&kind=buy

> {"errorType":"NotFound","description":"Fee path for given Token pair was not found"}