### PR TITLE
[Easy] Log OrderIds of all used order

### DIFF
--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -314,7 +314,7 @@ impl Display for OrderUid {
         let mut bytes = [0u8; 2 + 56 * 2];
         bytes[..2].copy_from_slice(b"0x");
         // Unwrap because the length is always correct.
-        hex::encode_to_slice(self.0, &mut bytes[2..]).unwrap();
+        hex::encode_to_slice(&self.0, &mut bytes[2..]).unwrap();
         // Unwrap because the string is always valid utf8.
         let str = std::str::from_utf8(&bytes).unwrap();
         f.write_str(str)

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -296,7 +296,7 @@ impl Default for OrderMetaData {
 }
 
 // uid as 56 bytes: 32 for orderDigest, 20 for ownerAddress and 4 for validTo
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct OrderUid(pub [u8; 56]);
 
 impl FromStr for OrderUid {
@@ -309,15 +309,26 @@ impl FromStr for OrderUid {
     }
 }
 
-impl Display for OrderUid {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl From<&OrderUid> for String {
+    fn from(uid: &OrderUid) -> Self {
         let mut bytes = [0u8; 2 + 56 * 2];
         bytes[..2].copy_from_slice(b"0x");
         // Unwrap because the length is always correct.
-        hex::encode_to_slice(&self.0, &mut bytes[2..]).unwrap();
+        hex::encode_to_slice(uid.0, &mut bytes[2..]).unwrap();
         // Unwrap because the string is always valid utf8.
-        let str = std::str::from_utf8(&bytes).unwrap();
-        f.write_str(str)
+        std::str::from_utf8(&bytes).unwrap().to_owned()
+    }
+}
+
+impl Display for OrderUid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&String::from(self))
+    }
+}
+
+impl fmt::Debug for OrderUid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -309,20 +309,15 @@ impl FromStr for OrderUid {
     }
 }
 
-impl From<&OrderUid> for String {
-    fn from(uid: &OrderUid) -> Self {
+impl Display for OrderUid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut bytes = [0u8; 2 + 56 * 2];
         bytes[..2].copy_from_slice(b"0x");
         // Unwrap because the length is always correct.
-        hex::encode_to_slice(uid.0, &mut bytes[2..]).unwrap();
+        hex::encode_to_slice(self.0, &mut bytes[2..]).unwrap();
         // Unwrap because the string is always valid utf8.
-        std::str::from_utf8(&bytes).unwrap().to_owned()
-    }
-}
-
-impl Display for OrderUid {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&String::from(self))
+        let str = std::str::from_utf8(&bytes).unwrap();
+        f.write_str(str)
     }
 }
 

