### PR TITLE
Remove boilerplate for implementing `EventRetrieving` for contracts

### DIFF
--- a/orderbook/src/event_updater.rs
+++ b/orderbook/src/event_updater.rs
@@ -1,16 +1,20 @@
 use crate::database::Database;
 use anyhow::{Context, Result};
-use contracts::{g_pv_2_settlement::Event as ContractEvent, GPv2Settlement};
-use ethcontract::contract::AllEventsBuilder;
-use ethcontract::{dyns::DynTransport, Event};
-use shared::event_handling::{BlockNumber, EventHandler, EventRetrieving, EventStoring};
+use contracts::{
+    g_pv_2_settlement::{self, Event as ContractEvent},
+    GPv2Settlement,
+};
+use ethcontract::{dyns::DynWeb3, Event};
+use shared::{
+    event_handling::{BlockNumber, EventHandler, EventStoring},
+    impl_event_retrieving,
+};
 use std::ops::{Deref, DerefMut, RangeInclusive};
-use web3::Web3;
 
-pub struct EventUpdater(EventHandler<GPv2SettlementContract, Database>);
+pub struct EventUpdater(EventHandler<DynWeb3, GPv2SettlementContract, Database>);
 
 impl Deref for EventUpdater {
-    type Target = EventHandler<GPv2SettlementContract, Database>;
+    type Target = EventHandler<DynWeb3, GPv2SettlementContract, Database>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -60,22 +64,14 @@ impl EventStoring<ContractEvent> for Database {
     }
 }
 
