### PR TITLE
Check that balance is transferable on new order

### DIFF
--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -159,7 +159,11 @@ async fn test_with_ganache() {
         domain_separator,
         db.clone(),
         event_updater,
-        Box::new(Web3BalanceFetcher::new(web3.clone(), gp_allowance)),
+        Box::new(Web3BalanceFetcher::new(
+            web3.clone(),
+            gp_allowance,
+            gp_settlement.address(),
+        )),
         fee_calculator.clone(),
     ));
 

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -22,6 +22,7 @@ ethcontract = { version = "0.11", default-features = false }
 futures = "0.3.14"
 gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.0", features = ["web3_"] }
 hex = { version = "0.4", default-features = false }
+hex-literal = "0.3"
 maplit = "1.0"
 model = { path = "../model" }
 num-bigint = "0.3"
@@ -42,6 +43,5 @@ web3 = { version = "0.15", default-features = false, features = ["http-tls"] }
 num = "0.4"
 
 [dev-dependencies]
-hex-literal = "0.3"
 secp256k1 = "0.20"
 mockall = "0.9"

--- a/orderbook/src/account_balances.rs
+++ b/orderbook/src/account_balances.rs
@@ -168,7 +168,7 @@ impl BalanceFetching for Web3BalanceFetcher {
         let block = Some(BlockId::Number(BlockNumber::Latest));
         let response = self.web3.eth().call(call_request, block).await;
         response
-            .map(|bytes| is_empty_or_nonzero(bytes.0.as_slice()))
+            .map(|bytes| is_empty_or_truthy(bytes.0.as_slice()))
             .unwrap_or(false)
     }
 }

