### PR TITLE
Use trace_callMany api for more accurate bad token detection

### DIFF
--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -15,8 +15,8 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-async-trait = "0.1"
 assert_approx_eq = "1.1"
+async-trait = "0.1"
 bigdecimal = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 contracts = { path = "../contracts" }
@@ -27,23 +27,23 @@ hex = { version = "0.4", default-features = false }
 hex-literal = "0.3"
 maplit = "1.0"
 model = { path = "../model" }
+num = "0.4"
 num-bigint = "0.3"
 primitive-types = { version = "0.8", features = ["fp-conversion"] }
 prometheus = "0.12"
+reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "1.9", default-features = false, features = ["macros"] }
 shared= { path = "../shared" }
 sqlx = { version = "0.4", default-features = false, features = ["bigdecimal", "chrono", "macros", "runtime-tokio-native-tls", "postgres"] }
 structopt = "0.3"
-reqwest = { version = "0.10", features = ["json"] }
 thiserror = "1.0"
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "sync", "time"] }
 tracing = "0.1"
 url = "2.2"
 warp = "0.2"
 web3 = { version = "0.15", default-features = false, features = ["http-tls"] }
-num = "0.4"
 
 [dev-dependencies]
 secp256k1 = "0.20"

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -6,6 +6,7 @@ pub mod event_updater;
 pub mod fee;
 pub mod metrics;
 pub mod orderbook;
+pub mod trace_many;
 
 use crate::database::Database;
 use crate::orderbook::Orderbook;

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -116,6 +116,7 @@ impl Orderbook {
                 min_balance,
             )
             .await
+            .unwrap_or(false)
         {
             return Ok(AddOrderResult::InsufficientFunds);
         }

--- a/orderbook/src/trace_many.rs
+++ b/orderbook/src/trace_many.rs
@@ -1,0 +1,112 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use shared::Web3;
+use web3::{
+    types::{BlockNumber, BlockTrace, CallRequest, TraceType},
+    Transport,
+};
+
+// Use the trace_callMany api https://openethereum.github.io/JSONRPC-trace-module#trace_callmany
+// api to simulate whether these call requests if applied together in order would succeed.
+// Err if communication with the node failed.
+// Ok(true) if transactions simulate without reverting
+// Ok(false) if transactions simulate with at least one revert.
+pub async fn trace_many(requests: Vec<CallRequest>, web3: &Web3) -> Result<bool> {
+    let transport = web3.transport();
+    let requests = requests
+        .into_iter()
+        .map(|request| {
+            Ok(vec![
+                serde_json::to_value(request)?,
+                serde_json::to_value(vec![TraceType::Trace])?,
+            ])
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let block = BlockNumber::Latest;
+    let params = vec![
+        serde_json::to_value(requests)?,
+        serde_json::to_value(block)?,
+    ];
+    let response = transport.execute("trace_callMany", params).await?;
+    handle_trace_many_response(response)
+}
+
+// Same return value as above but factored out for easier testing.
+fn handle_trace_many_response(response: Value) -> Result<bool> {
+    let traces: Vec<BlockTrace> = serde_json::from_value(response)?;
+    for trace in traces {
+        let transaction_trace = trace.trace.ok_or_else(|| anyhow!("trace not set"))?;
+        let first = transaction_trace
+            .first()
+            .ok_or_else(|| anyhow!("expected at least one trace"))?;
+        if first.error.is_some() {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn communication_fails() {
+        let result = handle_trace_many_response(Value::Null);
+        assert!(result.is_err());
+
+        let response = json!([{"output": "0x", "trace": []}]);
+        let result = handle_trace_many_response(response);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn ok_true() {
+        let response = json!(
+        [{
+            "output": "0x",
+            "trace": [{
+              "traceAddress": [],
+              "subtraces": 0,
+              "action": {
+                "callType": "call",
+                "from": "0x0000000000000000000000000000000000000000",
+                "gas": "0x00",
+                "input": "0x",
+                "to": "0x0000000000000000000000000000000000000000",
+                "value": "0x00"
+              },
+              "type": "call"
+            }],
+          }]);
+
+        let result = handle_trace_many_response(response);
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn ok_false() {
+        let response = json!(
+        [{
+            "output": "0x",
+            "trace": [{
+              "traceAddress": [],
+              "subtraces": 0,
+              "action": {
+                "callType": "call",
+                "from": "0x0000000000000000000000000000000000000000",
+                "gas": "0x00",
+                "input": "0x",
+                "to": "0x0000000000000000000000000000000000000000",
+                "value": "0x00"
+              },
+              "type": "call",
+              "error": "Reverted"
+            }],
+          }]);
+
+        let result = handle_trace_many_response(response);
+        assert!(!result.unwrap());
+    }
+}


### PR DESCRIPTION
This api allows us to simulate multiple transactions together. If it is
not available we fall back to the existing method.

Related to #475

### Test Plan
Adjusted the tests for this module which you can run with `cargo test -p orderbook account_balances::tests::mainnet -- --ignored`.