### PR TITLE
Make weth available to order settlement handling

### DIFF
--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -1,5 +1,8 @@
-use contracts::{ERC20Mintable, UniswapV2Factory, UniswapV2Router02};
-use ethcontract::prelude::{Account, Address, Http, PrivateKey, Web3, U256};
+use contracts::{ERC20Mintable, UniswapV2Factory, UniswapV2Router02, WETH9};
+use ethcontract::{
+    prelude::{Account, Address, Http, PrivateKey, U256},
+    H160,
+};
 use hex_literal::hex;
 use model::{
     order::{OrderBuilder, OrderKind},
@@ -16,6 +19,7 @@ use shared::{
     price_estimate::UniswapPriceEstimator,
     transport::LoggingTransport,
     uniswap_pool::{CachedPoolFetcher, PoolFetcher},
+    Web3,
 };
 use solver::{liquidity::uniswap::UniswapLiquidity, metrics::NoopMetrics, orderbook::OrderBookApi};
 use std::{collections::HashSet, str::FromStr, sync::Arc, time::Duration};
@@ -227,10 +231,10 @@ async fn test_with_ganache() {
     let mut driver = solver::driver::Driver::new(
         gp_settlement.clone(),
         uniswap_liquidity,
-        create_orderbook_api(),
+        create_orderbook_api(&web3),
         price_estimator,
         vec![Box::new(solver)],
-        Box::new(web3),
+        Box::new(web3.clone()),
         Duration::from_secs(1),
         Duration::from_secs(30),
         native_token,
@@ -257,7 +261,7 @@ async fn test_with_ganache() {
     // Drive orderbook in order to check the removal of settled order_b
     orderbook.run_maintenance(&gp_settlement).await.unwrap();
 
-    let orders = create_orderbook_api().get_orders().await.unwrap();
+    let orders = create_orderbook_api(&web3).get_orders().await.unwrap();
     assert!(orders.is_empty());
 
     // Drive again to ensure we can continue solution finding
@@ -268,9 +272,11 @@ fn to_wei(base: u32) -> U256 {
     U256::from(base) * U256::from(10).pow(18.into())
 }
 
-fn create_orderbook_api() -> OrderBookApi {
+fn create_orderbook_api(web3: &Web3) -> OrderBookApi {
+    let native_token = WETH9::at(web3, H160([0x42; 20]));
     solver::orderbook::OrderBookApi::new(
         reqwest::Url::from_str(API_HOST).unwrap(),
         std::time::Duration::from_secs(10),
+        native_token,
     )
 }

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -7,6 +7,8 @@ use strum_macros::{AsStaticStr, EnumVariantNames};
 
 #[cfg(test)]
 use mockall::automock;
+#[cfg(test)]
+use model::order::Order;
 
 use crate::settlement;
 
@@ -31,6 +33,18 @@ pub struct LimitOrder {
     pub kind: OrderKind,
     pub partially_fillable: bool,
     pub settlement_handling: Arc<dyn LimitOrderSettlementHandling>,
+}
+
+#[cfg(test)]
+impl From<Order> for LimitOrder {
+    fn from(order: Order) -> Self {
+        use self::offchain_orderbook::normalize_limit_order;
+        use crate::interactions::dummy_web3;
+        use contracts::WETH9;
+
+        let native_token = WETH9::at(&dummy_web3::dummy_web3(), H160([0x42; 20]));
+        normalize_limit_order(order, native_token)
+    }
 }
 
 /// Specifies how a limit order fulfillment translates into Trade and Interactions for the settlement

--- a/solver/src/liquidity/offchain_orderbook.rs
+++ b/solver/src/liquidity/offchain_orderbook.rs
@@ -1,6 +1,7 @@
 use crate::orderbook::OrderBookApi;
 use crate::settlement::{Interaction, Trade};
 use anyhow::{Context, Result};
+use contracts::WETH9;
 use model::order::Order;
 use primitive_types::U256;
 use std::sync::Arc;
@@ -15,32 +16,39 @@ impl OrderBookApi {
             .await
             .context("failed to get orderbook")?
             .into_iter()
-            .map(|order| order.into())
+            .map(|order| normalize_limit_order(order, self.get_native_token()))
             .collect())
     }
 }
 
-impl From<Order> for LimitOrder {
-    fn from(order: Order) -> Self {
-        LimitOrder {
-            id: order.order_meta_data.uid.to_string(),
-            sell_token: order.order_creation.sell_token,
-            // TODO handle ETH buy token address (0xe...e) by making the handler include an WETH.unwrap() interaction
-            buy_token: order.order_creation.buy_token,
-            // TODO discount previously executed sell amount
-            sell_amount: order.order_creation.sell_amount,
-            buy_amount: order.order_creation.buy_amount,
-            kind: order.order_creation.kind,
-            partially_fillable: order.order_creation.partially_fillable,
-            settlement_handling: Arc::new(order),
-        }
+struct OrderSettlementHandling {
+    #[allow(dead_code)]
+    native_token: WETH9,
+    order: Order,
+}
+
+pub fn normalize_limit_order(order: Order, native_token: WETH9) -> LimitOrder {
+    LimitOrder {
+        id: order.order_meta_data.uid.to_string(),
+        sell_token: order.order_creation.sell_token,
+        // TODO handle ETH buy token address (0xe...e) by making the handler include an WETH.unwrap() interaction
+        buy_token: order.order_creation.buy_token,
+        // TODO discount previously executed sell amount
+        sell_amount: order.order_creation.sell_amount,
+        buy_amount: order.order_creation.buy_amount,
+        kind: order.order_creation.kind,
+        partially_fillable: order.order_creation.partially_fillable,
+        settlement_handling: Arc::new(OrderSettlementHandling {
+            order,
+            native_token,
+        }),
     }
 }
 
-impl LimitOrderSettlementHandling for Order {
+impl LimitOrderSettlementHandling for OrderSettlementHandling {
     fn settle(&self, executed_amount: U256) -> (Option<Trade>, Vec<Box<dyn Interaction>>) {
         (
-            Some(Trade::matched(self.clone(), executed_amount)),
+            Some(Trade::matched(self.order.clone(), executed_amount)),
             Vec::new(),
         )
     }

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -126,8 +126,11 @@ async fn main() {
     let native_token_contract = WETH9::deployed(&web3)
         .await
         .expect("couldn't load deployed native token");
-    let orderbook_api =
-        solver::orderbook::OrderBookApi::new(args.orderbook_url, args.orderbook_timeout);
+    let orderbook_api = solver::orderbook::OrderBookApi::new(
+        args.orderbook_url,
+        args.orderbook_timeout,
+        native_token_contract.clone(),
+    );
     let mut base_tokens = HashSet::from_iter(args.shared.base_tokens);
     // We should always use the native token as a base token.
     base_tokens.insert(native_token_contract.address());

--- a/solver/src/orderbook.rs
+++ b/solver/src/orderbook.rs
@@ -1,3 +1,4 @@
+use contracts::WETH9;
 use model::order::Order;
 use reqwest::{Client, Url};
 use std::time::Duration;
@@ -5,14 +6,19 @@ use std::time::Duration;
 pub struct OrderBookApi {
     base: Url,
     client: Client,
+    native_token: WETH9,
 }
 
 impl OrderBookApi {
     /// base: protocol and host of the url. example: `https://example.com`
-    pub fn new(base: Url, request_timeout: Duration) -> Self {
+    pub fn new(base: Url, request_timeout: Duration, native_token: WETH9) -> Self {
         // Unwrap because we cannot handle client creation failing.
         let client = Client::builder().timeout(request_timeout).build().unwrap();
-        Self { base, client }
+        Self {
+            base,
+            client,
+            native_token,
+        }
     }
 
     pub async fn get_orders(&self) -> reqwest::Result<Vec<Order>> {
@@ -21,19 +27,29 @@ impl OrderBookApi {
         url.set_path(PATH);
         self.client.get(url).send().await?.json().await
     }
+
+    pub fn get_native_token(&self) -> WETH9 {
+        self.native_token.clone()
+    }
 }
 
 #[cfg(test)]
 pub mod test_util {
+    use ethcontract::H160;
+
+    use crate::interactions::dummy_web3;
+
     use super::*;
 
     // cargo test real_orderbook -- --ignored --nocapture
     #[tokio::test]
     #[ignore]
     async fn real_orderbook() {
+        let native_token = WETH9::at(&dummy_web3::dummy_web3(), H160([0x42; 20]));
         let api = OrderBookApi::new(
             Url::parse("http://localhost:8080").unwrap(),
             Duration::from_secs(10),
+            native_token,
         );
         let orders = api.get_orders().await.unwrap();
         println!("{:?}", orders);


### PR DESCRIPTION
This PR makes a weth instance available when computing a limit order. It doesn't change the behavior of the current code.
It will later be used to replace the placeholder ETH address with the correct WETH address, and to help changing the settlement procedure.

/cc @nlordell 

### Test Plan
Existing unit tests.