### PR TITLE
Solver Metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,12 +2500,15 @@ dependencies = [
  "num",
  "orderbook",
  "primitive-types",
+ "prometheus",
  "reqwest",
  "serde",
  "serde_json",
  "serde_with",
  "shared",
  "structopt",
+ "strum",
+ "strum_macros",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2660,6 +2663,24 @@ checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+
+[[package]]
+name = "strum_macros"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
+dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
  "syn",

--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -17,7 +17,7 @@ use shared::{
     transport::LoggingTransport,
     uniswap_pool::{CachedPoolFetcher, PoolFetcher},
 };
-use solver::{liquidity::uniswap::UniswapLiquidity, orderbook::OrderBookApi};
+use solver::{liquidity::uniswap::UniswapLiquidity, metrics::NoopMetrics, orderbook::OrderBookApi};
 use std::{collections::HashSet, str::FromStr, sync::Arc, time::Duration};
 use web3::signing::SecretKeyRef;
 
@@ -235,6 +235,7 @@ async fn test_with_ganache() {
         Duration::from_secs(30),
         native_token,
         Duration::from_secs(0),
+        Arc::new(NoopMetrics::default()),
     );
     driver.single_run().await.unwrap();
 

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -27,12 +27,15 @@ maplit = "1.0"
 model = { path = "../model" }
 num = "0.4"
 primitive-types = { version = "0.8", features = ["fp-conversion"] }
+prometheus = "0.12"
 reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "1.8", default-features = false }
 shared = { path = "../shared" }
 structopt = { version = "0.3" }
+strum = "0.20"
+strum_macros = "0.20"
 tokio = { version = "0.2", features =["macros", "rt-threaded", "time"] }
 tracing = "0.1"
 web3 = { version = "0.15", default-features = false, features = ["http-tls"] }

--- a/solver/src/lib.rs
+++ b/solver/src/lib.rs
@@ -3,6 +3,7 @@ pub mod encoding;
 pub mod http_solver;
 pub mod interactions;
 pub mod liquidity;
+pub mod metrics;
 pub mod naive_solver;
 pub mod orderbook;
 pub mod settlement;

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -3,6 +3,7 @@ use num::rational::Ratio;
 use primitive_types::{H160, U256};
 use settlement::{Interaction, Trade};
 use std::sync::Arc;
+use strum_macros::{AsStaticStr, EnumVariantNames};
 
 #[cfg(test)]
 use mockall::automock;
@@ -13,7 +14,7 @@ pub mod offchain_orderbook;
 pub mod uniswap;
 
 /// Defines the different types of liquidity our solvers support
-#[derive(Clone)]
+#[derive(Clone, AsStaticStr, EnumVariantNames)]
 pub enum Liquidity {
     Limit(LimitOrder),
     Amm(AmmOrder),

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -1,13 +1,17 @@
 use contracts::WETH9;
 use ethcontract::{Account, PrivateKey};
+use prometheus::Registry;
 use reqwest::Url;
 use shared::{
+    metrics::serve_metrics,
     price_estimate::UniswapPriceEstimator,
     token_info::{CachedTokenInfoFetcher, TokenInfoFetcher},
     transport::LoggingTransport,
     uniswap_pool::PoolFetcher,
 };
-use solver::{driver::Driver, liquidity::uniswap::UniswapLiquidity, solver::SolverType};
+use solver::{
+    driver::Driver, liquidity::uniswap::UniswapLiquidity, metrics::Metrics, solver::SolverType,
+};
 use std::iter::FromIterator as _;
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use structopt::StructOpt;
@@ -77,6 +81,15 @@ struct Arguments {
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
     min_order_age: Duration,
+
+    /// The port at which we serve our metrics
+    #[structopt(
+        long,
+        env = "METRICS_PORT",
+        default_value = "9587",
+        case_insensitive = true
+    )]
+    metrics_port: u16,
 }
 
 #[tokio::main]
