### PR TITLE
Expose full order struct on Trade

### DIFF
--- a/solver/src/http_solver/settlement.rs
+++ b/solver/src/http_solver/settlement.rs
@@ -215,7 +215,10 @@ mod tests {
     };
     use maplit::hashmap;
     use mockall::predicate::eq;
-    use model::{order::OrderCreation, TokenPair};
+    use model::{
+        order::{Order, OrderCreation},
+        TokenPair,
+    };
     use std::sync::Arc;
 
     #[derive(Debug)]
@@ -236,11 +239,14 @@ mod tests {
         limit_handling.expect_settle().returning(move |_| {
             (
                 Some(Trade {
-                    order: OrderCreation {
-                        sell_token: t0,
-                        buy_token: t1,
-                        sell_amount: 1.into(),
-                        buy_amount: 2.into(),
+                    order: Order {
+                        order_creation: OrderCreation {
+                            sell_token: t0,
+                            buy_token: t1,
+                            sell_amount: 1.into(),
+                            buy_amount: 2.into(),
+                            ..Default::default()
+                        },
                         ..Default::default()
                     },
                     ..Default::default()

--- a/solver/src/liquidity/offchain_orderbook.rs
+++ b/solver/src/liquidity/offchain_orderbook.rs
@@ -1,7 +1,7 @@
 use crate::orderbook::OrderBookApi;
 use crate::settlement::{Interaction, Trade};
 use anyhow::{Context, Result};
-use model::order::{Order, OrderCreation};
+use model::order::Order;
 use primitive_types::U256;
 use std::sync::Arc;
 
@@ -32,13 +32,16 @@ impl From<Order> for LimitOrder {
             buy_amount: order.order_creation.buy_amount,
             kind: order.order_creation.kind,
             partially_fillable: order.order_creation.partially_fillable,
-            settlement_handling: Arc::new(order.order_creation),
+            settlement_handling: Arc::new(order),
         }
     }
 }
 
-impl LimitOrderSettlementHandling for OrderCreation {
+impl LimitOrderSettlementHandling for Order {
     fn settle(&self, executed_amount: U256) -> (Option<Trade>, Vec<Box<dyn Interaction>>) {
-        (Some(Trade::matched(*self, executed_amount)), Vec::new())
+        (
+            Some(Trade::matched(self.clone(), executed_amount)),
+            Vec::new(),
+        )
     }
 }

--- a/solver/src/naive_solver/multi_order_solver.rs
+++ b/solver/src/naive_solver/multi_order_solver.rs
@@ -262,7 +262,7 @@ fn compute_uniswap_in(
 ///
 fn is_valid_solution(solution: &Settlement) -> bool {
     for trade in solution.trades.iter() {
-        let order = trade.order;
+        let order = trade.order.order_creation;
         let buy_token_price = solution
             .clearing_prices
             .get(&order.buy_token)
@@ -691,22 +691,28 @@ mod tests {
         let token_a = Address::from_low_u64_be(0);
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
-            OrderCreation {
-                sell_token: token_a,
-                buy_token: token_b,
-                sell_amount: to_wei(10),
-                buy_amount: to_wei(8),
-                kind: OrderKind::Sell,
-                partially_fillable: false,
+            Order {
+                order_creation: OrderCreation {
+                    sell_token: token_a,
+                    buy_token: token_b,
+                    sell_amount: to_wei(10),
+                    buy_amount: to_wei(8),
+                    kind: OrderKind::Sell,
+                    partially_fillable: false,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
-            OrderCreation {
-                sell_token: token_b,
-                buy_token: token_a,
-                sell_amount: to_wei(10),
-                buy_amount: to_wei(9),
-                kind: OrderKind::Sell,
-                partially_fillable: false,
+            Order {
+                order_creation: OrderCreation {
+                    sell_token: token_b,
+                    buy_token: token_a,
+                    sell_amount: to_wei(10),
+                    buy_amount: to_wei(9),
+                    kind: OrderKind::Sell,
+                    partially_fillable: false,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
         ];


### PR DESCRIPTION
Prerequisite for solver metrics. I'd like to measure how long orders take from creation to successful settlement. For this we need to have access to the order's creation date from the settlement struct. We already expose `OrderCreation` data on the settlements via the trades field, however the creation timestamp is part of `OrderMetadata`

This PR therefore modifies the Trade struct to contain the full order instead of just the creation data.

### Test Plan
CI
