### PR TITLE
[Trivial] Reducing default min order age to 30s

### DIFF
--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -77,7 +77,7 @@ struct Arguments {
     #[structopt(
         long,
         env = "MIN_ORDER_AGE",
-        default_value = "60",
+        default_value = "30",
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
     min_order_age: Duration,


### PR DESCRIPTION
We are currently seeing average execution times (order first seen in orderbook until settlement tx is conirmed) of 75-100s. In order to achieve 1 minute UX for traders, we should therefore only wait 30s before attempting to match an order against the baseline.

### Test Plan
CI (use it at ☕ Kränzchen tomorrow)
