### PR TITLE
Collecting metrics for our API requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,6 +1724,7 @@ dependencies = [
  "num",
  "num-bigint 0.3.2",
  "primitive-types",
+ "prometheus",
  "reqwest",
  "secp256k1",
  "serde",

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -26,6 +26,7 @@ maplit = "1.0"
 model = { path = "../model" }
 num-bigint = "0.3"
 primitive-types = { version = "0.8", features = ["fp-conversion"] }
+prometheus = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "1.8", default-features = false, features = ["macros"] }

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -7,7 +7,7 @@ mod get_orders;
 mod get_solvable_orders;
 mod get_trades;
 
-use crate::metrics::{end_request, Metrics};
+use crate::metrics::{end_request, LabelledReply, Metrics};
 use crate::{database::Database, metrics::start_request};
 use crate::{fee::MinFeeCalculator, orderbook::Orderbook};
 use anyhow::Error as anyhowError;
@@ -44,18 +44,26 @@ pub fn handle_all_routes(
         .allow_any_origin()
         .allow_methods(vec!["GET", "POST", "DELETE", "OPTIONS", "PUT", "PATCH"])
         .allow_headers(vec!["Origin", "Content-Type", "X-Auth-Token", "X-AppId"]);
-    warp::path!("api" / "v1" / ..)
-        .and(
-            create_order
-                .or(get_orders)
-                .or(fee_info)
-                .or(legacy_fee_info)
-                .or(get_order)
-                .or(get_solvable_orders)
-                .or(get_trades)
-                .or(cancel_order)
-                .or(get_amount_estimate),
-        )
+    let routes_with_labels = warp::path!("api" / "v1" / ..).and(
+        (create_order.map(|reply| LabelledReply::new(reply, "create_order")))
+            .or(get_orders.map(|reply| LabelledReply::new(reply, "get_orders")))
+            .unify()
+            .or(fee_info.map(|reply| LabelledReply::new(reply, "fee_info")))
+            .unify()
+            .or(legacy_fee_info.map(|reply| LabelledReply::new(reply, "legacy_fee_info")))
+            .unify()
+            .or(get_order.map(|reply| LabelledReply::new(reply, "get_order")))
+            .unify()
+            .or(get_solvable_orders.map(|reply| LabelledReply::new(reply, "get_solvable_orders")))
+            .unify()
+            .or(get_trades.map(|reply| LabelledReply::new(reply, "get_trades")))
+            .unify()
+            .or(cancel_order.map(|reply| LabelledReply::new(reply, "cancel_order")))
+            .unify()
+            .or(get_amount_estimate.map(|reply| LabelledReply::new(reply, "get_amount_estimate")))
+            .unify(),
+    );
+    routes_with_labels
         .with(wrap_fn(|f| wrap_metrics(f, metrics.clone())))
         .recover(handle_rejection)
         .with(cors)
@@ -66,13 +74,12 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
     Ok(err.default_response())
 }
 
-fn wrap_metrics<F, T>(
+fn wrap_metrics<F>(
     filter: F,
     metrics: Arc<Metrics>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone
 where
-    F: Filter<Extract = (T,), Error = Rejection> + Clone + Send + Sync + 'static,
-    T: warp::Reply,
+    F: Filter<Extract = (LabelledReply,), Error = Rejection> + Clone + Send + Sync + 'static,
 {
     warp::any()
         .and(start_request())

--- a/orderbook/src/metrics.rs
+++ b/orderbook/src/metrics.rs
@@ -1,0 +1,48 @@
+use std::{convert::Infallible, sync::Arc, time::Instant};
+
+use prometheus::{HistogramOpts, HistogramVec, Registry};
+use warp::Filter;
+use warp::{reply::Response, Reply};
+
+pub struct Metrics {
+    requests: HistogramVec,
+}
+
+impl Metrics {
+    pub fn new(registry: &Registry) -> Self {
+        let opts = HistogramOpts::new(
+            "gp_v2_api_requests",
+            "API Request durations labelled by route and response status code",
+        );
+        let requests = HistogramVec::new(opts, &["response", "request_type"]).unwrap();
+        registry
+            .register(Box::new(requests.clone()))
+            .expect("Failed to register metric");
+        Self { requests }
+    }
+}
+
+// Response wrapper needed because we cannot inspect the reply's status code without consuming it
+struct MetricsReply {
+    response: Response,
+}
+
+impl Reply for MetricsReply {
+    fn into_response(self) -> Response {
+        self.response
+    }
+}
+
+pub fn start_request() -> impl Filter<Extract = (Instant,), Error = Infallible> + Clone {
+    warp::any().map(Instant::now)
+}
+
+pub fn end_request(metrics: Arc<Metrics>, timer: Instant, reply: impl Reply) -> impl Reply {
+    let response = reply.into_response();
+    let elapsed = timer.elapsed().as_secs_f64();
+    metrics
+        .requests
+        .with_label_values(&[response.status().as_str(), "TODO"])
+        .observe(elapsed);
+    MetricsReply { response }
+}


### PR DESCRIPTION
Part of #425 

This PR wraps our warp routing system with a function to log all incoming request/responses to prometheus. This single metric will allow us to get a bunch of interesting insights
- Number of orders created per time interval
- Failure Rate (based on status code) per route
- Execution time (histogram information)

I'm currently still struggling on how to do the labelling of the requests (see inline discussion).

### Test Plan
Run orderbook, query a few routes. Then query `http://localhost:9586/metrics` and see collected metrics.