--- a/orderbook/src/account_balances.rs
+++ b/orderbook/src/account_balances.rs
@@ -174,10 +174,11 @@ impl BalanceFetching for Web3BalanceFetcher {
 }
 
 fn is_empty_or_nonzero(bytes: &[u8]) -> bool {
-    if bytes.is_empty() {
-        return true;
+    match bytes.len() {
+        0 => true,
+        32 => bytes.iter().any(|byte| *byte > 0),
+        _ => false,
     }
-    bytes.iter().any(|byte| *byte > 0)
 }
 
 #[cfg(test)]
@@ -242,7 +243,8 @@ mod tests {
             .await
             .expect("MintableERC20 deployment failed");
 
-        let fetcher = Web3BalanceFetcher::new(web3, allowance_target.address(), H160::zero());
+        let fetcher =
+            Web3BalanceFetcher::new(web3, allowance_target.address(), H160::from_low_u64_be(1));
 
         // Not available until registered
         assert_eq!(fetcher.get_balance(trader.address(), token.address()), None,);

--- a/orderbook/src/account_balances.rs
+++ b/orderbook/src/account_balances.rs
@@ -173,7 +173,7 @@ impl BalanceFetching for Web3BalanceFetcher {
     }
 }
 
-fn is_empty_or_nonzero(bytes: &[u8]) -> bool {
+fn is_empty_or_truthy(bytes: &[u8]) -> bool {
     match bytes.len() {
         0 => true,
         32 => bytes.iter().any(|byte| *byte > 0),

--- a/orderbook/src/account_balances.rs
+++ b/orderbook/src/account_balances.rs
@@ -1,12 +1,10 @@
 use anyhow::Result;
+use contracts::ERC20;
 use ethcontract::batch::CallBatch;
 use futures::future::{join3, join_all};
-use std::collections::HashMap;
-use std::sync::Mutex;
-
-use contracts::ERC20;
 use primitive_types::{H160, U256};
 use shared::Web3;
+use std::{collections::HashMap, sync::Mutex};
 
 const MAX_BATCH_SIZE: usize = 100;
 
@@ -25,11 +23,19 @@ pub trait BalanceFetching: Send + Sync {
 
     // Called periodically to perform potential updates on registered balances
     async fn update(&self);
+
+    // Check if the allowance manager would be able to call transfer_from with these parameters.
+    // This is useful for tokens that are not consistent about their internal checks and what they
+    // report as balance and allowance. By checking whether the actual transfer would suceed we can
+    // be more certain (but still not 100%) that the balance really is available to the settlement
+    // contract.
+    async fn can_transfer(&self, token: H160, from: H160, amount: U256) -> bool;
 }
 
 pub struct Web3BalanceFetcher {
     web3: Web3,
     allowance_manager: H160,
+    settlement_contract: H160,
     // Mapping of address, token to balance, allowance
     balances: Mutex<HashMap<SubscriptionKey, SubscriptionValue>>,
 }
@@ -47,10 +53,11 @@ struct SubscriptionValue {
 }
 
 impl Web3BalanceFetcher {
-    pub fn new(web3: Web3, allowance_manager: H160) -> Self {
+    pub fn new(web3: Web3, allowance_manager: H160, settlement_contract: H160) -> Self {
         Self {
             web3,
             allowance_manager,
+            settlement_contract,
             balances: Default::default(),
         }
     }
@@ -143,6 +150,17 @@ impl BalanceFetching for Web3BalanceFetcher {
         };
         let _ = self._register_many(subscriptions.into_iter()).await;
     }
+
+    async fn can_transfer(&self, token: H160, from: H160, amount: U256) -> bool {
+        let instance = ERC20::at(&self.web3, token);
+        instance
+            .transfer_from(from, self.settlement_contract, amount)
+            .view()
+            .from(self.allowance_manager)
+            .call()
+            .await
+            .unwrap_or(false)
+    }
 }
 
 #[cfg(test)]
@@ -150,7 +168,45 @@ mod tests {
     use super::*;
     use contracts::ERC20Mintable;
     use ethcontract::{prelude::Account, Http};
+    use hex_literal::hex;
     use shared::transport::LoggingTransport;
+
+    #[tokio::test]
+    #[ignore]
+    async fn rinkeby_can_transfer() {
+        let http = LoggingTransport::new(
+            Http::new("https://dev-openethereum.rinkeby.gnosisdev.com/").unwrap(),
+        );
+        let web3 = Web3::new(http);
+        let settlement = contracts::GPv2Settlement::deployed(&web3).await.unwrap();
+        let allowance = settlement.allowance_manager().call().await.unwrap();
+        let fetcher = Web3BalanceFetcher::new(web3, allowance, settlement.address());
+        let owner = H160(hex!("52DF85E9De71aa1C210873bcF37EC46d36c99dc2"));
+        let token = H160(hex!("5592ec0cfb4dbc12d3ab100b257153436a1f0fea"));
+
+        let result = fetcher.can_transfer(token, owner, 1000.into()).await;
+        assert!(result);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn mainnet_cannot_transfer() {
+        let http = LoggingTransport::new(
+            Http::new("https://dev-openethereum.mainnet.gnosisdev.com/").unwrap(),
+        );
+        let web3 = Web3::new(http);
+        let settlement = contracts::GPv2Settlement::deployed(&web3).await.unwrap();
+        let allowance = settlement.allowance_manager().call().await.unwrap();
+        let fetcher = Web3BalanceFetcher::new(web3, allowance, settlement.address());
+        let owner = H160(hex!("c978f4364c03a00352e8c7d9619b42e26b6424ab"));
+        let token = H160(hex!("c12d1c73ee7dc3615ba4e37e4abfdbddfa38907e"));
+
+        // The owner has balance and approval but still the transfer fails.
+        fetcher.register(owner, token).await;
+        assert!(fetcher.get_balance(owner, token).unwrap() >= U256::from(1000));
+        let result = fetcher.can_transfer(token, owner, 1000.into()).await;
+        assert!(!result);
+    }
 
     #[tokio::test]
     #[ignore]
@@ -169,7 +225,7 @@ mod tests {
             .await
             .expect("MintableERC20 deployment failed");
 
-        let fetcher = Web3BalanceFetcher::new(web3, allowance_target.address());
+        let fetcher = Web3BalanceFetcher::new(web3, allowance_target.address(), H160::zero());
 
         // Not available until registered
         assert_eq!(fetcher.get_balance(trader.address(), token.address()), None,);

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -113,7 +113,8 @@ async fn main() {
 
     let event_updater =
         EventUpdater::new(settlement_contract.clone(), database.clone(), sync_start);
-    let balance_fetcher = Web3BalanceFetcher::new(web3.clone(), gp_allowance);
+    let balance_fetcher =
+        Web3BalanceFetcher::new(web3.clone(), gp_allowance, settlement_contract.address());
 
     let gas_price_estimator = shared::gas_price_estimation::create_priority_estimator(
         &reqwest::Client::new(),

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -88,15 +88,31 @@ impl Orderbook {
             return Ok(AddOrderResult::WrongOwner(order.order_meta_data.owner));
         }
 
-        if !new_order_has_balance(&order, self.balance_fetcher.as_ref()).await {
+        let min_balance = match minimum_balance(&order) {
+            Some(amount) => amount,
+            None => return Ok(AddOrderResult::InsufficientFunds),
+        };
+        if !self
+            .balance_fetcher
+            .can_transfer(
+                order.order_creation.sell_token,
+                order.order_meta_data.owner,
+                min_balance,
+            )
+            .await
+        {
             return Ok(AddOrderResult::InsufficientFunds);
         }
 
         match self.database.insert_order(&order).await {
-            Ok(()) => Ok(AddOrderResult::Added(order.order_meta_data.uid)),
-            Err(InsertionError::DuplicatedRecord) => Ok(AddOrderResult::DuplicatedOrder),
-            Err(InsertionError::DbError(err)) => Err(err.into()),
+            Err(InsertionError::DuplicatedRecord) => return Ok(AddOrderResult::DuplicatedOrder),
+            Err(InsertionError::DbError(err)) => return Err(err.into()),
+            _ => (),
         }
+        self.balance_fetcher
+            .register(order.order_creation.sell_token, order.order_meta_data.owner)
+            .await;
+        Ok(AddOrderResult::Added(order.order_meta_data.uid))
     }
 
     pub async fn cancel_order(
@@ -247,25 +263,16 @@ fn solvable_orders(mut orders: Vec<Order>, balances: &HashMap<(H160, H160), U256
     result
 }
 
-async fn new_order_has_balance(order: &Order, balance_fetcher: &dyn BalanceFetching) -> bool {
-    balance_fetcher
-        .register(order.order_meta_data.owner, order.order_creation.sell_token)
-        .await;
-    let owner = order.order_meta_data.owner;
-    let token = order.order_creation.sell_token;
-    balance_fetcher.register(owner, token).await;
-    let minimum_balance = if order.order_creation.partially_fillable {
-        1.into()
+// Mininum balance user must have in sell token for order to be accepted. None if no balance is
+// sufficient.
+fn minimum_balance(order: &Order) -> Option<U256> {
+    if order.order_creation.partially_fillable {
+        Some(U256::from(1))
     } else {
         order
             .order_creation
             .sell_amount
-            .saturating_add(order.order_creation.fee_amount)
-    };
-    let balance = balance_fetcher.get_balance(owner, token);
-    match balance {
-        Some(balance) => balance >= minimum_balance,
-        None => false,
+            .checked_add(order.order_creation.fee_amount)
     }
 }
 
@@ -277,7 +284,7 @@ mod tests {
     use ethcontract::H160;
     use maplit::hashmap;
     use mockall::{predicate::eq, Sequence};
-    use model::order::{OrderBuilder, OrderCreation, OrderMetaData};
+    use model::order::{OrderCreation, OrderMetaData};
 
     #[tokio::test]
     async fn track_and_get_balances_() {
@@ -386,61 +393,5 @@ mod tests {
             DateTime::from_utc(NaiveDateTime::from_timestamp(3, 0), Utc);
         let orders_ = solvable_orders(orders.clone(), &balances);
         assert_eq!(orders_, orders[..1]);
-    }
-
-    #[tokio::test]
-    async fn new_order_has_balance_true_fillkill() {
-        let order = OrderBuilder::default()
-            .with_fee_amount(2.into())
-            .with_sell_amount(3.into())
-            .build();
-        let mut balance_fetcher = MockBalanceFetching::new();
-        balance_fetcher.expect_register().return_const(());
-        balance_fetcher
-            .expect_get_balance()
-            .return_const(Some(5.into()));
-        assert!(new_order_has_balance(&order, &balance_fetcher).await);
-    }
-
-    #[tokio::test]
-    async fn new_order_has_balance_true_partially_fillable() {
-        let order = OrderBuilder::default()
-            .with_fee_amount(2.into())
-            .with_sell_amount(3.into())
-            .with_partially_fillable(true)
-            .build();
-        let mut balance_fetcher = MockBalanceFetching::new();
-        balance_fetcher.expect_register().return_const(());
-        balance_fetcher
-            .expect_get_balance()
-            .return_const(Some(1.into()));
-        assert!(new_order_has_balance(&order, &balance_fetcher).await);
-    }
-
-    #[tokio::test]
-    async fn new_order_has_balance_false_fillkill() {
-        let order = OrderBuilder::default()
-            .with_fee_amount(2.into())
-            .with_sell_amount(3.into())
-            .build();
-        let mut balance_fetcher = MockBalanceFetching::new();
-        balance_fetcher.expect_register().return_const(());
-        balance_fetcher
-            .expect_get_balance()
-            .return_const(Some(4.into()));
-        assert!(!new_order_has_balance(&order, &balance_fetcher).await);
-    }
-
-    #[tokio::test]
-    async fn new_order_has_balance_false_balance_unavailable() {
-        let order = OrderBuilder::default()
-            .with_fee_amount(2.into())
-            .with_sell_amount(3.into())
-            .with_partially_fillable(true)
-            .build();
-        let mut balance_fetcher = MockBalanceFetching::new();
-        balance_fetcher.expect_register().return_const(());
-        balance_fetcher.expect_get_balance().return_const(None);
-        assert!(!new_order_has_balance(&order, &balance_fetcher).await);
     }
 }


### PR DESCRIPTION
We can improve checking for available balance by checking whether the
balance is transferable. This can detect many weird erc20 tokens like the kick token where the result of getBalance is inconsistent with what is checked during the transfer.
The transfer check implies balance existing so I removed the balance check.
A todo is that we should also do this as part of maintenance for example for tokens that can be "paused" which disables all trading until unpaused. I wasn't yet sure how to organize that code correctly and wanted the base functionality independently reviewed.

### Test Plan
e2e test still works and tested new function with the 2 ignored tests on real networks