### PR TITLE
[NaiveSolver] Using BigRational in in/out comp. to avoid rounding issues

### DIFF
--- a/shared/src/conversions.rs
+++ b/shared/src/conversions.rs
@@ -1,10 +1,18 @@
-use num::bigint::Sign;
+use anyhow::{anyhow, Result};
 use num::BigInt;
+use num::{bigint::Sign, Zero};
 use num::{BigRational, ToPrimitive as _};
 use primitive_types::U256;
 
 pub fn big_rational_to_float(ratio: &BigRational) -> Option<f64> {
     Some(ratio.numer().to_f64()? / ratio.denom().to_f64()?)
+}
+
+pub fn big_rational_to_u256(ratio: &BigRational) -> Result<U256> {
+    if ratio.denom() == &BigInt::zero() {
+        return Err(anyhow!(" Division by 0 in BigRational to U256 conversion"));
+    }
+    big_int_to_u256(&(ratio.numer() / ratio.denom()))
 }
 
 pub fn u256_to_big_int(input: &U256) -> BigInt {
@@ -16,6 +24,17 @@ pub fn u256_to_big_int(input: &U256) -> BigInt {
 pub fn u256_to_big_rational(input: &U256) -> BigRational {
     let as_bigint = u256_to_big_int(input);
     BigRational::new(as_bigint, 1.into())
+}
+
+pub fn big_int_to_u256(input: &BigInt) -> Result<U256> {
+    let (sign, bytes) = input.to_bytes_be();
+    if sign == Sign::Minus {
+        return Err(anyhow!("Negative BigInt to U256 conversion"));
+    }
+    if bytes.len() > 32 {
+        return Err(anyhow!("BigInt too big for U256 conversion"));
+    }
+    Ok(U256::from_big_endian(&bytes))
 }
 
 // Convenience:

--- a/shared/src/conversions.rs
+++ b/shared/src/conversions.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, ensure, Result};
 use num::BigInt;
 use num::{bigint::Sign, Zero};
 use num::{BigRational, ToPrimitive as _};
@@ -9,9 +9,10 @@ pub fn big_rational_to_float(ratio: &BigRational) -> Option<f64> {
 }
 
 pub fn big_rational_to_u256(ratio: &BigRational) -> Result<U256> {
-    if ratio.denom() == &BigInt::zero() {
-        return Err(anyhow!(" Division by 0 in BigRational to U256 conversion"));
-    }
+    ensure!(
+        !ratio.denom().is_zero(),
+        "Division by 0 in BigRational to U256 conversion"
+    );
     big_int_to_u256(&(ratio.numer() / ratio.denom()))
 }
 
@@ -28,12 +29,8 @@ pub fn u256_to_big_rational(input: &U256) -> BigRational {
 
 pub fn big_int_to_u256(input: &BigInt) -> Result<U256> {
     let (sign, bytes) = input.to_bytes_be();
-    if sign == Sign::Minus {
-        return Err(anyhow!("Negative BigInt to U256 conversion"));
-    }
-    if bytes.len() > 32 {
-        return Err(anyhow!("BigInt too big for U256 conversion"));
-    }
+    ensure!(sign == Sign::Plus, "Negative BigInt to U256 conversion");
+    ensure!(bytes.len() <= 32, "BigInt too big for U256 conversion");
     Ok(U256::from_big_endian(&bytes))
 }
 

--- a/shared/src/conversions.rs
+++ b/shared/src/conversions.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{ensure, Result};
 use num::BigInt;
 use num::{bigint::Sign, Zero};
 use num::{BigRational, ToPrimitive as _};

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -229,8 +229,8 @@ fn compute_uniswap_out(shortage: &TokenContext, excess: &TokenContext) -> BigRat
     let numerator_subtrahend = 1000
         * (u256_to_big_int(&shortage.sell_volume) - u256_to_big_int(&shortage.buy_volume))
         * u256_to_big_int(&excess.reserve);
-    let denominator = (1000 * u256_to_big_int(&excess.reserve))
-        + (997 * (u256_to_big_int(&excess.sell_volume) - u256_to_big_int(&excess.buy_volume)));
+    let denominator = 1000 * u256_to_big_int(&excess.reserve)
+        + 997 * (u256_to_big_int(&excess.sell_volume) - u256_to_big_int(&excess.buy_volume));
     BigRational::new(numerator_minuend - numerator_subtrahend, denominator)
 }
 

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use liquidity::{AmmOrder, LimitOrder};
 use model::order::OrderKind;
-use num::BigRational;
+use num::{BigInt, BigRational, Zero};
 use primitive_types::U256;
 use shared::conversions::{big_rational_to_u256, u256_to_big_int, U256Ext};
 use std::collections::HashMap;
@@ -229,8 +229,12 @@ fn compute_uniswap_out(shortage: &TokenContext, excess: &TokenContext) -> BigRat
     let numerator_subtrahend = 1000
         * (u256_to_big_int(&shortage.sell_volume) - u256_to_big_int(&shortage.buy_volume))
         * u256_to_big_int(&excess.reserve);
-    let denominator = 1000 * u256_to_big_int(&excess.reserve)
+    let denominator: BigInt = 1000 * u256_to_big_int(&excess.reserve)
         + 997 * (u256_to_big_int(&excess.sell_volume) - u256_to_big_int(&excess.buy_volume));
+    assert!(
+        !denominator.is_zero(),
+        "reserve values cannot be zero (it's impossible to fully drain a pool)"
+    );
     BigRational::new(numerator_minuend - numerator_subtrahend, denominator)
 }
 

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -2,15 +2,15 @@ use crate::{
     liquidity,
     settlement::{Interaction, Settlement, Trade},
 };
