### PR TITLE
[API] Align cancellation request handler with spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Several pieces of functionality are shared between the order book and the solver
 
 - `contract` provides ethcontract based smart contract bindings
 - `model` provides the serialization model for orders in the order book api
-- `shared` provides other shared functionality between solver and order book
+- `shared` provides other shared functionality between the solver and order book
 
 ## Testing
 
@@ -73,7 +73,7 @@ At this point the database should be running and reachable. You can test connect
 psql postgresql://localhost/
 ```
 
-Finally we need to apply schema (set up in the `database` folder).
+Finally, we need to apply the schema (set up in the `database` folder).
 
 * Docker
 ```sh

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -360,7 +360,7 @@ components:
         partiallyFillable:
           description: Is this a fill-or-kill order or a partially fillable order?
           type: boolean
-        Signature:
+        signature:
           $ref: "#/components/schemas/Signature"
     OrderMetaData:
       description: |

--- a/orderbook/src/api/cancel_order.rs
+++ b/orderbook/src/api/cancel_order.rs
@@ -2,14 +2,14 @@ use crate::api::extract_payload;
 use crate::orderbook::{OrderCancellationResult, Orderbook};
 use anyhow::Result;
 use model::order::{OrderCancellation, OrderUid};
-use std::{convert::Infallible, sync::Arc};
-use warp::{hyper::StatusCode, Filter, Rejection, Reply};
 use model::Signature;
 use serde::{Deserialize, Serialize};
+use std::{convert::Infallible, sync::Arc};
+use warp::{hyper::StatusCode, Filter, Rejection, Reply};
 
 #[derive(Deserialize, Serialize)]
 struct CancellationPayload {
-    signature: Signature
+    signature: Signature,
 }
 
 pub fn cancel_order_request(
@@ -17,11 +17,9 @@ pub fn cancel_order_request(
     warp::path!("orders" / OrderUid)
         .and(warp::delete())
         .and(extract_payload())
-        .map(|uid, payload: CancellationPayload| {
-            OrderCancellation {
-                order_uid: uid,
-                signature: payload.signature,
-            }
+        .map(|uid, payload: CancellationPayload| OrderCancellation {
+            order_uid: uid,
+            signature: payload.signature,
         })
 }
 
@@ -78,8 +76,8 @@ mod tests {
             .method("DELETE")
             .header("content-type", "application/json")
             .json(&CancellationPayload {
-                signature: cancellation.signature
-            } );
+                signature: cancellation.signature,
+            });
         let result = request.filter(&filter).await.unwrap();
         assert_eq!(result, cancellation);
     }

--- a/orderbook/src/api/cancel_order.rs
+++ b/orderbook/src/api/cancel_order.rs
@@ -1,15 +1,28 @@
 use crate::api::extract_payload;
 use crate::orderbook::{OrderCancellationResult, Orderbook};
 use anyhow::Result;
-use model::order::OrderCancellation;
+use model::order::{OrderCancellation, OrderUid};
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, Filter, Rejection, Reply};
+use model::Signature;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+struct CancellationPayload {
+    signature: Signature
+}
 
 pub fn cancel_order_request(
 ) -> impl Filter<Extract = (OrderCancellation,), Error = Rejection> + Clone {
-    warp::path!("orders")
+    warp::path!("orders" / OrderUid)
         .and(warp::delete())
         .and(extract_payload())
+        .map(|uid, payload: CancellationPayload| {
+            OrderCancellation {
+                order_uid: uid,
+                signature: payload.signature,
+            }
+        })
 }
 
 pub fn cancel_order_response(result: Result<OrderCancellationResult>) -> impl Reply {
@@ -59,11 +72,14 @@ mod tests {
     async fn cancel_order_request_ok() {
         let filter = cancel_order_request();
         let cancellation = OrderCancellation::default();
+
         let request = request()
-            .path("/orders")
+            .path(&format!("/orders/{:}", cancellation.order_uid))
             .method("DELETE")
             .header("content-type", "application/json")
-            .json(&cancellation);
+            .json(&CancellationPayload {
+                signature: cancellation.signature
+            } );
         let result = request.filter(&filter).await.unwrap();
         assert_eq!(result, cancellation);
     }


### PR DESCRIPTION
Existing implementation of cancellation is not aligned with API spec so this fixes it. We create a new local struct `CancellationPayload` and update the request handler to take the `orderId` from the URL and `signature` from the request body in order to construct a complete `OrderCancellation` struct.

### Test Plan






#### Quick & Easy Check
Run the services locally with 

```sh
 cargo run --bin orderbook -- --node-url https://rpc.xdaichain.com/ --skip-event-sync
```

In a separate terminal run:

```sh
curl -X DELETE "http://localhost:8080/api/v1/orders/0x1b871b2f4bd6cdb892f471b3b67c760748c275e309612cf9aebb038462ea6830262d23a2d916f6cf08e0235315aa51e22d142d0b60520190" -H  "accept: */*" -H  "Content-Type: application/json" -d "{\"signature\":\"0xde218eee20234eab72f9f51a697a291b647cfc1580565902580411e490dd8a4b635791310ea561e2d2ea0580ac05b9e2c4b84e1f0cc58e1dbac067b13aa893f21b\"}"
```

and expect to see

```
{"errorType":"OrderNotFound","description":"order not located in database"}% 
```

Since you won't have this order in your local database.


#### Proper E2E test for cancellation


1. Run the orderbook service locally with 
```sh
cargo run --bin orderbook -- --node-url https://rpc.xdaichain.com/ --skip-event-sync 
```

2. Run the trading [interface](https://github.com/gnosis/gp-swap-ui) locally with API pointed at 'http://0.0.0.0:8080/api/v1' (note you will have to manually edit the URLS [here](https://github.com/gnosis/gp-swap-ui/blob/a62ded4838775c8c53f934cd3d957e3704fe85ad/src/custom/utils/operator.ts#L10-L14))

```sh
yarn && yarn start
```

2. Place an order via the local interface (http://localhost:3000/#/swap) and copy the UID


3. From within the [contracts repo](https://github.com/gnosis/gp-v2-contracts) Export your PK and order UID into your local env
     export PK=...
    export UID=...
4. Run `yarn build:ts` to ensure all TS is uptodate.

5. Enter a node shell and run the cancelOrder method provided below as
```sh
cancelOrder(URL, UID, wallet)
```

6. You should get back "Cancelled" from this request, but you can also check the invalidated field in your local DB with

```sh
curl -X GET "http://localhost:8080/api/v1/orders?includeInvalidated=true" -H  "accept: application/json"
```


<details>
  <summary>cancelOrder.js</summary>
  
```js
const ethers = require("ethers");
const fetch = require("node-fetch");

const { domain } = require("./lib/commonjs");
const { signOrderCancellation, signOrder } = require("./lib/commonjs/sign");


const wallet = new ethers.Wallet(process.env.PK);
const UID = provess.env.UID
const URL = "http://localhost:8080"

async function cancelOrder(URL, UID, wallet) {
  const xdaiDomain = domain(100, "0x4E608b7Da83f8E9213F554BDAA77C72e125529d0");
  const headers = { "Content-Type": "application/json" };

  async function sig(UID) {
    const { data } = await signOrderCancellation(xdaiDomain, UID, wallet, 0);
    return data;
  }

  let response = sig(UID)
    .then((data) =>
      fetch(`${URL}/api/v1/orders/${UID}`, {
        method: "DELETE",
        body: `{"signature": "${data}"}`,
        headers,
      }),
    )
    .then((r) => r.text())
    .then(console.log);

  return response;
}
```
</details>