### PR TITLE
[Trivial] Omit transport debug logs from default filter

### DIFF
--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -9,7 +9,7 @@ pub struct Arguments {
     #[structopt(
         long,
         env = "LOG_FILTER",
-        default_value = "warn,orderbook=debug,solver=debug,shared=debug"
+        default_value = "warn,orderbook=debug,solver=debug,shared=debug,shared::transport=info"
     )]
     pub log_filter: String,
 


### PR DESCRIPTION
Otherwise running the api/solver locally becomes too noisy

In combination with explicitly enabling it in staging: https://gitlab.gnosisdev.com/devops/gnosis-staging/-/merge_requests/422

### Test Plan
Run it and see no request logs.
