### PR TITLE
Remove boilerplate for implementing `EventRetrieving` for contracts

### DIFF
--- a/contracts/build.rs
+++ b/contracts/build.rs
@@ -1,7 +1,6 @@
 use ethcontract::common::DeploymentInformation;
-use ethcontract_generate::{Address, Builder, TransactionHash};
-use maplit::hashmap;
-use std::{collections::HashMap, env, fs, path::Path, str::FromStr};
+use ethcontract_generate::{Address, Builder};
+use std::{env, fs, path::Path};
 
 #[path = "src/paths.rs"]
 mod paths;
@@ -16,76 +15,73 @@ fn main() {
     // - https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
     println!("cargo:rerun-if-changed=build.rs");
 
-    generate_contract("ERC20", hashmap! {});
-    generate_contract("ERC20Mintable", hashmap! {});
-    generate_contract(
-        "UniswapV2Router02",
-        hashmap! {
-            1 => (Address::from_str("7a250d5630B4cF539739dF2C5dAcb4c659F2488D").unwrap(), None),
-            4 => (Address::from_str("7a250d5630B4cF539739dF2C5dAcb4c659F2488D").unwrap(), None),
-            100 => (Address::from_str("1C232F01118CB8B424793ae03F870aa7D0ac7f77").unwrap(), None),
-        },
-    );
-    generate_contract(
-        "UniswapV2Factory",
-        hashmap! {
-            1 => (Address::from_str("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f").unwrap(), None),
-            4 => (Address::from_str("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f").unwrap(), None),
-            100 => (Address::from_str("A818b4F111Ccac7AA31D0BCc0806d64F2E0737D7").unwrap(), None),
-        },
-    );
-    generate_contract("UniswapV2Pair", hashmap! {});
+    generate_contract("ERC20");
+    generate_contract("ERC20Mintable");
+    generate_contract_with_config("UniswapV2Router02", |builder| {
+        builder
+            .add_deployment_str(1, "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D")
+            .add_deployment_str(4, "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D")
+            .add_deployment_str(100, "0x1C232F01118CB8B424793ae03F870aa7D0ac7f77")
+    });
+    generate_contract_with_config("UniswapV2Factory", |builder| {
+        builder
+            .add_deployment_str(1, "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f")
+            .add_deployment_str(4, "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f")
+            .add_deployment_str(100, "0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7")
+    });
+    generate_contract("UniswapV2Pair");
     // This is done to have a common interface for Sushiswap, Uniswap & Honeyswap
-    generate_contract("IUniswapLikeRouter", hashmap! {});
-    generate_contract("IUniswapLikePair", hashmap! {});
-    generate_contract(
-        "SushiswapV2Router02",
-        hashmap! {
-            1 => (Address::from_str("d9e1cE17f2641f24aE83637ab66a2cca9C378B9F").unwrap(), None),
-            4 => (Address::from_str("1b02dA8Cb0d097eB8D57A175b88c7D8b47997506").unwrap(), None),
-            100 => (Address::from_str("1b02dA8Cb0d097eB8D57A175b88c7D8b47997506").unwrap(), None),
-        },
-    );
-    generate_contract(
-        "SushiswapV2Factory",
-        hashmap! {
-            1 => (Address::from_str("C0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac").unwrap(), None),
-            4 => (Address::from_str("c35DADB65012eC5796536bD9864eD8773aBc74C4").unwrap(), None),
-            100 => (Address::from_str("c35DADB65012eC5796536bD9864eD8773aBc74C4").unwrap(), None),
-        },
-    );
-    generate_contract("SushiswapV2Pair", hashmap! {});
-    generate_contract_with_config(
-        "GPv2Settlement",
-        hashmap! {
-            1 => (Address::from_str("0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf").unwrap(), Some("0x34b7f9a340e663df934fcc662b3ec5fcd7cd0c93d3c46f8ce612e94fff803909".parse().unwrap())),
-            4 => (Address::from_str("0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf").unwrap(), Some("0x52badda922fd91052e6682d125daa59dea3ce5c57add5a9d362bec2d6ccfd2b1".parse().unwrap())),
-            100 => (Address::from_str("0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf").unwrap(), Some("0x95bbefbca7162435eeb71bac6960aae4d7112abce87a51ad3952d7b7af0279e3".parse().unwrap())),
-        },
-        |builder| builder.with_contract_mod_override(Some("gpv2_settlement")),
-    );
-    generate_contract("GPv2AllowListAuthentication", hashmap! {});
-    generate_contract(
-        "WETH9",
-        hashmap! {
-            // Rinkeby & Mainnet Addresses are part of the artefact
-            100 => (Address::from_str("e91D153E0b41518A2Ce8Dd3D7944Fa863463a97d").unwrap(), None),
-        },
-    );
+    generate_contract("IUniswapLikeRouter");
+    generate_contract("IUniswapLikePair");
+    generate_contract_with_config("SushiswapV2Router02", |builder| {
+        builder
+            .add_deployment_str(1, "0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F")
+            .add_deployment_str(4, "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506")
+            .add_deployment_str(100, "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506")
+    });
+    generate_contract_with_config("SushiswapV2Factory", |builder| {
+        builder
+            .add_deployment_str(1, "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac")
+            .add_deployment_str(4, "0xc35DADB65012eC5796536bD9864eD8773aBc74C4")
+            .add_deployment_str(100, "0xc35DADB65012eC5796536bD9864eD8773aBc74C4")
+    });
+    generate_contract("SushiswapV2Pair");
+    generate_contract_with_config("GPv2Settlement", |builder| {
+        builder
+            .with_contract_mod_override(Some("gpv2_settlement"))
+            .add_deployment(
+                1,
+                addr("0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf"),
+                Some(tx(
+                    "0x34b7f9a340e663df934fcc662b3ec5fcd7cd0c93d3c46f8ce612e94fff803909",
+                )),
+            )
+            .add_deployment(
+                4,
+                addr("0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf"),
+                Some(tx(
+                    "0x52badda922fd91052e6682d125daa59dea3ce5c57add5a9d362bec2d6ccfd2b1",
+                )),
+            )
+            .add_deployment(
+                100,
+                addr("0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf"),
+                Some(tx(
+                    "0x95bbefbca7162435eeb71bac6960aae4d7112abce87a51ad3952d7b7af0279e3",
+                )),
+            )
+    });
+    generate_contract("GPv2AllowListAuthentication");
+    generate_contract_with_config("WETH9", |builder| {
+        builder.add_deployment_str(1, "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d")
+    });
 }
 
