### PR TITLE
Add Ganache wrapper for e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "contracts",
  "ethcontract",
  "hex-literal",
+ "lazy_static",
  "model",
  "orderbook",
  "reqwest",

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 contracts = { path = "../contracts" }
 ethcontract = { version = "0.11",  default-features = false, features = ["http"] }
 hex-literal = "0.3"
+lazy_static = "1.4"
 model = { path = "../model" }
 orderbook = { path = "../orderbook" }
 reqwest = "0.10"

--- a/e2e/tests/ganache.rs
+++ b/e2e/tests/ganache.rs
@@ -1,0 +1,94 @@
+use ethcontract::futures::FutureExt;
+use ethcontract::{Http, U256};
+use shared::{transport::LoggingTransport, Web3};
+use std::{
+    fmt::Debug,
+    future::Future,
+    panic::{self, AssertUnwindSafe},
+};
+use web3::{api::Namespace, helpers::CallFuture, Transport};
+
+const NODE_HOST: &str = "http://127.0.0.1:8545";
+
+/// *Testing* function that takes a closure and executes it on Ganache.
+/// Before each test, it creates a snapshot of the current state of the chain.
+/// The saved state is restored at the end of the test.
+///
+/// This function must not be called again until the current execution has
+/// terminated.
+pub async fn test<F, Fut>(f: F)
+where
+    F: FnOnce(Web3) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let http = LoggingTransport::new(Http::new(NODE_HOST).expect("transport failure"));
+    let web3 = Web3::new(http);
+    let resetter = Resetter::new(&web3).await;
+
+    // Hack: the closure may actually be unwind unsafe; moreover, `catch_unwind`
+    // does not catch some types of panics. In this cases, the state of the node
+    // is not restored. This is not considered an issue since this function
+    // is supposed to be used in a test environment.
+    let result = AssertUnwindSafe(f(web3.clone())).catch_unwind().await;
+
+    resetter.reset().await;
+
+    if let Err(err) = result {
+        panic::resume_unwind(err);
+    }
+}
+
+struct Resetter<T> {
+    ganache: GanacheApi<T>,
+    snapshot_id: U256,
+}
+
+impl<T: Transport> Resetter<T> {
+    async fn new(web3: &web3::Web3<T>) -> Self {
+        let ganache = web3.api::<GanacheApi<_>>();
+        let snapshot_id = ganache
+            .snapshot()
+            .await
+            .expect("Test network must support evm_snapshot");
+        Self {
+            ganache,
+            snapshot_id,
+        }
+    }
+
+    async fn reset(&self) {
+        self.ganache
+            .revert(&self.snapshot_id)
+            .await
+            .expect("Test network must support evm_revert");
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GanacheApi<T> {
+    transport: T,
+}
+
+impl<T: Transport> Namespace<T> for GanacheApi<T> {
+    fn new(transport: T) -> Self
+    where
+        Self: Sized,
+    {
+        GanacheApi { transport }
+    }
+
+    fn transport(&self) -> &T {
+        &self.transport
+    }
+}
+
+impl<T: Transport> GanacheApi<T> {
+    pub fn snapshot(&self) -> CallFuture<U256, T::Out> {
+        CallFuture::new(self.transport.execute("evm_snapshot", vec![]))
+    }
+
+    pub fn revert(&self, snapshot_id: &U256) -> CallFuture<bool, T::Out> {
+        let value_id = serde_json::json!(snapshot_id);
+        CallFuture::new(self.transport.execute("evm_revert", vec![value_id]))
+    }
+}

--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -1,6 +1,6 @@
 use contracts::{ERC20Mintable, IUniswapLikeRouter, UniswapV2Factory, UniswapV2Router02, WETH9};
 use ethcontract::{
-    prelude::{Account, Address, Http, PrivateKey, U256},
+    prelude::{Account, Address, PrivateKey, U256},
     H160,
 };
 use hex_literal::hex;
@@ -19,7 +19,6 @@ use shared::{
     current_block::current_block_stream,
     pool_fetching::{CachedPoolFetcher, PoolFetcher},
     price_estimate::UniswapPriceEstimator,
-    transport::LoggingTransport,
     Web3,
 };
 use solver::{
@@ -29,20 +28,23 @@ use solver::{
 use std::{collections::HashSet, str::FromStr, sync::Arc, time::Duration};
 use web3::signing::SecretKeyRef;
 
+mod ganache;
+
 const TRADER_A_PK: [u8; 32] =
     hex!("0000000000000000000000000000000000000000000000000000000000000001");
 const TRADER_B_PK: [u8; 32] =
     hex!("0000000000000000000000000000000000000000000000000000000000000002");
 
-const NODE_HOST: &str = "http://127.0.0.1:8545";
 const API_HOST: &str = "http://127.0.0.1:8080";
 const ORDER_PLACEMENT_ENDPOINT: &str = "/api/v1/orders/";
 
 #[tokio::test]
-async fn test_with_ganache() {
+async fn ganache_onchain_settlement() {
+    ganache::test(onchain_settlement).await;
+}
+
+async fn onchain_settlement(web3: Web3) {
     shared::tracing::initialize("warn,orderbook=debug,solver=debug");
-    let http = LoggingTransport::new(Http::new(NODE_HOST).expect("transport failure"));
-    let web3 = Web3::new(http);
     let chain_id = web3
         .eth()
         .chain_id()


### PR DESCRIPTION
Adds a wrapper function to be used when running end to end tests in order to reset the state of the blockchain to that before the test was run. The state is notably reset also if the test fails.
This is helpful to run all e2e tests starting from a clean state, particularly in light of a future e2e test which will change the eth balances of the funded accounts.

The code is copied from [ido-services](https://github.com/gnosis/ido-services/pull/85), in turn suggested by Nick. As mentioned by Alex, it would be a good candidate to be moved to a standalone utils crate.

### Test Plan

The existing unit test still passes.

To observe that a failing test still restores the snapshot on Ganache:
1. Start database and Ganache.
2. Add a `panic!` at the start of the function `onchain_settlement`. 
2. Run `cargo test --locked --package e2e` with Ganache running.
3. Observe that the test fails and the Ganache output reports:
```
Saved snapshot #1
evm_revert
Reverting to snapshot #1
```
