### PR TITLE
Revert "Use gas price from pending transaction if detected"

### DIFF
--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -14,13 +14,11 @@ use ethcontract::{
     transaction::TransactionBuilder,
     Web3,
 };
-use futures::stream::StreamExt;
 use gas_estimation::GasPriceEstimating;
 use gas_price_stream::gas_price_stream;
 use primitive_types::{H160, U256};
 use std::time::Duration;
 use transaction_retry::RetryResult;
-use web3::types::{BlockId, BlockNumber};
 
 const GAS_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
 const ESTIMATE_GAS_LIMIT_FACTOR: f64 = 1.2;
@@ -33,23 +31,12 @@ pub async fn submit(
     gas_price_cap: f64,
     settlement: Settlement,
 ) -> Result<()> {
-    let settlement = encode_settlement(&settlement)?;
-    // Check that a simulation of the transaction works before submitting it.
-    simulate_settlement(&settlement, contract).await?;
-
     let nonce = transaction_count(contract)
         .await
         .context("failed to get transaction_count")?;
-    let address = &contract
-        .defaults()
-        .from
-        .clone()
-        .expect("no default sender address")
-        .address();
-    let web3 = contract.raw_instance().web3();
-    let pending_gas_price = recover_gas_price_from_pending_transaction(&web3, &address, nonce)
-        .await
-        .context("failed to get pending gas price")?;
+    let settlement = encode_settlement(&settlement)?;
+    // Check that a simulation of the transaction works before submitting it.
+    simulate_settlement(&settlement, contract).await?;
 
     // Account for some buffer in the gas limit in case racing state changes result in slightly more heavy computation at execution time
     let gas_limit = retry::settle_method_builder(contract, settlement.clone())
@@ -68,30 +55,7 @@ pub async fn submit(
     };
     // We never cancel.
     let cancel_future = std::future::pending::<CancelSender>();
-    if let Some(gas_price) = pending_gas_price {
-        tracing::info!(
-            "detected existing pending transaction with gas price {}",
-            gas_price
-        );
-    }
-
-    // It is possible that there is a pending transaction we don't know about because the driver
-    // got restarted while it was in progress. Sending a new transaction could fail in that case
-    // because the gas price has not increased. So we make sure that the starting gas price is at
-    // least high enough to accommodate. This isn't perfect because it's still possible that that
-    // transaction gets mined first in which case our new transaction would fail with "nonce already
-    // used".
-    let pending_gas_price = pending_gas_price.map(|gas_price| {
-        transaction_retry::gas_price_increase::minimum_increase(gas_price.to_f64_lossy())
-    });
-    let stream = gas_price_stream(
-        target_confirm_time,
-        gas_price_cap,
-        gas_limit,
-        gas,
-        pending_gas_price,
-    )
-    .boxed();
+    let stream = gas_price_stream(target_confirm_time, gas_price_cap, gas_limit, gas);
 
     match transaction_retry::retry(settlement_sender, cancel_future, stream).await {
         Some(RetryResult::Submitted(result)) => {
@@ -178,21 +142,4 @@ async fn tenderly_link(
         hex::encode(tx.data.unwrap().0),
         network_id
     ))
-}
-
-async fn recover_gas_price_from_pending_transaction(
-    web3: &Web3<DynTransport>,
-    address: &H160,
-    nonce: U256,
-) -> Result<Option<U256>> {
-    let block = web3
-        .eth()
-        .block_with_txs(BlockId::Number(BlockNumber::Pending))
-        .await?
-        .ok_or_else(|| anyhow!("empty block"))?;
-    let transaction = block
-        .transactions
-        .iter()
-        .find(|transaction| transaction.from == *address && transaction.nonce == nonce);
-    Ok(transaction.map(|transaction| transaction.gas_price))
 }

--- a/solver/src/settlement_submission/gas_price_stream.rs
+++ b/solver/src/settlement_submission/gas_price_stream.rs
@@ -10,14 +10,9 @@ pub fn gas_price_stream(
     gas_price_cap: f64,
     gas_limit: f64,
     estimator: &dyn GasPriceEstimating,
-    initial_gas_price: Option<f64>,
 ) -> impl Stream<Item = f64> + '_ {
     let stream = stream::unfold(true, move |first_call| async move {
-        if first_call {
-            if let Some(initial_gas_price) = initial_gas_price {
-                return Some((Ok(initial_gas_price), false));
-            }
-        } else {
+        if !first_call {
             tokio::time::delay_for(GAS_PRICE_REFRESH_INTERVAL).await;
         }
         let estimate = estimator


### PR DESCRIPTION
Reverts gnosis/gp-v2-services#472

because of alerts we saw on rinkeby in staging. Not sure yet was it is going but looks like the response from the node can't be decoded by web3. Reverting until I have investigated.

Am going to merge this myself since approval doesn't seem necessary for revert.