### PR TITLE
Log settlement simulation errors only if fails with original block

### DIFF
--- a/shared/src/current_block.rs
+++ b/shared/src/current_block.rs
@@ -98,6 +98,13 @@ impl CurrentBlockStream {
     pub fn current_block(&self) -> Block {
         self.most_recent.lock().unwrap().clone()
     }
+
+    pub fn current_block_number(&self) -> Result<u64> {
+        self.current_block()
+            .number
+            .ok_or_else(|| anyhow!("no block number"))
+            .map(|number| number.as_u64())
+    }
 }
 
 impl Stream for CurrentBlockStream {


### PR DESCRIPTION
It is annoying when we get alerts for settlements that failed to
simulate on the current block at time of submission but would have
succeeded at time of liquidity fetching.
Here the solver worked correctly but the chain moved in unfavorably.
This is not an error so it doesn't make sense to alert.

Fixes #527

### Test Plan
Ran the adjusted test with real node to see that tenderly link is still generated.
report_simulation_errors doesn't influence the correctness of the solver so I am planning on manually checking the logs