### PR TITLE
Enforce some filters on get_trades and get_orders

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -53,6 +53,7 @@ paths:
         By default all currently valid orders are returned. The set of returned orders can be
         reduced by setting owner, sell token, buy token filters. It can be increased by disabling
         different order validity exclusion criteria.
+        At least one of owner, sellToken, buyToken has to be set.
       parameters:
         - name: owner
           in: query
@@ -181,8 +182,7 @@ paths:
     get:
       summary: Get existing Trades.
       description: |
-        By default all trades are returned.
-        Queries can be refined by specifiying owner or order_uid.
+        Exactly one of owner or order_uid has to be set.
       parameters:
         - name: owner
           in: query


### PR DESCRIPTION
These routes have the potential return a large number of database rows
which is expensive for the backend and shouldn't be requested by users
anyway (at least until we have pagination).

### Test Plan
adapted unit tests and manually tested with swagger
