### PR TITLE
Fix panic in naive solver

### DIFF
--- a/solver/src/naive_solver.rs
+++ b/solver/src/naive_solver.rs
@@ -64,7 +64,7 @@ async fn settle_pair(
             return None;
         }
     };
-    Some(multi_order_solver::solve(orders.into_iter(), &uniswap))
+    multi_order_solver::solve(orders.into_iter(), &uniswap)
 }
 
 fn organize_orders_by_token_pair(


### PR DESCRIPTION
We saw in the alerts that compute_uniswap_in paniced. Looking at the function we see that it can overflow. 
This fix does the multiplication in BigInt and propagates potential errors through an Option.
There might be a smarter fix by removing the offending order and continuing but I wasn't sure how to best implement that. In the meantime this should fix the panic at least.

### Test Plan
New test that used to panic but now doesn't