-pub struct GPv2SettlementContract(GPv2Settlement);
-
-impl EventRetrieving for GPv2SettlementContract {
-    type Event = ContractEvent;
-    fn get_events(&self) -> AllEventsBuilder<DynTransport, Self::Event> {
-        self.0.all_events()
-    }
-
-    fn web3(&self) -> Web3<DynTransport> {
-        self.0.raw_instance().web3()
-    }
+impl_event_retrieving! {
+    pub GPv2SettlementContract for g_pv_2_settlement
 }
 
 impl EventUpdater {
     pub fn new(contract: GPv2Settlement, db: Database, start_sync_at_block: Option<u64>) -> Self {
         Self(EventHandler::new(
+            contract.raw_instance().web3(),
             GPv2SettlementContract(contract),
             db,
             start_sync_at_block,

--- a/shared/src/current_block.rs
+++ b/shared/src/current_block.rs
@@ -11,7 +11,10 @@ use std::{
     time::Duration,
 };
 use tokio::sync::watch;
-use web3::types::{BlockId, BlockNumber};
+use web3::{
+    types::{BlockId, BlockNumber},
+    Transport,
+};
 
 pub type Block = web3::types::Block<H256>;
 
@@ -28,7 +31,7 @@ const POLL_INTERVAL: Duration = Duration::from_secs(1);
 /// result with several consumers. Calling this function again would create a new poller so it is
 /// preferable to clone an existing stream instead.
 pub async fn current_block_stream(web3: Web3) -> Result<CurrentBlockStream> {
-    let first_block = current_block(&web3).await?;
+    let first_block = web3.current_block().await?;
     let first_hash = first_block.hash.ok_or_else(|| anyhow!("missing hash"))?;
 
     let (sender, receiver) = watch::channel(first_block.clone());
@@ -40,7 +43,7 @@ pub async fn current_block_stream(web3: Web3) -> Result<CurrentBlockStream> {
         let mut previous_hash = first_hash;
         loop {
             tokio::time::delay_for(POLL_INTERVAL).await;
-            let block = match current_block(&web3).await {
+            let block = match web3.current_block().await {
                 Ok(block) => block,
                 Err(err) => {
                     tracing::warn!("failed to get current block: {:?}", err);
@@ -123,12 +126,36 @@ impl FusedStream for CurrentBlockStream {
     }
 }
 
-async fn current_block(web3: &Web3) -> Result<Block> {
-    web3.eth()
-        .block(BlockId::Number(BlockNumber::Latest))
-        .await
-        .context("failed to get current block")?
-        .ok_or_else(|| anyhow!("no current block"))
+/// Trait for abstracting the retrieval of the block information such as the
+/// latest block number.
+#[async_trait::async_trait]
+pub trait BlockRetrieving {
+    async fn current_block(&self) -> Result<Block>;
+    async fn current_block_number(&self) -> Result<u64>;
+}
+
+#[async_trait::async_trait]
+impl<T> BlockRetrieving for web3::Web3<T>
+where
+    T: Transport + Send + Sync,
+    T::Out: Send,
+{
+    async fn current_block(&self) -> Result<Block> {
+        self.eth()
+            .block(BlockId::Number(BlockNumber::Latest))
+            .await
+            .context("failed to get current block")?
+            .ok_or_else(|| anyhow!("no current block"))
+    }
+
+    async fn current_block_number(&self) -> Result<u64> {
+        Ok(self
+            .eth()
+            .block_number()
+            .await
+            .context("failed to get current block")?
+            .as_u64())
+    }
 }
 
 #[cfg(test)]

--- a/shared/src/event_handling.rs
+++ b/shared/src/event_handling.rs
@@ -1,17 +1,23 @@
+use crate::current_block::BlockRetrieving;
 use anyhow::{Context, Error, Result};
 use ethcontract::contract::{AllEventsBuilder, ParseLog};
 use ethcontract::errors::ExecutionError;
 use ethcontract::{dyns::DynTransport, BlockNumber as Web3BlockNumber, Event as EthcontractEvent};
 use futures::{Stream, StreamExt, TryStreamExt};
 use std::ops::RangeInclusive;
-use web3::Web3;
 
 // We expect that there is never a reorg that changes more than the last n blocks.
 const MAX_REORG_BLOCK_COUNT: u64 = 25;
 // Saving events, we process at most this many at a time.
 const INSERT_EVENT_BATCH_SIZE: usize = 10_000;
 
-pub struct EventHandler<C: EventRetrieving, S: EventStoring<C::Event>> {
+pub struct EventHandler<B, C, S>
+where
+    B: BlockRetrieving,
+    C: EventRetrieving,
+    S: EventStoring<C::Event>,
+{
+    block_retriever: B,
     contract: C,
     store: S,
     last_handled_block: Option<u64>,
@@ -48,16 +54,22 @@ pub trait EventStoring<T> {
 pub trait EventRetrieving {
     type Event: ParseLog;
     fn get_events(&self) -> AllEventsBuilder<DynTransport, Self::Event>;
-    fn web3(&self) -> Web3<DynTransport>;
 }
 
-impl<C, S> EventHandler<C, S>
+impl<B, C, S> EventHandler<B, C, S>
 where
+    B: BlockRetrieving,
     C: EventRetrieving,
     S: EventStoring<C::Event>,
 {
-    pub fn new(contract: C, store: S, start_sync_at_block: Option<u64>) -> Self {
+    pub fn new(
+        block_retriever: B,
+        contract: C,
+        store: S,
+        start_sync_at_block: Option<u64>,
+    ) -> Self {
         Self {
+            block_retriever,
             contract,
             store,
             last_handled_block: start_sync_at_block,
@@ -65,7 +77,6 @@ where
     }
 
     async fn event_block_range(&self) -> Result<RangeInclusive<BlockNumber>> {
-        let web3 = self.contract.web3();
         // Instead of using only the most recent event block from the db we also store the last
         // handled block in self so that during long times of no events we do not query needlessly
         // large block ranges.
@@ -73,12 +84,7 @@ where
             Some(block) => block,
             None => self.store.last_event_block().await?,
         };
-        let current_block = web3
-            .eth()
-            .block_number()
-            .await
-            .context("failed to get current block")?
-            .as_u64();
+        let current_block = self.block_retriever.current_block_number().await?;
         let from_block = last_handled_block.saturating_sub(MAX_REORG_BLOCK_COUNT);
         anyhow::ensure!(
             from_block <= current_block,
@@ -180,4 +186,22 @@ impl BlockNumber {
             BlockNumber::Latest(_) => Web3BlockNumber::Latest,
         }
     }
+}
+
+#[macro_export]
+macro_rules! impl_event_retrieving {
+    ($vis:vis $name:ident for $($contract_module:tt)*) => {
+        $vis struct $name($($contract_module)*::Contract);
+
+        impl ::shared::event_handling::EventRetrieving for $name {
+            type Event = $($contract_module)*::Event;
+
+            fn get_events(&self) -> ::ethcontract::contract::AllEventsBuilder<
+                ::ethcontract::dyns::DynTransport,
+                Self::Event,
+            > {
+                self.0.all_events()
+            }
+        }
+    };
 }


### PR DESCRIPTION
This PR was re-created from #614 because there were issues on xDAI. The issues were unrelated to the `EventRetrieving` trait and instead caused by issues in the `contracts/build.rs` refactor. That refactor has been reverted in this PR and will be proposed in a follow up change.

This PR addresses comments from the previous PR, specifically:
- Implements a declarative macro to implement `EventRetrieving` for contracts bindings generated by `ethcontract`.
- Removes the `web3()` function from the `EventRetrieving` trait, requiring a `BlockRetrieving` to be passed when constructing event handler

### Test Plan

No logic changes, just refactoring (and moveing small amounts of code around). CI should continue to pass.

