### PR TITLE
[Trivial] Slightly more practical tenderly link

### DIFF
--- a/solver/src/settlement_simulation.rs
+++ b/solver/src/settlement_simulation.rs
@@ -64,12 +64,12 @@ pub fn tenderly_link(
     tx: TransactionBuilder<DynTransport>,
 ) -> String {
     format!(
-        "https://dashboard.tenderly.co/gp-v2/staging/simulator/new?block={}&blockIndex=0&from={:#x}&gas=8000000&gasPrice=0&value=0&contractAddress={:#x}&rawFunctionInput=0x{}&network={}",
+        "https://dashboard.tenderly.co/gp-v2/staging/simulator/new?block={}&blockIndex=0&from={:#x}&gas=8000000&gasPrice=0&value=0&contractAddress={:#x}&network={}&rawFunctionInput=0x{}",
         current_block,
         tx.from.unwrap().address(),
         tx.to.unwrap(),
-        hex::encode(tx.data.unwrap().0),
-        network_id
+        network_id,
+        hex::encode(tx.data.unwrap().0)
     )
 }
 


### PR DESCRIPTION
Some simulations can contain a lot of calldata (e.g. after merging or when using complex 1Inch routes). This can lead to the tenderly link not working because of 

> Error: URI Too Long

In this case it's usually easy enough to copy the link without the calldata (or just 0x) and manually paste the in the text field. This PR makes it that when doing so the network Id can also be copied (right now it's at the very end after the long blob)

### Test Plan
CI
