### PR TITLE
Support settlement merging

### DIFF
--- a/solver/src/http_solver/settlement.rs
+++ b/solver/src/http_solver/settlement.rs
@@ -204,21 +204,11 @@ fn i128_abs_to_u256(i: i128) -> U256 {
 mod tests {
     use super::*;
     use crate::{
-        encoding::EncodedInteraction,
         http_solver::model::{ExecutedOrderModel, UpdatedUniswapModel},
         liquidity::tests::CapturingSettlementHandler,
-        settlement::Interaction,
     };
     use maplit::hashmap;
     use model::TokenPair;
-
-    #[derive(Debug)]
-    struct NoopInteraction;
-    impl Interaction for NoopInteraction {
-        fn encode(&self) -> Vec<EncodedInteraction> {
-            Vec::new()
-        }
-    }
 
     #[test]
     fn convert_settlement_() {

--- a/solver/src/settlement.rs
+++ b/solver/src/settlement.rs
@@ -73,6 +73,17 @@ impl Interaction for EncodedInteraction {
     }
 }
 
+#[cfg(test)]
+#[derive(Debug)]
+pub struct NoopInteraction;
+
+#[cfg(test)]
+impl Interaction for NoopInteraction {
+    fn encode(&self) -> Vec<EncodedInteraction> {
+        Vec::new()
+    }
+}
+
 #[derive(Debug)]
 pub struct Settlement {
     encoder: SettlementEncoder,
@@ -122,6 +133,12 @@ impl Settlement {
                 num::zero()
             }
         }
+    }
+
+    /// See SettlementEncoder::merge
+    pub fn merge(self, other: Self) -> Result<Self> {
+        let merged = self.encoder.merge(other.encoder)?;
+        Ok(Self { encoder: merged })
     }
 }
 


### PR DESCRIPTION
Adds a basic way of merging settlements. Prices and trades are combined
and it is checked that the prices are the same and no trade is used
twice. Interactions are appended. This could be more efficient because
in some case it might be possible to for example merge uniswap
interactions the way we merge unwrapping but the current simple
implementation is what we want in the short term.

### Test Plan
new unit tests
