### PR TITLE
Re-enable gas price from pending transactions with fix

### DIFF
--- a/solver/src/lib.rs
+++ b/solver/src/lib.rs
@@ -6,6 +6,7 @@ pub mod liquidity;
 pub mod metrics;
 pub mod naive_solver;
 pub mod orderbook;
+pub mod pending_transactions;
 pub mod settlement;
 pub mod settlement_submission;
 pub mod solver;

--- a/solver/src/pending_transactions.rs
+++ b/solver/src/pending_transactions.rs
@@ -1,0 +1,39 @@
+use anyhow::{Context, Result};
+use ethcontract::transport::DynTransport;
+use serde::Deserialize;
+use web3::{types::Transaction, Transport};
+
+#[derive(Deserialize)]
+struct Block {
+    transactions: Vec<Transaction>,
+}
+
+// Get the pending transactions from a node.
+//
+// This works better than rust-web3's `block_with_txs` because some nodes set the `miner` field to
+// `null`. This does not follow the ethrpc specification and fails deserialization in rust-web3.
+pub async fn pending_transactions(transport: &DynTransport) -> Result<Vec<Transaction>> {
+    let params = vec!["pending".into(), true.into()];
+    let response = transport
+        .execute("eth_getBlockByNumber", params)
+        .await
+        .context("transport failed")?;
+    let block: Block = serde_json::from_value(response).context("deserialize failed")?;
+    Ok(block.transactions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // cargo test -p solver pending_transactions::tests::mainnet -- --nocapture --ignored
+    #[tokio::test]
+    #[ignore]
+    async fn mainnet() {
+        let node = "https://staging-openethereum.mainnet.gnosisdev.com";
+        let transport = DynTransport::new(web3::transports::Http::new(node).unwrap());
+        let transactions = pending_transactions(&transport).await.unwrap();
+        dbg!(transactions.as_slice());
+        assert!(!transactions.is_empty());
+    }
+}

--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -3,7 +3,7 @@ mod retry;
 
 use self::retry::{CancelSender, SettlementSender};
 use crate::{encoding::EncodedSettlement, settlement::Settlement};
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use contracts::GPv2Settlement;
 use ethcontract::{
     dyns::DynTransport,
@@ -11,11 +11,13 @@ use ethcontract::{
     transaction::TransactionBuilder,
     Web3,
 };
+use futures::stream::StreamExt;
 use gas_estimation::GasPriceEstimating;
 use gas_price_stream::gas_price_stream;
-use primitive_types::U256;
+use primitive_types::{H160, U256};
 use std::time::Duration;
 use transaction_retry::RetryResult;
+use web3::types::{BlockId, BlockNumber};
 
 const GAS_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
 const ESTIMATE_GAS_LIMIT_FACTOR: f64 = 1.2;
@@ -28,12 +30,23 @@ pub async fn submit(
     gas_price_cap: f64,
     settlement: Settlement,
 ) -> Result<()> {
-    let nonce = transaction_count(contract)
-        .await
-        .context("failed to get transaction_count")?;
     let settlement = settlement.into();
     // Check that a simulation of the transaction works before submitting it.
     simulate_settlement(&settlement, contract).await?;
+
+    let nonce = transaction_count(contract)
+        .await
+        .context("failed to get transaction_count")?;
+    let address = &contract
+        .defaults()
+        .from
+        .clone()
+        .expect("no default sender address")
+        .address();
+    let web3 = contract.raw_instance().web3();
+    let pending_gas_price = recover_gas_price_from_pending_transaction(&web3, &address, nonce)
+        .await
+        .context("failed to get pending gas price")?;
 
     // Account for some buffer in the gas limit in case racing state changes result in slightly more heavy computation at execution time
     let gas_limit = retry::settle_method_builder(contract, settlement.clone())
@@ -52,7 +65,30 @@ pub async fn submit(
     };
     // We never cancel.
     let cancel_future = std::future::pending::<CancelSender>();
-    let stream = gas_price_stream(target_confirm_time, gas_price_cap, gas_limit, gas);
+    if let Some(gas_price) = pending_gas_price {
+        tracing::info!(
+            "detected existing pending transaction with gas price {}",
+            gas_price
+        );
+    }
+
+    // It is possible that there is a pending transaction we don't know about because the driver
+    // got restarted while it was in progress. Sending a new transaction could fail in that case
+    // because the gas price has not increased. So we make sure that the starting gas price is at
+    // least high enough to accommodate. This isn't perfect because it's still possible that that
+    // transaction gets mined first in which case our new transaction would fail with "nonce already
+    // used".
+    let pending_gas_price = pending_gas_price.map(|gas_price| {
+        transaction_retry::gas_price_increase::minimum_increase(gas_price.to_f64_lossy())
+    });
+    let stream = gas_price_stream(
+        target_confirm_time,
+        gas_price_cap,
+        gas_limit,
+        gas,
+        pending_gas_price,
+    )
+    .boxed();
 
     match transaction_retry::retry(settlement_sender, cancel_future, stream).await {
         Some(RetryResult::Submitted(result)) => {
@@ -118,4 +154,21 @@ async fn tenderly_link(
         hex::encode(tx.data.unwrap().0),
         network_id
     ))
+}
+
+async fn recover_gas_price_from_pending_transaction(
+    web3: &Web3<DynTransport>,
+    address: &H160,
+    nonce: U256,
+) -> Result<Option<U256>> {
+    let block = web3
+        .eth()
+        .block_with_txs(BlockId::Number(BlockNumber::Pending))
+        .await?
+        .ok_or_else(|| anyhow!("empty block"))?;
+    let transaction = block
+        .transactions
+        .iter()
+        .find(|transaction| transaction.from == *address && transaction.nonce == nonce);
+    Ok(transaction.map(|transaction| transaction.gas_price))
 }

--- a/solver/src/settlement_submission/gas_price_stream.rs
+++ b/solver/src/settlement_submission/gas_price_stream.rs
@@ -10,9 +10,14 @@ pub fn gas_price_stream(
     gas_price_cap: f64,
     gas_limit: f64,
     estimator: &dyn GasPriceEstimating,
+    initial_gas_price: Option<f64>,
 ) -> impl Stream<Item = f64> + '_ {
     let stream = stream::unfold(true, move |first_call| async move {
-        if !first_call {
+        if first_call {
+            if let Some(initial_gas_price) = initial_gas_price {
+                return Some((Ok(initial_gas_price), false));
+            }
+        } else {
             tokio::time::delay_for(GAS_PRICE_REFRESH_INTERVAL).await;
         }
         let estimate = estimator


### PR DESCRIPTION
This PR contains the original reverted commit and then  a second commit on top to fix the issue on rinkeby:

> // This works better than rust-web3's `block_with_txs` because some nodes set the `miner` field to
> // `null`. This does not follow the ethrpc specification and fails deserialization in rust-web3.

https://eth.wiki/json-rpc/API#returns-27

For the staging pods this happens on the rinkeby node but not on the mainnet node (didn't test xdai).

### Test Plan
Added test
