### PR TITLE
Separate ERC20 approval into its own interaction

### DIFF
--- a/solver/src/interactions.rs
+++ b/solver/src/interactions.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 pub mod dummy_web3;
+mod erc20;
 mod uniswap;
 mod weth;
-mod erc20;
 
+pub use erc20::Erc20ApproveInteraction;
 pub use uniswap::UniswapInteraction;
 pub use weth::UnwrapWethInteraction;
-pub use erc20::Erc20ApproveInteraction;

--- a/solver/src/interactions.rs
+++ b/solver/src/interactions.rs
@@ -2,6 +2,8 @@
 pub mod dummy_web3;
 mod uniswap;
 mod weth;
+mod erc20;
 
 pub use uniswap::UniswapInteraction;
 pub use weth::UnwrapWethInteraction;
+pub use erc20::Erc20ApproveInteraction;

--- a/solver/src/interactions/erc20.rs
+++ b/solver/src/interactions/erc20.rs
@@ -1,0 +1,56 @@
+//! Module continaing ERC20 token interaction implementations.
+
+use crate::{encoding::EncodedInteraction, settlement::Interaction};
+use contracts::ERC20;
+use primitive_types::{H160, U256};
+
+#[derive(Debug)]
+pub struct Erc20ApproveInteraction {
+    pub token: ERC20,
+    pub owner: H160,
+    pub spender: H160,
+    pub amount: U256,
+}
+
+impl Erc20ApproveInteraction {
+    pub fn as_encoded(&self) -> EncodedInteraction {
+        let method = self.token.approve(self.spender, self.amount);
+        let calldata = method.tx.data.expect("no calldata").0;
+        (self.token.address(), 0.into(), calldata)
+    }
+}
+
+impl Interaction for Erc20ApproveInteraction {
+    fn encode(&self) -> Vec<EncodedInteraction> {
+        vec![self.as_encoded()]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interactions::dummy_web3;
+    use hex_literal::hex;
+
+    #[test]
+    fn encode_erc20_approve() {
+        let approve = Erc20ApproveInteraction {
+            token: ERC20::at(&dummy_web3::dummy_web3(), H160([0x01; 20])),
+            owner: H160([0x02; 20]),
+            spender: H160([0x02; 20]),
+            amount: U256::from_big_endian(&[0x03; 32]),
+        };
+
+        let (target, value, calldata) = approve.as_encoded();
+        assert_eq!(target, approve.token.address());
+        assert_eq!(value, 0.into());
+        assert_eq!(
+            calldata,
+            hex!(
+                "095ea7b3
+                 0000000000000000000000000202020202020202020202020202020202020202
+                 0303030303030303030303030303030303030303030303030303030303030303"
+            )
+        );
+    }
+}

--- a/solver/src/interactions/erc20.rs
+++ b/solver/src/interactions/erc20.rs
@@ -7,7 +7,6 @@ use primitive_types::{H160, U256};
 #[derive(Debug)]
 pub struct Erc20ApproveInteraction {
     pub token: ERC20,
-    pub owner: H160,
     pub spender: H160,
     pub amount: U256,
 }
@@ -36,7 +35,6 @@ mod tests {
     fn encode_erc20_approve() {
         let approve = Erc20ApproveInteraction {
             token: ERC20::at(&dummy_web3::dummy_web3(), H160([0x01; 20])),
-            owner: H160([0x02; 20]),
             spender: H160([0x02; 20]),
             amount: U256::from_big_endian(&[0x03; 32]),
         };

--- a/solver/src/interactions/uniswap.rs
+++ b/solver/src/interactions/uniswap.rs
@@ -1,3 +1,4 @@
+use super::Erc20ApproveInteraction;
 use crate::{encoding::EncodedInteraction, settlement::Interaction};
 use contracts::{GPv2Settlement, IUniswapLikeRouter, ERC20};
 use primitive_types::{H160, U256};
@@ -27,9 +28,13 @@ impl Interaction for UniswapInteraction {
 impl UniswapInteraction {
     fn encode_approve(&self) -> EncodedInteraction {
         let token = ERC20::at(&self.web3(), self.token_in);
-        let method = token.approve(self.router.address(), U256::MAX);
-        let calldata = method.tx.data.expect("no calldata").0;
-        (self.token_in, 0.into(), calldata)
+        Erc20ApproveInteraction {
+            token,
+            owner: self.settlement.address(),
+            spender: self.router.address(),
+            amount: U256::MAX,
+        }
+        .as_encoded()
     }
 
     fn encode_swap(&self) -> EncodedInteraction {

--- a/solver/src/interactions/uniswap.rs
+++ b/solver/src/interactions/uniswap.rs
@@ -30,7 +30,6 @@ impl UniswapInteraction {
         let token = ERC20::at(&self.web3(), self.token_in);
         Erc20ApproveInteraction {
             token,
-            owner: self.settlement.address(),
             spender: self.router.address(),
             amount: U256::MAX,
         }


### PR DESCRIPTION
This tiny PR just adds a ERC20 approval interaction and refactors the Uniswap one to use it.

While this PR is not very complex, when looking through the code I noticed that each liquidity implementation would have to manage approvals themselves. I believe this is better suited for the `SettlementEncoder` so that it can accumulate and group together separate approvals, as well as verify whether or not existing allowances suffice. That is a larger change that I started, but led to a thread that I kept on pulling and pulling. For now, I would rather just duplicate allowance checking code in the 1Inch solver and then work towards moving the responsibility towards the settlement encoder in separate PRs after the 1Inch solver is in place.

### Test Plan

Added unit test.
