### PR TITLE
Use Uniswap buy orders

### DIFF
--- a/solver/src/liquidity/slippage.rs
+++ b/solver/src/liquidity/slippage.rs
@@ -8,15 +8,33 @@ pub const MAX_SLIPPAGE_BPS: u32 = 10;
 /// Basis points in 100%.
 const BPS_BASE: u32 = 10000;
 
-/// Apply the constant slippage to the specified amount.
-pub fn amount_with_max_slippage(amount: U256) -> U256 {
-    // If we overflow the multiplication we are dealing with very large numbers. In that case it's fine to first divide.
-    let numerator = U256::from(BPS_BASE - MAX_SLIPPAGE_BPS);
-    let denominator = U256::from(BPS_BASE);
-    amount
-        .checked_mul(numerator)
-        .map(|v| v / denominator)
-        .unwrap_or_else(|| (amount / denominator) * numerator)
+/// Multiply an integer amount by a rational, with additional handling in case
+/// of overflows.
+fn slippage_for_amount(amount: U256) -> U256 {
+    let p = U256::from(MAX_SLIPPAGE_BPS);
+    let q = U256::from(BPS_BASE);
+
+    // In order to prevent overflow on the multiplication when dealing with
+    // very large numbers. In that case we divide first and add the computed
+    // rounding error.
+    let product = (amount / q) * p;
+    let rounding_error = {
+        let numerator = (amount % q) * p;
+        // Perform a ceil division so that we round up with slippage amount
+        (numerator + q - 1) / q
+    };
+
+    product + rounding_error
+}
+
+/// Reduce the specified amount by the constant slippage.
+pub fn amount_minus_max_slippage(amount: U256) -> U256 {
+    amount.saturating_sub(slippage_for_amount(amount))
+}
+
+/// Increase the specified amount by the constant slippage.
+pub fn amount_plus_max_slippage(amount: U256) -> U256 {
+    amount.saturating_add(slippage_for_amount(amount))
 }
 
 #[cfg(test)]
@@ -25,15 +43,27 @@ mod tests {
 
     #[test]
     fn test_out_amount_with_slippage() {
-        assert_eq!(amount_with_max_slippage(0.into()), 0.into());
-        assert_eq!(amount_with_max_slippage(100.into()), 99.into());
-        assert_eq!(amount_with_max_slippage(10000.into()), 9990.into());
+        assert_eq!(amount_minus_max_slippage(0.into()), 0.into());
+        assert_eq!(amount_minus_max_slippage(100.into()), 99.into());
+        assert_eq!(amount_minus_max_slippage(1000.into()), 999.into());
+        assert_eq!(amount_minus_max_slippage(10000.into()), 9990.into());
+        assert_eq!(amount_minus_max_slippage(10001.into()), 9990.into());
         assert_eq!(
-            amount_with_max_slippage(U256::MAX),
+            amount_minus_max_slippage(U256::MAX),
             U256::from_dec_str(
-                "115676297148078879228147414023679219945416714680974923475418126423905216500370"
+                "115676297148078879228147414023679219945416714680974923475418126423905216510295"
             )
             .unwrap()
         );
+    }
+
+    #[test]
+    fn test_in_amount_with_slippage() {
+        assert_eq!(amount_plus_max_slippage(0.into()), 0.into());
+        assert_eq!(amount_plus_max_slippage(100.into()), 101.into());
+        assert_eq!(amount_plus_max_slippage(1000.into()), 1001.into());
+        assert_eq!(amount_plus_max_slippage(10000.into()), 10010.into());
+        assert_eq!(amount_plus_max_slippage(10001.into()), 10012.into());
+        assert_eq!(amount_plus_max_slippage(U256::MAX), U256::MAX);
     }
 }


### PR DESCRIPTION
This PR switches the Uniswap interaction to use buy orders instead of sell orders. The reasoning is that this allows the slippage to be set on the **sell** token instead of the buy token, which is **guaranteed** to have a small buffer to absorb some slippage, as the fee is taken from the sell token. This would allow us to trade orders for new tokens without existing buffers without any issues.

### Test Plan

Unit tests pass.

Did a manual settlement to see if it would work on xDai:
- Started up services
- Created order
- The services were able to create a solution on xDAI:
  - Note that simulation **failed** because my PK is not a solver
  - [Modifying the simulation](https://dashboard.tenderly.co/gp-v2/staging/simulator/new?block=15807487&blockIndex=0&from=0x97d69672e8fe5be64d7d5bbba438ae9b08187667&gas=8000000&gasPrice=0&value=0&contractAddress=0x3328f5f2cecaf00a2443082b657cedeaf70bfaef&rawFunctionInput=0x13d79a0b00000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000003a00000000000000000000000000000000000000000000000000000000000000003000000000000000000000000e91d153e0b41518a2ce8dd3d7944fa863463a97d000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee000000000000000000000000f1738912ae7439475712520797583ac784ea903300000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000013ee6c9034b97cb940000000000000000000000000000000000000000000000013ee6c9034b97cb9400000000000000000000000000000000000000000000000021d9e25b8bca815100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000010000000000000000000000007524942f9283fbfa8f17b05cc0a9cbde397d25b30000000000000000000000000000000000000000000000013ee6c9034b97cb9400000000000000000000000000000000000000000000000021aec53627c0950d00000000000000000000000000000000000000000000000000000000608bd4a200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000049a120be64346c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000013ee6c9034b97cb9400000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000041d0a0dc785ed17e3e0f94ac9b36c45ba8198d4bb74058e687af19808f33c00dc15abd0a5b4f7fe11a11ad3ec283834260340d26e46fffc1ff46e5b293c2758a121c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000034000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000001e00000000000000000000000001c232f01118cb8b424793ae03f870aa7d0ac7f770000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001048803dbee00000000000000000000000000000000000000000000000021d9e25b8bca81510000000000000000000000000000000000000000000000013f386c8ab8fb04df00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000003328f5f2cecaf00a2443082b657cedeaf70bfaefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000f1738912ae7439475712520797583ac784ea9033000000000000000000000000e91d153e0b41518a2ce8dd3d7944fa863463a97d00000000000000000000000000000000000000000000000000000000000000000000000000000000e91d153e0b41518a2ce8dd3d7944fa863463a97d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000242e1a7d4d00000000000000000000000000000000000000000000000021d9e25b8bca8151000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000&network=100) to use a solver address succeeds: https://dashboard.tenderly.co/gp-v2/staging/simulator/68903b15-ebfc-4eee-8a8a-0fef9fb8c1d9
  - Verify that we are swapping with `swapTokensForExactTokens` (i.e. buy order)
- Services were able to create a settlement on Rinkeby
  - Sell order: https://rinkeby.etherscan.io/tx/0xd760af7a79a52f92d16879ae27bf38d19a7e229b0ade9ac6070da56b05d63760
  - Buy order: https://rinkeby.etherscan.io/tx/0xf290effd0371156ab1a2434cc49d99bd522c11b5ef68c68c20119d950b1a37b7
  - Note in both cases the swap output amount was exact and used `swapTokensForExactTokens`.
  
@fleupold @vkgnosis Do we have a "test solver" that we can use so we do actual on-chain settlements to test out these changes?
