### PR TITLE
Unsupported Token error on price estimate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2451,6 +2451,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -137,6 +137,7 @@ impl OrderbookServices {
         let price_estimator = Arc::new(BaselinePriceEstimator::new(
             Box::new(pool_fetcher),
             HashSet::new(),
+            HashSet::new(),
         ));
         let fee_calculator = Arc::new(MinFeeCalculator::new(
             price_estimator.clone(),

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -269,8 +269,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AmountEstimate"
+        400:
+          description: Token not supported by the protocol (e.g. token with fee on transfer)
         404:
           description: Token non-existent or no valid price found
+        500:
+          description: Unexpected internal error while processing the request
 components:
   schemas:
     TransactionHash:

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -157,6 +157,7 @@ async fn main() {
     let price_estimator = Arc::new(BaselinePriceEstimator::new(
         Box::new(pool_fetcher),
         base_tokens,
+        unsupported_tokens.clone(),
     ));
     let fee_calculator = Arc::new(MinFeeCalculator::new(
         price_estimator.clone(),

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -32,3 +32,4 @@ warp = "0.2"
 web3 = { version = "0.15", default-features = false, features = ["http-tls"] }
 num-bigint = "0.3"
 mockall = "0.9"
+thiserror = "1.0"

--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -14,7 +14,7 @@ use num::{BigRational, ToPrimitive};
 use primitive_types::H160;
 use reqwest::{header::HeaderValue, Client, Url};
 use shared::{
-    price_estimate::PriceEstimating,
+    price_estimate::{PriceEstimating, PriceEstimationError},
     token_info::{TokenInfo, TokenInfoFetching},
 };
 use std::{
@@ -114,7 +114,7 @@ impl HttpSolver {
         &self,
         tokens: &HashMap<String, H160>,
         token_infos: &HashMap<H160, TokenInfo>,
-        price_estimates: &HashMap<H160, Result<BigRational>>,
+        price_estimates: &HashMap<H160, Result<BigRational, PriceEstimationError>>,
     ) -> HashMap<String, TokenInfoModel> {
         tokens
             .iter()
@@ -220,10 +220,10 @@ impl HttpSolver {
             self.token_info_fetcher
                 .get_token_infos(addresses.as_slice()),
             self.price_estimator
-                .estimate_prices(addresses.as_slice(), addresses[0]),
+                .estimate_prices(addresses.as_slice(), addresses[0])
         );
 
-        let price_estimates: HashMap<H160, Result<BigRational>> =
+        let price_estimates: HashMap<H160, Result<BigRational, _>> =
             addresses.iter().cloned().zip(price_estimates).collect();
 
         let mut orders = split_liquidity(liquidity);

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -161,6 +161,7 @@ async fn main() {
     let price_estimator = Arc::new(BaselinePriceEstimator::new(
         Box::new(pool_aggregator),
         base_tokens.clone(),
+        args.shared.unsupported_tokens.into_iter().collect(),
     ));
     let uniswap_like_liquidity = build_amm_artifacts(
         args.shared.baseline_sources,


### PR DESCRIPTION
Same as #550 and #551 but for price estimation route.

### Test Plan
Added Unit test + manual e2e test

```
http://localhost:8080/api/v1/markets/0xfad45e47083e4607302aa43c65fb3106f1cd7607-0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/sell/1000000000000000000
```

> {"errorType":"UnsupportedToken","description":"Token address 0xfad45e47083e4607302aa43c65fb3106f1cd7607"}