--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -376,6 +376,7 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 settlement_handling: Arc::new(MockLimitOrderSettlementHandling::new()),
+                id: "0".to_string(),
             }),
             Liquidity::Amm(AmmOrder {
                 tokens: TokenPair::new(H160::zero(), H160::from_low_u64_be(1)).unwrap(),
@@ -443,6 +444,7 @@ mod tests {
             kind: OrderKind::Sell,
             partially_fillable: Default::default(),
             settlement_handling: limit_handling.clone(),
+            id: "0".to_string(),
         })
         .collect::<Vec<_>>();
 

--- a/solver/src/http_solver/settlement.rs
+++ b/solver/src/http_solver/settlement.rs
@@ -261,6 +261,7 @@ mod tests {
             kind: OrderKind::Sell,
             partially_fillable: false,
             settlement_handling: Arc::new(limit_handling),
+            id: "0".to_string(),
         };
         let orders = hashmap! { "lo0".to_string() => limit_order };
 

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -21,6 +21,7 @@ pub enum Liquidity {
 /// Basic limit sell and buy orders
 #[derive(Clone)]
 pub struct LimitOrder {
+    // Opaque Identifier for debugging purposes
     pub id: String,
     pub sell_token: H160,
     pub buy_token: H160,

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -21,6 +21,7 @@ pub enum Liquidity {
 /// Basic limit sell and buy orders
 #[derive(Clone)]
 pub struct LimitOrder {
+    pub id: String,
     pub sell_token: H160,
     pub buy_token: H160,
     pub sell_amount: U256,

--- a/solver/src/liquidity/offchain_orderbook.rs
+++ b/solver/src/liquidity/offchain_orderbook.rs
@@ -1,7 +1,7 @@
 use crate::orderbook::OrderBookApi;
 use crate::settlement::{Interaction, Trade};
 use anyhow::{Context, Result};
-use model::order::OrderCreation;
+use model::order::{Order, OrderCreation};
 use primitive_types::U256;
 use std::sync::Arc;
 
@@ -15,23 +15,24 @@ impl OrderBookApi {
             .await
             .context("failed to get orderbook")?
             .into_iter()
-            .map(|order| order.order_creation.into())
+            .map(|order| order.into())
             .collect())
     }
 }
 
-impl From<OrderCreation> for LimitOrder {
-    fn from(order: OrderCreation) -> Self {
+impl From<Order> for LimitOrder {
+    fn from(order: Order) -> Self {
         LimitOrder {
-            sell_token: order.sell_token,
+            id: order.order_meta_data.uid.to_string(),
+            sell_token: order.order_creation.sell_token,
             // TODO handle ETH buy token address (0xe...e) by making the handler include an WETH.unwrap() interaction
-            buy_token: order.buy_token,
+            buy_token: order.order_creation.buy_token,
             // TODO discount previously executed sell amount
-            sell_amount: order.sell_amount,
-            buy_amount: order.buy_amount,
-            kind: order.kind,
-            partially_fillable: order.partially_fillable,
-            settlement_handling: Arc::new(order),
+            sell_amount: order.order_creation.sell_amount,
+            buy_amount: order.order_creation.buy_amount,
+            kind: order.order_creation.kind,
+            partially_fillable: order.order_creation.partially_fillable,
+            settlement_handling: Arc::new(order.order_creation),
         }
     }
 }

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -280,7 +280,10 @@ fn is_valid_solution(solution: &Settlement) -> bool {
 #[cfg(test)]
 mod tests {
     use liquidity::tests::{CapturingAmmSettlementHandler, CapturingLimitOrderSettlementHandler};
-    use model::{order::OrderCreation, TokenPair};
+    use model::{
+        order::{Order, OrderCreation},
+        TokenPair,
+    };
     use num::rational::Ratio;
 
     use super::*;
@@ -302,6 +305,7 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 settlement_handling: CapturingLimitOrderSettlementHandler::arc(),
+                id: "0".to_string(),
             },
             LimitOrder {
                 sell_token: token_b,
@@ -311,6 +315,7 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 settlement_handling: CapturingLimitOrderSettlementHandler::arc(),
+                id: "1".to_string(),
             },
         ];
 
@@ -358,6 +363,7 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 settlement_handling: CapturingLimitOrderSettlementHandler::arc(),
+                id: "0".to_string(),
             },
             LimitOrder {
                 sell_token: token_a,
@@ -367,6 +373,7 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 settlement_handling: CapturingLimitOrderSettlementHandler::arc(),
+                id: "1".to_string(),
             },
         ];
 
@@ -410,6 +417,7 @@ mod tests {
                 kind: OrderKind::Buy,
                 partially_fillable: false,
                 settlement_handling: CapturingLimitOrderSettlementHandler::arc(),
+                id: "0".to_string(),
             },
             LimitOrder {
                 sell_token: token_b,
@@ -419,6 +427,7 @@ mod tests {
                 kind: OrderKind::Buy,
                 partially_fillable: false,
                 settlement_handling: CapturingLimitOrderSettlementHandler::arc(),
+                id: "1".to_string(),
             },
         ];
 
@@ -466,6 +475,7 @@ mod tests {
                 kind: OrderKind::Buy,
                 partially_fillable: false,
                 settlement_handling: CapturingLimitOrderSettlementHandler::arc(),
+                id: "0".to_string(),
             },
             LimitOrder {
                 sell_token: token_b,
@@ -475,6 +485,7 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 settlement_handling: CapturingLimitOrderSettlementHandler::arc(),
+                id: "1".to_string(),
             },
         ];
 
@@ -526,6 +537,7 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 settlement_handling: CapturingLimitOrderSettlementHandler::arc(),
+                id: "0".to_string(),
             },
             LimitOrder {
                 sell_token: token_b,
@@ -535,6 +547,7 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 settlement_handling: CapturingLimitOrderSettlementHandler::arc(),
+                id: "1".to_string(),
             },
         ];
 
