### PR TITLE
Add metric for settlement simulation succcess and failures

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -255,6 +255,9 @@ impl Driver {
             settlements.len(),
             errors.len()
         );
+        self.metrics
+            .settlement_simulations_succeeded(settlements.len());
+        self.metrics.settlement_simulations_failed(errors.len());
         if let Some(settlement) = settlements
             .into_iter()
             .max_by(|a, b| a.objective_value.cmp(&b.objective_value))


### PR DESCRIPTION
We are not emitting alerts anymore when settlements suceed on their
original block but fail on the current block before creating the
transaction. This metric allows us to keep track of how often this
occurs.

Part of #545

### Test Plan
new unit test for metrics
