### PR TITLE
Refactor settlement generation in solvers

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -208,7 +208,7 @@ impl Driver {
         for (solver, settlement) in settlements {
             tracing::info!("{} computed {:?}", solver, settlement);
 
-            if settlement.trades.is_empty() {
+            if settlement.trades().is_empty() {
                 tracing::info!("Skipping empty settlement");
                 continue;
             }
@@ -217,7 +217,7 @@ impl Driver {
             // be settled once they have been in the order book for longer. This makes coincidence
             // of wants more likely.
             let should_be_settled_immediately = settlement
-                .trades
+                .trades()
                 .iter()
                 .any(|trade| trade.order.order_meta_data.creation_date <= settle_orders_older_than);
             if !should_be_settled_immediately {
@@ -228,7 +228,7 @@ impl Driver {
                 continue;
             }
 
-            let trades = settlement.trades.clone();
+            let trades = settlement.trades().to_vec();
             match settlement_submission::submit(
                 &self.settlement_contract,
                 self.gas_price_estimator.as_ref(),

--- a/solver/src/encoding.rs
+++ b/solver/src/encoding.rs
@@ -61,3 +61,11 @@ pub type EncodedInteraction = (
     U256,    // value
     Vec<u8>, // callData
 );
+
+#[derive(Clone, Debug)]
+pub struct EncodedSettlement {
+    pub tokens: Vec<H160>,
+    pub clearing_prices: Vec<U256>,
+    pub trades: Vec<EncodedTrade>,
+    pub interactions: [Vec<EncodedInteraction>; 3],
+}

--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -371,9 +371,7 @@ impl fmt::Display for HttpSolver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::liquidity::{
-        AmmOrder, LimitOrder, MockAmmSettlementHandling, MockLimitOrderSettlementHandling,
-    };
+    use crate::liquidity::{tests::CapturingSettlementHandler, AmmOrder, LimitOrder};
     use ::model::TokenPair;
     use maplit::hashmap;
     use num::rational::Ratio;
@@ -429,14 +427,14 @@ mod tests {
                 sell_amount: base(2).into(),
                 kind: OrderKind::Sell,
                 partially_fillable: false,
-                settlement_handling: Arc::new(MockLimitOrderSettlementHandling::new()),
+                settlement_handling: CapturingSettlementHandler::arc(),
                 id: "0".to_string(),
             }),
             Liquidity::Amm(AmmOrder {
                 tokens: TokenPair::new(H160::zero(), H160::from_low_u64_be(1)).unwrap(),
                 reserves: (base(100), base(100)),
                 fee: Ratio::new(0, 1),
-                settlement_handling: Arc::new(MockAmmSettlementHandling::new()),
+                settlement_handling: CapturingSettlementHandler::arc(),
             }),
         ];
         let (model, _context) = solver.prepare_model(orders, gas_price).await.unwrap();
@@ -458,8 +456,8 @@ mod tests {
 
     #[test]
     fn remove_orders_without_native_connection_() {
-        let limit_handling = Arc::new(MockLimitOrderSettlementHandling::new());
-        let amm_handling = Arc::new(MockAmmSettlementHandling::new());
+        let limit_handling = CapturingSettlementHandler::arc();
+        let amm_handling = CapturingSettlementHandler::arc();
 
         let native_token = H160::from_low_u64_be(0);
         let tokens = [

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -1,16 +1,13 @@
+use crate::settlement::SettlementEncoder;
+use anyhow::Result;
 use model::{order::OrderKind, TokenPair};
 use num::rational::Ratio;
 use primitive_types::{H160, U256};
-use settlement::{Interaction, Trade};
 use std::sync::Arc;
 use strum_macros::{AsStaticStr, EnumVariantNames};
 
 #[cfg(test)]
-use mockall::automock;
-#[cfg(test)]
 use model::order::Order;
-
-use crate::settlement;
 
 pub mod offchain_orderbook;
 pub mod uniswap;
@@ -21,6 +18,23 @@ pub enum Liquidity {
     Limit(LimitOrder),
     Amm(AmmOrder),
 }
+
+/// A trait associating some liquidity model to how it is executed. This allows
+/// different liquidity types to be modeled the same way.
+pub trait LiquidityModel {
+    type Execution;
+
+    fn settlement_handling(&self) -> &dyn SettlementHandling<Self>;
+}
+
+/// Specifies how a liquidity exectution gets encoded into a settlement.
+pub trait SettlementHandling<Model>: Send + Sync
+where
+    Model: LiquidityModel,
+{
+    fn encode(&self, execution: Model::Execution, encoder: &mut SettlementEncoder) -> Result<()>;
+}
+
 /// Basic limit sell and buy orders
 #[derive(Clone)]
 pub struct LimitOrder {
@@ -32,7 +46,25 @@ pub struct LimitOrder {
     pub buy_amount: U256,
     pub kind: OrderKind,
     pub partially_fillable: bool,
-    pub settlement_handling: Arc<dyn LimitOrderSettlementHandling>,
+    pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
+}
+
+impl LimitOrder {
+    /// Returns the full execution amount for the specified limit order.
+    pub fn full_excution_amount(&self) -> U256 {
+        match self.kind {
+            OrderKind::Sell => self.sell_amount,
+            OrderKind::Buy => self.buy_amount,
+        }
+    }
+}
+
+impl LiquidityModel for LimitOrder {
+    type Execution = U256;
+
+    fn settlement_handling(&self) -> &dyn SettlementHandling<Self> {
+        &*self.settlement_handling
+    }
 }
 
 #[cfg(test)]
@@ -47,89 +79,105 @@ impl From<Order> for LimitOrder {
     }
 }
 
-/// Specifies how a limit order fulfillment translates into Trade and Interactions for the settlement
-#[cfg_attr(test, automock)]
-pub trait LimitOrderSettlementHandling: Send + Sync {
-    fn settle(&self, executed_amount: U256) -> (Option<Trade>, Vec<Box<dyn Interaction>>);
-}
-
 /// 2 sided constant product automated market maker with equal reserve value and a trading fee (e.g. Uniswap, Sushiswap)
 #[derive(Clone)]
 pub struct AmmOrder {
     pub tokens: TokenPair,
     pub reserves: (u128, u128),
     pub fee: Ratio<u32>,
-    pub settlement_handling: Arc<dyn AmmSettlementHandling>,
+    pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
 }
 
-/// Specifies how a AMM order fulfillment translates into Interactions for the settlement
-#[cfg_attr(test, automock)]
-pub trait AmmSettlementHandling: Send + Sync {
-    fn settle(&self, input: (H160, U256), output: (H160, U256)) -> Vec<Box<dyn Interaction>>;
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AmmOrderExecution {
+    pub input: (H160, U256),
+    pub output: (H160, U256),
+}
+
+impl LiquidityModel for AmmOrder {
+    type Execution = AmmOrderExecution;
+
+    fn settlement_handling(&self) -> &dyn SettlementHandling<Self> {
+        &*self.settlement_handling
+    }
 }
 
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use ethcontract::Address;
     use std::sync::Mutex;
 
-    #[derive(Default)]
-    pub struct CapturingLimitOrderSettlementHandler {
-        #[allow(clippy::type_complexity)]
-        pub calls: Mutex<Vec<U256>>,
+    pub struct CapturingSettlementHandler<Model>
+    where
+        Model: LiquidityModel,
+    {
+        pub calls: Mutex<Vec<Model::Execution>>,
     }
 
-    impl CapturingLimitOrderSettlementHandler {
+    // Manual implementation seems to be needed as `derive(Default)` adds an
+    // uneeded `Model::Execution: Default` type bound.
+    impl<Model> Default for CapturingSettlementHandler<Model>
+    where
+        Model: LiquidityModel,
+    {
+        fn default() -> Self {
+            Self {
+                calls: Default::default(),
+            }
+        }
+    }
+
+    impl<Model> CapturingSettlementHandler<Model>
+    where
+        Model: LiquidityModel,
+        Model::Execution: Clone,
+    {
         pub fn arc() -> Arc<Self> {
             Arc::new(Default::default())
         }
 
-        pub fn calls(&self) -> Vec<U256> {
+        pub fn calls(&self) -> Vec<Model::Execution> {
             self.calls.lock().unwrap().clone()
         }
     }
 
-    impl LimitOrderSettlementHandling for CapturingLimitOrderSettlementHandler {
-        fn settle(&self, executed_amount: U256) -> (Option<Trade>, Vec<Box<dyn Interaction>>) {
-            self.calls.lock().unwrap().push(executed_amount);
-            (None, Vec::new())
+    impl<Model> SettlementHandling<Model> for CapturingSettlementHandler<Model>
+    where
+        Model: LiquidityModel,
+        Model::Execution: Send + Sync,
+    {
+        fn encode(&self, execution: Model::Execution, _: &mut SettlementEncoder) -> Result<()> {
+            self.calls.lock().unwrap().push(execution);
+            Ok(())
         }
     }
 
-    #[derive(Default)]
-    pub struct CapturingAmmSettlementHandler {
-        #[allow(clippy::type_complexity)]
-        pub calls: Mutex<Vec<AmmSettlement>>,
-    }
-
-    #[derive(Clone, Copy, Debug, PartialEq)]
-    pub struct AmmSettlement {
-        pub token_in: Address,
-        pub token_out: Address,
-        pub amount_in: U256,
-        pub amount_out: U256,
-    }
-
-    impl CapturingAmmSettlementHandler {
-        pub fn arc() -> Arc<Self> {
-            Arc::new(Default::default())
+    #[test]
+    fn limit_order_full_execution_amounts() {
+        fn simple_limit_order(
+            kind: OrderKind,
+            sell_amount: impl Into<U256>,
+            buy_amount: impl Into<U256>,
+        ) -> LimitOrder {
+            LimitOrder {
+                id: Default::default(),
+                sell_token: Default::default(),
+                buy_token: Default::default(),
+                sell_amount: sell_amount.into(),
+                buy_amount: buy_amount.into(),
+                kind,
+                partially_fillable: Default::default(),
+                settlement_handling: CapturingSettlementHandler::arc(),
+            }
         }
 
-        pub fn calls(&self) -> Vec<AmmSettlement> {
-            self.calls.lock().unwrap().clone()
-        }
-    }
-
-    impl AmmSettlementHandling for CapturingAmmSettlementHandler {
-        fn settle(&self, input: (H160, U256), output: (H160, U256)) -> Vec<Box<dyn Interaction>> {
-            self.calls.lock().unwrap().push(AmmSettlement {
-                token_in: input.0,
-                token_out: output.0,
-                amount_in: input.1,
-                amount_out: output.1,
-            });
-            Vec::new()
-        }
+        assert_eq!(
+            simple_limit_order(OrderKind::Sell, 1, 2).full_excution_amount(),
+            1.into(),
+        );
+        assert_eq!(
+            simple_limit_order(OrderKind::Buy, 1, 2).full_excution_amount(),
+            2.into(),
+        );
     }
 }

--- a/solver/src/liquidity/uniswap.rs
+++ b/solver/src/liquidity/uniswap.rs
@@ -14,9 +14,9 @@ const MAX_BATCH_SIZE: usize = 100;
 pub const MAX_HOPS: usize = 2;
 
 use crate::interactions::UniswapInteraction;
-use crate::settlement::Interaction;
+use crate::settlement::SettlementEncoder;
 
-use super::{AmmOrder, AmmSettlementHandling, LimitOrder};
+use super::{AmmOrder, AmmOrderExecution, LimitOrder, SettlementHandling};
 
 pub struct UniswapLiquidity {
     inner: Arc<Inner>,
@@ -149,10 +149,11 @@ impl Inner {
     }
 }
 
-impl AmmSettlementHandling for Inner {
+impl SettlementHandling<AmmOrder> for Inner {
     // Creates the required interaction to convert the given input into output. Applies 0.1% slippage tolerance to the output.
-    fn settle(&self, input: (H160, U256), output: (H160, U256)) -> Vec<Box<dyn Interaction>> {
-        vec![Box::new(self._settle(input, output))]
+    fn encode(&self, execution: AmmOrderExecution, encoder: &mut SettlementEncoder) -> Result<()> {
+        encoder.append_to_execution_plan(self._settle(execution.input, execution.output));
+        Ok(())
     }
 }
 

--- a/solver/src/settlement.rs
+++ b/solver/src/settlement.rs
@@ -1,6 +1,6 @@
 use crate::{
     encoding::{self, EncodedInteraction, EncodedSettlement, EncodedTrade},
-    liquidity::LiquidityModel,
+    liquidity::Settleable,
 };
 use anyhow::{anyhow, Result};
 use model::order::{Order, OrderKind};
@@ -217,7 +217,7 @@ impl Settlement {
     /// .
     pub fn with_liquidity<L>(&mut self, liquidity: &L, execution: L::Execution) -> Result<()>
     where
-        L: LiquidityModel,
+        L: Settleable,
     {
         liquidity
             .settlement_handling()

--- a/solver/src/settlement.rs
+++ b/solver/src/settlement.rs
@@ -1,5 +1,8 @@
-use crate::encoding::{self, EncodedInteraction, EncodedTrade};
-use anyhow::Result;
+use crate::{
+    encoding::{self, EncodedInteraction, EncodedSettlement, EncodedTrade},
+    liquidity::LiquidityModel,
+};
+use anyhow::{anyhow, Result};
 use model::order::{Order, OrderKind};
 use num::{BigRational, Signed, Zero};
 use primitive_types::{H160, U256};
@@ -9,31 +12,12 @@ use std::collections::HashMap;
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Trade {
     pub order: Order,
+    pub sell_token_index: usize,
+    pub buy_token_index: usize,
     pub executed_amount: U256,
-    pub fee_discount: u16,
 }
 
 impl Trade {
-    pub fn fully_matched(order: Order) -> Self {
-        let executed_amount = match order.order_creation.kind {
-            model::order::OrderKind::Buy => order.order_creation.buy_amount,
-            model::order::OrderKind::Sell => order.order_creation.sell_amount,
-        };
-        Self {
-            order,
-            executed_amount,
-            fee_discount: 0,
-        }
-    }
-
-    pub fn matched(order: Order, executed_amount: U256) -> Self {
-        Self {
-            order,
-            executed_amount,
-            fee_discount: 0,
-        }
-    }
-
     // The difference between the minimum you were willing to buy/maximum you were willing to sell, and what you ended up buying/selling
     pub fn surplus(
         &self,
@@ -57,6 +41,17 @@ impl Trade {
             ),
         }
     }
+
+    /// Encodes the settlement trade as a tuple, as expected by the smart
+    /// contract.
+    pub fn encode(&self) -> EncodedTrade {
+        encoding::encode_trade(
+            &self.order.order_creation,
+            self.sell_token_index,
+            self.buy_token_index,
+            &self.executed_amount,
+        )
+    }
 }
 
 pub trait Interaction: std::fmt::Debug + Send {
@@ -67,56 +62,70 @@ pub trait Interaction: std::fmt::Debug + Send {
     fn encode(&self) -> Vec<EncodedInteraction>;
 }
 
-#[derive(Debug, Default)]
-pub struct Settlement {
-    pub clearing_prices: HashMap<H160, U256>,
-    pub fee_factor: U256,
-    pub trades: Vec<Trade>,
-    pub pre_interactions: Vec<Box<dyn Interaction>>,
-    pub intra_interactions: Vec<Box<dyn Interaction>>,
-    pub post_interactions: Vec<Box<dyn Interaction>>,
+/// An intermediate settlement representation that can be incrementally
+/// constructed.
+///
+/// This allows liquidity to to encode itself into the settlement, in a way that
+/// is completely decoupled from solvers, or how the liquidity is modelled.
+/// Additionally, the fact that the settlement is kept in an intermediate
+/// representation allows the encoder to potentially perform gas optimizations
+/// (e.g. collapsing two interactions into one equivalent one).
+#[derive(Debug)]
+pub struct SettlementEncoder {
+    tokens: Vec<H160>,
+    clearing_prices: HashMap<H160, U256>,
+    trades: Vec<Trade>,
+    execution_plan: Vec<Box<dyn Interaction>>,
 }
 
-impl Settlement {
-    pub fn tokens(&self) -> Vec<H160> {
-        self.clearing_prices.keys().copied().collect()
-    }
+impl SettlementEncoder {
+    /// Creates a new settlement encoder with the specified prices.
+    ///
+    /// The prices must be provided up front in order to ensure that all tokens
+    /// included in the settlement are known when encoding trades.
+    fn new(clearing_prices: HashMap<H160, U256>) -> Self {
+        // Explicitely define a token ordering based on the supplied clearing
+        // prices. This is done since `HashMap::keys` returns an iterator in
+        // arbitrary order ([1]), meaning that we can't rely that the ordering
+        // will be consistent across calls. The list is sorted so that
+        // settlements with the same encoded trades and interactions produce
+        // the same resulting encoded settlement, and so that we can use binary
+        // searching in order to find token indices.
+        // [1]: https://doc.rust-lang.org/beta/std/collections/hash_map/struct.HashMap.html#method.keys
+        let mut tokens = clearing_prices.keys().copied().collect::<Vec<_>>();
+        tokens.sort();
 
-    pub fn clearing_prices(&self) -> Vec<U256> {
-        self.clearing_prices.values().copied().collect()
-    }
-
-    // Returns None if a trade uses a token for which there is no price.
-    pub fn encode_trades(&self) -> Option<Vec<EncodedTrade>> {
-        let mut token_index = HashMap::new();
-        for (i, token) in self.clearing_prices.keys().enumerate() {
-            token_index.insert(token, i);
+        SettlementEncoder {
+            tokens,
+            clearing_prices,
+            trades: Vec::new(),
+            execution_plan: Vec::new(),
         }
-        self.trades
-            .iter()
-            .map(|trade| {
-                Some(encoding::encode_trade(
-                    &trade.order.order_creation,
-                    *token_index.get(&trade.order.order_creation.sell_token)?,
-                    *token_index.get(&trade.order.order_creation.buy_token)?,
-                    &trade.executed_amount,
-                ))
-            })
-            .collect()
     }
 
-    pub fn encode_interactions(&self) -> Result<[Vec<EncodedInteraction>; 3]> {
-        let encode = |interactions: &[Box<dyn Interaction>]| {
-            interactions
-                .iter()
-                .flat_map(|interaction| interaction.encode())
-                .collect()
-        };
-        Ok([
-            encode(&self.pre_interactions),
-            encode(&self.intra_interactions),
-            encode(&self.post_interactions),
-        ])
+    pub fn add_trade(&mut self, order: Order, executed_amount: U256) -> Result<()> {
+        let sell_token_index = self
+            .token_index(order.order_creation.sell_token)
+            .ok_or_else(|| anyhow!("settlement missing sell token"))?;
+        let buy_token_index = self
+            .token_index(order.order_creation.buy_token)
+            .ok_or_else(|| anyhow!("settlement missing buy token"))?;
+        self.trades.push(Trade {
+            order,
+            sell_token_index,
+            buy_token_index,
+            executed_amount,
+        });
+
+        Ok(())
+    }
+
+    pub fn append_to_execution_plan(&mut self, interaction: impl Interaction + 'static) {
+        self.execution_plan.push(Box::new(interaction));
+    }
+
+    fn token_index(&self, token: H160) -> Option<usize> {
+        self.tokens.binary_search(&token).ok()
     }
 
     fn total_surplus(
@@ -160,15 +169,93 @@ impl Settlement {
         })
     }
 
+    pub fn finish(self) -> EncodedSettlement {
+        let clearing_prices = self
+            .tokens
+            .iter()
+            .map(|token| {
+                *self
+                    .clearing_prices
+                    .get(token)
+                    .expect("missing clearing price for token")
+            })
+            .collect();
+
+        EncodedSettlement {
+            tokens: self.tokens,
+            clearing_prices,
+            trades: self
+                .trades
+                .into_iter()
+                .map(|trade| trade.encode())
+                .collect(),
+            interactions: [
+                Vec::new(),
+                self.execution_plan
+                    .iter()
+                    .flat_map(|interaction| interaction.encode())
+                    .collect(),
+                Vec::new(),
+            ],
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Settlement {
+    encoder: SettlementEncoder,
+}
+
+impl Settlement {
+    /// Creates a new settlement builder for the specified clearing prices.
+    pub fn new(clearing_prices: HashMap<H160, U256>) -> Self {
+        Self {
+            encoder: SettlementEncoder::new(clearing_prices),
+        }
+    }
+
+    /// .
+    pub fn with_liquidity<L>(&mut self, liquidity: &L, execution: L::Execution) -> Result<()>
+    where
+        L: LiquidityModel,
+    {
+        liquidity
+            .settlement_handling()
+            .encode(execution, &mut self.encoder)
+    }
+
+    /// Returns the clearing prices map.
+    pub fn clearing_prices(&self) -> &HashMap<H160, U256> {
+        &self.encoder.clearing_prices
+    }
+
+    /// Returns the clearing price for the specified token.
+    ///
+    /// Returns `None` if the token is not part of the settlement.
+    pub fn clearing_price(&self, token: H160) -> Option<U256> {
+        self.encoder.clearing_prices.get(&token).copied()
+    }
+
+    /// Returns the currently encoded trades.
+    pub fn trades(&self) -> &[Trade] {
+        &self.encoder.trades
+    }
+
     // For now this computes the total surplus of all EOA trades.
     pub fn objective_value(&self, external_prices: &HashMap<H160, BigRational>) -> BigRational {
-        match self.total_surplus(&external_prices) {
+        match self.encoder.total_surplus(&external_prices) {
             Some(value) => value,
             None => {
                 tracing::error!("Overflow computing objective value for: {:?}", self);
                 num::zero()
             }
         }
+    }
+}
+
+impl From<Settlement> for EncodedSettlement {
+    fn from(settlement: Settlement) -> Self {
+        settlement.encoder.finish()
     }
 }
 
@@ -241,25 +328,30 @@ mod tests {
             },
             ..Default::default()
         };
-        let trade0 = Trade {
-            order: order0,
-            ..Default::default()
-        };
-        let trade1 = Trade {
-            order: order1,
-            ..Default::default()
-        };
-        let settlement = Settlement {
-            clearing_prices: maplit::hashmap! {token0 => 0.into(), token1 => 0.into()},
-            trades: vec![trade0, trade1],
-            ..Default::default()
-        };
-        assert!(settlement.encode_trades().is_some());
+
+        let mut settlement = SettlementEncoder::new(maplit::hashmap! {
+            token0 => 0.into(),
+            token1 => 0.into(),
+        });
+
+        assert!(settlement.add_trade(order0, 0.into()).is_ok());
+        assert!(settlement.add_trade(order1, 0.into()).is_ok());
     }
 
     // Helper function to save some repeatition below.
     fn r(u: u128) -> BigRational {
         BigRational::from_u128(u).unwrap()
+    }
+
+    /// Helper function for creating a settlement for the specified prices and
+    /// trades for testing objective value computations.
+    fn test_settlement(prices: HashMap<H160, U256>, trades: Vec<Trade>) -> Settlement {
+        Settlement {
+            encoder: SettlementEncoder {
+                trades,
+                ..SettlementEncoder::new(prices)
+            },
+        }
     }
 
     #[test]
@@ -306,17 +398,9 @@ mod tests {
         let clearing_prices0 = maplit::hashmap! {token0 => 1.into(), token1 => 1.into()};
         let clearing_prices1 = maplit::hashmap! {token0 => 2.into(), token1 => 2.into()};
 
-        let settlement0 = Settlement {
-            clearing_prices: clearing_prices0,
-            trades: vec![trade0.clone(), trade1.clone()],
-            ..Default::default()
-        };
+        let settlement0 = test_settlement(clearing_prices0, vec![trade0.clone(), trade1.clone()]);
 
-        let settlement1 = Settlement {
-            clearing_prices: clearing_prices1,
-            trades: vec![trade0, trade1],
-            ..Default::default()
-        };
+        let settlement1 = test_settlement(clearing_prices1, vec![trade0, trade1]);
 
         let external_prices = maplit::hashmap! {token0 => r(1), token1 => r(1)};
         assert_eq!(
@@ -348,11 +432,7 @@ mod tests {
         // Settlement0 gets the following surpluses:
         // trade0: 81 - 81 = 0
         // trade1: 100 - 81 = 19
-        let settlement0 = Settlement {
-            clearing_prices: clearing_prices0,
-            trades: vec![trade0, trade1],
-            ..Default::default()
-        };
+        let settlement0 = test_settlement(clearing_prices0, vec![trade0, trade1]);
 
         let trade0 = Trade {
             order: order0,
@@ -370,11 +450,7 @@ mod tests {
         // Settlement1 gets the following surpluses:
         // trade0: 90 - 72.9 = 17.1
         // trade1: 100 - 100 = 0
-        let settlement1 = Settlement {
-            clearing_prices: clearing_prices1,
-            trades: vec![trade0, trade1],
-            ..Default::default()
-        };
+        let settlement1 = test_settlement(clearing_prices1, vec![trade0, trade1]);
 
         // If the external prices of the two tokens is the same, then both settlements are symmetric.
         let external_prices = maplit::hashmap! {token0 => r(1), token1 => r(1)};
@@ -437,11 +513,7 @@ mod tests {
 
         let clearing_prices = maplit::hashmap! {token0 => 1.into(), token1 => 0.into()};
 
-        let settlement = Settlement {
-            clearing_prices,
-            trades: vec![trade],
-            ..Default::default()
-        };
+        let settlement = test_settlement(clearing_prices, vec![trade]);
 
         let external_prices = maplit::hashmap! {token0 => r(1), token1 => r(1)};
         settlement.objective_value(&external_prices);

--- a/solver/src/settlement_submission/retry.rs
+++ b/solver/src/settlement_submission/retry.rs
@@ -59,8 +59,8 @@ pub fn settle_method_builder(
     contract.settle(
         settlement.tokens,
         settlement.clearing_prices,
-        settlement.encoded_trades,
-        settlement.encoded_interactions,
+        settlement.trades,
+        settlement.interactions,
     )
 }
 


### PR DESCRIPTION
This unfortunately large PR refactors how settlements are built in the solver implementations. Specifically, there is an inversion of control, where liquidity doesn't return things (trade and interactions) to be added to the settlement, but instead gets passed a `SettlementEncoder` and adds things directly to it. This is nice as:
- We can have a single `SettlementHandling` trait used for all liquidity
- Extending the settlement intermediate representation will not require changes to existing liquidity
- Solvers are now completely agnostic to how liquidity encodes itself in the solution, both `LimitOrder`s and `AmmOrder`s get added with the same `with_liquidity` method.

Furthermore, this opens the door for implementing a "settlement optimizer" which would take the intermediate `SettlementEncoder` representation and spit out an optimized solution (by, for example, collapsing interactions that can be collapsed).

This is based off of a discussion with @fleupold where we decided that having a "settlement builder" type interface would be beneficial and allow keeping solvers completely how liquidity actually get included into the settlement, only caring about how the liquidity is modeled.

Suggestions open to suggestions on how to make this smaller. Unfortunately, the `Settlement` struct and liquidity gets encoded into it was used in a lot of source and tests.

### Test Plan

CI still passes. This PR is a refactor, which modifies existing traits and how they are called.