@@ -562,46 +575,58 @@ mod tests {
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
             // Unreasonable order a -> b
-            OrderCreation {
-                sell_token: token_a,
-                buy_token: token_b,
-                sell_amount: to_wei(1),
-                buy_amount: to_wei(1000),
-                kind: OrderKind::Sell,
-                partially_fillable: false,
+            Order {
+                order_creation: OrderCreation {
+                    sell_token: token_a,
+                    buy_token: token_b,
+                    sell_amount: to_wei(1),
+                    buy_amount: to_wei(1000),
+                    kind: OrderKind::Sell,
+                    partially_fillable: false,
+                    ..Default::default()
+                },
                 ..Default::default()
             }
             .into(),
             // Reasonable order a -> b
-            OrderCreation {
-                sell_token: token_a,
-                buy_token: token_b,
-                sell_amount: to_wei(1000),
-                buy_amount: to_wei(1000),
-                kind: OrderKind::Sell,
-                partially_fillable: false,
+            Order {
+                order_creation: OrderCreation {
+                    sell_token: token_a,
+                    buy_token: token_b,
+                    sell_amount: to_wei(1000),
+                    buy_amount: to_wei(1000),
+                    kind: OrderKind::Sell,
+                    partially_fillable: false,
+                    ..Default::default()
+                },
                 ..Default::default()
             }
             .into(),
             // Reasonable order b -> a
-            OrderCreation {
-                sell_token: token_b,
-                buy_token: token_a,
-                sell_amount: to_wei(1000),
-                buy_amount: to_wei(1000),
-                kind: OrderKind::Sell,
-                partially_fillable: false,
+            Order {
+                order_creation: OrderCreation {
+                    sell_token: token_b,
+                    buy_token: token_a,
+                    sell_amount: to_wei(1000),
+                    buy_amount: to_wei(1000),
+                    kind: OrderKind::Sell,
+                    partially_fillable: false,
+                    ..Default::default()
+                },
                 ..Default::default()
             }
             .into(),
             // Unreasonable order b -> a
-            OrderCreation {
-                sell_token: token_b,
-                buy_token: token_a,
-                sell_amount: to_wei(2),
-                buy_amount: to_wei(1000),
-                kind: OrderKind::Sell,
-                partially_fillable: false,
+            Order {
+                order_creation: OrderCreation {
+                    sell_token: token_b,
+                    buy_token: token_a,
+                    sell_amount: to_wei(2),
+                    buy_amount: to_wei(1000),
+                    kind: OrderKind::Sell,
+                    partially_fillable: false,
+                    ..Default::default()
+                },
                 ..Default::default()
             }
             .into(),
@@ -633,6 +658,7 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 settlement_handling: CapturingLimitOrderSettlementHandler::arc(),
+                id: "0".to_string(),
             },
             LimitOrder {
                 sell_token: token_b,
@@ -642,6 +668,7 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 settlement_handling: CapturingLimitOrderSettlementHandler::arc(),
+                id: "1".to_string(),
             },
         ];
 
@@ -781,6 +808,7 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 settlement_handling: CapturingLimitOrderSettlementHandler::arc(),
+                id: "0".into(),
             },
             LimitOrder {
                 sell_token: token_b,
@@ -790,6 +818,7 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 settlement_handling: CapturingLimitOrderSettlementHandler::arc(),
+                id: "1".into(),
             },
         ];
 
@@ -809,23 +838,29 @@ mod tests {
         let token_a = Address::from_low_u64_be(0);
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
-            OrderCreation {
-                sell_token: token_a,
-                buy_token: token_b,
-                sell_amount: 70145218378783248142575u128.into(),
-                buy_amount: 70123226323u128.into(),
-                kind: OrderKind::Sell,
-                partially_fillable: false,
+            Order {
+                order_creation: OrderCreation {
+                    sell_token: token_a,
+                    buy_token: token_b,
+                    sell_amount: 70145218378783248142575u128.into(),
+                    buy_amount: 70123226323u128.into(),
+                    kind: OrderKind::Sell,
+                    partially_fillable: false,
+                    ..Default::default()
+                },
                 ..Default::default()
             }
             .into(),
-            OrderCreation {
-                sell_token: token_a,
-                buy_token: token_b,
-                sell_amount: 900_000_000_000_000u128.into(),
-                buy_amount: 100.into(),
-                kind: OrderKind::Sell,
-                partially_fillable: false,
+            Order {
+                order_creation: OrderCreation {
+                    sell_token: token_a,
+                    buy_token: token_b,
+                    sell_amount: 900_000_000_000_000u128.into(),
+                    buy_amount: 100.into(),
+                    kind: OrderKind::Sell,
+                    partially_fillable: false,
+                    ..Default::default()
+                },
                 ..Default::default()
             }
             .into(),

--- a/solver/src/uniswap_solver.rs
+++ b/solver/src/uniswap_solver.rs
@@ -213,6 +213,7 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 settlement_handling: order_handler[0].clone(),
+                id: "0".into(),
             },
             // Second order has a more lax limit
             LimitOrder {
@@ -223,6 +224,7 @@ mod tests {
                 kind: OrderKind::Sell,
                 partially_fillable: false,
                 settlement_handling: order_handler[1].clone(),
+                id: "1".into(),
             },
         ];
 
@@ -311,6 +313,7 @@ mod tests {
                 kind: OrderKind::Buy,
                 partially_fillable: false,
                 settlement_handling: order_handler[0].clone(),
+                id: "0".into(),
             },
             // Second order has a more lax limit
             LimitOrder {
@@ -321,6 +324,7 @@ mod tests {
                 kind: OrderKind::Buy,
                 partially_fillable: false,
                 settlement_handling: order_handler[1].clone(),
+                id: "1".into(),
             },
         ];
 


### PR DESCRIPTION
Adding an opaque id string field to the LimitOrder type so that we can print order identifiers in the driver. This makes it easier to debug instances as it allows easy lookup of the orders involved.

### Test Plan
CI


Running the solver on Rinkeby shows the following output now:

```
2021-03-30T13:05:08.316Z DEBUG solver::driver: starting single run
2021-03-30T13:05:08.676Z DEBUG solver::driver: got 2 orders
2021-03-30T13:05:09.113Z  WARN solver::driver: failed to estimate price for token 0xeeee…eeee: No valid path found between 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee and 0xc778417e063141139fce010982780140aa0cd5ab
2021-03-30T13:05:09.114Z DEBUG solver::driver: pruned 1 orders: ["0x0735c673e3fc4e5b7045538ddb8d86ce4ccb7ed9a5188c16471422ecea7c4f2052df85e9de71aa1c210873bcf37ec46d36c99dc260a43a6a"]
2021-03-30T13:05:09.114Z DEBUG solver::driver: Using orders: ["0xac6411f925653cff65c8fd643cc16a588ca6e27cb1caf1263b24e6ebc618cf5152df85e9de71aa1c210873bcf37ec46d36c99dc260a41388"]
```