### PR TITLE
Create Tenderly Simulation on failed solution

### DIFF
--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -5,6 +5,7 @@ use self::retry::{CancelSender, SettlementSender};
 use crate::settlement::Settlement;
 use anyhow::{anyhow, Context, Result};
 use contracts::GPv2Settlement;
+use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder, Web3};
 use gas_estimation::GasPriceEstimating;
 use gas_price_stream::gas_price_stream;
 use primitive_types::{H160, U256};
@@ -92,8 +93,34 @@ async fn simulate_settlement(
     contract: &GPv2Settlement,
 ) -> Result<()> {
     let method = retry::settle_method_builder(contract, settlement.clone());
-    let data = method.tx.data.as_ref().expect("no data").0.as_slice();
-    tracing::info!("Settlement call: {}", hex::encode(data));
-    method.call().await.context("settle simulation failed")?;
-    Ok(())
+    let tx = method.tx.clone();
+    let result = method.call().await;
+    match &result {
+        Ok(_) => Ok(()),
+        Err(_) => {
+            let tenderly_link = tenderly_link(&contract.raw_instance().web3(), tx)
+                .await
+                .unwrap_or_else(|err| format!("Unable to create simulation link due to: {}", err));
+            result
+                .map(|_| ())
+                .context(format!("Settle simulation failed. Link: {}", tenderly_link))
+        }
+    }
+}
+
+// Creates a simulation link in the gp-v2 tenderly workspace
+async fn tenderly_link(
+    web3: &Web3<DynTransport>,
+    tx: TransactionBuilder<DynTransport>,
+) -> Result<String> {
+    let current_block = web3.eth().block_number().await?;
+    let network_id = web3.net().version().await?;
+    Ok(format!(
+        "https://dashboard.tenderly.co/gp-v2/staging/simulator/new?block={}&blockIndex=0&from={:#x}&gas=8000000&gasPrice=0&value=0&contractAddress={:#x}&rawFunctionInput=0x{}&network={}",
+        current_block,
+        tx.from.unwrap().address(),
+        tx.to.unwrap(),
+        hex::encode(tx.data.unwrap().0),
+        network_id
+    ))
 }


### PR DESCRIPTION
Fixes #422

We should now see a link in our alerts that makes us 1 click away from creating the tenderly simulation for the failed settlement. I believe this will speed up debugging by an order of magnitude

Note, that in order to profit from this I need to add your tenderly account to our organization. Let me know your tenderly account via slack.

### Test Plan
Run rinkeby solver with bad private key. See tenderly link in logs and when following it land on a page where all we need to do is click "Simulate Transaction" (all other values are already filled out).
