### PR TITLE
Chose AmmOrder with deepest liquidity

### DIFF
--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -95,6 +95,12 @@ pub struct AmmOrderExecution {
     pub output: (H160, U256),
 }
 
+impl AmmOrder {
+    pub fn constant_product(&self) -> U256 {
+        U256::from(self.reserves.0) * U256::from(self.reserves.1)
+    }
+}
+
 impl Settleable for AmmOrder {
     type Execution = AmmOrderExecution;
 

--- a/solver/src/naive_solver.rs
+++ b/solver/src/naive_solver.rs
@@ -19,15 +19,14 @@ impl Solver for NaiveSolver {
         liquidity: Vec<Liquidity>,
         _gas_price: f64,
     ) -> Result<Option<Settlement>> {
-        let mut limit_orders = Vec::new();
         let uniswaps = extract_deepest_amm_liquidity(&liquidity);
-        for liquidity in liquidity {
-            match liquidity {
-                Liquidity::Limit(order) => limit_orders.push(order),
-                Liquidity::Amm(_) => continue,
-            }
-        }
-        Ok(settle(limit_orders.into_iter(), uniswaps).await)
+        let limit_orders = liquidity
+            .into_iter()
+            .filter_map(|liquidity| match liquidity {
+                Liquidity::Limit(order) => Some(order),
+                _ => None,
+            });
+        Ok(settle(limit_orders, uniswaps).await)
     }
 }
 


### PR DESCRIPTION
This PR is in preparation of adding SushiSwap liquidity, which can lead to having more than 1 AMM order per token pair. At the moment one of them would be chosen rather arbitrarily (based on hashing/ordering in the liqudity list).

This PR makes it so that we chose the most liquid pool. While this is not necessarily the best strategy (e.g. a slightly less liquid pool could have a "better spot" price at the moment) it seems like a good heuristic (trusting in market efficiency to arbitrage away large differences in prices).

Regardless, we should adopt the Naive Solver and baseline solver to deal with a list of liquidity on the same pair.

### Test Plan
Added a unit test for the filtering logic.
