### PR TITLE
Default to creating 1Inch swap without splitting

### DIFF
--- a/solver/src/oneinch_solver.rs
+++ b/solver/src/oneinch_solver.rs
@@ -5,7 +5,7 @@
 
 pub mod api;
 
-use self::api::{OneInchClient, Slippage, Swap, SwapQuery};
+use self::api::{OneInchClient, Parts, Slippage, Swap, SwapQuery};
 use crate::{
     encoding::EncodedInteraction,
     interactions::Erc20ApproveInteraction,
@@ -73,6 +73,9 @@ impl OneInchSolver {
                 // Disable balance/allowance checks, as the settlement contract
                 // does not hold balances to traded tokens.
                 disable_estimate: Some(true),
+                // Use only 1 main route for cheaper trades.
+                max_route_parts: Some(Parts::one()),
+                parts: Some(Parts::one()),
             })
             .await?;
 

--- a/solver/src/oneinch_solver.rs
+++ b/solver/src/oneinch_solver.rs
@@ -5,7 +5,7 @@
 
 pub mod api;
 
-use self::api::{OneInchClient, Parts, Slippage, Swap, SwapQuery};
+use self::api::{Amount, OneInchClient, Slippage, Swap, SwapQuery};
 use crate::{
     encoding::EncodedInteraction,
     interactions::Erc20ApproveInteraction,
@@ -73,9 +73,13 @@ impl OneInchSolver {
                 // Disable balance/allowance checks, as the settlement contract
                 // does not hold balances to traded tokens.
                 disable_estimate: Some(true),
+                // Use at most 1 connector token, reducing overall gas usage.
+                complexity_level: Some(Amount::new(1).unwrap()),
+                // Cap swap gas to 750K.
+                gas_limit: Some(750_000),
                 // Use only 1 main route for cheaper trades.
-                max_route_parts: Some(Parts::one()),
-                parts: Some(Parts::one()),
+                max_route_parts: Some(Amount::new(1).unwrap()),
+                parts: Some(Amount::new(1).unwrap()),
             })
             .await?;
 

