### PR TITLE
Makes network native token the ref token for http solver.

### DIFF
--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -133,6 +133,7 @@ impl HttpSolver {
                     TokenInfoModel {
                         decimals: token_info.decimals.map(|d| d as u32),
                         external_price,
+                        normalize_priority: Some(if &self.native_token == address { 1 } else { 0 }),
                     },
                 )
             })

--- a/solver/src/http_solver/model.rs
+++ b/solver/src/http_solver/model.rs
@@ -43,6 +43,7 @@ pub struct UniswapModel {
 pub struct TokenInfoModel {
     pub decimals: Option<u32>,
     pub external_price: Option<f64>,
+    pub normalize_priority: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
Because @twalth3r suggested that this can improve numerical stability of the solver.
