### PR TITLE
Merge multiple settlements in driver

### DIFF
--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -262,6 +262,7 @@ async fn onchain_settlement(web3: Web3) {
         Arc::new(NoopMetrics::default()),
         web3.clone(),
         network_id,
+        1,
     );
     driver.single_run().await.unwrap();
 

--- a/solver/src/driver/solver_settlements.rs
+++ b/solver/src/driver/solver_settlements.rs
@@ -1,0 +1,204 @@
+use crate::settlement::Settlement;
+use anyhow::Result;
+use num::BigRational;
+use primitive_types::H160;
+use std::{collections::HashMap, time::Duration};
+
+// Return None if the result is an error or there are no settlements remaining after removing
+// settlements with no trades.
+pub fn filter_bad_settlements(
+    (solver_name, solver_result): (&'static str, Result<Vec<Settlement>>),
+) -> Option<(&'static str, Vec<Settlement>)> {
+    let mut settlements = match solver_result {
+        Ok(settlements) => settlements,
+        Err(err) => {
+            tracing::error!("solver {} error: {:?}", solver_name, err);
+            return None;
+        }
+    };
+    settlements.retain(|settlement| !settlement.trades().is_empty());
+    if settlements.is_empty() {
+        return None;
+    }
+    Some((solver_name, settlements))
+}
+
+// A single solver produces multiple settlements
+#[derive(Debug)]
+pub struct SolverWithSettlements {
+    pub name: &'static str,
+    pub settlements: Vec<RatedSettlement>,
+}
+
+// Each individual settlement has an objective value.
+#[derive(Debug)]
+pub struct RatedSettlement {
+    pub settlement: Settlement,
+    pub objective_value: BigRational,
+}
+
+// Takes the settlements of a single solver and adds a merged settlement.
+pub fn merge_settlements(
+    max_merged_settlements: usize,
+    prices: &HashMap<H160, BigRational>,
+    name: &'static str,
+    settlements: Vec<Settlement>,
+) -> SolverWithSettlements {
+    let mut settlements = settlements
+        .into_iter()
+        .map(|settlement| {
+            let objective_value = settlement.objective_value(prices);
+            RatedSettlement {
+                settlement,
+                objective_value,
+            }
+        })
+        .collect::<Vec<_>>();
+    settlements.sort_by(|a, b| b.objective_value.cmp(&a.objective_value));
+    if let Some(settlement) = merge_at_most_settlements(
+        max_merged_settlements,
+        settlements
+            .iter()
+            .map(|settlement| settlement.settlement.clone()),
+    ) {
+        let objective_value = settlement.objective_value(prices);
+        settlements.push(RatedSettlement {
+            settlement,
+            objective_value,
+        });
+    }
+    SolverWithSettlements { name, settlements }
+}
+
+// Goes through the settlements in order and tries to merge a number of them. Keeps going on merge
+// error.
+fn merge_at_most_settlements(
+    max_merges: usize,
+    mut settlements: impl Iterator<Item = Settlement>,
+) -> Option<Settlement> {
+    let mut merged = settlements.next()?;
+    let mut merge_count = 1;
+    while merge_count < max_merges {
+        let next = match settlements.next() {
+            Some(settlement) => settlement,
+            None => break,
+        };
+        merged = match merged.clone().merge(next) {
+            Ok(settlement) => settlement,
+            Err(err) => {
+                tracing::error!("failed to merge settlement: {:?}", err);
+                continue;
+            }
+        };
+        merge_count += 1;
+    }
+    if merge_count > 1 {
+        Some(merged)
+    } else {
+        None
+    }
+}
+
+pub fn filter_settlements_without_old_orders(
+    min_order_age: Duration,
+    settlements: &mut Vec<RatedSettlement>,
+) {
+    let settle_orders_older_than =
+        chrono::offset::Utc::now() - chrono::Duration::from_std(min_order_age).unwrap();
+    settlements.retain(|settlement| {
+        settlement
+            .settlement
+            .trades()
+            .iter()
+            .any(|trade| trade.order.order_meta_data.creation_date <= settle_orders_older_than)
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settlement::Trade;
+    use maplit::hashmap;
+    use model::order::{Order, OrderCreation, OrderKind, OrderMetaData, OrderUid};
+    use num::rational::BigRational;
+    use num::traits::FromPrimitive;
+    use primitive_types::U256;
+    use std::collections::HashSet;
+
+    #[test]
+    fn merges_settlements_with_highest_objective_value() {
+        let token0 = H160::from_low_u64_be(0);
+        let token1 = H160::from_low_u64_be(1);
+        let prices = hashmap! { token0 => 1.into(), token1 => 1.into()};
+        let prices_rational = hashmap! {
+            token0 => BigRational::from_u8(1).unwrap(),
+            token1 => BigRational::from_u8(1).unwrap()
+        };
+        fn uid(number: u8) -> OrderUid {
+            OrderUid([number; 56])
+        }
+
+        let trade = |executed_amount, uid_: u8| Trade {
+            sell_token_index: 0,
+            buy_token_index: 1,
+            executed_amount,
+            order: Order {
+                order_meta_data: OrderMetaData {
+                    uid: uid(uid_),
+                    ..Default::default()
+                },
+                order_creation: OrderCreation {
+                    sell_token: token0,
+                    buy_token: token1,
+                    sell_amount: executed_amount,
+                    buy_amount: 1.into(),
+                    kind: OrderKind::Buy,
+                    ..Default::default()
+                },
+            },
+        };
+        let settlement = |executed_amount: U256, order_uid: u8| {
+            Settlement::with_trades(prices.clone(), vec![trade(executed_amount, order_uid)])
+        };
+
+        let settlements = vec![
+            settlement(1.into(), 1),
+            settlement(2.into(), 2),
+            settlement(3.into(), 3),
+        ];
+        let settlements = merge_settlements(2, &prices_rational, "", settlements).settlements;
+
+        assert_eq!(settlements.len(), 4);
+        assert!(settlements.iter().any(|settlement| {
+            let trades = settlement.settlement.trades();
+            let uids: HashSet<OrderUid> = trades
+                .iter()
+                .map(|trade| trade.order.order_meta_data.uid)
+                .collect();
+            uids.len() == 2 && uids.contains(&uid(2)) && uids.contains(&uid(3))
+        }));
+    }
+
+    #[test]
+    fn merge_continues_on_error() {
+        let token0 = H160::from_low_u64_be(0);
+        let token1 = H160::from_low_u64_be(1);
+        let settlement0 = Settlement::new(hashmap! {token0 => 0.into()});
+        let settlement1 = Settlement::new(hashmap! {token0 => 2.into()});
+        let settlement2 = Settlement::new(hashmap! {token0 => 0.into(), token1 => 1.into()});
+        let settlements = vec![settlement0, settlement1, settlement2];
+
+        // Can't merge 0 with 1 because token0 clearing prices is different.
+        let merged = merge_at_most_settlements(2, settlements.into_iter()).unwrap();
+        assert_eq!(merged.clearing_price(token0), Some(0.into()));
+        assert_eq!(merged.clearing_price(token1), Some(1.into()));
+    }
+
+    #[test]
+    fn merge_does_nothing_on_max_1_merge() {
+        let token0 = H160::from_low_u64_be(0);
+        let settlement = Settlement::new(hashmap! {token0 => 0.into()});
+        let settlements = vec![settlement.clone(), settlement];
+        assert!(merge_at_most_settlements(1, settlements.into_iter()).is_none());
+    }
+}

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -108,6 +108,10 @@ struct Arguments {
         use_delimiter = true
     )]
     pub amm_sources: Vec<AmmSources>,
+
+    /// The port at which we serve our metrics
+    #[structopt(long, env = "MAX_MERGED_SETTLEMENTS", default_value = "5")]
+    max_merged_settlements: usize,
 }
 
 #[tokio::main]
@@ -209,6 +213,7 @@ async fn main() {
         metrics,
         web3,
         network_id,
+        args.max_merged_settlements,
     );
 
     serve_metrics(registry, ([0, 0, 0, 0], args.metrics_port).into());

--- a/solver/src/settlement.rs
+++ b/solver/src/settlement.rs
@@ -107,6 +107,12 @@ impl Settlement {
             .encode(execution, &mut self.encoder)
     }
 
+    #[cfg(test)]
+    pub fn with_trades(clearing_prices: HashMap<H160, U256>, trades: Vec<Trade>) -> Self {
+        let encoder = SettlementEncoder::with_trades(clearing_prices, trades);
+        Self { encoder }
+    }
+
     /// Returns the clearing prices map.
     pub fn clearing_prices(&self) -> &HashMap<H160, U256> {
         self.encoder.clearing_prices()


### PR DESCRIPTION
Finally enabled merging of multiple settlements.

How do you think we should test this? I could adapt the e2e test so that we assert that in a single run it settles 4 orders instead of the current two.
