### PR TITLE
Better defend against potential 0 division in naive solver

### DIFF
--- a/shared/src/conversions.rs
+++ b/shared/src/conversions.rs
@@ -1,6 +1,6 @@
 use anyhow::{ensure, Result};
-use num::BigInt;
 use num::{bigint::Sign, Zero};
+use num::{rational::Ratio, BigInt};
 use num::{BigRational, ToPrimitive as _};
 use primitive_types::U256;
 
@@ -35,6 +35,20 @@ pub fn big_int_to_u256(input: &BigInt) -> Result<U256> {
 }
 
 // Convenience:
+
+pub trait RatioExt<T> {
+    fn new_checked(numerator: T, denominator: T) -> Result<Ratio<T>>;
+}
+
+impl<T: num::Integer + Clone> RatioExt<T> for Ratio<T> {
+    fn new_checked(numerator: T, denominator: T) -> Result<Ratio<T>> {
+        ensure!(
+            !denominator.is_zero(),
+            "Cannot create Ratio with 0 denominator"
+        );
+        Ok(Ratio::new(numerator, denominator))
+    }
+}
 
 pub trait U256Ext {
     fn to_big_int(&self) -> BigInt;

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use liquidity::{AmmOrder, LimitOrder};
 use model::order::OrderKind;
-use num::{rational::Ratio, BigInt, BigRational, Zero};
+use num::{rational::Ratio, BigInt, BigRational};
 use primitive_types::U256;
 use shared::conversions::{big_rational_to_u256, u256_to_big_int, RatioExt, U256Ext};
 use std::collections::HashMap;


### PR DESCRIPTION
Fixes https://github.com/gnosis/gp-v2-services/pull/427#discussion_r603978442

Adding a checked new helper for Ratio since it seems like this is a safety mechanism we might want to do elsewhere too.

### Test Plan
Unit tests still passing
