### PR TITLE
Token Deny List

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,6 +1481,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "lazy_static",
+ "maplit",
  "num-bigint 0.3.2",
  "primitive-types",
  "secp256k1",

--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -146,6 +146,7 @@ async fn test_with_ganache() {
     let price_estimator = Arc::new(UniswapPriceEstimator::new(
         Box::new(pool_fetcher),
         HashSet::new(),
+        HashSet::new(),
     ));
     let native_token = token_a.address();
     let fee_calculator = Arc::new(MinFeeCalculator::new(
@@ -161,6 +162,7 @@ async fn test_with_ganache() {
         event_updater,
         Box::new(Web3BalanceFetcher::new(web3.clone(), gp_allowance)),
         fee_calculator.clone(),
+        HashSet::new(),
     ));
 
     orderbook::serve_task(

--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -146,7 +146,6 @@ async fn test_with_ganache() {
     let price_estimator = Arc::new(UniswapPriceEstimator::new(
         Box::new(pool_fetcher),
         HashSet::new(),
-        HashSet::new(),
     ));
     let native_token = token_a.address();
     let fee_calculator = Arc::new(MinFeeCalculator::new(

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -10,6 +10,7 @@ enum-utils = "0.1"
 hex = { version = "0.4", default-features = false }
 hex-literal = "0.3"
 lazy_static = "1.4"
+maplit = "1.0"
 num-bigint = "0.3"
 primitive-types = { version = "0.8" }
 secp256k1 = "0.20"

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -171,6 +171,11 @@ impl TokenPair {
         }
     }
 
+    /// Used to determine if `token` is among the pair.
+    pub fn contains(&self, token: &H160) -> bool {
+        self.0 == *token || self.1 == *token
+    }
+
     /// The first address is always the lower one.
     /// The addresses are never equal.
     pub fn get(&self) -> (H160, H160) {

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -14,6 +14,7 @@ use secp256k1::key::ONE_KEY;
 use serde::{de, Deserialize, Serialize};
 use serde::{Deserializer, Serializer};
 use serde_with::serde_as;
+use std::collections::HashSet;
 use std::fmt::{self, Display};
 use std::str::FromStr;
 use web3::signing::{self, Key, SecretKeyRef};
@@ -55,6 +56,10 @@ impl Order {
             },
             order_creation,
         })
+    }
+    pub fn contains_token_from(&self, token_list: &HashSet<H160>) -> bool {
+        token_list.contains(&self.order_creation.buy_token)
+            || token_list.contains(&self.order_creation.sell_token)
     }
 }
 
@@ -421,6 +426,7 @@ mod tests {
     use super::*;
     use chrono::NaiveDateTime;
     use hex_literal::hex;
+    use maplit::hashset;
     use primitive_types::H256;
     use secp256k1::{PublicKey, Secp256k1, SecretKey};
     use serde_json::json;
@@ -579,6 +585,24 @@ mod tests {
         let expected = "0x01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff";
         assert_eq!(uid.to_string(), expected);
         assert_eq!(format!("{}", uid), expected);
+    }
+
+    #[test]
+    fn order_contains_token_from() {
+        let order = Order::default();
+        assert_eq!(
+            order.contains_token_from(&hashset!(order.order_creation.sell_token)),
+            true
+        );
+        assert_eq!(
+            order.contains_token_from(&hashset!(order.order_creation.buy_token)),
+            true
+        );
+        assert_eq!(order.contains_token_from(&HashSet::new()), false);
+        let other_token = H160::from_low_u64_be(1);
+        assert_ne!(other_token, order.order_creation.sell_token);
+        assert_ne!(other_token, order.order_creation.buy_token);
+        assert_eq!(order.contains_token_from(&hashset!(other_token)), false);
     }
 
     pub fn h160_from_public_key(key: PublicKey) -> H160 {

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -87,9 +87,9 @@ paths:
           schema:
             type: boolean
             default: false
-        - name: includeDeniedTokens
+        - name: includeUnsupportedTokens
           in: query
-          description: Should the orders containing denied tokens be included?
+          description: Should the orders containing unsupported tokens be included?
           schema:
             type: boolean
             default: false
@@ -554,8 +554,7 @@ components:
               PastValidTo,
               InsufficientFunds,
               InsufficientFee,
-              BuyTokenDenied,
-              SellTokenDenied,
+              UnsupportedToken,
               WrongOwner,
             ]
         description:

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -539,6 +539,8 @@ components:
               PastValidTo,
               InsufficientFunds,
               InsufficientFee,
+              BuyTokenDenied,
+              SellTokenDenied,
             ]
         description:
           type: string

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -81,6 +81,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: includeDeniedTokens
+          in: query
+          description: Should the orders containing denied tokens be included?
+          schema:
+            type: boolean
+            default: false
         - name: minValidTo
           in: query
           description: |

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -16,11 +16,11 @@ pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
     let (body, status_code) = match result {
         Ok(AddOrderResult::Added(uid)) => (warp::reply::json(&uid), StatusCode::CREATED),
         Ok(AddOrderResult::BuyTokenDenied(token)) => (
-            super::error("TokenDenied", format!("Buy Token {}", token)),
+            super::error("TokenDenied", format!("Buy token denied {}", token)),
             StatusCode::BAD_REQUEST,
         ),
         Ok(AddOrderResult::SellTokenDenied(token)) => (
-            super::error("TokenDenied", format!("Sell Token {}", token)),
+            super::error("TokenDenied", format!("Sell token denied {}", token)),
             StatusCode::BAD_REQUEST,
         ),
         Ok(AddOrderResult::DuplicatedOrder) => (

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -15,12 +15,8 @@ pub fn create_order_request(
 pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
     let (body, status_code) = match result {
         Ok(AddOrderResult::Added(uid)) => (warp::reply::json(&uid), StatusCode::CREATED),
-        Ok(AddOrderResult::BuyTokenDenied(token)) => (
-            super::error("TokenDenied", format!("Buy token denied {}", token)),
-            StatusCode::BAD_REQUEST,
-        ),
-        Ok(AddOrderResult::SellTokenDenied(token)) => (
-            super::error("TokenDenied", format!("Sell token denied {}", token)),
+        Ok(AddOrderResult::UnsupportedToken(token)) => (
+            super::error("UnsupportedToken", format!("Token address {}", token)),
             StatusCode::BAD_REQUEST,
         ),
         Ok(AddOrderResult::WrongOwner(owner)) => (

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -15,6 +15,14 @@ pub fn create_order_request() -> impl Filter<Extract = (OrderCreation,), Error =
 pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
     let (body, status_code) = match result {
         Ok(AddOrderResult::Added(uid)) => (warp::reply::json(&uid), StatusCode::CREATED),
+        Ok(AddOrderResult::BuyTokenDenied(token)) => (
+            super::error("TokenDenied", format!("Buy Token {}", token)),
+            StatusCode::BAD_REQUEST,
+        ),
+        Ok(AddOrderResult::SellTokenDenied(token)) => (
+            super::error("TokenDenied", format!("Sell Token {}", token)),
+            StatusCode::BAD_REQUEST,
+        ),
         Ok(AddOrderResult::DuplicatedOrder) => (
             super::error("DuplicatedOrder", "order already exists"),
             StatusCode::BAD_REQUEST,

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -21,6 +21,7 @@ pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
         ),
         Ok(AddOrderResult::SellTokenDenied(token)) => (
             super::error("TokenDenied", format!("Sell token denied {}", token)),
+            StatusCode::BAD_REQUEST,
         ),
         Ok(AddOrderResult::WrongOwner(owner)) => (
             super::error(

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -24,6 +24,8 @@ struct Query {
     include_invalidated: bool,
     #[serde(default)]
     include_insufficient_balance: bool,
+    #[serde(default)]
+    include_denied_tokens: bool,
 }
 
 impl Query {
@@ -37,6 +39,7 @@ impl Query {
             exclude_fully_executed: !self.include_fully_executed,
             exclude_invalidated: !self.include_invalidated,
             exclude_insufficient_balance: !self.include_insufficient_balance,
+            exclude_deny_list: !self.include_denied_tokens,
             uid: None,
         }
     }

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -25,7 +25,7 @@ struct Query {
     #[serde(default)]
     include_insufficient_balance: bool,
     #[serde(default)]
-    include_denied_tokens: bool,
+    include_unsupported_tokens: bool,
 }
 
 impl Query {
@@ -39,7 +39,7 @@ impl Query {
             exclude_fully_executed: !self.include_fully_executed,
             exclude_invalidated: !self.include_invalidated,
             exclude_insufficient_balance: !self.include_insufficient_balance,
-            exclude_deny_list: !self.include_denied_tokens,
+            exclude_unsupported_tokens: !self.include_unsupported_tokens,
             uid: None,
         }
     }

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -21,6 +21,7 @@ pub struct OrderFilter {
     pub exclude_fully_executed: bool,
     pub exclude_invalidated: bool,
     pub exclude_insufficient_balance: bool,
+    pub exclude_deny_list: bool,
     pub uid: Option<OrderUid>,
 }
 

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -21,7 +21,7 @@ pub struct OrderFilter {
     pub exclude_fully_executed: bool,
     pub exclude_invalidated: bool,
     pub exclude_insufficient_balance: bool,
-    pub exclude_deny_list: bool,
+    pub exclude_unsupported_tokens: bool,
     pub uid: Option<OrderUid>,
 }
 

--- a/orderbook/src/database/trades.rs
+++ b/orderbook/src/database/trades.rs
@@ -410,9 +410,6 @@ mod tests {
         )
         .await;
         assert_trades(&db, &TradeFilter::default(), &[trade_a, trade_b]).await;
-
-        // TODO - drop orders and make last assertion again.
-        // Then remove test postgres_trades_with_same_settlement_no_orders
     }
 
     #[tokio::test]

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -147,7 +147,6 @@ async fn main() {
     let price_estimator = Arc::new(UniswapPriceEstimator::new(
         Box::new(pool_fetcher),
         base_tokens,
-        deny_tokens.clone(),
     ));
     let fee_calculator = Arc::new(MinFeeCalculator::new(
         price_estimator.clone(),

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -10,6 +10,7 @@ use orderbook::{
     orderbook::Orderbook,
     serve_task, verify_deployed_contract_constants,
 };
+use shared::uniswap_pool::FilteredPoolFetcher;
 use shared::{
     current_block::{current_block_stream, CurrentBlockStream},
     price_estimate::UniswapPriceEstimator,
@@ -136,7 +137,7 @@ async fn main() {
     );
 
     let current_block_stream = current_block_stream(web3.clone()).await.unwrap();
-    let pool_fetcher = CachedPoolFetcher::new(
+    let cached_pool_fetcher = CachedPoolFetcher::new(
         Box::new(PoolFetcher {
             factory: uniswap_factory,
             web3,
@@ -144,6 +145,7 @@ async fn main() {
         }),
         current_block_stream.clone(),
     );
+    let pool_fetcher = FilteredPoolFetcher::new(Box::new(cached_pool_fetcher), deny_tokens.clone());
     let price_estimator = Arc::new(UniswapPriceEstimator::new(
         Box::new(pool_fetcher),
         base_tokens,

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -46,6 +46,10 @@ pub struct Arguments {
     /// Should be the most liquid tokens of the given network.
     #[structopt(long, env = "BASE_TOKENS", use_delimiter = true)]
     pub base_tokens: Vec<H160>,
+
+    /// List of token addresses to be ignored throughout service
+    #[structopt(long, env = "TOKEN_FILTER", use_delimiter = true)]
+    pub token_filter: Vec<H160>,
 }
 
 pub fn duration_from_seconds(s: &str) -> Result<Duration, ParseFloatError> {

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -48,8 +48,8 @@ pub struct Arguments {
     pub base_tokens: Vec<H160>,
 
     /// List of token addresses to be ignored throughout service
-    #[structopt(long, env = "TOKEN_FILTER", use_delimiter = true)]
-    pub token_filter: Vec<H160>,
+    #[structopt(long, env = "UNSUPPORTED_TOKENS", use_delimiter = true)]
+    pub unsupported_tokens: Vec<H160>,
 }
 
 pub fn duration_from_seconds(s: &str) -> Result<Duration, ParseFloatError> {

--- a/shared/src/price_estimate.rs
+++ b/shared/src/price_estimate.rs
@@ -90,16 +90,6 @@ impl UniswapPriceEstimator {
             deny_tokens,
         }
     }
-    /// Deny List Validation for price estimation.
-    fn token_validation(&self, buy_token: &H160, sell_token: &H160) -> Result<()> {
-        if self.deny_tokens.contains(&sell_token) {
-            return Err(anyhow!("Sell Token {} Denied!", sell_token));
-        }
-        if self.deny_tokens.contains(&buy_token) {
-            return Err(anyhow!("Buy Token {} Denied!", buy_token));
-        }
-        Ok(())
-    }
 }
 
 #[async_trait::async_trait]
@@ -114,7 +104,6 @@ impl PriceEstimating for UniswapPriceEstimator {
         amount: U256,
         kind: OrderKind,
     ) -> Result<BigRational> {
-        self.token_validation(&buy_token, &sell_token)?;
         if sell_token == buy_token {
             return Ok(num::one());
         }
@@ -158,7 +147,6 @@ impl PriceEstimating for UniswapPriceEstimator {
         amount: U256,
         kind: OrderKind,
     ) -> Result<U256> {
-        self.token_validation(&buy_token, &sell_token)?;
         if sell_token == buy_token || amount.is_zero() {
             return Ok(U256::zero());
         }

--- a/shared/src/price_estimate.rs
+++ b/shared/src/price_estimate.rs
@@ -75,19 +75,13 @@ pub trait PriceEstimating: Send + Sync {
 pub struct UniswapPriceEstimator {
     pool_fetcher: Box<dyn PoolFetching>,
     base_tokens: HashSet<H160>,
-    deny_tokens: HashSet<H160>,
 }
 
 impl UniswapPriceEstimator {
-    pub fn new(
-        pool_fetcher: Box<dyn PoolFetching>,
-        base_tokens: HashSet<H160>,
-        deny_tokens: HashSet<H160>,
-    ) -> Self {
+    pub fn new(pool_fetcher: Box<dyn PoolFetching>, base_tokens: HashSet<H160>) -> Self {
         Self {
             pool_fetcher,
             base_tokens,
-            deny_tokens,
         }
     }
 }

--- a/shared/src/uniswap_pool.rs
+++ b/shared/src/uniswap_pool.rs
@@ -29,13 +29,22 @@ pub trait PoolFetching: Send + Sync {
     async fn fetch(&self, token_pairs: HashSet<TokenPair>) -> Vec<Pool>;
 }
 
-pub struct FilteredPoolFetching {
+pub struct FilteredPoolFetcher {
     inner: Box<dyn PoolFetching>,
     token_filter: HashSet<H160>,
 }
 
+impl FilteredPoolFetcher {
+    pub fn new(inner: Box<dyn PoolFetching>, token_filter: HashSet<H160>) -> Self {
+        Self {
+            inner,
+            token_filter,
+        }
+    }
+}
+
 #[async_trait::async_trait]
-impl PoolFetching for FilteredPoolFetching {
+impl PoolFetching for FilteredPoolFetcher {
     async fn fetch(&self, token_pairs: HashSet<TokenPair>) -> Vec<Pool> {
         let filtered_pairs = token_pairs
             .into_iter()

--- a/shared/src/uniswap_pool.rs
+++ b/shared/src/uniswap_pool.rs
@@ -31,14 +31,14 @@ pub trait PoolFetching: Send + Sync {
 
 pub struct FilteredPoolFetcher {
     inner: Box<dyn PoolFetching>,
-    token_filter: HashSet<H160>,
+    unsupported_tokens: HashSet<H160>,
 }
 
 impl FilteredPoolFetcher {
-    pub fn new(inner: Box<dyn PoolFetching>, token_filter: HashSet<H160>) -> Self {
+    pub fn new(inner: Box<dyn PoolFetching>, unsupported_tokens: HashSet<H160>) -> Self {
         Self {
             inner,
-            token_filter,
+            unsupported_tokens,
         }
     }
 }
@@ -48,7 +48,7 @@ impl PoolFetching for FilteredPoolFetcher {
     async fn fetch(&self, token_pairs: HashSet<TokenPair>) -> Vec<Pool> {
         let filtered_pairs = token_pairs
             .into_iter()
-            .filter(|pair| !self.token_filter.iter().any(|t| pair.contains(t)))
+            .filter(|pair| !self.unsupported_tokens.iter().any(|t| pair.contains(t)))
             .collect();
         self.inner.fetch(filtered_pairs).await
     }

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -146,8 +146,6 @@ async fn main() {
             chain_id,
         }),
         base_tokens.clone(),
-        // No need to provide denied tokens here, since they won't make it this far
-        HashSet::new(),
     ));
     let token_info_fetcher = Arc::new(CachedTokenInfoFetcher::new(Box::new(TokenInfoFetcher {
         web3: web3.clone(),

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -118,6 +118,8 @@ async fn main() {
             chain_id,
         }),
         base_tokens.clone(),
+        // No need to provide denied tokens here, since they won't make it this far
+        HashSet::new(),
     ));
     let token_info_fetcher = Arc::new(CachedTokenInfoFetcher::new(Box::new(TokenInfoFetcher {
         web3: web3.clone(),


### PR DESCRIPTION
Fixes #450

This PR introduces a token deny list which is passed as a comma separated list of Ethereum addresses to the `token_filter` argument. The deny list is handled in three separate parts of the service namely

1. `UniswapPriceEstimator` where these tokens are ignored for both price and gas estimations
2. `Order Creation` when calling `add_order`, the response has been updated with two `AddOrderResponse` errors (`BuyTokenDenied` and `SellTokenDenied`) each returning the token address with the error message
3. `get_solvable_orders` here we introduce a new boolean flag `exclude_deny_tokens` into the order filter which is set to `true` when fetching solvable orders.

Furthermore, we assert that the `deny_list` doesn't overlap with the `base_tokens` list on startup.

### Test Plan

There are three different callsites where this change should be tested. All of which are verified with the following instructions:

1. Run the orderbook on rinkeby with `--token-filter 0xd0dab4e640d95e9e8a47545598c33e31bdb53c7c` (this is rGNO)
Run the web interface locally 

2. (Testing Price Estimator) In the interface select GNO as the sell token

Find this warning on price estimation in the services logs

```
WARN orderbook::fee: Failed to estimate sell token price: Sell Token 0xd0da…3c7c Denied!
```
Alternatively, you can make these requests to the API:
```sh
curl -X GET "http://localhost:8080/api/v1/fee?sellToken=0xd0dab4e640d95e9e8a47545598c33e31bdb53c7c&buyToken=0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b&amount=1234567890&kind=sell" -H  "accept: application/json"
```

```sh
curl -X GET "http://localhost:8080/api/v1/fee?sellToken0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b=&buyToken=0xd0dab4e640d95e9e8a47545598c33e31bdb53c7c&amount=1234567890&kind=sell" -H  "accept: application/json"
```

which will both respond with

```
{"errorType":"NotFound","description":"Fee path for given Token pair was not found"}%
```

3. (Testing Token Denied on order placement) Now select `GNO` as the buy token and choose something else for the sell token
When attempting to place the order find the following Response with code 400
```
{"errorType":"TokenDenied","description":"Buy Token 0xd0da…3c7c"}
```

4. (Testing OrderFilter) Now place an order selling USDC for DAI (or whatever isn't currently denied), but record the address of one (or both) of the tokens. We will use `DAI-0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa`, `USDC-0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b`

Once this order is placed, restart the orderbook services and add one (or both) of these tokens to the token filter
```sh
cargo run --bin orderbook -- --node-url https://rinkeby.infura.io/v3/c8a386aaa40349eda89325818dbc40e9 --token-filter 0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa
```

Run:
```sh
curl -X GET "http://localhost:8080/api/v1/orders?includeFullyExecuted=false&includeInvalidated=false&includeInsufficientBalance=false&includeDeniedTokens=false" -H  "accept: application/json"
```

to get nothing returned and 

```sh
curl -X GET "http://localhost:8080/api/v1/orders?includeFullyExecuted=false&includeInvalidated=false&includeInsufficientBalance=false&includeDeniedTokens=true" -H  "accept: application/json"
```

to see the order you had placed.

Note that - We haven't managed to test a Sell Token Denied (can't get sell token denied through the interface because the failed fee estimate prevents us from placing orders this way).
