### PR TITLE
Settle orders after a minimum wait period to increase cow chance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,6 +2485,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "contracts",
  "ethcontract",
  "futures",

--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -234,6 +234,7 @@ async fn test_with_ganache() {
         Duration::from_secs(1),
         Duration::from_secs(30),
         native_token,
+        Duration::from_secs(0),
     );
     driver.single_run().await.unwrap();
 

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 contracts = { path = "../contracts" }
 ethcontract = { version = "0.11", default-features = false }
 futures = "0.3"

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -51,7 +51,7 @@ struct Arguments {
     #[structopt(
         long,
         env = "SETTLE_INTERVAL",
-        default_value = "30",
+        default_value = "10",
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
     settle_interval: Duration,
@@ -66,6 +66,17 @@ struct Arguments {
         use_delimiter = true,
     )]
     solvers: Vec<SolverType>,
+
+    /// A settlement must contain at least one order older than this duration for it to be applied.
+    /// Larger values delay individual settlements more but have a higher coincidence of wants
+    /// chance.
+    #[structopt(
+        long,
+        env = "MIN_ORDER_AGE",
+        default_value = "60",
+        parse(try_from_str = shared::arguments::duration_from_seconds),
+    )]
+    min_order_age: Duration,
 }
 
 #[tokio::main]
@@ -147,6 +158,7 @@ async fn main() {
         args.target_confirm_time,
         args.settle_interval,
         native_token_contract.address(),
+        args.min_order_age,
     );
     driver.run_forever().await;
 }


### PR DESCRIPTION
Currently the driver attempts settlement every 30 seconds and settles
what the solvers produce immediately. This makes it harder to get
coincidence of wants because the timing of order submission has to be
right as we have seen in the friday tests.
Instead of using a long settlement interval this commit only applies
settlements if they contain at least one order that is older than some
minimum age like 1 minute. This increases the cow chance and speeds of
settlements of several individual settlements one after another as the
wait time between them is decreases.

Once there are multiple solvers this might be something that needs more discussion or dao rule but until then this seems like a strict improvement to the existing logic.

### Test Plan
e2e test still works. couldn't find a great way to factor this out and the logic is simply.
