### PR TITLE
Refactor liquidity collection into its own component

### DIFF
--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -23,7 +23,8 @@ use shared::{
     Web3,
 };
 use solver::{
-    liquidity::uniswap::UniswapLikeLiquidity, metrics::NoopMetrics, orderbook::OrderBookApi,
+    liquidity::uniswap::UniswapLikeLiquidity, liquidity_collector::LiquidityCollector,
+    metrics::NoopMetrics, orderbook::OrderBookApi,
 };
 use std::{collections::HashSet, str::FromStr, sync::Arc, time::Duration};
 use web3::signing::SecretKeyRef;
@@ -242,10 +243,13 @@ async fn test_with_ganache() {
         web3.clone(),
     );
     let solver = solver::naive_solver::NaiveSolver {};
+    let liquidity_collector = LiquidityCollector {
+        uniswap_liquidity,
+        orderbook_api: create_orderbook_api(&web3),
+    };
     let mut driver = solver::driver::Driver::new(
         gp_settlement.clone(),
-        uniswap_liquidity,
-        create_orderbook_api(&web3),
+        liquidity_collector,
         price_estimator,
         vec![Box::new(solver)],
         Box::new(web3.clone()),

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -1,14 +1,13 @@
-use crate::{chain, liquidity_collector::LiquidityCollector, metrics::SolverMetrics};
 use crate::{liquidity::Liquidity, settlement::Settlement, settlement_submission, solver::Solver};
+use crate::{liquidity_collector::LiquidityCollector, metrics::SolverMetrics};
 use anyhow::{Context, Result};
 use contracts::GPv2Settlement;
 use futures::future::join_all;
 use gas_estimation::GasPriceEstimating;
-use itertools::Itertools;
 use num::BigRational;
 use primitive_types::H160;
 use shared::price_estimate::PriceEstimating;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::{
     cmp::Reverse,
     sync::Arc,
@@ -74,21 +73,13 @@ impl Driver {
         liquidity: &[Liquidity],
     ) -> HashMap<H160, BigRational> {
         // Computes set of traded tokens (limit orders only).
-        let tokens: Vec<H160> = liquidity
-            .iter()
-            // .flat_map(|lo| vec![lo.sell_token, lo.buy_token].into_iter())
-            .flat_map(|liquidity| {
-                let iter: Box<dyn Iterator<Item = H160>> = match liquidity {
-                    Liquidity::Limit(limit_order) => {
-                        Box::new(chain![limit_order.sell_token, limit_order.buy_token])
-                    }
-                    _ => Box::new(std::iter::empty()),
-                };
-                iter
-            })
-            .sorted()
-            .dedup()
-            .collect();
+        let mut tokens = HashSet::new();
+        for liquid in liquidity {
+            if let Liquidity::Limit(limit_order) = liquid {
+                tokens.insert(limit_order.sell_token);
+                tokens.insert(limit_order.buy_token);
+            }
+        }
 
         // For ranking purposes it doesn't matter how the external price vector is scaled,
         // but native_token is used here anyway for better logging/debugging.
@@ -96,7 +87,7 @@ impl Driver {
 
         let estimated_prices = self
             .price_estimator
-            .estimate_prices(tokens.as_slice(), denominator_token)
+            .estimate_prices(&tokens.drain().collect::<Vec<_>>(), denominator_token)
             .await;
 
         tokens

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -80,6 +80,7 @@ impl Driver {
                 tokens.insert(limit_order.buy_token);
             }
         }
+        let tokens = tokens.drain().collect::<Vec<_>>();
 
         // For ranking purposes it doesn't matter how the external price vector is scaled,
         // but native_token is used here anyway for better logging/debugging.
@@ -87,7 +88,7 @@ impl Driver {
 
         let estimated_prices = self
             .price_estimator
-            .estimate_prices(&tokens.drain().collect::<Vec<_>>(), denominator_token)
+            .estimate_prices(&tokens, denominator_token)
             .await;
 
         tokens

--- a/solver/src/lib.rs
+++ b/solver/src/lib.rs
@@ -3,6 +3,7 @@ pub mod encoding;
 pub mod http_solver;
 pub mod interactions;
 pub mod liquidity;
+pub mod liquidity_collector;
 pub mod metrics;
 pub mod naive_solver;
 pub mod orderbook;

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -13,7 +13,7 @@ pub mod offchain_orderbook;
 pub mod uniswap;
 
 /// Defines the different types of liquidity our solvers support
-#[derive(Clone, AsStaticStr, EnumVariantNames)]
+#[derive(Clone, AsStaticStr, EnumVariantNames, Debug)]
 pub enum Liquidity {
     Limit(LimitOrder),
     Amm(AmmOrder),
@@ -48,6 +48,12 @@ pub struct LimitOrder {
     pub kind: OrderKind,
     pub partially_fillable: bool,
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
+}
+
+impl std::fmt::Debug for LimitOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Limit Order {}", self.id)
+    }
 }
 
 impl LimitOrder {
@@ -87,6 +93,12 @@ pub struct AmmOrder {
     pub reserves: (u128, u128),
     pub fee: Ratio<u32>,
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
+}
+
+impl std::fmt::Debug for AmmOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AMM {:?}", self.tokens)
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/solver/src/liquidity_collector.rs
+++ b/solver/src/liquidity_collector.rs
@@ -1,0 +1,34 @@
+use anyhow::{Context, Result};
+
+use crate::{
+    liquidity::uniswap::UniswapLikeLiquidity, liquidity::Liquidity, orderbook::OrderBookApi,
+};
+
+pub struct LiquidityCollector {
+    pub uniswap_liquidity: UniswapLikeLiquidity,
+    pub orderbook_api: OrderBookApi,
+}
+
+impl LiquidityCollector {
+    pub async fn get_liquidity(&self) -> Result<Vec<Liquidity>> {
+        let limit_orders = self
+            .orderbook_api
+            .get_liquidity()
+            .await
+            .context("failed to get orderbook")?;
+        tracing::debug!("got {} orders", limit_orders.len());
+
+        let amms = self
+            .uniswap_liquidity
+            .get_liquidity(limit_orders.iter())
+            .await
+            .context("failed to get uniswap pools")?;
+        tracing::debug!("got {} AMMs", amms.len());
+
+        Ok(limit_orders
+            .into_iter()
+            .map(Liquidity::Limit)
+            .chain(amms.into_iter().map(Liquidity::Amm))
+            .collect())
+    }
+}

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -11,7 +11,8 @@ use shared::{
     transport::LoggingTransport,
 };
 use solver::{
-    driver::Driver, liquidity::uniswap::UniswapLikeLiquidity, metrics::Metrics, solver::SolverType,
+    driver::Driver, liquidity::uniswap::UniswapLikeLiquidity,
+    liquidity_collector::LiquidityCollector, metrics::Metrics, solver::SolverType,
 };
 use std::iter::FromIterator as _;
 use std::{collections::HashSet, sync::Arc, time::Duration};
@@ -171,10 +172,13 @@ async fn main() {
         token_info_fetcher,
         price_estimator.clone(),
     );
-    let mut driver = Driver::new(
-        settlement_contract,
+    let liquidity_collector = LiquidityCollector {
         uniswap_liquidity,
         orderbook_api,
+    };
+    let mut driver = Driver::new(
+        settlement_contract,
+        liquidity_collector,
         price_estimator,
         solver,
         Box::new(gas_price_estimator),


### PR DESCRIPTION
This PR moves the code of collecting the `Vec<Liquidity>` from our different sources from the driver into its own component. This is to not overload the number of dependencies we pass into the driver further (we already need to allow clippy's `too_many_arguments` warning)

We left the "price estimation filtering" logic in the driver, as we didn't want to pass a price estimator into the liquidity collector.

### Test Plan
e2e tests and CI (no logic change).