--- a/solver/src/oneinch_solver/api.rs
+++ b/solver/src/oneinch_solver/api.rs
@@ -52,27 +52,23 @@ impl Display for Slippage {
 ///
 /// This type is generic on the maximum number of splits allowed.
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
-pub struct Parts<const N: usize>(usize);
+pub struct Amount<const MIN: usize, const MAX: usize>(usize);
 
-impl<const N: usize> Parts<N> {
+impl<const MIN: usize, const MAX: usize> Amount<MIN, MAX> {
     /// Creates a parts amount from the specified count.
     pub fn new(amount: usize) -> Result<Self> {
         // 1Inch API only accepts a slippage from 0 to 50.
         ensure!(
-            (1..=N).contains(&amount),
-            "parts outside of [1, {}] range",
-            N,
+            (MIN..=MAX).contains(&amount),
+            "parts outside of [{}, {}] range",
+            MIN,
+            MAX,
         );
-        Ok(Parts(amount))
-    }
-
-    /// One part.
-    pub fn one() -> Self {
-        Parts::new(1).unwrap()
+        Ok(Amount(amount))
     }
 }
 
-impl<const N: usize> Display for Parts<N> {
+impl<const MIN: usize, const MAX: usize> Display for Amount<MIN, MAX> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }
@@ -99,10 +95,14 @@ pub struct SwapQuery {
     pub slippage: Slippage,
     /// Flag to disable checks of the required quantities.
     pub disable_estimate: Option<bool>,
+    /// Maximum number of token-connectors to be used in a transaction.
+    pub complexity_level: Option<Amount<0, 3>>,
+    /// Maximum amount of gas for a swap.
+    pub gas_limit: Option<u64>,
     /// Limit maximum number of main route parts.
-    pub max_route_parts: Option<Parts<50>>,
+    pub max_route_parts: Option<Amount<1, 50>>,
     /// Limit maximum number of parts each main route part can be split into.
-    pub parts: Option<Parts<100>>,
+    pub parts: Option<Amount<1, 100>>,
 }
 
 impl SwapQuery {
@@ -128,6 +128,14 @@ impl SwapQuery {
         if let Some(disable_estimate) = self.disable_estimate {
             url.query_pairs_mut()
                 .append_pair("disableEstimate", &disable_estimate.to_string());
+        }
+        if let Some(complexity_level) = self.complexity_level {
+            url.query_pairs_mut()
+                .append_pair("complexityLevel", &complexity_level.to_string());
+        }
+        if let Some(gas_limit) = self.gas_limit {
+            url.query_pairs_mut()
+                .append_pair("gasLimit", &gas_limit.to_string());
         }
         if let Some(max_route_parts) = self.max_route_parts {
             url.query_pairs_mut()
@@ -290,11 +298,11 @@ mod tests {
     }
 
     #[test]
-    fn parts_valid_range() {
-        assert!(Parts::<42>::new(0).is_err());
-        assert!(Parts::<42>::new(1).is_ok());
-        assert!(Parts::<42>::new(42).is_ok());
-        assert!(Parts::<42>::new(43).is_err());
+    fn amounts_valid_range() {
+        assert!(Amount::<42, 1337>::new(41).is_err());
+        assert!(Amount::<42, 1337>::new(42).is_ok());
+        assert!(Amount::<42, 1337>::new(1337).is_ok());
+        assert!(Amount::<42, 1337>::new(1338).is_err());
     }
 
     #[test]
@@ -307,6 +315,8 @@ mod tests {
             from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
             slippage: Slippage::basis_points(50).unwrap(),
             disable_estimate: None,
+            complexity_level: None,
+            gas_limit: None,
             max_route_parts: None,
             parts: None,
         }
@@ -333,8 +343,10 @@ mod tests {
             from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
             slippage: Slippage::basis_points(50).unwrap(),
             disable_estimate: Some(true),
-            max_route_parts: Some(Parts::new(28).unwrap()),
-            parts: Some(Parts::new(42).unwrap()),
+            complexity_level: Some(Amount::new(1).unwrap()),
+            gas_limit: Some(133700),
+            max_route_parts: Some(Amount::new(28).unwrap()),
+            parts: Some(Amount::new(42).unwrap()),
         }
         .into_url(&base_url);
 
@@ -347,6 +359,8 @@ mod tests {
                 &fromAddress=0x00000000219ab540356cbb839cbe05303d7705fa\
                 &slippage=0.5\
                 &disableEstimate=true\
+                &complexityLevel=1\
+                &gasLimit=133700\
                 &maxRouteParts=28\
                 &parts=42",
         );
@@ -478,6 +492,8 @@ mod tests {
                 from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
                 slippage: Slippage::basis_points(50).unwrap(),
                 disable_estimate: None,
+                complexity_level: None,
+                gas_limit: None,
                 max_route_parts: None,
                 parts: None,
             })
@@ -497,8 +513,10 @@ mod tests {
                 from_address: addr!("4e608b7da83f8e9213f554bdaa77c72e125529d0"),
                 slippage: Slippage::basis_points(50).unwrap(),
                 disable_estimate: Some(true),
-                max_route_parts: Some(Parts::one()),
-                parts: Some(Parts::one()),
+                complexity_level: Some(Amount::new(1).unwrap()),
+                gas_limit: Some(750_000),
+                max_route_parts: Some(Amount::new(1).unwrap()),
+                parts: Some(Amount::new(1).unwrap()),
             })
             .await
             .unwrap();


### PR DESCRIPTION
This PR configures the 1Inch solver make more gas efficient swaps by:
- To use a maximum of 1 swap "path"
- Setting a limit on gas prices
- Only allowing a single connector token.

### Test Plan

Added a test around new `Amount` type, previous tests continue to pass, including:
```
$ cargo test -- --ignored --nocapture solve_order_on_one
...
Spender {
    address: 0x11111112542d85b3ef69ae05771c2dccff4faa26,
}
test oneinch_solver::api::tests::oneinch_spender_address ... ok
Swap {
...
}
test oneinch_solver::api::tests::oneinch_swap_without_amount_checks_and_splitting ... ok
Swap {
...
}
test oneinch_solver::api::tests::oneinch_swap ... ok
Settlement {
...
}
test oneinch_solver::tests::solve_order_on_oneinch ... ok
...
```
