### PR TITLE
Allow disabling trace api and log trace results

### DIFF
--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -156,6 +156,7 @@ impl OrderbookServices {
                 web3.clone(),
                 gpv2.allowance,
                 gpv2.settlement.address(),
+                true,
             )),
             fee_calculator.clone(),
             HashSet::new(),


### PR DESCRIPTION
We want this in prod to reduce alerts but as a safety measure in case something goes wrong this adds more logging and allows us to disable the trace api without rebuilding.

### Test Plan
locally check that the argument gets set