### PR TITLE
Update gp estimation dependency to use gas now with cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,10 +898,11 @@ dependencies = [
 [[package]]
 name = "gas-estimation"
 version = "0.1.0"
-source = "git+https://github.com/gnosis/gp-gas-estimation.git?tag=v0.1.0#dfae4041e37009698cfbefdf778f26b08dd20808"
+source = "git+https://github.com/gnosis/gp-gas-estimation.git?tag=v0.1.1#ebb760eb9db27e97cb6646c2db80e632bebdf4c8"
 dependencies = [
  "anyhow",
  "async-trait",
+ "futures",
  "log",
  "primitive-types",
  "serde",

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -22,7 +22,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 contracts = { path = "../contracts" }
 ethcontract = { version = "0.11", default-features = false }
 futures = "0.3.14"
-gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.0", features = ["web3_"] }
+gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.1", features = ["web3_"] }
 hex = { version = "0.4", default-features = false }
 hex-literal = "0.3"
 maplit = "1.0"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -13,7 +13,7 @@ atty = "0.2"
 contracts = { path = "../contracts" }
 ethcontract = { version = "0.11", default-features = false }
 futures = "0.3"
-gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.0", features = ["web3_"] }
+gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.1", features = ["web3_"] }
 hex-literal = "0.3"
 maplit = "1.0"
 model = { path = "../model" }

--- a/shared/src/gas_price_estimation.rs
+++ b/shared/src/gas_price_estimation.rs
@@ -23,7 +23,7 @@ struct Client(reqwest::Client);
 
 #[async_trait::async_trait]
 impl Transport for Client {
-    async fn get_json<'a, T: DeserializeOwned>(&self, url: &'a str) -> Result<T> {
+    async fn get_json<T: DeserializeOwned>(&self, url: &str) -> Result<T> {
         self.0
             .get(url)
             .send()

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -21,7 +21,7 @@ contracts = { path = "../contracts" }
 ethcontract = { version = "0.11", default-features = false }
 futures = "0.3"
 transaction-retry = { git = "https://github.com/gnosis/gp-transaction-retry.git", tag = "v0.1.0" }
-gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.0", features = ["web3_"] }
+gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.1", features = ["web3_"] }
 hex = "0.4"
 hex-literal = "0.3"
 jsonrpc-core = "16.0"


### PR DESCRIPTION
This is more urgent than I thought because we're already querying the
estimator every time a fee is calculated if the fee isn't cached.

### Test Plan
CI