### PR TITLE
Add seperate groups of interactions for settlement

### DIFF
--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -1,7 +1,7 @@
 use model::{order::OrderKind, TokenPair};
 use num::rational::Ratio;
 use primitive_types::{H160, U256};
-use settlement::{Interaction, Trade};
+use settlement::{Interaction, Trade, UnwrapInteraction};
 use std::sync::Arc;
 use strum_macros::{AsStaticStr, EnumVariantNames};
 
@@ -50,7 +50,7 @@ impl From<Order> for LimitOrder {
 /// Specifies how a limit order fulfillment translates into Trade and Interactions for the settlement
 #[cfg_attr(test, automock)]
 pub trait LimitOrderSettlementHandling: Send + Sync {
-    fn settle(&self, executed_amount: U256) -> (Option<Trade>, Vec<Box<dyn Interaction>>);
+    fn settle(&self, executed_amount: U256) -> (Option<Trade>, Option<Box<dyn UnwrapInteraction>>);
 }
 
 /// 2 sided constant product automated market maker with equal reserve value and a trading fee (e.g. Uniswap, Sushiswap)
@@ -91,9 +91,12 @@ pub mod tests {
     }
 
     impl LimitOrderSettlementHandling for CapturingLimitOrderSettlementHandler {
-        fn settle(&self, executed_amount: U256) -> (Option<Trade>, Vec<Box<dyn Interaction>>) {
+        fn settle(
+            &self,
+            executed_amount: U256,
+        ) -> (Option<Trade>, Option<Box<dyn UnwrapInteraction>>) {
             self.calls.lock().unwrap().push(executed_amount);
-            (None, Vec::new())
+            (None, None)
         }
     }
 

--- a/solver/src/liquidity/offchain_orderbook.rs
+++ b/solver/src/liquidity/offchain_orderbook.rs
@@ -1,5 +1,5 @@
 use crate::orderbook::OrderBookApi;
-use crate::settlement::{Interaction, Trade};
+use crate::settlement::{Trade, UnwrapInteraction};
 use anyhow::{Context, Result};
 use contracts::WETH9;
 use model::order::Order;
@@ -46,10 +46,10 @@ pub fn normalize_limit_order(order: Order, native_token: WETH9) -> LimitOrder {
 }
 
 impl LimitOrderSettlementHandling for OrderSettlementHandling {
-    fn settle(&self, executed_amount: U256) -> (Option<Trade>, Vec<Box<dyn Interaction>>) {
+    fn settle(&self, executed_amount: U256) -> (Option<Trade>, Option<Box<dyn UnwrapInteraction>>) {
         (
             Some(Trade::matched(self.order.clone(), executed_amount)),
-            Vec::new(),
+            None,
         )
     }
 }

--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -86,9 +86,7 @@ fn encode_settlement(settlement: &Settlement) -> Result<EncodedSettlement> {
     Ok(EncodedSettlement {
         tokens: settlement.tokens(),
         clearing_prices: settlement.clearing_prices(),
-        encoded_interactions: settlement
-            .encode_interactions()
-            .context("interaction encoding failed")?,
+        encoded_interactions: settlement.encode_interactions(),
         encoded_trades: settlement
             .encode_trades()
             .ok_or_else(|| anyhow!("trade encoding failed"))?,


### PR DESCRIPTION
This PR refactors the settlement interactions to use "interaction groups" to allow for smarter combinations. This allows, for example, to combine multiple unwraps into a single one without requiring separate implementations of the solver. Additionally, this avoids some implicit ordering that would otherwise be needed in all solvers (they would all require unwraps to come after AMM interactions for example).

/cc @fedgiac 

### Test Plan

Added new unit tests.
