### PR TITLE
[Easy] Make one unit test more concise

### DIFF
--- a/orderbook/src/database.rs
+++ b/orderbook/src/database.rs
@@ -44,7 +44,7 @@ impl Database {
     /// Delete all data in the database. Only used by tests.
     pub async fn clear(&self) -> Result<()> {
         use sqlx::Executor;
-        self.pool.execute(sqlx::query("TRUNCATE orders;")).await?;
+        self.drop_orders().await?;
         self.pool.execute(sqlx::query("TRUNCATE trades;")).await?;
         self.pool
             .execute(sqlx::query("TRUNCATE invalidations;"))
@@ -58,7 +58,7 @@ impl Database {
         Ok(())
     }
 
-    pub async fn drop_orders(&self, table_name: &str) -> Result<()> {
+    pub async fn drop_orders(&self) -> Result<()> {
         use sqlx::Executor;
         self.pool.execute(sqlx::query("TRUNCATE orders;")).await?;
         Ok(())

--- a/orderbook/src/database.rs
+++ b/orderbook/src/database.rs
@@ -57,4 +57,10 @@ impl Database {
             .await?;
         Ok(())
     }
+
+    pub async fn drop_table(&self, table_name: &str) -> Result<()> {
+        use sqlx::Executor;
+        self.pool.execute(sqlx::query(format!("TRUNCATE {};", table_name).as_str())).await?;
+        Ok(())
+    }
 }

--- a/orderbook/src/database.rs
+++ b/orderbook/src/database.rs
@@ -58,9 +58,9 @@ impl Database {
         Ok(())
     }
 
-    pub async fn drop_table(&self, table_name: &str) -> Result<()> {
+    pub async fn drop_orders(&self, table_name: &str) -> Result<()> {
         use sqlx::Executor;
-        self.pool.execute(sqlx::query(format!("TRUNCATE {};", table_name).as_str())).await?;
+        self.pool.execute(sqlx::query("TRUNCATE orders;")).await?;
         Ok(())
     }
 }

--- a/orderbook/src/database/trades.rs
+++ b/orderbook/src/database/trades.rs
@@ -412,7 +412,7 @@ mod tests {
         assert_trades(&db, &TradeFilter::default(), &[trade_a, trade_b]).await;
 
         // No trades returned without corresponding orders.
-        db.drop_table("orders").await.unwrap();
+        db.drop_orders().await.unwrap();
         assert_trades(&db, &TradeFilter::default(), &[]).await;
     }
 

--- a/orderbook/src/database/trades.rs
+++ b/orderbook/src/database/trades.rs
@@ -411,53 +411,8 @@ mod tests {
         .await;
         assert_trades(&db, &TradeFilter::default(), &[trade_a, trade_b]).await;
 
-        // TODO - drop orders and make last assertion again.
-        // Then remove test postgres_trades_with_same_settlement_no_orders
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn postgres_trades_with_same_settlement_no_orders() {
-        let db = Database::new("postgresql://").unwrap();
-        db.clear().await.unwrap();
-        let (owners, order_ids) = generate_owners_and_order_ids(2, 2).await;
-        assert_trades(&db, &TradeFilter::default(), &[]).await;
-
-        let settlement = add_settlement(
-            &db,
-            EventIndex {
-                block_number: 0,
-                log_index: 4,
-            },
-            H160::default(),
-            H256::from_low_u64_be(1),
-        )
-        .await;
-
-        add_trade(
-            &db,
-            owners[0],
-            order_ids[0],
-            EventIndex {
-                block_number: 0,
-                log_index: 0,
-            },
-            Some(settlement.transaction_hash),
-        )
-        .await;
-
-        add_trade(
-            &db,
-            owners[0],
-            order_ids[1],
-            EventIndex {
-                block_number: 0,
-                log_index: 1,
-            },
-            Some(settlement.transaction_hash),
-        )
-        .await;
-        // Trades query returns nothing when there are no corresponding orders.
+        // No trades returned without corresponding orders.
+        db.drop_table("orders").await.unwrap();
         assert_trades(&db, &TradeFilter::default(), &[]).await;
     }
 


### PR DESCRIPTION
This PR fixes and easy todo that was missed when merging the settlements/transaction hash PR #334 where we verify that no trades are returned if there are no orders.

By introducing a drop_table method, we can simply drop the orders table at the end of a more relevant test and make one last assertion when the orders table is truncated.

This PR also starts to make me think a bit more about #438, which I will try and tackle next. Especially since it is incredibly unprofessional to be passing a string into this public `drop_table` method. We should surely be passing an enum here and only allow very specific strings to be passed into this method.

### Test Plan
Existing CI