@@ -84,6 +97,10 @@ async fn main() {
     let args = Arguments::from_args();
     shared::tracing::initialize(args.shared.log_filter.as_str());
     tracing::info!("running solver with {:#?}", args);
+
+    let registry = Registry::default();
+    let metrics = Arc::new(Metrics::new(&registry).expect("Couldn't register metrics"));
+
     // TODO: custom transport that allows setting timeout
     let transport = LoggingTransport::new(
         web3::transports::Http::new(args.shared.node_url.as_str())
@@ -159,6 +176,9 @@ async fn main() {
         args.settle_interval,
         native_token_contract.address(),
         args.min_order_age,
+        metrics,
     );
+
+    serve_metrics(registry, ([0, 0, 0, 0], args.metrics_port).into());
     driver.run_forever().await;
 }

--- a/solver/src/metrics.rs
+++ b/solver/src/metrics.rs
@@ -1,0 +1,107 @@
+use std::{convert::TryInto, time::Instant};
+
+use anyhow::Result;
+use model::order::Order;
+use prometheus::{IntCounter, IntCounterVec, IntGaugeVec, Opts, Registry};
+use strum::{AsStaticRef, VariantNames};
+
+use crate::liquidity::Liquidity;
+
+pub trait SolverMetrics {
+    fn liquidity_fetched(&self, liquidity: &[Liquidity]);
+    fn settlement_computed(&self, solver_type: &str, start: Instant);
+    fn order_settled(&self, order: &Order);
+}
+
+// TODO add labeled interaction counter once we support more than one interaction
+pub struct Metrics {
+    trade_counter: IntCounter,
+    order_settlement_time: IntCounter,
+    solver_computation_time: IntCounterVec,
+    liquidity: IntGaugeVec,
+}
+
+impl Metrics {
+    pub fn new(registry: &Registry) -> Result<Self> {
+        let trade_counter =
+            IntCounter::new("gp_v2_solver_trade_counter", "Number of trades settled")?;
+        registry.register(Box::new(trade_counter.clone()))?;
+
+        let order_settlement_time = IntCounter::new(
+            "gp_v2_solver_order_settlement_time_seconds",
+            "Counter for the number of seconds between creation and settlement of an order",
+        )?;
+        registry.register(Box::new(order_settlement_time.clone()))?;
+
+        let solver_computation_time = IntCounterVec::new(
+            Opts::new(
+                "gp_v2_solver_computation_time_ms",
+                "Ms each solver takes to compute their solution",
+            ),
+            &["solver_type"],
+        )?;
+        registry.register(Box::new(solver_computation_time.clone()))?;
+
+        let liquidity = IntGaugeVec::new(
+            Opts::new(
+                "gp_v2_solver_liquidity_gauge",
+                "Amount of orders labeled by liquidity type currently available to the solvers",
+            ),
+            &["liquidity_type"],
+        )?;
+        registry.register(Box::new(liquidity.clone()))?;
+
+        Ok(Self {
+            trade_counter,
+            order_settlement_time,
+            solver_computation_time,
+            liquidity,
+        })
+    }
+}
+
+impl SolverMetrics for Metrics {
+    fn liquidity_fetched(&self, liquidity: &[Liquidity]) {
+        // Reset all gauges and start from scratch
+        Liquidity::VARIANTS.iter().for_each(|label| {
+            self.liquidity.with_label_values(&[label]).set(0);
+        });
+        liquidity.iter().for_each(|liquidity| {
+            let label = liquidity.as_static();
+            self.liquidity.with_label_values(&[label]).inc();
+        })
+    }
+
+    fn settlement_computed(&self, solver_type: &str, start: Instant) {
+        self.solver_computation_time
+            .with_label_values(&[solver_type])
+            .inc_by(
+                Instant::now()
+                    .duration_since(start)
+                    .as_millis()
+                    .try_into()
+                    .unwrap_or(u64::MAX),
+            )
+    }
+
+    fn order_settled(&self, order: &Order) {
+        let time_to_settlement =
+            chrono::offset::Utc::now().signed_duration_since(order.order_meta_data.creation_date);
+        self.trade_counter.inc();
+        self.order_settlement_time.inc_by(
+            time_to_settlement
+                .num_seconds()
+                .try_into()
+                .unwrap_or_default(),
+        )
+    }
+}
+
+#[derive(Default)]
+pub struct NoopMetrics {}
+
+impl SolverMetrics for NoopMetrics {
+    fn liquidity_fetched(&self, _liquidity: &[Liquidity]) {}
+    fn settlement_computed(&self, _solver_type: &str, _start: Instant) {}
+    fn order_settled(&self, _order: &Order) {}
+}


### PR DESCRIPTION
For now, last part of #425.

Adding some hopefully useful metrics to the driver which can give insight on how many orders of what type are currently considered, how many trades are happening and how long people wait on average to see their trade matched locall.

### Test Plan
Run locally and do a e2e swap on CowSwap. Afterwards check `http://localhost:9587/metrics` to see the relevant metrics
