### PR TITLE
Extend api description of the order post data from field

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -397,6 +397,11 @@ components:
         signingScheme:
           $ref: "#/components/schemas/SigningScheme"
         from:
+          description: |
+            If set, the backend enforces that this address matches what is decoded as the signer of
+            the signature. This helps catch errors with invalid signature encodings as the backend
+            might otherwise silently work with an unexpected address that for example does not have
+            any balance.
           $ref: "#/components/schemas/Address"
           nullable: true
       required:


### PR DESCRIPTION
With the current openapi version (3.0) this does not yet show up in the
generated documentation because you cannot overwrite fields from the
$ref but in the next version (3.1) it should work.
