### PR TITLE
Reduce settlement merge error log level

### DIFF
--- a/solver/src/driver/solver_settlements.rs
+++ b/solver/src/driver/solver_settlements.rs
@@ -86,7 +86,7 @@ fn merge_at_most_settlements(
         merged = match merged.clone().merge(next) {
             Ok(settlement) => settlement,
             Err(err) => {
-                tracing::error!("failed to merge settlement: {:?}", err);
+                tracing::debug!("failed to merge settlement: {:?}", err);
                 continue;
             }
         };


### PR DESCRIPTION
During testing I realized this will happen commonly and is even expected
to happen like when token A is traded in one settlement for token B and
in another for token C so that the price is different.

Here is a merged settlement btw https://rinkeby.etherscan.io/tx/0x782aa0f05fc8c5a1ffeb1fb2e09ac5de8cf50c4f85a69769773480ada610b982 .

### Test Plan
not needed, saw this on rinkeby staging