### PR TITLE
Only executing settlements without interactions if all sell tokens are in allowList

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "ethcontract",
  "hex-literal",
  "lazy_static",
+ "maplit",
  "model",
  "orderbook",
  "prometheus",

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -10,6 +10,7 @@ contracts = { path = "../contracts" }
 ethcontract = { version = "0.11",  default-features = false, features = ["http"] }
 hex-literal = "0.3"
 lazy_static = "1.4"
+maplit = "1.0"
 model = { path = "../model" }
 orderbook = { path = "../orderbook" }
 prometheus = "0.12"

--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -179,6 +179,7 @@ async fn onchain_settlement(web3: Web3) {
         network_id,
         1,
         Duration::from_secs(30),
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -7,7 +7,11 @@ use model::{
 };
 use secp256k1::SecretKey;
 use serde_json::json;
-use shared::{amm_pair_provider::UniswapPairProvider, Web3};
+use shared::{
+    amm_pair_provider::UniswapPairProvider,
+    token_list::{Token, TokenList},
+    Web3,
+};
 use solver::{
     liquidity::uniswap::UniswapLikeLiquidity, liquidity_collector::LiquidityCollector,
     metrics::NoopMetrics,
@@ -153,6 +157,14 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         orderbook_api: create_orderbook_api(&web3),
     };
     let network_id = web3.net().version().await.unwrap();
+    let market_makable_token_list = TokenList::new(maplit::hashmap! {
+        token_a.address() => Token {
+            address: token_a.address(),
+            name: "Test Coin".into(),
+            symbol: "TC".into(),
+            decimals: 18,
+        }
+    });
     let mut driver = solver::driver::Driver::new(
         gpv2.settlement.clone(),
         liquidity_collector,
@@ -168,6 +180,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         network_id,
         1,
         Duration::from_secs(10),
+        Some(market_makable_token_list),
     );
     driver.single_run().await.unwrap();
 

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -20,7 +20,7 @@ use itertools::{Either, Itertools};
 use model::order::BUY_ETH_ADDRESS;
 use num::BigRational;
 use primitive_types::H160;
-use shared::{price_estimate::PriceEstimating, Web3};
+use shared::{price_estimate::PriceEstimating, token_list::TokenList, Web3};
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -46,6 +46,7 @@ pub struct Driver {
     network_id: String,
     max_merged_settlements: usize,
     solver_time_limit: Duration,
+    market_makable_token_list: Option<TokenList>,
 }
 impl Driver {
     #[allow(clippy::too_many_arguments)]
@@ -64,6 +65,7 @@ impl Driver {
         network_id: String,
         max_merged_settlements: usize,
         solver_time_limit: Duration,
+        market_makable_token_list: Option<TokenList>,
     ) -> Self {
         Self {
             settlement_contract,
@@ -80,6 +82,7 @@ impl Driver {
             network_id,
             max_merged_settlements,
             solver_time_limit,
+            market_makable_token_list,
         }
     }
 
@@ -156,9 +159,19 @@ impl Driver {
         }
     }
 
-    async fn can_settle(&self, settlement: RatedSettlement) -> Result<bool> {
+    async fn can_settle_without_liquidity(&self, settlement: &RatedSettlement) -> Result<bool> {
+        // We don't want to buy tokens that we don't trust. If no list is set, we settle with external liquidity.
+        if !self
+            .market_makable_token_list
+            .as_ref()
+            .map(|list| is_only_selling_trusted_tokens(settlement.clone().into(), list))
+            .unwrap_or(false)
+        {
+            return Ok(false);
+        }
+
         let simulations = settlement_simulation::simulate_settlements(
-            chain![settlement.into()],
+            chain![settlement.without_onchain_liquidity().into()],
             &self.settlement_contract,
             &self.web3,
             &self.network_id,
@@ -344,7 +357,7 @@ impl Driver {
         }) {
             // If we have enough buffer in the settlement contract to not use on-chain interactions, remove those
             if self
-                .can_settle(settlement.without_onchain_liquidity())
+                .can_settle_without_liquidity(&settlement)
                 .await
                 .unwrap_or(false)
             {
@@ -428,14 +441,31 @@ fn liquidity_with_price(
     liquidity
 }
 
+fn is_only_selling_trusted_tokens(settlement: Settlement, token_list: &TokenList) -> bool {
+    !settlement.encoder.trades().iter().any(|trade| {
+        token_list
+            .get(&trade.order.order_creation.sell_token)
+            .is_none()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::liquidity::{tests::CapturingSettlementHandler, AmmOrder, LimitOrder};
+    use crate::{
+        liquidity::{tests::CapturingSettlementHandler, AmmOrder, LimitOrder},
+        settlement::Trade,
+    };
     use maplit::hashmap;
-    use model::{order::OrderKind, TokenPair};
+    use model::{
+        order::{Order, OrderCreation, OrderKind},
+        TokenPair,
+    };
     use num::{rational::Ratio, traits::One};
-    use shared::price_estimate::mocks::{FailingPriceEstimator, FakePriceEstimator};
+    use shared::{
+        price_estimate::mocks::{FailingPriceEstimator, FakePriceEstimator},
+        token_list::Token,
+    };
 
     #[tokio::test]
     async fn collect_estimated_prices_adds_prices_for_buy_and_sell_token_of_limit_orders() {
@@ -545,5 +575,54 @@ mod tests {
         assert!(
             matches!(&filtered[0], Liquidity::Limit(order) if order.sell_token == tokens[0] && order.buy_token == tokens[1])
         );
+    }
+
+    #[test]
+    fn test_is_only_selling_trusted_tokens() {
+        let good_token = H160::from_low_u64_be(1);
+        let another_good_token = H160::from_low_u64_be(2);
+        let bad_token = H160::from_low_u64_be(3);
+
+        let token_list = TokenList::new(hashmap! {
+            good_token => Token {
+                address: good_token,
+                symbol: "Foo".into(),
+                name: "FooCoin".into(),
+                decimals: 18,
+            },
+            another_good_token => Token {
+                address: another_good_token,
+                symbol: "Bar".into(),
+                name: "BarCoin".into(),
+                decimals: 18,
+            }
+        });
+
+        let trade = |token| Trade {
+            order: Order {
+                order_creation: OrderCreation {
+                    sell_token: token,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let settlement = Settlement::with_trades(
+            HashMap::new(),
+            vec![trade(good_token), trade(another_good_token)],
+        );
+        assert!(is_only_selling_trusted_tokens(settlement, &token_list));
+
+        let settlement = Settlement::with_trades(
+            HashMap::new(),
+            vec![
+                trade(good_token),
+                trade(another_good_token),
+                trade(bad_token),
+            ],
+        );
+        assert!(!is_only_selling_trusted_tokens(settlement, &token_list));
     }
 }

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -164,7 +164,7 @@ impl Driver {
         if !self
             .market_makable_token_list
             .as_ref()
-            .map(|list| is_only_selling_trusted_tokens(settlement.clone().into(), list))
+            .map(|list| is_only_selling_trusted_tokens(&settlement.settlement.settlement, list))
             .unwrap_or(false)
         {
             return Ok(false);
@@ -441,7 +441,7 @@ fn liquidity_with_price(
     liquidity
 }
 
-fn is_only_selling_trusted_tokens(settlement: Settlement, token_list: &TokenList) -> bool {
+fn is_only_selling_trusted_tokens(settlement: &Settlement, token_list: &TokenList) -> bool {
     !settlement.encoder.trades().iter().any(|trade| {
         token_list
             .get(&trade.order.order_creation.sell_token)
@@ -613,7 +613,7 @@ mod tests {
             HashMap::new(),
             vec![trade(good_token), trade(another_good_token)],
         );
-        assert!(is_only_selling_trusted_tokens(settlement, &token_list));
+        assert!(is_only_selling_trusted_tokens(&settlement, &token_list));
 
         let settlement = Settlement::with_trades(
             HashMap::new(),
@@ -623,6 +623,6 @@ mod tests {
                 trade(bad_token),
             ],
         );
-        assert!(!is_only_selling_trusted_tokens(settlement, &token_list));
+        assert!(!is_only_selling_trusted_tokens(&settlement, &token_list));
     }
 }


### PR DESCRIPTION
To make us less attackable. Using an Option in case we cannot fetch the list to not crash but instead just not market make between our own tokens.

### Test Plan
Added a unit test for the added logic in the driver. E2E test for this feature was adapted and still passes.
