### PR TITLE
[Trivial] Sync OrderPostError OpenAPI type and AddOrderResult

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -466,10 +466,12 @@ components:
           type: string
           enum:
             [
-              MissingOrderData,
-              InvalidSignature,
               DuplicateOrder,
+              InvalidSignature,
+              MissingOrderData,
+              PastValidTo,
               InsufficientFunds,
+              InsufficientFee,
             ]
         description:
           type: string


### PR DESCRIPTION
The OpenaAPI spec and [AddOrderResult type](https://github.com/gnosis/oba-services/blob/2a7800d74f513f279fc188dc9f17fa14ec432db3/orderbook/src/orderbook.rs#L26) have gone out of sync. This PR updates them.

Note, Forbidden is handled via as separate response code (403)

### Test Plan
CI