-fn generate_contract(
-    name: &str,
-    deployment_overrides: HashMap<u32, (Address, Option<TransactionHash>)>,
-) {
-    generate_contract_with_config(name, deployment_overrides, |builder| builder)
+fn generate_contract(name: &str) {
+    generate_contract_with_config(name, |builder| builder)
 }
 
-fn generate_contract_with_config(
-    name: &str,
-    deployment_overrides: HashMap<u32, (Address, Option<TransactionHash>)>,
-    config: impl FnOnce(Builder) -> Builder,
-) {
+fn generate_contract_with_config(name: &str, config: impl FnOnce(Builder) -> Builder) {
     let artifact = paths::contract_artifacts_dir().join(format!("{}.json", name));
     let address_file = paths::contract_address_file(name);
     let dest = env::var("OUT_DIR").unwrap();
@@ -102,17 +98,17 @@ fn generate_contract_with_config(
         builder = builder.add_deployment_str(5777, address.trim());
     }
 
-    for (network_id, (address, transaction_hash)) in deployment_overrides.into_iter() {
-        builder = builder.add_deployment(
-            network_id,
-            address,
-            transaction_hash.map(DeploymentInformation::TransactionHash),
-        );
-    }
-
     config(builder)
         .generate()
         .unwrap()
         .write_to_file(Path::new(&dest).join(format!("{}.rs", name)))
         .unwrap();
+}
+
+fn addr(s: &str) -> Address {
+    s.parse().unwrap()
+}
+
+fn tx(s: &str) -> DeploymentInformation {
+    DeploymentInformation::TransactionHash(s.parse().unwrap())
 }

--- a/contracts/build.rs
+++ b/contracts/build.rs
@@ -55,13 +55,14 @@ fn main() {
         },
     );
     generate_contract("SushiswapV2Pair", hashmap! {});
-    generate_contract(
+    generate_contract_with_config(
         "GPv2Settlement",
         hashmap! {
             1 => (Address::from_str("0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf").unwrap(), Some("0x34b7f9a340e663df934fcc662b3ec5fcd7cd0c93d3c46f8ce612e94fff803909".parse().unwrap())),
             4 => (Address::from_str("0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf").unwrap(), Some("0x52badda922fd91052e6682d125daa59dea3ce5c57add5a9d362bec2d6ccfd2b1".parse().unwrap())),
             100 => (Address::from_str("0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf").unwrap(), Some("0x95bbefbca7162435eeb71bac6960aae4d7112abce87a51ad3952d7b7af0279e3".parse().unwrap())),
         },
+        |builder| builder.with_contract_mod_override(Some("gpv2_settlement")),
     );
     generate_contract("GPv2AllowListAuthentication", hashmap! {});
     generate_contract(
@@ -76,6 +77,14 @@ fn main() {
 fn generate_contract(
     name: &str,
     deployment_overrides: HashMap<u32, (Address, Option<TransactionHash>)>,
+) {
+    generate_contract_with_config(name, deployment_overrides, |builder| builder)
+}
+
+fn generate_contract_with_config(
+    name: &str,
+    deployment_overrides: HashMap<u32, (Address, Option<TransactionHash>)>,
+    config: impl FnOnce(Builder) -> Builder,
 ) {
     let artifact = paths::contract_artifacts_dir().join(format!("{}.json", name));
     let address_file = paths::contract_address_file(name);
@@ -101,7 +110,7 @@ fn generate_contract(
         );
     }
 
-    builder
+    config(builder)
         .generate()
         .unwrap()
         .write_to_file(Path::new(&dest).join(format!("{}.rs", name)))

--- a/orderbook/src/database/events.rs
+++ b/orderbook/src/database/events.rs
@@ -1,7 +1,7 @@
 use super::Database;
 use crate::conversions::*;
 use anyhow::{anyhow, Context, Result};
-use contracts::g_pv_2_settlement::{
+use contracts::gpv2_settlement::{
     event_data::{
         OrderInvalidated as ContractInvalidation, Settlement as ContractSettlement,
         Trade as ContractTrade,

--- a/shared/src/current_block.rs
+++ b/shared/src/current_block.rs
@@ -11,7 +11,10 @@ use std::{
     time::Duration,
 };
 use tokio::sync::watch;
-use web3::types::{BlockId, BlockNumber};
+use web3::{
+    types::{BlockId, BlockNumber},
+    Transport,
+};
 
 pub type Block = web3::types::Block<H256>;
 
@@ -28,7 +31,7 @@ const POLL_INTERVAL: Duration = Duration::from_secs(1);
 /// result with several consumers. Calling this function again would create a new poller so it is
 /// preferable to clone an existing stream instead.
 pub async fn current_block_stream(web3: Web3) -> Result<CurrentBlockStream> {
-    let first_block = current_block(&web3).await?;
+    let first_block = web3.current_block().await?;
     let first_hash = first_block.hash.ok_or_else(|| anyhow!("missing hash"))?;
 
     let (sender, receiver) = watch::channel(first_block.clone());
@@ -40,7 +43,7 @@ pub async fn current_block_stream(web3: Web3) -> Result<CurrentBlockStream> {
         let mut previous_hash = first_hash;
         loop {
             tokio::time::delay_for(POLL_INTERVAL).await;
-            let block = match current_block(&web3).await {
+            let block = match web3.current_block().await {
                 Ok(block) => block,
                 Err(err) => {
                     tracing::warn!("failed to get current block: {:?}", err);
@@ -123,12 +126,36 @@ impl FusedStream for CurrentBlockStream {
     }
 }
 
-async fn current_block(web3: &Web3) -> Result<Block> {
-    web3.eth()
-        .block(BlockId::Number(BlockNumber::Latest))
-        .await
-        .context("failed to get current block")?
-        .ok_or_else(|| anyhow!("no current block"))
+/// Trait for abstracting the retrieval of the block information such as the
+/// latest block number.
+#[async_trait::async_trait]
+pub trait BlockRetrieving {
+    async fn current_block(&self) -> Result<Block>;
+    async fn current_block_number(&self) -> Result<u64>;
+}
+
+#[async_trait::async_trait]
+impl<T> BlockRetrieving for web3::Web3<T>
+where
+    T: Transport + Send + Sync,
+    T::Out: Send,
+{
+    async fn current_block(&self) -> Result<Block> {
+        self.eth()
+            .block(BlockId::Number(BlockNumber::Latest))
+            .await
+            .context("failed to get current block")?
+            .ok_or_else(|| anyhow!("no current block"))
+    }
+
+    async fn current_block_number(&self) -> Result<u64> {
+        Ok(self
+            .eth()
+            .block_number()
+            .await
+            .context("failed to get current block")?
+            .as_u64())
+    }
 }
 
 #[cfg(test)]

--- a/shared/src/event_handling.rs
+++ b/shared/src/event_handling.rs
@@ -1,17 +1,23 @@
+use crate::current_block::BlockRetrieving;
 use anyhow::{Context, Error, Result};
 use ethcontract::contract::{AllEventsBuilder, ParseLog};
 use ethcontract::errors::ExecutionError;
 use ethcontract::{dyns::DynTransport, BlockNumber as Web3BlockNumber, Event as EthcontractEvent};
 use futures::{Stream, StreamExt, TryStreamExt};
 use std::ops::RangeInclusive;
-use web3::Web3;
 
 // We expect that there is never a reorg that changes more than the last n blocks.
 const MAX_REORG_BLOCK_COUNT: u64 = 25;
 // Saving events, we process at most this many at a time.
 const INSERT_EVENT_BATCH_SIZE: usize = 10_000;
 
-pub struct EventHandler<C: EventRetrieving, S: EventStoring<C::Event>> {
+pub struct EventHandler<B, C, S>
+where
+    B: BlockRetrieving,
+    C: EventRetrieving,
+    S: EventStoring<C::Event>,
+{
+    block_retriever: B,
     contract: C,
     store: S,
     last_handled_block: Option<u64>,
@@ -48,16 +54,22 @@ pub trait EventStoring<T> {
 pub trait EventRetrieving {
     type Event: ParseLog;
     fn get_events(&self) -> AllEventsBuilder<DynTransport, Self::Event>;
-    fn web3(&self) -> Web3<DynTransport>;
 }
 
-impl<C, S> EventHandler<C, S>
+impl<B, C, S> EventHandler<B, C, S>
 where
+    B: BlockRetrieving,
     C: EventRetrieving,
     S: EventStoring<C::Event>,
 {
-    pub fn new(contract: C, store: S, start_sync_at_block: Option<u64>) -> Self {
+    pub fn new(
+        block_retriever: B,
+        contract: C,
+        store: S,
+        start_sync_at_block: Option<u64>,
+    ) -> Self {
         Self {
+            block_retriever,
             contract,
             store,
             last_handled_block: start_sync_at_block,
@@ -65,7 +77,6 @@ where
     }
 
     async fn event_block_range(&self) -> Result<RangeInclusive<BlockNumber>> {
-        let web3 = self.contract.web3();
         // Instead of using only the most recent event block from the db we also store the last
         // handled block in self so that during long times of no events we do not query needlessly
         // large block ranges.
@@ -73,12 +84,7 @@ where
             Some(block) => block,
             None => self.store.last_event_block().await?,
         };
-        let current_block = web3
-            .eth()
-            .block_number()
-            .await
-            .context("failed to get current block")?
-            .as_u64();
+        let current_block = self.block_retriever.current_block_number().await?;
         let from_block = last_handled_block.saturating_sub(MAX_REORG_BLOCK_COUNT);
         anyhow::ensure!(
             from_block <= current_block,
@@ -180,4 +186,22 @@ impl BlockNumber {
             BlockNumber::Latest(_) => Web3BlockNumber::Latest,
         }
     }
+}
+
+#[macro_export]
+macro_rules! impl_event_retrieving {
+    ($vis:vis $name:ident for $contract_module:ident) => {
+        $vis struct $name(self::$contract_module::Contract);
+
+        impl ::shared::event_handling::EventRetrieving for $name {
+            type Event = self::$contract_module::Event;
+
+            fn get_events(&self) -> ::ethcontract::contract::AllEventsBuilder<
+                ::ethcontract::dyns::DynTransport,
+                Self::Event,
+            > {
+                self.0.all_events()
+            }
+        }
+    };
 }

--- a/shared/src/event_handling.rs
+++ b/shared/src/event_handling.rs
@@ -190,11 +190,11 @@ impl BlockNumber {
 
 #[macro_export]
 macro_rules! impl_event_retrieving {
-    ($vis:vis $name:ident for $contract_module:ident) => {
-        $vis struct $name(self::$contract_module::Contract);
+    ($vis:vis $name:ident for $($contract_module:tt)*) => {
+        $vis struct $name($($contract_module)*::Contract);
 
         impl ::shared::event_handling::EventRetrieving for $name {
-            type Event = self::$contract_module::Event;
+            type Event = $($contract_module)*::Event;
 
             fn get_events(&self) -> ::ethcontract::contract::AllEventsBuilder<
                 ::ethcontract::dyns::DynTransport,


### PR DESCRIPTION
Follow up to #606.

This PR addresses comments from the previous PR, specifically:
- Implements a declarative macro to implement `EventRetrieving` for contracts bindings generated by `ethcontract`.
- Removes the `web3()` function from the `EventRetrieving` trait, requiring a `BlockRetrieving` to be passed when constructing event handlers.

With help from @bh2smith!

### Test Plan

No logic changes, just refactoring (and moveing small amounts of code around). CI should continue to pass.
