### PR TITLE
Enforce timeout for solvers

### DIFF
--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -178,6 +178,7 @@ async fn onchain_settlement(web3: Web3) {
         web3.clone(),
         network_id,
         1,
+        Duration::from_secs(30),
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -167,6 +167,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         web3.clone(),
         network_id,
         1,
+        Duration::from_secs(10),
     );
     driver.single_run().await.unwrap();
 

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -98,6 +98,15 @@ struct Arguments {
     /// The port at which we serve our metrics
     #[structopt(long, env = "MAX_MERGED_SETTLEMENTS", default_value = "5")]
     max_merged_settlements: usize,
+
+    /// The maximum amount of time a solver is allowed to take.
+    #[structopt(
+        long,
+        env = "SOLVER_TIME_LIMIT",
+        default_value = "30",
+        parse(try_from_str = shared::arguments::duration_from_seconds),
+    )]
+    solver_time_limit: Duration,
 }
 
 #[tokio::main]
@@ -182,6 +191,7 @@ async fn main() {
         network_name.to_string(),
         chain_id,
         args.shared.fee_discount_factor,
+        args.solver_time_limit,
     )
     .expect("failure creating solvers");
     let liquidity_collector = LiquidityCollector {
@@ -202,6 +212,7 @@ async fn main() {
         web3,
         network_id,
         args.max_merged_settlements,
+        args.solver_time_limit,
     );
 
     serve_metrics(registry, ([0, 0, 0, 0], args.metrics_port).into());


### PR DESCRIPTION
We haven't run into this but it's to good to handle this case
preemptively. For whatever reason a solver could take very long to run
like a network request getting stuck. In this case we want to continue
with the other solvers and not let one hold up the whole settlement
process.

### Test Plan
CI still works which tests the ok case still works.