### PR TITLE
Change semantic of markets/A-B/buy/amount

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -240,7 +240,7 @@ paths:
   /api/v1/markets/{baseToken}-{quoteToken}/{kind}/{amount}:
     get:
       description: |
-        The estimated amount received for selling a `amount` of baseToken or the amount required to spend for buying `amount` of quote token.
+        The estimated amount in quote token for either buying or selling `amount` of baseToken.
       parameters:
         - name: baseToken
           in: path

--- a/orderbook/src/api/get_markets.rs
+++ b/orderbook/src/api/get_markets.rs
@@ -75,20 +75,14 @@ fn get_amount_estimate_response(
 ) -> impl Reply {
     match result {
         Ok(price) => {
-            let (amount, token) = match query.kind {
-                OrderKind::Buy => (
-                    query.amount.to_big_rational() * price,
-                    query.market.base_token,
-                ),
-                OrderKind::Sell => (
-                    query.amount.to_big_rational() / price,
-                    query.market.quote_token,
-                ),
+            let amount = match query.kind {
+                OrderKind::Buy => query.amount.to_big_rational() * price,
+                OrderKind::Sell => query.amount.to_big_rational() / price,
             };
             reply::with_status(
                 reply::json(&AmountEstimateResult {
                     amount: amount.to_integer(),
-                    token,
+                    token: query.market.quote_token,
                 }),
                 StatusCode::OK,
             )
@@ -110,13 +104,14 @@ pub fn get_amount_estimate(
     get_amount_estimate_request().and_then(move |query: AmountEstimateQuery| {
         let price_estimator = price_estimator.clone();
         async move {
+            let (buy_token, sell_token) = match query.kind {
+                // Buy in WETH/DAI means buying ETH (selling DAI)
+                OrderKind::Buy => (query.market.base_token, query.market.quote_token),
+                // Sell in WETH/DAI means selling ETH (buying DAI)
+                OrderKind::Sell => (query.market.quote_token, query.market.base_token),
+            };
             let result = price_estimator
-                .estimate_price(
-                    query.market.base_token,
-                    query.market.quote_token,
-                    query.amount,
-                    query.kind,
-                )
+                .estimate_price(sell_token, buy_token, query.amount, query.kind)
                 .await;
             Result::<_, Infallible>::Ok(get_amount_estimate_response(result, query))
         }
@@ -192,6 +187,6 @@ mod tests {
         let estimate: AmountEstimateResult =
             serde_json::from_slice(response_body(response).await.as_slice()).unwrap();
         assert_eq!(estimate.amount, 200.into());
-        assert_eq!(estimate.token, query.market.base_token);
+        assert_eq!(estimate.token, query.market.quote_token);
     }
 }


### PR DESCRIPTION
@anxolin has [brought to our attention](https://gnosisinc.slack.com/archives/CPZA1AGKY/p1620325243303700) that the current semantics of the markets route for buy orders is counterintuitive.

If you are looking at a market like ETH/USD

![image](https://user-images.githubusercontent.com/1200333/117418834-28991c00-af1c-11eb-993b-0235869cc41d.png)


And want to "sell 10" you are arguably want to sell 10 ETH for USD (this is how the route behaves today and remains unchanged by this PR).
If you want to "buy 10" you arguably also want to buy 10 ETH for USD (our route currently behaves the opposite).

Note that while this is a breaking change, as far as we know there are no users of this API yet (the trading bot only uses sell orders).

### Test Plan
Updated the unit tests. Also made sure I get the following results on Mainnet WETH/DAI pair

Sell 10 WETH will give me 3423 DAI

```
http://localhost:8080/api/v1/markets/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2-0x6b175474e89094c44da98b954eedeac495271d0f/sell/10000000000000000000
{"amount":"34230311550701541010695","token":"0x6b175474e89094c44da98b954eedeac495271d0f"}
```

Buying 10 WETH will cost me 3444 DAI (0.7% spread)

```
http://localhost:8080/api/v1/markets/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2-0x6b175474e89094c44da98b954eedeac495271d0f/buy/10000000000000000000
{"amount":"34448381278413813395628","token":"0x6b175474e89094c44da98b954eedeac495271d0f"}
```