### PR TITLE
Make fee calculator eth aware

### DIFF
--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -5,8 +5,11 @@ use ethcontract::{
 };
 use model::DomainSeparator;
 use orderbook::{
-    account_balances::Web3BalanceFetcher, database::Database, event_updater::EventUpdater,
-    fee::MinFeeCalculator, orderbook::Orderbook,
+    account_balances::Web3BalanceFetcher,
+    database::Database,
+    event_updater::EventUpdater,
+    fee::{EthAwareMinFeeCalculator, MinFeeCalculating},
+    orderbook::Orderbook,
 };
 use shared::{
     amm_pair_provider::UniswapPairProvider,
@@ -139,7 +142,7 @@ impl OrderbookServices {
             HashSet::new(),
             HashSet::new(),
         ));
-        let fee_calculator = Arc::new(MinFeeCalculator::new(
+        let fee_calculator = Arc::new(EthAwareMinFeeCalculator::new(
             price_estimator.clone(),
             Box::new(web3.clone()),
             native_token,

--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -5,11 +5,8 @@ use ethcontract::{
 };
 use model::DomainSeparator;
 use orderbook::{
-    account_balances::Web3BalanceFetcher,
-    database::Database,
-    event_updater::EventUpdater,
-    fee::{EthAwareMinFeeCalculator, MinFeeCalculating},
-    orderbook::Orderbook,
+    account_balances::Web3BalanceFetcher, database::Database, event_updater::EventUpdater,
+    fee::EthAwareMinFeeCalculator, orderbook::Orderbook,
 };
 use shared::{
     amm_pair_provider::UniswapPairProvider,

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -19,6 +19,10 @@ use std::fmt::{self, Display};
 use std::str::FromStr;
 use web3::signing::{self, Key, SecretKeyRef};
 
+/// The flag denoting that an order is buying ETH (or the chain's native token).
+/// It is used in place of an actual buy token address in an order.
+pub const BUY_ETH_ADDRESS: H160 = H160([0xee; 20]);
+
 /// An order that is returned when querying the orderbook.
 ///
 /// Contains extra fields that are populated by the orderbook.

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -9,7 +9,7 @@ mod get_trades;
 
 use crate::metrics::{end_request, LabelledReply, Metrics};
 use crate::{database::Database, metrics::start_request};
-use crate::{fee::MinFeeCalculator, orderbook::Orderbook};
+use crate::{fee::EthAwareMinFeeCalculator, orderbook::Orderbook};
 use anyhow::Error as anyhowError;
 use hex::{FromHex, FromHexError};
 use model::h160_hexadecimal;
@@ -27,7 +27,7 @@ use warp::{
 pub fn handle_all_routes(
     database: Database,
     orderbook: Arc<Orderbook>,
-    fee_calculator: Arc<MinFeeCalculator>,
+    fee_calculator: Arc<EthAwareMinFeeCalculator>,
     price_estimator: Arc<dyn PriceEstimating>,
     metrics: Arc<Metrics>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -1,4 +1,4 @@
-use crate::fee::{MinFeeCalculationError, MinFeeCalculator};
+use crate::fee::{EthAwareMinFeeCalculator, MinFeeCalculating, MinFeeCalculationError};
 
 use super::H160Wrapper;
 use anyhow::Result;
@@ -64,7 +64,7 @@ pub fn get_fee_info_response(
 }
 
 pub fn get_fee_info(
-    fee_calculator: Arc<MinFeeCalculator>,
+    fee_calculator: Arc<EthAwareMinFeeCalculator>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     get_fee_info_request().and_then(move |query: Query| {
         let fee_calculator = fee_calculator.clone();
@@ -131,7 +131,7 @@ pub fn legacy_get_fee_info_response(
 }
 
 pub fn legacy_get_fee_info(
-    fee_calculator: Arc<MinFeeCalculator>,
+    fee_calculator: Arc<EthAwareMinFeeCalculator>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     legacy_get_fee_info_request().and_then(move |token| {
         let fee_calculator = fee_calculator.clone();

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use chrono::{DateTime, Duration, Utc};
-use model::order::OrderKind;
+use model::order::{OrderKind, BUY_ETH_ADDRESS};
 use primitive_types::{H160, U256};
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
@@ -13,6 +13,13 @@ use shared::price_estimate::PriceEstimating;
 
 type Measurement = (U256, DateTime<Utc>);
 
+pub type EthAwareMinFeeCalculator = EthAdapter<MinFeeCalculator>;
+
+pub struct EthAdapter<T> {
+    calculator: T,
+    weth: H160,
+}
+
 pub struct MinFeeCalculator {
     price_estimator: Arc<dyn PriceEstimating>,
     gas_estimator: Box<dyn GasPriceEstimating>,
@@ -21,6 +28,34 @@ pub struct MinFeeCalculator {
     now: Box<dyn Fn() -> DateTime<Utc> + Send + Sync>,
     discount_factor: f64,
     unsupported_tokens: HashSet<H160>,
+}
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait::async_trait]
+pub trait MinFeeCalculating {
+    fn new(
+        price_estimator: Arc<dyn PriceEstimating>,
+        gas_estimator: Box<dyn GasPriceEstimating>,
+        native_token: H160,
+        database: Database,
+        discount_factor: f64,
+        unsupported_tokens: HashSet<H160>,
+    ) -> Self;
+
+    // Returns the minimum amount of fee required to accept an order selling the specified order
+    // and an expiry date for the estimate.
+    // Returns an error if there is some estimation error and Ok(None) if no information about the given
+    // token exists
+    async fn min_fee(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
+    ) -> Result<Measurement, MinFeeCalculationError>;
+
+    // Returns true if the fee satisfies a previous not yet expired estimate, or the fee is high enough given the current estimate.
+    async fn is_valid_fee(&self, sell_token: H160, fee: U256) -> bool;
 }
 
 #[async_trait::async_trait]
@@ -69,8 +104,113 @@ pub enum MinFeeCalculationError {
     Other(#[from] anyhow::Error),
 }
 
+fn normalize_buy_token(buy_token: H160, weth: H160) -> H160 {
+    if buy_token == BUY_ETH_ADDRESS {
+        weth
+    } else {
+        buy_token
+    }
+}
+
+#[async_trait::async_trait]
+impl<T> MinFeeCalculating for EthAdapter<T>
+where
+    T: MinFeeCalculating + Send + Sync,
+{
+    fn new(
+        price_estimator: Arc<dyn PriceEstimating>,
+        gas_estimator: Box<dyn GasPriceEstimating>,
+        native_token: H160,
+        database: Database,
+        discount_factor: f64,
+        unsupported_tokens: HashSet<H160>,
+    ) -> Self {
+        Self {
+            calculator: T::new(
+                price_estimator,
+                gas_estimator,
+                native_token,
+                database,
+                discount_factor,
+                unsupported_tokens,
+            ),
+            weth: native_token,
+        }
+    }
+
+    async fn min_fee(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
+    ) -> Result<Measurement, MinFeeCalculationError> {
+        self.calculator
+            .min_fee(
+                sell_token,
+                buy_token.map(|token| normalize_buy_token(token, self.weth)),
+                amount,
+                kind,
+            )
+            .await
+    }
+
+    async fn is_valid_fee(&self, sell_token: H160, fee: U256) -> bool {
+        self.calculator.is_valid_fee(sell_token, fee).await
+    }
+}
+
 impl MinFeeCalculator {
-    pub fn new(
+    async fn compute_min_fee(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
+    ) -> Result<Option<U256>> {
+        let gas_price = self.gas_estimator.estimate().await?;
+        let gas_amount =
+            if let (Some(buy_token), Some(amount), Some(kind)) = (buy_token, amount, kind) {
+                // We only apply the discount to the more sophisticated fee estimation, as the legacy one is already very favorable to the user in most cases
+                match self
+                    .price_estimator
+                    .estimate_gas(sell_token, buy_token, amount, kind)
+                    .await
+                {
+                    Ok(amount) => amount.to_f64_lossy() * self.discount_factor,
+                    Err(err) => {
+                        tracing::warn!("Failed to estimate gas amount: {}", err);
+                        return Ok(None);
+                    }
+                }
+            } else {
+                GAS_PER_ORDER
+            };
+        let fee_in_eth = gas_price * gas_amount;
+        let token_price = match self
+            .price_estimator
+            .estimate_price_as_f64(
+                sell_token,
+                self.native_token,
+                U256::from_f64_lossy(fee_in_eth),
+                model::order::OrderKind::Buy,
+            )
+            .await
+        {
+            Ok(price) => price,
+            Err(err) => {
+                tracing::warn!("Failed to estimate sell token price: {}", err);
+                return Ok(None);
+            }
+        };
+
+        Ok(Some(U256::from_f64_lossy(fee_in_eth * token_price)))
+    }
+}
+
+#[async_trait::async_trait]
+impl MinFeeCalculating for MinFeeCalculator {
+    fn new(
         price_estimator: Arc<dyn PriceEstimating>,
         gas_estimator: Box<dyn GasPriceEstimating>,
         native_token: H160,
@@ -93,7 +233,7 @@ impl MinFeeCalculator {
     // and an expiry date for the estimate.
     // Returns an error if there is some estimation error and Ok(None) if no information about the given
     // token exists
-    pub async fn min_fee(
+    async fn min_fee(
         &self,
         sell_token: H160,
         buy_token: Option<H160>,
@@ -147,54 +287,8 @@ impl MinFeeCalculator {
         Ok((min_fee, official_valid_until))
     }
 
-    async fn compute_min_fee(
-        &self,
-        sell_token: H160,
-        buy_token: Option<H160>,
-        amount: Option<U256>,
-        kind: Option<OrderKind>,
-    ) -> Result<Option<U256>> {
-        let gas_price = self.gas_estimator.estimate().await?;
-        let gas_amount =
-            if let (Some(buy_token), Some(amount), Some(kind)) = (buy_token, amount, kind) {
-                // We only apply the discount to the more sophisticated fee estimation, as the legacy one is already very favorable to the user in most cases
-                match self
-                    .price_estimator
-                    .estimate_gas(sell_token, buy_token, amount, kind)
-                    .await
-                {
-                    Ok(amount) => amount.to_f64_lossy() * self.discount_factor,
-                    Err(err) => {
-                        tracing::warn!("Failed to estimate gas amount: {}", err);
-                        return Ok(None);
-                    }
-                }
-            } else {
-                GAS_PER_ORDER
-            };
-        let fee_in_eth = gas_price * gas_amount;
-        let token_price = match self
-            .price_estimator
-            .estimate_price_as_f64(
-                sell_token,
-                self.native_token,
-                U256::from_f64_lossy(fee_in_eth),
-                model::order::OrderKind::Buy,
-            )
-            .await
-        {
-            Ok(price) => price,
-            Err(err) => {
-                tracing::warn!("Failed to estimate sell token price: {}", err);
-                return Ok(None);
-            }
-        };
-
-        Ok(Some(U256::from_f64_lossy(fee_in_eth * token_price)))
-    }
-
     // Returns true if the fee satisfies a previous not yet expired estimate, or the fee is high enough given the current estimate.
-    pub async fn is_valid_fee(&self, sell_token: H160, fee: U256) -> bool {
+    async fn is_valid_fee(&self, sell_token: H160, fee: U256) -> bool {
         if let Ok(Some(past_fee)) = self
             .measurements
             .get_min_fee(sell_token, None, None, None, (self.now)())
@@ -279,12 +373,61 @@ impl MinFeeStoring for InMemoryFeeStore {
 #[cfg(test)]
 mod tests {
     use chrono::Duration;
+    use chrono::NaiveDateTime;
     use maplit::hashset;
     use shared::gas_price_estimation::FakeGasPriceEstimator;
     use shared::price_estimate::mocks::FakePriceEstimator;
     use std::{collections::HashSet, sync::Arc};
 
     use super::*;
+
+    #[tokio::test]
+    async fn eth_aware_min_fees() {
+        let weth = H160([0x42; 20]);
+        let token = H160([0x21; 20]);
+        let mut calculator = MockMinFeeCalculating::default();
+        calculator
+            .expect_min_fee()
+            .withf(move |&sell_token, &buy_token, &amount, &kind| {
+                sell_token == token
+                    && buy_token == Some(weth)
+                    && amount == Some(1337.into())
+                    && kind == Some(OrderKind::Sell)
+            })
+            .times(1)
+            .returning(|_, _, _, _| {
+                Ok((
+                    0.into(),
+                    DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
+                ))
+            });
+
+        let eth_aware = EthAdapter { calculator, weth };
+        assert!(eth_aware
+            .min_fee(
+                token,
+                Some(BUY_ETH_ADDRESS),
+                Some(1337.into()),
+                Some(OrderKind::Sell)
+            )
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn eth_aware_is_valid_fee() {
+        let weth = H160([0x42; 20]);
+        let token = H160([0x21; 20]);
+        let mut calculator = MockMinFeeCalculating::default();
+        calculator
+            .expect_is_valid_fee()
+            .withf(move |&sell_token, &fee| sell_token == token && fee == 42.into())
+            .times(1)
+            .returning(|_, _| true);
+
+        let eth_aware = EthAdapter { calculator, weth };
+        assert!(eth_aware.is_valid_fee(token, 42.into()).await);
+    }
 
     impl MinFeeCalculator {
         fn new_for_test(

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -11,7 +11,7 @@ use crate::database::Database;
 use crate::orderbook::Orderbook;
 use anyhow::{anyhow, Context as _, Result};
 use contracts::GPv2Settlement;
-use fee::MinFeeCalculator;
+use fee::EthAwareMinFeeCalculator;
 use metrics::Metrics;
 use model::DomainSeparator;
 use prometheus::Registry;
@@ -25,7 +25,7 @@ use tokio::{task, task::JoinHandle};
 pub fn serve_task(
     database: Database,
     orderbook: Arc<Orderbook>,
-    fee_calculator: Arc<MinFeeCalculator>,
+    fee_calculator: Arc<EthAwareMinFeeCalculator>,
     price_estimator: Arc<dyn PriceEstimating>,
     address: SocketAddr,
 ) -> JoinHandle<()> {

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -6,7 +6,7 @@ use orderbook::{
     account_balances::Web3BalanceFetcher,
     database::{Database, OrderFilter},
     event_updater::EventUpdater,
-    fee::MinFeeCalculator,
+    fee::{EthAwareMinFeeCalculator, MinFeeCalculating},
     orderbook::Orderbook,
     serve_task, verify_deployed_contract_constants,
 };
@@ -156,7 +156,7 @@ async fn main() {
         base_tokens,
         unsupported_tokens.clone(),
     ));
-    let fee_calculator = Arc::new(MinFeeCalculator::new(
+    let fee_calculator = Arc::new(EthAwareMinFeeCalculator::new(
         price_estimator.clone(),
         Box::new(gas_price_estimator),
         native_token.address(),

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -6,7 +6,7 @@ use orderbook::{
     account_balances::Web3BalanceFetcher,
     database::{Database, OrderFilter},
     event_updater::EventUpdater,
-    fee::{EthAwareMinFeeCalculator, MinFeeCalculating},
+    fee::EthAwareMinFeeCalculator,
     orderbook::Orderbook,
     serve_task, verify_deployed_contract_constants,
 };

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use crate::{
     database::{Database, InsertionError},
-    fee::MinFeeCalculator,
+    fee::{EthAwareMinFeeCalculator, MinFeeCalculating},
 };
 use anyhow::Result;
 use chrono::Utc;
@@ -50,7 +50,7 @@ pub struct Orderbook {
     database: Database,
     event_updater: Mutex<EventUpdater>,
     balance_fetcher: Box<dyn BalanceFetching>,
-    fee_validator: Arc<MinFeeCalculator>,
+    fee_validator: Arc<EthAwareMinFeeCalculator>,
     unsupported_tokens: HashSet<H160>,
     min_order_validity_period: Duration,
 }
@@ -61,7 +61,7 @@ impl Orderbook {
         database: Database,
         event_updater: EventUpdater,
         balance_fetcher: Box<dyn BalanceFetching>,
-        fee_validator: Arc<MinFeeCalculator>,
+        fee_validator: Arc<EthAwareMinFeeCalculator>,
         unsupported_tokens: HashSet<H160>,
         min_order_validity_period: Duration,
     ) -> Self {

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -2,19 +2,15 @@ pub mod solver_settlements;
 
 use self::solver_settlements::{RatedSettlement, SettlementWithSolver};
 use crate::{
-    chain,
-    liquidity::{offchain_orderbook::BUY_ETH_ADDRESS, Liquidity},
-    liquidity_collector::LiquidityCollector,
-    metrics::SolverMetrics,
-    settlement::Settlement,
-    settlement_simulation, settlement_submission,
-    solver::Solver,
+    chain, liquidity::Liquidity, liquidity_collector::LiquidityCollector, metrics::SolverMetrics,
+    settlement::Settlement, settlement_simulation, settlement_submission, solver::Solver,
 };
 use anyhow::{anyhow, Context, Error, Result};
 use contracts::GPv2Settlement;
 use futures::future::join_all;
 use gas_estimation::GasPriceEstimating;
 use itertools::{Either, Itertools};
+use model::order::BUY_ETH_ADDRESS;
 use num::BigRational;
 use primitive_types::H160;
 use shared::{price_estimate::PriceEstimating, Web3};

--- a/solver/src/liquidity/offchain_orderbook.rs
+++ b/solver/src/liquidity/offchain_orderbook.rs
@@ -4,13 +4,11 @@ use crate::settlement::SettlementEncoder;
 use anyhow::{anyhow, Context, Result};
 use contracts::WETH9;
 use ethcontract::H160;
-use model::order::{Order, OrderKind};
+use model::order::{Order, OrderKind, BUY_ETH_ADDRESS};
 use primitive_types::U256;
 use std::{collections::HashMap, sync::Arc};
 
 use super::{LimitOrder, SettlementHandling};
-
-pub const BUY_ETH_ADDRESS: H160 = H160([0xee; 20]);
 
 impl OrderBookApi {
     /// Returns a list of limit orders coming from the offchain orderbook API


### PR DESCRIPTION
Supersedes and closes #528.

The PR adds eth support to the price estimator.
I noticed that a recently introduced function `is_valid_fee` is also called with `ETH_BUY_ADDRESS` in the e2e test supporting eth. This PR creates a wrapper around a `MinFeeCalculator` that replaces the eth address in `buy_token` by the weth address. If new functions were to be added to `MinFeeCalculator`, this would be easily detected and fixed.
The new trait helps testing this wrapper.

### Test Plan

New unit tests. Also, as in #528:
```
$ sell_dai_for() {
   curl -X 'GET' \
     'http://localhost:8080/api/v1/fee?sellToken=0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea&buyToken='"$1"'&amount=12&kind=buy' \
     -H 'accept: application/json'
   echo
 }
$ sell_dai_for 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE # eth
{"expirationDate":"2021-05-07T19:35:40.857485792Z","amount":"164621342166646656"}
$ sell_dai_for 0xc778417E063141139Fce010982780140Aa0cD5Ab # weth
{"expirationDate":"2021-05-07T19:35:50.551925497Z","amount":"164621342166646656"}
$ sell_dai_for 0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea # dai
{"expirationDate":"2021-05-07T19:36:05.183569640Z","amount":"0"}
```
