### PR TITLE
Use gas price from pending transaction if detected

### DIFF
--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -14,11 +14,13 @@ use ethcontract::{
     transaction::TransactionBuilder,
     Web3,
 };
+use futures::stream::StreamExt;
 use gas_estimation::GasPriceEstimating;
 use gas_price_stream::gas_price_stream;
 use primitive_types::{H160, U256};
 use std::time::Duration;
 use transaction_retry::RetryResult;
+use web3::types::{BlockId, BlockNumber};
 
 const GAS_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
 const ESTIMATE_GAS_LIMIT_FACTOR: f64 = 1.2;
@@ -31,12 +33,23 @@ pub async fn submit(
     gas_price_cap: f64,
     settlement: Settlement,
 ) -> Result<()> {
-    let nonce = transaction_count(contract)
-        .await
-        .context("failed to get transaction_count")?;
     let settlement = encode_settlement(&settlement)?;
     // Check that a simulation of the transaction works before submitting it.
     simulate_settlement(&settlement, contract).await?;
+
+    let nonce = transaction_count(contract)
+        .await
+        .context("failed to get transaction_count")?;
+    let address = &contract
+        .defaults()
+        .from
+        .clone()
+        .expect("no default sender address")
+        .address();
+    let web3 = contract.raw_instance().web3();
+    let pending_gas_price = recover_gas_price_from_pending_transaction(&web3, &address, nonce)
+        .await
+        .context("failed to get pending gas price")?;
 
     // Account for some buffer in the gas limit in case racing state changes result in slightly more heavy computation at execution time
     let gas_limit = retry::settle_method_builder(contract, settlement.clone())
@@ -55,7 +68,30 @@ pub async fn submit(
     };
     // We never cancel.
     let cancel_future = std::future::pending::<CancelSender>();
-    let stream = gas_price_stream(target_confirm_time, gas_price_cap, gas_limit, gas);
+    if let Some(gas_price) = pending_gas_price {
+        tracing::info!(
+            "detected existing pending transaction with gas price {}",
+            gas_price
+        );
+    }
+
+    // It is possible that there is a pending transaction we don't know about because the driver
+    // got restarted while it was in progress. Sending a new transaction could fail in that case
+    // because the gas price has not increased. So we make sure that the starting gas price is at
+    // least high enough to accommodate. This isn't perfect because it's still possible that that
+    // transaction gets mined first in which case our new transaction would fail with "nonce already
+    // used".
+    let pending_gas_price = pending_gas_price.map(|gas_price| {
+        transaction_retry::gas_price_increase::minimum_increase(gas_price.to_f64_lossy())
+    });
+    let stream = gas_price_stream(
+        target_confirm_time,
+        gas_price_cap,
+        gas_limit,
+        gas,
+        pending_gas_price,
+    )
+    .boxed();
 
     match transaction_retry::retry(settlement_sender, cancel_future, stream).await {
         Some(RetryResult::Submitted(result)) => {
@@ -142,4 +178,21 @@ async fn tenderly_link(
         hex::encode(tx.data.unwrap().0),
         network_id
     ))
+}
+
+async fn recover_gas_price_from_pending_transaction(
+    web3: &Web3<DynTransport>,
+    address: &H160,
+    nonce: U256,
+) -> Result<Option<U256>> {
+    let block = web3
+        .eth()
+        .block_with_txs(BlockId::Number(BlockNumber::Pending))
+        .await?
+        .ok_or_else(|| anyhow!("empty block"))?;
+    let transaction = block
+        .transactions
+        .iter()
+        .find(|transaction| transaction.from == *address && transaction.nonce == nonce);
+    Ok(transaction.map(|transaction| transaction.gas_price))
 }

--- a/solver/src/settlement_submission/gas_price_stream.rs
+++ b/solver/src/settlement_submission/gas_price_stream.rs
@@ -10,9 +10,14 @@ pub fn gas_price_stream(
     gas_price_cap: f64,
     gas_limit: f64,
     estimator: &dyn GasPriceEstimating,
+    initial_gas_price: Option<f64>,
 ) -> impl Stream<Item = f64> + '_ {
     let stream = stream::unfold(true, move |first_call| async move {
-        if !first_call {
+        if first_call {
+            if let Some(initial_gas_price) = initial_gas_price {
+                return Some((Ok(initial_gas_price), false));
+            }
+        } else {
             tokio::time::delay_for(GAS_PRICE_REFRESH_INTERVAL).await;
         }
         let estimate = estimator


### PR DESCRIPTION
This is a partial fix for https://github.com/gnosis/gp-v2-services/issues/445 . It should work fine in case of restarts but it might still print an error if the pending transactions gets mined first. It can also help against the case where the node forgets a transaction.

A more proper solution should go into the transaction-retry crate but that's harder to figure out how to do so I'd like to have this in the mean time.

### Test Plan
Hard to test until we see this actually happening. I did test the getBlock(Pending) call to see that it really returns pending transactions and I saw that the total gas use of pending transactions was well above 12 mil so it seems to be bigger than just "one" pending block.
