### PR TITLE
Prepare min fee route to return dedicated unsupported token error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,6 +1735,7 @@ dependencies = [
  "shared",
  "sqlx",
  "structopt",
+ "thiserror",
  "tokio",
  "tracing",
  "url",

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -37,6 +37,7 @@ shared= { path = "../shared" }
 sqlx = { version = "0.4", default-features = false, features = ["bigdecimal", "chrono", "macros", "runtime-tokio-native-tls", "postgres"] }
 structopt = "0.3"
 reqwest = { version = "0.10", features = ["json"] }
+thiserror = "1.0"
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "sync", "time"] }
 tracing = "0.1"
 url = "2.2"

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -252,8 +252,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/FeeInformation"
+        400:
+          description: Token not supported by the protocol (e.g. token with fee on transfer)
         404:
           description: Token non-existent or not connected to native token
+        500:
+          description: Unexpected internal error while processing the request
   /api/v1/markets/{baseToken}-{quoteToken}/{kind}/{amount}:
     get:
       description: |


### PR DESCRIPTION
We received some feedback that users get confused by the UX for unsupported tokens. Atm we handle them like NotFound errors (as pools for those tokens get ignored). However, the tokens might have liquidity on Uniswap.

This PR introduces a MinFeeCalculation error type which can indicate to the frontend that the token is indeed not supported and thus give a better error message + a pointer to the FAQ explaining why this is not possible.

Note, that we don't return this error yet (next PR).

### Test Plan
Unit tests still pass
