### PR TITLE
Enforce a minimum order validity period

### DIFF
--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -178,6 +178,7 @@ async fn onchain_settlement(web3: Web3) {
         )),
         fee_calculator.clone(),
         HashSet::new(),
+        Duration::from_secs(120),
     ));
 
     orderbook::serve_task(
@@ -194,7 +195,7 @@ async fn onchain_settlement(web3: Web3) {
         .with_sell_amount(to_wei(100))
         .with_buy_token(token_b.address())
         .with_buy_amount(to_wei(80))
-        .with_valid_to(u32::max_value())
+        .with_valid_to(shared::time::now_in_epoch_seconds() + 300)
         .with_kind(OrderKind::Sell)
         .with_signing_scheme(SigningScheme::Eip712)
         .sign_with(
@@ -215,7 +216,7 @@ async fn onchain_settlement(web3: Web3) {
         .with_sell_amount(to_wei(50))
         .with_buy_token(token_a.address())
         .with_buy_amount(to_wei(40))
-        .with_valid_to(u32::max_value())
+        .with_valid_to(shared::time::now_in_epoch_seconds() + 300)
         .with_kind(OrderKind::Sell)
         .with_signing_scheme(SigningScheme::EthSign)
         .sign_with(

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -551,7 +551,7 @@ components:
               DuplicateOrder,
               InvalidSignature,
               MissingOrderData,
-              PastValidTo,
+              InsufficientValidTo,
               InsufficientFunds,
               InsufficientFee,
               UnsupportedToken,

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -41,8 +41,11 @@ pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
             super::error("Forbidden", "Forbidden, your account is deny-listed"),
             StatusCode::FORBIDDEN,
         ),
-        Ok(AddOrderResult::PastValidTo) => (
-            super::error("PastValidTo", "validTo is in the past"),
+        Ok(AddOrderResult::InsufficientValidTo) => (
+            super::error(
+                "InsufficientValidTo",
+                "validTo is not far enough in the future",
+            ),
             StatusCode::BAD_REQUEST,
         ),
         Ok(AddOrderResult::MissingOrderData) => (


### PR DESCRIPTION
The motivation for this that our solver takes some time to run and the transaction time to get mined. If an order is only valid for a short time we would be including it in the solution but then not be able to use it anymore.
Based on this I thought it would make sense to only consider orders that are still valid for some period when solving and then also to not accept orders that would immediately not be considered because of this.

### Test Plan
changed e2e test to set a realistic validity period