### PR TITLE
Refactor bad token detector into trait and module

### DIFF
--- a/orderbook/src/bad_token/cache.rs
+++ b/orderbook/src/bad_token/cache.rs
@@ -1,0 +1,67 @@
+use super::{BadTokenDetecting, TokenQuality};
+use anyhow::Result;
+use primitive_types::H160;
+use std::{collections::HashMap, sync::Mutex};
+
+pub struct CachingDetector {
+    inner: Box<dyn BadTokenDetecting>,
+    // std mutex is fine because we don't hold lock across await.
+    cache: Mutex<HashMap<H160, TokenQuality>>,
+}
+
+#[async_trait::async_trait]
+impl BadTokenDetecting for CachingDetector {
+    async fn detect(&self, token: H160) -> Result<TokenQuality> {
+        if let Some(result) = self.get_from_cache(&token) {
+            return Ok(result);
+        }
+
+        let result = self.inner.detect(token).await?;
+        self.insert_into_cache(token, result.clone());
+        Ok(result)
+    }
+}
+
+impl CachingDetector {
+    pub fn new(inner: Box<dyn BadTokenDetecting>) -> Self {
+        Self {
+            inner,
+            cache: Default::default(),
+        }
+    }
+
+    fn get_from_cache(&self, token: &H160) -> Option<TokenQuality> {
+        self.cache.lock().unwrap().get(token).cloned()
+    }
+
+    fn insert_into_cache(&self, token: H160, quality: TokenQuality) {
+        self.cache.lock().unwrap().insert(token, quality);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bad_token::MockBadTokenDetecting;
+    use futures::FutureExt;
+
+    #[test]
+    fn goes_to_cache() {
+        // Would panic if called twice.
+        let mut inner = MockBadTokenDetecting::new();
+        inner
+            .expect_detect()
+            .times(1)
+            .returning(|_| Ok(TokenQuality::Good));
+
+        let detector = CachingDetector::new(Box::new(inner));
+
+        for _ in 0..2 {
+            let result = detector
+                .detect(H160::from_low_u64_le(0))
+                .now_or_never()
+                .unwrap();
+            assert!(result.unwrap().is_good());
+        }
+    }
+}

--- a/orderbook/src/bad_token/list_based.rs
+++ b/orderbook/src/bad_token/list_based.rs
@@ -1,0 +1,116 @@
+use super::{BadTokenDetecting, TokenQuality};
+use anyhow::Result;
+use primitive_types::H160;
+
+/// If a token is neither in the allow nor the deny list treat it this way.
+pub enum UnknownTokenStrategy {
+    Allow,
+    Deny,
+    Forward(Box<dyn BadTokenDetecting>),
+}
+
+/// Classify tokens with explicit allow and deny lists.
+pub struct ListBasedDetector {
+    pub allow_list: Vec<H160>,
+    pub deny_list: Vec<H160>,
+    pub strategy: UnknownTokenStrategy,
+}
+
+#[async_trait::async_trait]
+impl BadTokenDetecting for ListBasedDetector {
+    async fn detect(&self, token: ethcontract::H160) -> Result<TokenQuality> {
+        if self.allow_list.contains(&token) {
+            return Ok(TokenQuality::Good);
+        }
+
+        if self.deny_list.contains(&token) {
+            return Ok(TokenQuality::Bad {
+                reason: "deny listed".to_string(),
+            });
+        }
+
+        match &self.strategy {
+            UnknownTokenStrategy::Allow => Ok(TokenQuality::Good),
+            UnknownTokenStrategy::Deny => Ok(TokenQuality::Bad {
+                reason: "default deny".to_string(),
+            }),
+            UnknownTokenStrategy::Forward(inner) => inner.detect(token).await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bad_token::MockBadTokenDetecting;
+    use futures::FutureExt;
+
+    #[test]
+    fn uses_lists() {
+        // Would panic if used.
+        let inner = MockBadTokenDetecting::new();
+        let detector = ListBasedDetector {
+            allow_list: vec![H160::from_low_u64_le(0)],
+            deny_list: vec![H160::from_low_u64_le(1)],
+            strategy: UnknownTokenStrategy::Forward(Box::new(inner)),
+        };
+
+        let result = detector
+            .detect(H160::from_low_u64_le(0))
+            .now_or_never()
+            .unwrap();
+        assert!(result.unwrap().is_good());
+
+        let result = detector
+            .detect(H160::from_low_u64_le(1))
+            .now_or_never()
+            .unwrap();
+        assert!(!result.unwrap().is_good());
+    }
+
+    #[test]
+    fn not_in_list_default() {
+        let detector = ListBasedDetector {
+            allow_list: Vec::new(),
+            deny_list: Vec::new(),
+            strategy: UnknownTokenStrategy::Allow,
+        };
+        let result = detector
+            .detect(H160::from_low_u64_le(0))
+            .now_or_never()
+            .unwrap();
+        assert!(result.unwrap().is_good());
+
+        let detector = ListBasedDetector {
+            allow_list: Vec::new(),
+            deny_list: Vec::new(),
+            strategy: UnknownTokenStrategy::Deny,
+        };
+        let result = detector
+            .detect(H160::from_low_u64_le(0))
+            .now_or_never()
+            .unwrap();
+        assert!(!result.unwrap().is_good());
+    }
+
+    #[test]
+    fn not_in_list_forwards() {
+        let mut inner = MockBadTokenDetecting::new();
+        inner
+            .expect_detect()
+            .times(1)
+            .returning(|_| Ok(TokenQuality::Good));
+
+        let detector = ListBasedDetector {
+            allow_list: Vec::new(),
+            deny_list: Vec::new(),
+            strategy: UnknownTokenStrategy::Forward(Box::new(inner)),
+        };
+
+        let result = detector
+            .detect(H160::from_low_u64_le(0))
+            .now_or_never()
+            .unwrap();
+        assert!(result.unwrap().is_good());
+    }
+}

--- a/orderbook/src/bad_token/mod.rs
+++ b/orderbook/src/bad_token/mod.rs
@@ -1,0 +1,30 @@
+pub mod trace_call;
+
+use anyhow::Result;
+use primitive_types::H160;
+
+/// How well behaved a token is.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum TokenQuality {
+    Good,
+    Bad { reason: String },
+}
+
+impl TokenQuality {
+    pub fn is_good(&self) -> bool {
+        matches!(self, Self::Good { .. })
+    }
+
+    pub fn bad(reason: impl ToString) -> Self {
+        Self::Bad {
+            reason: reason.to_string(),
+        }
+    }
+}
+
+/// Detect how well behaved a token is.
+#[cfg_attr(test, mockall::automock)]
+#[async_trait::async_trait]
+pub trait BadTokenDetecting: Send + Sync {
+    async fn detect(&self, token: H160) -> Result<TokenQuality>;
+}

--- a/orderbook/src/bad_token/mod.rs
+++ b/orderbook/src/bad_token/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod list_based;
 pub mod trace_call;
 
 use anyhow::Result;

--- a/orderbook/src/bad_token/mod.rs
+++ b/orderbook/src/bad_token/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod trace_call;
 
 use anyhow::Result;


### PR DESCRIPTION
I plan on using the trait to implement wrapping detectors that can add a
cache and explicit allow and deny lists.

I dropped the gas price from TokenQuality because I am not sure yet how it should work with the allow and deny lists. Can add this back later.

### Test Plan
not needed