### PR TITLE
Revert "Remove legacy fee (#542)"

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -156,6 +156,27 @@ paths:
           description: Invalid signature
         404:
           description: Order was not found
+  /api/v1/tokens/{sellToken}/fee:
+    get:
+      description: |
+        The fee that is charged for placing an order.
+        The fee is described by a minimum fee - in order to cover the gas costs for onchain settling - and
+        a feeRatio charged to the users for using the service.
+      parameters:
+        - name: sellToken
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Address"
+      responses:
+        200:
+          description: the fee
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LegacyFeeInformation"
+        404:
+          description: sellToken non-existent
   /api/v1/trades:
     get:
       summary: Get existing Trades.
@@ -312,6 +333,29 @@ components:
       required:
         - expirationDate
         - amount
+    LegacyFeeInformation:
+      description: |
+        Provides the information to calculate the fees.
+      type: object
+      properties:
+        expirationDate:
+          description: |
+            Expiration date of the offered fee. Order service might not accept
+            the fee after this expiration date. Encoded as ISO 8601 UTC.
+          type: string
+          example: "2020-12-03T18:35:18.814523Z"
+        minimalFee:
+          description: Absolute amount of minimal fee charged per order in specified sellToken
+          $ref: "#/components/schemas/TokenAmount"
+        feeRatio:
+          description: The fee ratio charged on a sellAmount. Denoted in basis points
+          example: 10
+          type: number
+          format: int32
+      required:
+        - expirationDate
+        - minimalFee
+        - feeRatio
     OrderType:
       description: Is this a buy order or sell order?
       type: string

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -33,6 +33,7 @@ pub fn handle_all_routes(
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     let create_order = create_order::create_order(orderbook.clone());
     let get_orders = get_orders::get_orders(orderbook.clone());
+    let legacy_fee_info = get_fee_info::legacy_get_fee_info(fee_calculator.clone());
     let fee_info = get_fee_info::get_fee_info(fee_calculator);
     let get_order = get_order_by_uid::get_order_by_uid(orderbook.clone());
     let get_solvable_orders = get_solvable_orders::get_solvable_orders(orderbook.clone());
@@ -48,6 +49,8 @@ pub fn handle_all_routes(
             .or(get_orders.map(|reply| LabelledReply::new(reply, "get_orders")))
             .unify()
             .or(fee_info.map(|reply| LabelledReply::new(reply, "fee_info")))
+            .unify()
+            .or(legacy_fee_info.map(|reply| LabelledReply::new(reply, "legacy_fee_info")))
             .unify()
             .or(get_order.map(|reply| LabelledReply::new(reply, "get_order")))
             .unify()

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -4,7 +4,7 @@ use super::H160Wrapper;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use model::{order::OrderKind, u256_decimal};
-use primitive_types::U256;
+use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -73,11 +73,71 @@ pub fn get_fee_info(
                 fee_calculator
                     .min_fee(
                         query.sell_token.0,
-                        query.buy_token.0,
-                        query.amount,
-                        query.kind,
+                        Some(query.buy_token.0),
+                        Some(query.amount),
+                        Some(query.kind),
                     )
                     .await,
+            ))
+        }
+    })
+}
+
+// TODO remove legacy fee endpoint once frontend is updated
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LegacyFeeInfo {
+    pub expiration_date: DateTime<Utc>,
+    #[serde(with = "u256_decimal")]
+    pub minimal_fee: U256,
+    pub fee_ratio: u32,
+}
+
+pub fn legacy_get_fee_info_request() -> impl Filter<Extract = (H160,), Error = Rejection> + Clone {
+    warp::path!("tokens" / H160Wrapper / "fee")
+        .and(warp::get())
+        .map(|token: H160Wrapper| token.0)
+}
+
+pub fn legacy_get_fee_info_response(
+    result: Result<(U256, DateTime<Utc>), MinFeeCalculationError>,
+) -> impl Reply {
+    match result {
+        Ok((minimal_fee, expiration_date)) => {
+            let fee_info = LegacyFeeInfo {
+                expiration_date,
+                minimal_fee,
+                fee_ratio: 0u32,
+            };
+            Ok(reply::with_status(reply::json(&fee_info), StatusCode::OK))
+        }
+        Err(MinFeeCalculationError::NotFound) => Ok(reply::with_status(
+            super::error("NotFound", "Token was not found"),
+            StatusCode::NOT_FOUND,
+        )),
+        Err(MinFeeCalculationError::UnsupportedToken(token)) => Ok(reply::with_status(
+            super::error("UnsupportedToken", format!("Token address {:?}", token)),
+            StatusCode::BAD_REQUEST,
+        )),
+        Err(MinFeeCalculationError::Other(err)) => {
+            tracing::error!(?err, "get_fee error");
+            Ok(reply::with_status(
+                super::internal_error(),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ))
+        }
+    }
+}
+
+pub fn legacy_get_fee_info(
+    fee_calculator: Arc<MinFeeCalculator>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    legacy_get_fee_info_request().and_then(move |token| {
+        let fee_calculator = fee_calculator.clone();
+        async move {
+            Result::<_, Infallible>::Ok(legacy_get_fee_info_response(
+                fee_calculator.min_fee(token, None, None, None).await,
             ))
         }
     })
@@ -88,7 +148,6 @@ mod tests {
     use super::*;
     use crate::api::response_body;
     use chrono::FixedOffset;
-    use primitive_types::H160;
     use warp::test::request;
 
     #[tokio::test]
@@ -119,6 +178,29 @@ mod tests {
         let body = response_body(response).await;
         let body: FeeInfo = serde_json::from_slice(body.as_slice()).unwrap();
         assert_eq!(body.amount, U256::zero());
+        assert!(body.expiration_date.gt(&chrono::offset::Utc::now()))
+    }
+
+    #[tokio::test]
+    async fn legacy_get_fee_info_request_ok() {
+        let filter = legacy_get_fee_info_request();
+        let token = String::from("0x0000000000000000000000000000000000000001");
+        let path_string = format!("/tokens/{}/fee", token);
+        let request = request().path(&path_string).method("GET");
+        let result = request.filter(&filter).await.unwrap();
+        assert_eq!(result, H160::from_low_u64_be(1));
+    }
+
+    #[tokio::test]
+    async fn legacy_get_fee_info_response_() {
+        let response =
+            legacy_get_fee_info_response(Ok((U256::zero(), Utc::now() + FixedOffset::east(10))))
+                .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body(response).await;
+        let body: LegacyFeeInfo = serde_json::from_slice(body.as_slice()).unwrap();
+        assert_eq!(body.minimal_fee, U256::zero());
+        assert_eq!(body.fee_ratio, 0);
         assert!(body.expiration_date.gt(&chrono::offset::Utc::now()))
     }
 }

--- a/orderbook/src/database/fees.rs
+++ b/orderbook/src/database/fees.rs
@@ -13,9 +13,9 @@ impl MinFeeStoring for Database {
     async fn save_fee_measurement(
         &self,
         sell_token: H160,
-        buy_token: H160,
-        amount: U256,
-        kind: OrderKind,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
         expiry: DateTime<Utc>,
         min_fee: U256,
     ) -> Result<()> {
@@ -23,9 +23,9 @@ impl MinFeeStoring for Database {
             "INSERT INTO min_fee_measurements (sell_token, buy_token, amount, order_kind, expiration_timestamp, min_fee) VALUES ($1, $2, $3, $4, $5, $6);";
         sqlx::query(QUERY)
             .bind(sell_token.as_bytes())
-            .bind(buy_token.as_bytes())
-            .bind(u256_to_big_decimal(&amount))
-            .bind(DbOrderKind::from(kind))
+            .bind(buy_token.as_ref().map(|t| t.as_bytes()))
+            .bind(amount.map(|a| u256_to_big_decimal(&a)))
+            .bind(kind.map(DbOrderKind::from))
             .bind(expiry)
             .bind(u256_to_big_decimal(&min_fee))
             .execute(&self.pool)
@@ -37,25 +37,25 @@ impl MinFeeStoring for Database {
     async fn get_min_fee(
         &self,
         sell_token: H160,
-        buy_token: H160,
-        amount: U256,
-        kind: OrderKind,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
         min_expiry: DateTime<Utc>,
     ) -> Result<Option<U256>> {
         const QUERY: &str = "\
             SELECT MIN(min_fee) FROM min_fee_measurements \
             WHERE sell_token = $1 \
-            AND buy_token = $2 \
-            AND amount = $3 \
-            AND order_kind = $4 \
+            AND ($2 IS NULL OR buy_token = $2) \
+            AND ($3 IS NULL OR amount = $3) \
+            AND ($4 IS NULL OR order_kind = $4) \
             AND expiration_timestamp >= $5
             ";
 
         let result: Option<BigDecimal> = sqlx::query_scalar(QUERY)
             .bind(sell_token.as_bytes())
-            .bind(buy_token.as_bytes())
-            .bind(u256_to_big_decimal(&amount))
-            .bind(DbOrderKind::from(kind))
+            .bind(buy_token.as_ref().map(|t| t.as_bytes()))
+            .bind(amount.map(|a| u256_to_big_decimal(&a)))
+            .bind(kind.map(DbOrderKind::from))
             .bind(min_expiry)
             .fetch_one(&self.pool)
             .await
@@ -100,21 +100,14 @@ mod tests {
         let token_b = H160::from_low_u64_be(2);
 
         // Save two measurements for token_a
+        db.save_fee_measurement(token_a, None, None, None, now, 100u32.into())
+            .await
+            .unwrap();
         db.save_fee_measurement(
             token_a,
-            token_b,
-            100.into(),
-            OrderKind::Sell,
-            now,
-            100u32.into(),
-        )
-        .await
-        .unwrap();
-        db.save_fee_measurement(
-            token_a,
-            token_b,
-            100.into(),
-            OrderKind::Sell,
+            None,
+            None,
+            None,
             now + Duration::seconds(60),
             200u32.into(),
         )
@@ -124,9 +117,9 @@ mod tests {
         // Save one measurement for token_b
         db.save_fee_measurement(
             token_b,
-            token_a,
-            100.into(),
-            OrderKind::Buy,
+            Some(token_a),
+            Some(100.into()),
+            Some(OrderKind::Buy),
             now,
             10u32.into(),
         )
@@ -135,44 +128,61 @@ mod tests {
 
         // Token A has readings valid until now and in 30s
         assert_eq!(
-            db.get_min_fee(token_a, token_b, 100.into(), OrderKind::Sell, now)
+            db.get_min_fee(token_a, None, None, None, now)
                 .await
                 .unwrap()
                 .unwrap(),
             100_u32.into()
         );
         assert_eq!(
-            db.get_min_fee(
-                token_a,
-                token_b,
-                100.into(),
-                OrderKind::Sell,
-                now + Duration::seconds(30)
-            )
-            .await
-            .unwrap()
-            .unwrap(),
+            db.get_min_fee(token_a, None, None, None, now + Duration::seconds(30))
+                .await
+                .unwrap()
+                .unwrap(),
             200u32.into()
         );
 
         // Token B only has readings valid until now
         assert_eq!(
-            db.get_min_fee(token_b, token_a, 100.into(), OrderKind::Buy, now)
+            db.get_min_fee(token_b, None, None, None, now)
                 .await
                 .unwrap()
                 .unwrap(),
             10u32.into()
         );
         assert_eq!(
-            db.get_min_fee(
-                token_b,
-                token_a,
-                100.into(),
-                OrderKind::Buy,
-                now + Duration::seconds(30)
-            )
-            .await
-            .unwrap(),
+            db.get_min_fee(token_b, None, None, None, now + Duration::seconds(30))
+                .await
+                .unwrap(),
+            None
+        );
+
+        // Token B has readings for right filters
+        assert_eq!(
+            db.get_min_fee(token_b, Some(token_a), None, None, now)
+                .await
+                .unwrap()
+                .unwrap(),
+            10u32.into()
+        );
+        assert_eq!(
+            db.get_min_fee(token_b, None, Some(100.into()), None, now)
+                .await
+                .unwrap()
+                .unwrap(),
+            10u32.into()
+        );
+        assert_eq!(
+            db.get_min_fee(token_b, None, None, Some(OrderKind::Buy), now)
+                .await
+                .unwrap()
+                .unwrap(),
+            10u32.into()
+        );
+        assert_eq!(
+            db.get_min_fee(token_b, None, Some(U256::zero()), None, now)
+                .await
+                .unwrap(),
             None
         );
 
@@ -180,7 +190,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            db.get_min_fee(token_b, token_a, 100.into(), OrderKind::Buy, now)
+            db.get_min_fee(token_b, None, None, None, now)
                 .await
                 .unwrap(),
             None

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -29,9 +29,9 @@ pub trait MinFeeStoring: Send + Sync {
     async fn save_fee_measurement(
         &self,
         sell_token: H160,
-        buy_token: H160,
-        amount: U256,
-        kind: OrderKind,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
         expiry: DateTime<Utc>,
         min_fee: U256,
     ) -> Result<()>;
@@ -41,12 +41,14 @@ pub trait MinFeeStoring: Send + Sync {
     async fn get_min_fee(
         &self,
         sell_token: H160,
-        buy_token: H160,
-        amount: U256,
-        kind: OrderKind,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
         min_expiry: DateTime<Utc>,
     ) -> Result<Option<U256>>;
 }
+
+const GAS_PER_ORDER: f64 = 100_000.0;
 
 // We use a longer validity internally for persistence to avoid writing a value to storage on every request
 // This way we can serve a previous estimate if the same token is queried again shortly after
@@ -94,15 +96,21 @@ impl MinFeeCalculator {
     pub async fn min_fee(
         &self,
         sell_token: H160,
-        buy_token: H160,
-        amount: U256,
-        kind: OrderKind,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
     ) -> Result<Measurement, MinFeeCalculationError> {
         if self.unsupported_tokens.contains(&sell_token) {
             return Err(MinFeeCalculationError::UnsupportedToken(sell_token));
         }
-        if self.unsupported_tokens.contains(&buy_token) {
-            return Err(MinFeeCalculationError::UnsupportedToken(buy_token));
+
+        if buy_token
+            .map(|t| self.unsupported_tokens.contains(&t))
+            .unwrap_or_default()
+        {
+            return Err(MinFeeCalculationError::UnsupportedToken(
+                buy_token.expect("Must exist"),
+            ));
         }
 
         let now = (self.now)();
@@ -142,22 +150,28 @@ impl MinFeeCalculator {
     async fn compute_min_fee(
         &self,
         sell_token: H160,
-        buy_token: H160,
-        amount: U256,
-        kind: OrderKind,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
     ) -> Result<Option<U256>> {
         let gas_price = self.gas_estimator.estimate().await?;
-        let gas_amount = match self
-            .price_estimator
-            .estimate_gas(sell_token, buy_token, amount, kind)
-            .await
-        {
-            Ok(amount) => amount.to_f64_lossy() * self.discount_factor,
-            Err(err) => {
-                tracing::warn!("Failed to estimate gas amount: {}", err);
-                return Ok(None);
-            }
-        };
+        let gas_amount =
+            if let (Some(buy_token), Some(amount), Some(kind)) = (buy_token, amount, kind) {
+                // We only apply the discount to the more sophisticated fee estimation, as the legacy one is already very favorable to the user in most cases
+                match self
+                    .price_estimator
+                    .estimate_gas(sell_token, buy_token, amount, kind)
+                    .await
+                {
+                    Ok(amount) => amount.to_f64_lossy() * self.discount_factor,
+                    Err(err) => {
+                        tracing::warn!("Failed to estimate gas amount: {}", err);
+                        return Ok(None);
+                    }
+                }
+            } else {
+                GAS_PER_ORDER
+            };
         let fee_in_eth = gas_price * gas_amount;
         let token_price = match self
             .price_estimator
@@ -180,27 +194,17 @@ impl MinFeeCalculator {
     }
 
     // Returns true if the fee satisfies a previous not yet expired estimate, or the fee is high enough given the current estimate.
-    pub async fn is_valid_fee(
-        &self,
-        sell_token: H160,
-        buy_token: H160,
-        amount: U256,
-        kind: OrderKind,
-        fee: U256,
-    ) -> bool {
+    pub async fn is_valid_fee(&self, sell_token: H160, fee: U256) -> bool {
         if let Ok(Some(past_fee)) = self
             .measurements
-            .get_min_fee(sell_token, buy_token, amount, kind, (self.now)())
+            .get_min_fee(sell_token, None, None, None, (self.now)())
             .await
         {
             if fee >= past_fee {
                 return true;
             }
         }
-        if let Ok(Some(current_fee)) = self
-            .compute_min_fee(sell_token, buy_token, amount, kind)
-            .await
-        {
+        if let Ok(Some(current_fee)) = self.compute_min_fee(sell_token, None, None, None).await {
             return fee >= current_fee;
         }
         false
@@ -208,9 +212,9 @@ impl MinFeeCalculator {
 }
 
 struct FeeMeasurement {
-    buy_token: H160,
-    amount: U256,
-    kind: OrderKind,
+    buy_token: Option<H160>,
+    amount: Option<U256>,
+    kind: Option<OrderKind>,
     expiry: DateTime<Utc>,
     min_fee: U256,
 }
@@ -222,9 +226,9 @@ impl MinFeeStoring for InMemoryFeeStore {
     async fn save_fee_measurement(
         &self,
         sell_token: H160,
-        buy_token: H160,
-        amount: U256,
-        kind: OrderKind,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
         expiry: DateTime<Utc>,
         min_fee: U256,
     ) -> Result<()> {
@@ -246,21 +250,21 @@ impl MinFeeStoring for InMemoryFeeStore {
     async fn get_min_fee(
         &self,
         sell_token: H160,
-        buy_token: H160,
-        amount: U256,
-        kind: OrderKind,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
         min_expiry: DateTime<Utc>,
     ) -> Result<Option<U256>> {
         let mut guard = self.0.lock().expect("Thread holding Mutex panicked");
         let measurements = guard.entry(sell_token).or_default();
         measurements.retain(|measurement| {
-            if buy_token != measurement.buy_token {
+            if buy_token.is_some() && buy_token != measurement.buy_token {
                 return false;
             }
-            if amount != measurement.amount {
+            if amount.is_some() && amount != measurement.amount {
                 return false;
             }
-            if kind != measurement.kind {
+            if kind.is_some() && kind != measurement.kind {
                 return false;
             }
             measurement.expiry >= min_expiry
@@ -313,10 +317,9 @@ mod tests {
         let fee_estimator =
             MinFeeCalculator::new_for_test(gas_price_estimator, price_estimator, Box::new(now));
 
-        let sell_token = H160::from_low_u64_be(1);
-        let buy_token = H160::from_low_u64_be(2);
+        let token = H160::from_low_u64_be(1);
         let (fee, expiry) = fee_estimator
-            .min_fee(sell_token, buy_token, 100.into(), OrderKind::Sell)
+            .min_fee(token, None, None, None)
             .await
             .unwrap();
 
@@ -325,20 +328,11 @@ mod tests {
 
         // fee is valid before expiry
         *time.lock().unwrap() = expiry - Duration::seconds(10);
-        assert!(
-            fee_estimator
-                .is_valid_fee(sell_token, buy_token, 100.into(), OrderKind::Sell, fee)
-                .await
-        );
+        assert!(fee_estimator.is_valid_fee(token, fee).await);
 
         // fee is invalid for some uncached token
         let token = H160::from_low_u64_be(2);
-        assert_eq!(
-            fee_estimator
-                .is_valid_fee(token, buy_token, 100.into(), OrderKind::Sell, fee)
-                .await,
-            false
-        );
+        assert_eq!(fee_estimator.is_valid_fee(token, fee).await, false);
     }
 
     #[tokio::test]
@@ -354,42 +348,20 @@ mod tests {
             Box::new(Utc::now),
         );
 
-        let sell_token = H160::from_low_u64_be(1);
-        let buy_token = H160::from_low_u64_be(2);
+        let token = H160::from_low_u64_be(1);
         let (fee, _) = fee_estimator
-            .min_fee(sell_token, buy_token, 100.into(), OrderKind::Sell)
+            .min_fee(token, None, None, None)
             .await
             .unwrap();
 
         let lower_fee = fee - U256::one();
 
         // slightly lower fee is not valid
-        assert_eq!(
-            fee_estimator
-                .is_valid_fee(
-                    sell_token,
-                    buy_token,
-                    100.into(),
-                    OrderKind::Sell,
-                    lower_fee
-                )
-                .await,
-            false
-        );
+        assert_eq!(fee_estimator.is_valid_fee(token, lower_fee).await, false);
 
         // Gas price reduces, and slightly lower fee is now valid
         *gas_price.lock().unwrap() /= 2.0;
-        assert!(
-            fee_estimator
-                .is_valid_fee(
-                    sell_token,
-                    buy_token,
-                    100.into(),
-                    OrderKind::Sell,
-                    lower_fee
-                )
-                .await
-        );
+        assert!(fee_estimator.is_valid_fee(token, lower_fee).await);
     }
 
     #[tokio::test]
@@ -416,9 +388,10 @@ mod tests {
             fee_estimator
                 .min_fee(
                     unsupported_token,
-                    supported_token,
-                    100.into(),
-                    OrderKind::Sell)
+                    Some(supported_token),
+                    Some(100.into()),
+                    Some(OrderKind::Sell)
+                )
                 .await,
             Err(MinFeeCalculationError::UnsupportedToken(t)) if t == unsupported_token
         ));
@@ -428,9 +401,9 @@ mod tests {
             fee_estimator
                 .min_fee(
                     supported_token,
-                    unsupported_token,
-                    100.into(),
-                    OrderKind::Sell
+                    Some(unsupported_token),
+                    Some(100.into()),
+                    Some(OrderKind::Sell)
                 )
                 .await,
             Err(MinFeeCalculationError::UnsupportedToken(t)) if t == unsupported_token

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -89,19 +89,9 @@ impl Orderbook {
         {
             return Ok(AddOrderResult::InsufficientValidTo);
         }
-        let amount = match order.kind {
-            model::order::OrderKind::Buy => order.buy_amount,
-            model::order::OrderKind::Sell => order.sell_amount,
-        };
         if !self
             .fee_validator
-            .is_valid_fee(
-                order.sell_token,
-                order.buy_token,
-                amount,
-                order.kind,
-                order.fee_amount,
-            )
+            .is_valid_fee(order.sell_token, order.fee_amount)
             .await
         {
             return Ok(AddOrderResult::InsufficientFee);


### PR DESCRIPTION
#542 is causing issues with the frontend (cf. #569 and https://github.com/gnosis/gp-v2-trading-bot/issues/22)

This change changes the fee_validation logic back to just checking if a quote from the specified sell token was made in the last minute (not checking buy token and traded amount)

### Test Plan

CI
