### PR TITLE
Increase event insertion batch size

### DIFF
--- a/orderbook/src/event_updater.rs
+++ b/orderbook/src/event_updater.rs
@@ -26,7 +26,7 @@ use web3::Web3;
 const MAX_REORG_BLOCK_COUNT: u64 = 25;
 // When we insert new trade events into the database we will insert at most this many in one
 // transaction.
-const INSERT_EVENT_BATCH_SIZE: usize = 250;
+const INSERT_EVENT_BATCH_SIZE: usize = 10_000;
 
 pub struct EventUpdater {
     contract: GPv2Settlement,


### PR DESCRIPTION
To make it less likely that events are added outside of the replacing
postgres transaction we increase the batch size. Should help in case
multiple pods are updating the events at the same time.

See https://github.com/gnosis/gp-v2-services/issues/444

### Test Plan
CI
