### PR TITLE
Return multiple settlements in Solver trait and handle this in Driver

### DIFF
--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -246,6 +246,7 @@ async fn test_with_ganache() {
         uniswap_like_liquidity: vec![uniswap_liquidity],
         orderbook_api: create_orderbook_api(&web3),
     };
+    let network_id = web3.net().version().await.unwrap();
     let mut driver = solver::driver::Driver::new(
         gp_settlement.clone(),
         liquidity_collector,
@@ -258,6 +259,7 @@ async fn test_with_ganache() {
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),
         web3.clone(),
+        network_id,
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -257,6 +257,7 @@ async fn test_with_ganache() {
         native_token,
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),
+        web3.clone(),
     );
     driver.single_run().await.unwrap();
 

--- a/solver/src/baseline_solver.rs
+++ b/solver/src/baseline_solver.rs
@@ -24,12 +24,8 @@ pub struct BaselineSolver {
 
 #[async_trait::async_trait]
 impl Solver for BaselineSolver {
-    async fn solve(
-        &self,
-        liquidity: Vec<Liquidity>,
-        _gas_price: f64,
-    ) -> Result<Option<Settlement>> {
-        Ok(self.solve(liquidity).into_iter().next())
+    async fn solve(&self, liquidity: Vec<Liquidity>, _gas_price: f64) -> Result<Vec<Settlement>> {
+        Ok(self.solve(liquidity))
     }
 }
 

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -35,6 +35,7 @@ pub struct Driver {
     min_order_age: Duration,
     metrics: Arc<dyn SolverMetrics>,
     web3: Web3,
+    network_id: String,
 }
 impl Driver {
     #[allow(clippy::too_many_arguments)]
@@ -50,6 +51,7 @@ impl Driver {
         min_order_age: Duration,
         metrics: Arc<dyn SolverMetrics>,
         web3: Web3,
+        network_id: String,
     ) -> Self {
         Self {
             settlement_contract,
@@ -63,6 +65,7 @@ impl Driver {
             min_order_age,
             metrics,
             web3,
+            network_id,
         }
     }
 
@@ -162,6 +165,7 @@ impl Driver {
                 .map(|settlement| settlement.settlement.clone().into()),
             &self.settlement_contract,
             &self.web3,
+            &self.network_id,
         )
         .await
         .context("failed to simulate settlements")?;

--- a/solver/src/encoding.rs
+++ b/solver/src/encoding.rs
@@ -62,7 +62,7 @@ pub type EncodedInteraction = (
     Vec<u8>, // callData
 );
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct EncodedSettlement {
     pub tokens: Vec<H160>,
     pub clearing_prices: Vec<U256>,

--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -350,18 +350,18 @@ fn remove_orders_without_native_connection(
 
 #[async_trait::async_trait]
 impl Solver for HttpSolver {
-    async fn solve(&self, liquidity: Vec<Liquidity>, gas_price: f64) -> Result<Option<Settlement>> {
+    async fn solve(&self, liquidity: Vec<Liquidity>, gas_price: f64) -> Result<Vec<Settlement>> {
         let has_limit_orders = liquidity.iter().any(|l| matches!(l, Liquidity::Limit(_)));
         if !has_limit_orders {
-            return Ok(None);
+            return Ok(Vec::new());
         };
         let (model, context) = self.prepare_model(liquidity, gas_price).await?;
         let settled = self.send(&model).await?;
         tracing::trace!(?settled);
         if !settled.has_execution_plan() {
-            return Ok(None);
+            return Ok(Vec::new());
         }
-        settlement::convert_settlement(settled, context).map(Some)
+        settlement::convert_settlement(settled, context).map(|settlement| vec![settlement])
     }
 }
 

--- a/solver/src/lib.rs
+++ b/solver/src/lib.rs
@@ -11,6 +11,7 @@ pub mod oneinch_solver;
 pub mod orderbook;
 pub mod pending_transactions;
 pub mod settlement;
+pub mod settlement_simulation;
 pub mod settlement_submission;
 pub mod solver;
 mod util;

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -176,7 +176,7 @@ async fn main() {
         chain_id,
         settlement_contract.clone(),
         base_tokens.clone(),
-        web3,
+        web3.clone(),
     )
     .await;
     let solver = solver::solver::create(
@@ -202,6 +202,7 @@ async fn main() {
         native_token_contract.address(),
         args.min_order_age,
         metrics,
+        web3,
     );
 
     serve_metrics(registry, ([0, 0, 0, 0], args.metrics_port).into());

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -131,6 +131,11 @@ async fn main() {
         .await
         .expect("Could not get chainId")
         .as_u64();
+    let network_id = web3
+        .net()
+        .version()
+        .await
+        .expect("failed to get network id");
     let account = Account::Offline(args.private_key, Some(chain_id));
     let settlement_contract = solver::get_settlement_contract(&web3, account)
         .await
@@ -203,6 +208,7 @@ async fn main() {
         args.min_order_age,
         metrics,
         web3,
+        network_id,
     );
 
     serve_metrics(registry, ([0, 0, 0, 0], args.metrics_port).into());

--- a/solver/src/naive_solver.rs
+++ b/solver/src/naive_solver.rs
@@ -14,11 +14,7 @@ pub struct NaiveSolver;
 
 #[async_trait::async_trait]
 impl Solver for NaiveSolver {
-    async fn solve(
-        &self,
-        liquidity: Vec<Liquidity>,
-        _gas_price: f64,
-    ) -> Result<Option<Settlement>> {
+    async fn solve(&self, liquidity: Vec<Liquidity>, _gas_price: f64) -> Result<Vec<Settlement>> {
         let uniswaps = extract_deepest_amm_liquidity(&liquidity);
         let limit_orders = liquidity
             .into_iter()
@@ -26,7 +22,7 @@ impl Solver for NaiveSolver {
                 Liquidity::Limit(order) => Some(order),
                 _ => None,
             });
-        Ok(settle(limit_orders, uniswaps).await.into_iter().next())
+        Ok(settle(limit_orders, uniswaps).await)
     }
 }
 

--- a/solver/src/settlement.rs
+++ b/solver/src/settlement.rs
@@ -84,7 +84,7 @@ impl Interaction for NoopInteraction {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Settlement {
     encoder: SettlementEncoder,
 }

--- a/solver/src/settlement/settlement_encoder.rs
+++ b/solver/src/settlement/settlement_encoder.rs
@@ -8,6 +8,7 @@ use shared::conversions::U256Ext;
 use std::{
     collections::{hash_map::Entry, HashMap},
     iter,
+    sync::Arc,
 };
 
 /// An intermediate settlement representation that can be incrementally
@@ -18,7 +19,7 @@ use std::{
 /// Additionally, the fact that the settlement is kept in an intermediate
 /// representation allows the encoder to potentially perform gas optimizations
 /// (e.g. collapsing two interactions into one equivalent one).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SettlementEncoder {
     // Make sure to update the `merge` method when adding new fields.
 
@@ -27,7 +28,10 @@ pub struct SettlementEncoder {
     clearing_prices: HashMap<H160, U256>,
     // Invariant: Every trade's buy and sell token has an entry in clearing_prices.
     trades: Vec<Trade>,
-    execution_plan: Vec<Box<dyn Interaction>>,
+    // This is an Arc so that this struct is Clone. Cannot require `Interaction: Clone` because it
+    // would make the trait not be object safe which prevents using it through `dyn`.
+    // TODO: Can we fix this in a better way?
+    execution_plan: Vec<Arc<dyn Interaction>>,
     unwraps: Vec<UnwrapWethInteraction>,
 }
 
@@ -91,7 +95,7 @@ impl SettlementEncoder {
     }
 
     pub fn append_to_execution_plan(&mut self, interaction: impl Interaction + 'static) {
-        self.execution_plan.push(Box::new(interaction));
+        self.execution_plan.push(Arc::new(interaction));
     }
 
     pub fn add_unwrap(&mut self, unwrap: UnwrapWethInteraction) {

--- a/solver/src/settlement_simulation.rs
+++ b/solver/src/settlement_simulation.rs
@@ -1,0 +1,72 @@
+use crate::encoding::EncodedSettlement;
+use anyhow::{Context, Result};
+use contracts::GPv2Settlement;
+use ethcontract::{batch::CallBatch, dyns::DynTransport, transaction::TransactionBuilder};
+use futures::FutureExt;
+use shared::Web3;
+
+const SIMULATE_BATCH_SIZE: usize = 10;
+
+/// Simulate the settlement using a web3 `call`.
+// Clippy claims we don't need to collect `futures` but we do or the lifetimes with `join!` don't
+// work out.
+#[allow(clippy::needless_collect)]
+pub async fn simulate_settlements(
+    settlements: impl Iterator<Item = EncodedSettlement>,
+    contract: &GPv2Settlement,
+    web3: &Web3,
+) -> Result<Vec<Result<()>>> {
+    let mut batch = CallBatch::new(web3.transport());
+    let futures = settlements
+        .map(|settlement| {
+            let method =
+                crate::settlement_submission::retry::settle_method_builder(contract, settlement);
+            let transaction_builder = method.tx.clone();
+            (method.view().batch_call(&mut batch), transaction_builder)
+        })
+        .collect::<Vec<_>>();
+
+    // TODO: It would be nice to add this to the underlying web3 batch transport call used for the
+    // simulations.
+    let ((), current_block, network_id) = futures::join!(
+        batch.execute_all(SIMULATE_BATCH_SIZE),
+        web3.eth().block_number(),
+        web3.net().version()
+    );
+
+    let current_block = current_block
+        .context("failed to get current block")?
+        .as_u64();
+    let network_id = network_id.context("failed to get network_id")?;
+
+    Ok(futures
+        .into_iter()
+        .map(|(future, transaction_builder)| {
+            future
+                .now_or_never()
+                .unwrap()
+                .map(|_| ())
+                .context(tenderly_link(
+                    current_block,
+                    network_id.as_str(),
+                    transaction_builder,
+                ))
+        })
+        .collect())
+}
+
+// Creates a simulation link in the gp-v2 tenderly workspace
+pub fn tenderly_link(
+    current_block: u64,
+    network_id: &str,
+    tx: TransactionBuilder<DynTransport>,
+) -> String {
+    format!(
+        "https://dashboard.tenderly.co/gp-v2/staging/simulator/new?block={}&blockIndex=0&from={:#x}&gas=8000000&gasPrice=0&value=0&contractAddress={:#x}&rawFunctionInput=0x{}&network={}",
+        current_block,
+        tx.from.unwrap().address(),
+        tx.to.unwrap(),
+        hex::encode(tx.data.unwrap().0),
+        network_id
+    )
+}

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -15,7 +15,9 @@ use structopt::clap::arg_enum;
 
 #[async_trait::async_trait]
 pub trait Solver: Display {
-    async fn solve(&self, orders: Vec<Liquidity>, gas_price: f64) -> Result<Option<Settlement>>;
+    // The returned settlements should be independent (for example not reusing the same user
+    // order) so that they can be merged by the driver at its leisure.
+    async fn solve(&self, orders: Vec<Liquidity>, gas_price: f64) -> Result<Vec<Settlement>>;
 }
 
 arg_enum! {


### PR DESCRIPTION
Part of https://github.com/gnosis/gp-v2-services/issues/402 .

This PR makes the solver trait return a vector of settlements which in a future PR can be merged back into a single settlement.
The driver is updated so that it handles more settlements better even as it does not yet merge.
Previously we would go through the settlements ordered by objective value and try to submit them one by one. As part of the submission the settlement would get simulated.
Now we simulate all settlements (in parallel) and attempt to submit only the highest objective value settlement that passed the simulation.

This is advantageous because
* We can log simulation errors even for settlements that we did not attempt to submit. We want to see those errors so we can fix them in the solvers.
* The driver run loop only ever submits one settlement. If we attempt to submit a transaction which later fails it is very likely that the other settlements are out of date (would fail too or could be improved) at that point.

With this PR we are immediately making use of the naive solver potentially returning multiple settlements. The new code can pick the highest objective value in this case whereas the old code only observed an arbitrary single settlement.

### Test Plan
CI