### PR TITLE
Sends external price vector to the solver.

### DIFF
--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -250,29 +250,10 @@ impl MinFeeStoring for InMemoryFeeStore {
 #[cfg(test)]
 mod tests {
     use chrono::Duration;
-    use model::order::OrderKind;
-    use num::BigRational;
+    use shared::price_estimate::FakePriceEstimator;
     use std::sync::Arc;
 
     use super::*;
-
-    struct FakePriceEstimator(BigRational);
-    #[async_trait::async_trait]
-    impl PriceEstimating for FakePriceEstimator {
-        async fn estimate_price(
-            &self,
-            _: H160,
-            _: H160,
-            _: U256,
-            _: OrderKind,
-        ) -> Result<BigRational> {
-            Ok(self.0.clone())
-        }
-
-        async fn estimate_gas(&self, _: H160, _: H160, _: U256, _: OrderKind) -> Result<U256> {
-            Ok(100_000.into())
-        }
-    }
 
     struct FakeGasEstimator(Arc<Mutex<f64>>);
     #[async_trait::async_trait]

--- a/shared/src/price_estimate.rs
+++ b/shared/src/price_estimate.rs
@@ -7,7 +7,7 @@ use crate::uniswap_solver::{
 use anyhow::{anyhow, Result};
 use ethcontract::{H160, U256};
 use futures::future::join_all;
-use mockall::*;
+use mockall::automock;
 use model::{order::OrderKind, TokenPair};
 use num::{BigRational, ToPrimitive};
 use std::{

--- a/shared/src/price_estimate.rs
+++ b/shared/src/price_estimate.rs
@@ -7,7 +7,6 @@ use crate::uniswap_solver::{
 use anyhow::{anyhow, Result};
 use ethcontract::{H160, U256};
 use futures::future::join_all;
-use mockall::automock;
 use model::{order::OrderKind, TokenPair};
 use num::{BigRational, ToPrimitive};
 use std::{
@@ -17,7 +16,6 @@ use std::{
 
 const MAX_HOPS: usize = 2;
 
-#[automock]
 #[async_trait::async_trait]
 pub trait PriceEstimating: Send + Sync {
     // Price is given in how much of sell_token needs to be sold for one buy_token.
@@ -257,6 +255,18 @@ impl UniswapPriceEstimator {
                 ))
             })?,
         ))
+    }
+}
+
+pub struct FakePriceEstimator(pub BigRational);
+#[async_trait::async_trait]
+impl PriceEstimating for FakePriceEstimator {
+    async fn estimate_price(&self, _: H160, _: H160, _: U256, _: OrderKind) -> Result<BigRational> {
+        Ok(self.0.clone())
+    }
+
+    async fn estimate_gas(&self, _: H160, _: H160, _: U256, _: OrderKind) -> Result<U256> {
+        Ok(100_000.into())
     }
 }
 

--- a/shared/src/price_estimate.rs
+++ b/shared/src/price_estimate.rs
@@ -7,14 +7,17 @@ use crate::uniswap_solver::{
 use anyhow::{anyhow, Result};
 use ethcontract::{H160, U256};
 use futures::future::join_all;
+use mockall::*;
 use model::{order::OrderKind, TokenPair};
 use num::{BigRational, ToPrimitive};
 use std::{
     cmp::Reverse,
     collections::{HashMap, HashSet},
 };
+
 const MAX_HOPS: usize = 2;
 
+#[automock]
 #[async_trait::async_trait]
 pub trait PriceEstimating: Send + Sync {
     // Price is given in how much of sell_token needs to be sold for one buy_token.

--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -355,7 +355,7 @@ mod tests {
     use ::model::TokenPair;
     use maplit::hashmap;
     use num::rational::Ratio;
-    use shared::price_estimate::MockPriceEstimating;
+    use shared::price_estimate::FakePriceEstimator;
     use shared::token_info::MockTokenInfoFetching;
     use shared::token_info::TokenInfo;
     use std::sync::Arc;
@@ -382,12 +382,8 @@ mod tests {
             });
         let mock_token_info_fetcher: Arc<dyn TokenInfoFetching> = Arc::new(mock_token_info_fetcher);
 
-        let mut mock_price_estimation = MockPriceEstimating::new();
-        mock_price_estimation
-            .expect_estimate_prices()
-            .return_once(move |_, _| vec![Ok(num::one()), Ok(num::one())]);
-        let mock_price_estimation: Arc<dyn PriceEstimating> = Arc::new(mock_price_estimation);
-
+        let mock_price_estimation: Arc<dyn PriceEstimating> =
+            Arc::new(FakePriceEstimator(num::one()));
         let solver = HttpSolver::new(
             url.parse().unwrap(),
             None,

--- a/solver/src/http_solver/model.rs
+++ b/solver/src/http_solver/model.rs
@@ -41,6 +41,7 @@ pub struct UniswapModel {
 #[derive(Debug, Serialize)]
 pub struct TokenInfoModel {
     pub decimals: Option<u32>,
+    pub external_price: Option<f64>,
 }
 
 #[derive(Debug, Serialize)]

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -125,6 +125,7 @@ async fn main() {
         native_token_contract.address(),
         args.mip_solver_url,
         token_info_fetcher,
+        price_estimator.clone(),
     );
     let gas_price_estimator = shared::gas_price_estimation::create_priority_estimator(
         &reqwest::Client::new(),

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -10,7 +10,7 @@ use crate::{
 use anyhow::Result;
 use ethcontract::H160;
 use reqwest::Url;
-use shared::token_info::TokenInfoFetching;
+use shared::{price_estimate::PriceEstimating, token_info::TokenInfoFetching};
 use structopt::clap::arg_enum;
 
 #[async_trait::async_trait]
@@ -33,6 +33,7 @@ pub fn create(
     native_token: H160,
     mip_solver_url: Url,
     token_info_fetcher: Arc<dyn TokenInfoFetching>,
+    price_estimator: Arc<dyn PriceEstimating>,
 ) -> Vec<Box<dyn Solver>> {
     solvers
         .into_iter()
@@ -48,6 +49,7 @@ pub fn create(
                 },
                 native_token,
                 &token_info_fetcher,
+                &price_estimator,
             )),
         })
         .collect()


### PR DESCRIPTION
Could we send the price vector to the solver?

It can be used for:
* Better aligning the driver and solver objective.
* Computing fixed costs in a token that is not traded.
