### PR TITLE
1Inch Solver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
- "rand 0.8.2",
+ "rand 0.8.3",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2014,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
@@ -2503,6 +2503,7 @@ dependencies = [
  "orderbook",
  "primitive-types",
  "prometheus",
+ "rand 0.8.3",
  "reqwest",
  "serde",
  "serde_json",
@@ -2719,7 +2720,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.2",
+ "rand 0.8.3",
  "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi 0.3.9",

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -30,6 +30,7 @@ model = { path = "../model" }
 num = "0.4"
 primitive-types = { version = "0.8", features = ["fp-conversion"] }
 prometheus = "0.12"
+rand = "0.8"
 reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/solver/src/interactions/dummy_web3.rs
+++ b/solver/src/interactions/dummy_web3.rs
@@ -1,7 +1,8 @@
 use contracts::WETH9;
 use jsonrpc_core::Call as RpcCall;
 use serde_json::Value;
-use web3::{api::Web3, types::H160, Transport};
+use shared::transport::LoggingTransport;
+use web3::{api::Web3, transports::Http, types::H160, Transport};
 
 // To create an ethcontract instance we need to provide a web3 even though we never use it. This
 // module provides a dummy transport and web3.
@@ -23,4 +24,18 @@ pub fn dummy_web3() -> Web3<DummyTransport> {
 
 pub fn dummy_weth(addr: impl Into<H160>) -> WETH9 {
     WETH9::at(&dummy_web3(), addr.into())
+}
+
+pub fn infura(network: impl AsRef<str>) -> shared::Web3 {
+    let infura_project_id =
+        std::env::var("INFURA_PROJECT_ID").expect("Missing INFURA_PROJECT_ID env variable");
+    let node_url = format!(
+        "https://{}.infura.io/v3/{}",
+        network.as_ref(),
+        infura_project_id
+    );
+
+    Web3::new(LoggingTransport::new(
+        Http::new(&node_url).expect("transport creation failed"),
+    ))
 }

--- a/solver/src/interactions/dummy_web3.rs
+++ b/solver/src/interactions/dummy_web3.rs
@@ -29,13 +29,15 @@ pub fn dummy_weth(addr: impl Into<H160>) -> WETH9 {
 pub fn infura(network: impl AsRef<str>) -> shared::Web3 {
     let infura_project_id =
         std::env::var("INFURA_PROJECT_ID").expect("Missing INFURA_PROJECT_ID env variable");
-    let node_url = format!(
+    from_node_url(&format!(
         "https://{}.infura.io/v3/{}",
         network.as_ref(),
         infura_project_id
-    );
+    ))
+}
 
+fn from_node_url(node_url: &str) -> shared::Web3 {
     Web3::new(LoggingTransport::new(
-        Http::new(&node_url).expect("transport creation failed"),
+        Http::new(node_url).expect("transport creation failed"),
     ))
 }

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -87,6 +87,22 @@ impl From<Order> for LimitOrder {
     }
 }
 
+#[cfg(test)]
+impl Default for LimitOrder {
+    fn default() -> Self {
+        LimitOrder {
+            sell_token: Default::default(),
+            buy_token: Default::default(),
+            sell_amount: Default::default(),
+            buy_amount: Default::default(),
+            kind: Default::default(),
+            partially_fillable: Default::default(),
+            settlement_handling: tests::CapturingSettlementHandler::arc(),
+            id: Default::default(),
+        }
+    }
+}
+
 /// 2 sided constant product automated market maker with equal reserve value and a trading fee (e.g. Uniswap, Sushiswap)
 #[derive(Clone)]
 pub struct AmmOrder {
@@ -119,6 +135,18 @@ impl Settleable for AmmOrder {
 
     fn settlement_handling(&self) -> &dyn SettlementHandling<Self> {
         &*self.settlement_handling
+    }
+}
+
+#[cfg(test)]
+impl Default for AmmOrder {
+    fn default() -> Self {
+        AmmOrder {
+            tokens: Default::default(),
+            reserves: Default::default(),
+            fee: Ratio::new(0, 1),
+            settlement_handling: tests::CapturingSettlementHandler::arc(),
+        }
     }
 }
 

--- a/solver/src/liquidity/slippage.rs
+++ b/solver/src/liquidity/slippage.rs
@@ -3,10 +3,10 @@
 use ethcontract::U256;
 
 /// Constant maximum slippage of 10 BPS (0.1%) to use for on-chain liquidity.
-pub const MAX_SLIPPAGE_BPS: u32 = 10;
+pub const MAX_SLIPPAGE_BPS: u16 = 10;
 
 /// Basis points in 100%.
-const BPS_BASE: u32 = 10000;
+const BPS_BASE: u16 = 10000;
 
 /// Apply the constant slippage to the specified amount.
 pub fn amount_with_max_slippage(amount: U256) -> U256 {

--- a/solver/src/oneinch_solver.rs
+++ b/solver/src/oneinch_solver.rs
@@ -152,7 +152,7 @@ mod tests {
     use contracts::{GPv2Settlement, WETH9};
     use ethcontract::H160;
     use hex_literal::hex;
-    use model::order::OrderKind;
+    use model::order::{Order, OrderCreation, OrderKind};
 
     fn dummy_solver() -> OneInchSolver {
         let web3 = dummy_web3::dummy_web3();
@@ -202,14 +202,20 @@ mod tests {
 
         let solver = OneInchSolver::new(settlement);
         let settlement = solver
-            .settle_order(LimitOrder {
-                sell_token: weth.address(),
-                buy_token: gno,
-                sell_amount: 1_000_000_000_000_000_000u128.into(),
-                buy_amount: 1u128.into(),
-                kind: OrderKind::Sell,
-                ..Default::default()
-            })
+            .settle_order(
+                Order {
+                    order_creation: OrderCreation {
+                        sell_token: weth.address(),
+                        buy_token: gno,
+                        sell_amount: 1_000_000_000_000_000_000u128.into(),
+                        buy_amount: 1u128.into(),
+                        kind: OrderKind::Sell,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }
+                .into(),
+            )
             .await
             .unwrap();
 

--- a/solver/src/oneinch_solver.rs
+++ b/solver/src/oneinch_solver.rs
@@ -136,7 +136,7 @@ impl Solver for OneInchSolver {
             .filter_map(|settlement| match settlement {
                 Ok(settlement) => Some(settlement),
                 Err(err) => {
-                    // It could be that 1Inch can't find match an order and would
+                    // It could be that 1Inch can't match an order and would
                     // return an error for whatever reason. In that case, we want
                     // to continue trying to solve for other orders.
                     tracing::warn!("1Inch API error quoting swap: {}", err);

--- a/solver/src/oneinch_solver.rs
+++ b/solver/src/oneinch_solver.rs
@@ -4,3 +4,137 @@
 //! single GPv2 order and produce a settlement directly against 1Inch.
 
 pub mod api;
+
+use self::api::{OneInchClient, Slippage, Swap, SwapQuery};
+use crate::{
+    encoding::EncodedInteraction,
+    interactions::Erc20ApproveInteraction,
+    liquidity::{slippage::MAX_SLIPPAGE_BPS, LimitOrder, Liquidity},
+    settlement::{Interaction, Settlement},
+    solver::Solver,
+};
+use anyhow::Result;
+use contracts::{GPv2Settlement, ERC20};
+use ethcontract::U256;
+use maplit::hashmap;
+use model::order::OrderKind;
+use shared::Web3;
+use std::fmt::{self, Display, Formatter};
+
+/// A GPv2 solver that matches GP **sell** orders to direct 1Inch swaps.
+#[derive(Debug)]
+pub struct OneInchSolver {
+    web3: Web3,
+    settlement_contract: GPv2Settlement,
+    client: OneInchClient,
+}
+
+impl OneInchSolver {
+    /// Creates a new 1Inch solver instance for specified settlement contract
+    /// instance.
+    pub fn new(web3: Web3, settlement_contract: GPv2Settlement) -> Self {
+        Self {
+            web3,
+            settlement_contract,
+            client: Default::default(),
+        }
+    }
+
+    /// Settles a single sell order against a 1Inch swap.
+    async fn settle_order(&self, order: &LimitOrder) -> Result<Option<Settlement>> {
+        debug_assert_eq!(
+            order.kind,
+            OrderKind::Sell,
+            "only sell orders should be passed to settle_order"
+        );
+
+        let spender = self.client.get_spender().await?;
+        let sell_token = ERC20::at(&self.web3, order.sell_token);
+        let existing_allowance = sell_token
+            .allowance(self.settlement_contract.address(), spender.address)
+            .call()
+            .await?;
+
+        let swap = match self
+            .client
+            .get_swap(SwapQuery {
+                from_token_address: order.sell_token,
+                to_token_address: order.buy_token,
+                amount: order.sell_amount,
+                from_address: self.settlement_contract.address(),
+                slippage: Slippage::basis_points(MAX_SLIPPAGE_BPS).unwrap(),
+                // Disable balance/allowance checks, as the settlement contract
+                // does not hold balances to traded tokens.
+                disable_estimate: Some(true),
+            })
+            .await
+        {
+            Ok(swap) => swap,
+            Err(err) => {
+                // It could be that 1Inch can't find match an order and would
+                // return an error for whatever reason. In that case, we want to
+                // continue trying to solve for other orders.
+                tracing::warn!("1Inch API error quoting swap: {}", err);
+                return Ok(None);
+            }
+        };
+
+        let mut settlement = Settlement::new(hashmap! {
+            order.sell_token => swap.to_token_amount,
+            order.buy_token => swap.from_token_amount,
+        });
+
+        settlement.with_liquidity(order, order.sell_amount)?;
+
+        if existing_allowance < order.sell_amount {
+            settlement
+                .encoder
+                .append_to_execution_plan(Erc20ApproveInteraction {
+                    token: sell_token,
+                    owner: self.settlement_contract.address(),
+                    spender: spender.address,
+                    amount: U256::MAX,
+                });
+        }
+        settlement.encoder.append_to_execution_plan(swap);
+
+        Ok(None)
+    }
+}
+
+impl Interaction for Swap {
+    fn encode(&self) -> Vec<EncodedInteraction> {
+        vec![(self.tx.to, self.tx.value, self.tx.data.clone())]
+    }
+}
+
+#[async_trait::async_trait]
+impl Solver for OneInchSolver {
+    async fn solve(
+        &self,
+        liquidity: Vec<Liquidity>,
+        _gas_price: f64,
+    ) -> Result<Option<Settlement>> {
+        let sell_orders = liquidity
+            .into_iter()
+            .filter_map(|liquidity| match liquidity {
+                Liquidity::Limit(order) if order.kind == OrderKind::Sell => Some(order),
+                _ => None,
+            });
+
+        for order in sell_orders {
+            let settlement = self.settle_order(&order).await?;
+            if settlement.is_some() {
+                return Ok(settlement);
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+impl Display for OneInchSolver {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "OneInchSolver")
+    }
+}

--- a/solver/src/settlement.rs
+++ b/solver/src/settlement.rs
@@ -86,7 +86,7 @@ impl Interaction for NoopInteraction {
 
 #[derive(Debug, Clone)]
 pub struct Settlement {
-    encoder: SettlementEncoder,
+    pub encoder: SettlementEncoder,
 }
 
 impl Settlement {

--- a/solver/src/settlement.rs
+++ b/solver/src/settlement.rs
@@ -58,7 +58,7 @@ impl Trade {
     }
 }
 
-pub trait Interaction: std::fmt::Debug + Send {
+pub trait Interaction: std::fmt::Debug + Send + Sync {
     // TODO: not sure if this should return a result.
     // Write::write returns a result but we know we write to a vector in memory so we know it will
     // never fail. Then the question becomes whether interactions should be allowed to fail encoding

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -19,8 +19,10 @@ pub trait Solver {
     // order) so that they can be merged by the driver at its leisure.
     async fn solve(&self, orders: Vec<Liquidity>, gas_price: f64) -> Result<Vec<Settlement>>;
 
-    // Displayable name of the solver.
-    fn name(&self) -> &'static str;
+    // Displayable name of the solver. Defaults to the type name.
+    fn name(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
 }
 
 arg_enum! {


### PR DESCRIPTION
This PR adds an implementation for a 1Inch solver. It works by selecting a portion of orders and using the 1Inch API to directly get the transaction call data to use for an interaction to swap on 1Inch.

### Test Plan

Added a couple unit tests verifying the `solve` logic. Additionally one ignored test to get an actual settlement for a fictional order:
```
$ cargo test -p solver -- --ignored --nocapture solve_order_on_one
...
running 1 test
Settlement {
...
}
test oneinch_solver::tests::solve_order_on_oneinch ... ok
...
```

An end-to-end test that actually settles against 1Inch will be done when the solver is enabled.
