### PR TITLE
Small fixes to Cargo manifest files

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contracts"
 version = "0.1.0"
-authors = ["Nicholas Rodrigues Lordello <nicholas.lordello@gnosis.pm>"]
+authors = ["Gnosis Developers <developers@gnosis.io>"]
 edition = "2018"
 
 [[bin]]

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "e2e"
 version = "1.0.0"
+authors = ["Gnosis Developers <developers@gnosis.io>"]
 edition = "2018"
 
 [dev-dependencies]
@@ -14,5 +15,5 @@ secp256k1 = "0.20"
 serde_json = "1.0"
 shared = { path = "../shared" }
 solver = { path = "../solver" }
-tokio = { version = "0.2", features =[ "macros"] }
+tokio = { version = "0.2", features = ["macros"] }
 web3 = { version = "0.15", default-features = false }

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "model"
 version = "0.1.0"
+authors = ["Gnosis Developers <developers@gnosis.io>"]
 edition = "2018"
 
 [dependencies]

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "orderbook"
 version = "0.1.0"
+authors = ["Gnosis Developers <developers@gnosis.io>"]
 edition = "2018"
 
 [lib]
@@ -33,9 +34,9 @@ serde_json = "1.0"
 serde_with = { version = "1.8", default-features = false, features = ["macros"] }
 shared= { path = "../shared" }
 sqlx = { version = "0.4", default-features = false, features = ["bigdecimal", "chrono", "macros", "runtime-tokio-native-tls", "postgres"] }
-structopt = { version = "0.3" }
+structopt = "0.3"
 reqwest = { version = "0.10", features = ["json"] }
-tokio = { version = "0.2", features =["macros", "rt-threaded", "sync", "time"] }
+tokio = { version = "0.2", features = ["macros", "rt-threaded", "sync", "time"] }
 tracing = "0.1"
 url = "2.2"
 warp = "0.2"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "shared"
 version = "0.1.0"
+authors = ["Gnosis Developers <developers@gnosis.io>"]
 edition = "2018"
 
 [dependencies]
@@ -16,13 +17,13 @@ hex-literal = "0.3"
 maplit = "1.0"
 model = { path = "../model" }
 num = "0.4"
-primitive-types = { version = "0.8" }
+primitive-types = "0.8"
 prometheus = "0.12"
 reqwest = { version = "0.10", features = ["json"] }
-serde = { version = "1.0" }
+serde = "1.0"
 serde_json = "1.0"
 structopt = { version = "0.3", default-features = false }
-tokio = { version = "0.2", features =["macros", "time"] }
+tokio = { version = "0.2", features = ["macros", "time"] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 url = "2.2"

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "solver"
 version = "0.1.0"
+authors = ["Gnosis Developers <developers@gnosis.io>"]
 edition = "2018"
 
 [lib]
@@ -33,10 +34,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "1.8", default-features = false }
 shared = { path = "../shared" }
-structopt = { version = "0.3" }
+structopt = "0.3"
 strum = "0.20"
 strum_macros = "0.20"
-tokio = { version = "0.2", features =["macros", "rt-threaded", "time"] }
+tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
 tracing = "0.1"
 web3 = { version = "0.15", default-features = false, features = ["http-tls"] }
 itertools = "0.10"


### PR DESCRIPTION
This PR just does some trivial changes to the Cargo manifest files:
- Minor formatting
- Rewriting `{ version = "x" }` as `"x"` for consistency (they mean the exact same thing).
- Adding `authors` (and removing myself from one of the `authors` fields).

### Test Plan

No changes, just minor fix-ups.
