### PR TITLE
Pass in network id

### DIFF
--- a/e2e/tests/uniswap_trade_test.rs
+++ b/e2e/tests/uniswap_trade_test.rs
@@ -246,6 +246,7 @@ async fn test_with_ganache() {
         uniswap_like_liquidity: vec![uniswap_liquidity],
         orderbook_api: create_orderbook_api(&web3),
     };
+    let network_id = web3.net().version().await.unwrap();
     let mut driver = solver::driver::Driver::new(
         gp_settlement.clone(),
         liquidity_collector,
@@ -258,6 +259,7 @@ async fn test_with_ganache() {
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),
         web3.clone(),
+        network_id,
     );
     driver.single_run().await.unwrap();
 

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -35,6 +35,7 @@ pub struct Driver {
     min_order_age: Duration,
     metrics: Arc<dyn SolverMetrics>,
     web3: Web3,
+    network_id: String,
 }
 impl Driver {
     #[allow(clippy::too_many_arguments)]
@@ -50,6 +51,7 @@ impl Driver {
         min_order_age: Duration,
         metrics: Arc<dyn SolverMetrics>,
         web3: Web3,
+        network_id: String,
     ) -> Self {
         Self {
             settlement_contract,
@@ -63,6 +65,7 @@ impl Driver {
             min_order_age,
             metrics,
             web3,
+            network_id,
         }
     }
 
@@ -162,6 +165,7 @@ impl Driver {
                 .map(|settlement| settlement.settlement.clone().into()),
             &self.settlement_contract,
             &self.web3,
+            &self.network_id,
         )
         .await
         .context("failed to simulate settlements")?;

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -131,6 +131,11 @@ async fn main() {
         .await
         .expect("Could not get chainId")
         .as_u64();
+    let network_id = web3
+        .net()
+        .version()
+        .await
+        .expect("failed to get network id");
     let account = Account::Offline(args.private_key, Some(chain_id));
     let settlement_contract = solver::get_settlement_contract(&web3, account)
         .await
@@ -203,6 +208,7 @@ async fn main() {
         args.min_order_age,
         metrics,
         web3,
+        network_id,
     );
 
     serve_metrics(registry, ([0, 0, 0, 0], args.metrics_port).into());


### PR DESCRIPTION
Removes one unnecessary network request.
I didn't refactor the current block yet because it is surprisingly complicated do only get it when needed as this happens inside of a map and getting it is an async operation.

### Test Plan
solver binary is able to retrieve network id on start up