-use anyhow::{anyhow, Result};
 use liquidity::{AmmOrder, LimitOrder};
 use model::order::OrderKind;
-use num::{bigint::Sign, BigInt};
+use num::BigRational;
 use primitive_types::U256;
+use shared::conversions::{big_rational_to_u256, u256_to_big_int};
 use std::collections::HashMap;
 use web3::types::Address;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct TokenContext {
     address: Address,
     reserve: U256,
@@ -21,18 +21,18 @@ struct TokenContext {
 // TODO use concrete fee from AMMOrder
 impl TokenContext {
     pub fn is_excess_after_fees(&self, deficit: &TokenContext) -> bool {
-        1000 * u256_to_bigint(&self.reserve)
-            * (u256_to_bigint(&deficit.sell_volume) - u256_to_bigint(&deficit.buy_volume))
+        1000 * u256_to_big_int(&self.reserve)
+            * (u256_to_big_int(&deficit.sell_volume) - u256_to_big_int(&deficit.buy_volume))
             < 997
-                * u256_to_bigint(&deficit.reserve)
-                * (u256_to_bigint(&self.sell_volume) - u256_to_bigint(&self.buy_volume))
+                * u256_to_big_int(&deficit.reserve)
+                * (u256_to_big_int(&self.sell_volume) - u256_to_big_int(&self.buy_volume))
     }
 
     pub fn is_excess_before_fees(&self, deficit: &TokenContext) -> bool {
-        u256_to_bigint(&self.reserve)
-            * (u256_to_bigint(&deficit.sell_volume) - u256_to_bigint(&deficit.buy_volume))
-            < u256_to_bigint(&deficit.reserve)
-                * (u256_to_bigint(&self.sell_volume) - u256_to_bigint(&self.buy_volume))
+        u256_to_big_int(&self.reserve)
+            * (u256_to_big_int(&deficit.sell_volume) - u256_to_big_int(&deficit.buy_volume))
+            < u256_to_big_int(&deficit.reserve)
+                * (u256_to_big_int(&self.sell_volume) - u256_to_big_int(&self.buy_volume))
     }
 }
 
@@ -43,9 +43,11 @@ pub fn solve(
     let mut orders: Vec<LimitOrder> = orders.collect();
     while !orders.is_empty() {
         let (context_a, context_b) = split_into_contexts(orders.clone().into_iter(), pool);
-        let solution = solve_orders(orders.clone().into_iter(), &pool, &context_a, &context_b)?;
-        if is_valid_solution(&solution) {
-            return Some(solution);
+        if let Some(valid_solution) =
+            solve_orders(orders.clone().into_iter(), &pool, &context_a, &context_b)
+                .filter(is_valid_solution)
+        {
+            return Some(valid_solution);
         } else {
             // remove order with worst limit price that is selling excess token (to make it less excessive) and try again
             let excess_token = if context_a.is_excess_before_fees(&context_b) {
@@ -122,7 +124,10 @@ fn solve_with_uniswap(
     excess: &TokenContext,
 ) -> Option<Settlement> {
     let uniswap_out = compute_uniswap_out(&shortage, &excess);
-    let uniswap_in = compute_uniswap_in(uniswap_out, &shortage, &excess)?;
+    let uniswap_in = compute_uniswap_in(uniswap_out.clone(), &shortage, &excess);
+
+    let uniswap_out = big_rational_to_u256(&uniswap_out).ok()?;
+    let uniswap_in = big_rational_to_u256(&uniswap_in).ok()?;
 
     let (trades, mut interactions) = fully_matched(orders);
     interactions.extend(pool.settlement_handling.settle(
@@ -217,30 +222,32 @@ fn split_into_contexts(
 /// The derivation of this formula is described in https://docs.google.com/document/d/1jS22wxbCqo88fGsqEMZgRQgiAcHlPqxoMw3CJTHst6c/edit
 /// It assumes GP fee (φ) to be 1 and Uniswap fee (Φ) to be 0.997
 ///
-fn compute_uniswap_out(shortage: &TokenContext, excess: &TokenContext) -> U256 {
+fn compute_uniswap_out(shortage: &TokenContext, excess: &TokenContext) -> BigRational {
     let numerator_minuend = 997
-        * (u256_to_bigint(&excess.sell_volume) - u256_to_bigint(&excess.buy_volume))
-        * u256_to_bigint(&shortage.reserve);
+        * (u256_to_big_int(&excess.sell_volume) - u256_to_big_int(&excess.buy_volume))
+        * u256_to_big_int(&shortage.reserve);
     let numerator_subtrahend = 1000
-        * (u256_to_bigint(&shortage.sell_volume) - u256_to_bigint(&shortage.buy_volume))
-        * u256_to_bigint(&excess.reserve);
-    let denominator = (1000 * u256_to_bigint(&excess.reserve))
-        + (997 * (u256_to_bigint(&excess.sell_volume) - u256_to_bigint(&excess.buy_volume)));
-    bigint_to_u256(&((numerator_minuend - numerator_subtrahend) / denominator))
-        .expect("uniswap_out should always be U256 compatible if excess is chosen correctly")
+        * (u256_to_big_int(&shortage.sell_volume) - u256_to_big_int(&shortage.buy_volume))
+        * u256_to_big_int(&excess.reserve);
+    let denominator = (1000 * u256_to_big_int(&excess.reserve))
+        + (997 * (u256_to_big_int(&excess.sell_volume) - u256_to_big_int(&excess.buy_volume)));
+    BigRational::new(numerator_minuend - numerator_subtrahend, denominator)
 }
 
 ///
 /// Given the desired amount to receive and the state of the pool, this computes the required amount
 /// of tokens to be sent to the pool.
 /// Taken from: https://github.com/Uniswap/uniswap-v2-periphery/blob/4123f93278b60bcf617130629c69d4016f9e7584/contracts/libraries/UniswapV2Library.sol#L53
+/// Not adding + 1 in the end, because we are working with rationals and thus don't round up.
 ///
-fn compute_uniswap_in(out: U256, shortage: &TokenContext, excess: &TokenContext) -> Option<U256> {
-    U256::from(1000)
-        .checked_mul(out)?
-        .checked_mul(excess.reserve)?
-        .checked_div(U256::from(997).checked_mul(shortage.reserve.checked_sub(out)?)?)?
-        .checked_add(U256::from(1))
+fn compute_uniswap_in(
+    out: BigRational,
+    shortage: &TokenContext,
+    excess: &TokenContext,
+) -> BigRational {
+    BigRational::from_integer(1000.into()) * out.clone() * u256_to_big_int(&excess.reserve)
+        / (BigRational::from_integer(997.into())
+            * (BigRational::from(u256_to_big_int(&shortage.reserve)) - out))
 }
 
 ///
@@ -265,23 +272,6 @@ fn is_valid_solution(solution: &Settlement) -> bool {
     }
 
     true
-}
-
-fn u256_to_bigint(input: &U256) -> BigInt {
-    let mut bytes = [0; 32];
-    input.to_big_endian(&mut bytes);
-    BigInt::from_bytes_be(Sign::Plus, &bytes)
-}
-
-fn bigint_to_u256(input: &BigInt) -> Result<U256> {
-    let (sign, bytes) = input.to_bytes_be();
-    if sign == Sign::Minus {
-        return Err(anyhow!("Negative BigInt to U256 conversion"));
-    }
-    if bytes.len() > 32 {
-        return Err(anyhow!("BigInt too big for U256 conversion"));
-    }
-    Ok(U256::from_big_endian(&bytes))
 }
 
 #[cfg(test)]
@@ -809,5 +799,47 @@ mod tests {
         };
         // This line should not panic.
         solve(orders.into_iter(), &pool);
+    }
+
+    #[test]
+    fn reserves_are_too_small() {
+        let token_a = Address::from_low_u64_be(0);
+        let token_b = Address::from_low_u64_be(1);
+        let orders = vec![
+            OrderCreation {
+                sell_token: token_a,
+                buy_token: token_b,
+                sell_amount: 70145218378783248142575u128.into(),
+                buy_amount: 70123226323u128.into(),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            }
+            .into(),
+            OrderCreation {
+                sell_token: token_a,
+                buy_token: token_b,
+                sell_amount: 900_000_000_000_000u128.into(),
+                buy_amount: 100.into(),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            }
+            .into(),
+        ];
+        // Reserves are much smaller than buy amount
+        let pool = AmmOrder {
+            tokens: TokenPair::new(token_a, token_b).unwrap(),
+            reserves: (25000075, 2500007500),
+            fee: Ratio::new(3, 1000),
+            settlement_handling: CapturingAmmSettlementHandler::arc(),
+        };
+
+        // The first order by itself should not be matchable.
+        assert!(solve(orders[0..1].to_vec().into_iter(), &pool).is_none());
+
+        // Only the second order should match
+        let result = solve(orders.into_iter(), &pool).unwrap();
+        assert_eq!(result.trades.len(), 1);
     }
 }

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -6,7 +6,7 @@ use liquidity::{AmmOrder, LimitOrder};
 use model::order::OrderKind;
 use num::BigRational;
 use primitive_types::U256;
-use shared::conversions::{big_rational_to_u256, u256_to_big_int};
+use shared::conversions::{big_rational_to_u256, u256_to_big_int, U256Ext};
 use std::collections::HashMap;
 use web3::types::Address;
 
@@ -246,8 +246,7 @@ fn compute_uniswap_in(
     excess: &TokenContext,
 ) -> BigRational {
     BigRational::from_integer(1000.into()) * out.clone() * u256_to_big_int(&excess.reserve)
-        / (BigRational::from_integer(997.into())
-            * (BigRational::from(u256_to_big_int(&shortage.reserve)) - out))
+        / (BigRational::from_integer(997.into()) * (shortage.reserve.to_big_rational() - out))
 }
 
 ///


### PR DESCRIPTION
Hopefully 🤞 Fixes #421 

For more history on the algorithm, cf. https://docs.google.com/document/d/1jS22wxbCqo88fGsqEMZgRQgiAcHlPqxoMw3CJTHst6c/edit

See added test case for the problematic instance. Let me try to explain what happens:

In the instance we are trading a very large amount over a very small (in terms of reserve values) AMM:
- In order to balance excess supply and shortage demand we have to provide **all** our excess tokens into the AMM. 
- This results in moving the uniswap price to almost 0/Inf (depending from which side you look) and a `uniswap_out` value of `|reserve| - epsilon`, with **epsilon << 1** (note that an exact `|reserve|` amount can only be reached if we provide an infinite amount of excess token). 
- Due to the division inside `compute_uniswap_out` the whole integer `uniswap_out` value is `|reserve| - 1`. This value is in turn used to compute the exact `uniswap_in` amount based on the Uniswap formula.
-  Because the tiny epsilon was rounded to 1 and the crazy prices, this results in an `in_amount`  << `excess.sell_volume` (although those values should be roughly equal).
- This then down the line leads to a "valid solution" which respects the limit price but ultimately would fail in the token conservation (a property that we currently don't validate in the driver).

I tried different approaches such as validating token conservation in `is_valid_solution`, incrementing the computed `uniswap_out` amount to deal with the rounding error, trying to spot when our `uniswap_in` computation is less than expected, but always ran into issues with other test cases (requiring some form of buffer and knowledge of that buffer in the test cases).

Since the problem stems from the fact that `|reserve| - epsilon` becomes `|reserve| - 1` in `compute_uniswap_out` and then leads to a insufficient `uniswap_in` amount, the solution proposed in this PR is to compute these values using rationals (thus conserving the very small epsilon) and only convert to U256 for computing the final interactions. 

This addresses the problem without requiring knowledge of buffers or another larger change to the settlement logic.

### Test Plan
Added Test Case
