### PR TITLE
Split tenderly link error message into its own error

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -175,11 +175,8 @@ impl Driver {
             .filter_map(|(settlement, simulation)| match simulation {
                 Ok(()) => Some(settlement),
                 Err(err) => {
-                    tracing::error!(
-                        "simulation of settlement failed\nsettlement: {:?}\n error:{:?}",
-                        settlement.settlement,
-                        err
-                    );
+                    tracing::error!("settlement simulation failed\n error: {:?}", err);
+                    tracing::debug!("settlement failure for: \n{:#?}", settlement.settlement,);
                     None
                 }
             })


### PR DESCRIPTION
This PR just splits the tenderly alert error into its own log. This is done because including the settlement + tenderly link is too long, and leads to the link getting cut off in the alert message (making it harder to debug issues).

![image](https://user-images.githubusercontent.com/4210206/116355634-68645300-a7fa-11eb-94cf-6a306dcf61d9.png)

To address this, the settlement gets dumped in the following log statement so that it can still be retrieved in the logs.

### Test Plan

Tenderly links in alerts don't get cut off.
