### PR TITLE
Include line debug information in docker build

### DIFF
--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -3,7 +3,7 @@ WORKDIR /usr/src/oba-services
 
 # Copy and Build Code
 COPY . .
-RUN cargo build --target x86_64-unknown-linux-musl --release
+RUN env CARGO_PROFILE_RELEASE_DEBUG=1 cargo build --target x86_64-unknown-linux-musl --release
 
 RUN \
     cd .. && \


### PR DESCRIPTION
By default rust does not include line debug information in release
builds which we have seen for example in the divison by 0 panic in the
objective_value calcuation.
By setting the env variable in this commit the line number information
is included. This increases the size of the binaries and thus the docker
image significantly. The image goes from 55 MB to 210 MB.
I feel that this is worth the tradeoff.

See https://github.com/gnosis/gp-v2-services/issues/420
https://doc.rust-lang.org/cargo/reference/profiles.html#debug

### Test Plan
Locally tested by building and changing code to include a panic
