### PR TITLE
Refactor build script to allow arbitrary config extensions

### DIFF
--- a/contracts/build.rs
+++ b/contracts/build.rs
@@ -1,7 +1,6 @@
 use ethcontract::common::DeploymentInformation;
-use ethcontract_generate::{Address, Builder, TransactionHash};
-use maplit::hashmap;
-use std::{collections::HashMap, env, fs, path::Path, str::FromStr};
+use ethcontract_generate::{Address, Builder};
+use std::{env, fs, path::Path};
 
 #[path = "src/paths.rs"]
 mod paths;
@@ -16,67 +15,73 @@ fn main() {
     // - https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
     println!("cargo:rerun-if-changed=build.rs");
 
-    generate_contract("ERC20", hashmap! {});
-    generate_contract("ERC20Mintable", hashmap! {});
-    generate_contract(
-        "UniswapV2Router02",
-        hashmap! {
-            1 => (Address::from_str("7a250d5630B4cF539739dF2C5dAcb4c659F2488D").unwrap(), None),
-            4 => (Address::from_str("7a250d5630B4cF539739dF2C5dAcb4c659F2488D").unwrap(), None),
-            100 => (Address::from_str("1C232F01118CB8B424793ae03F870aa7D0ac7f77").unwrap(), None),
-        },
-    );
-    generate_contract(
-        "UniswapV2Factory",
-        hashmap! {
-            1 => (Address::from_str("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f").unwrap(), None),
-            4 => (Address::from_str("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f").unwrap(), None),
-            100 => (Address::from_str("A818b4F111Ccac7AA31D0BCc0806d64F2E0737D7").unwrap(), None),
-        },
-    );
-    generate_contract("UniswapV2Pair", hashmap! {});
+    generate_contract("ERC20");
+    generate_contract("ERC20Mintable");
+    generate_contract_with_config("UniswapV2Router02", |builder| {
+        builder
+            .add_deployment_str(1, "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D")
+            .add_deployment_str(4, "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D")
+            .add_deployment_str(100, "0x1C232F01118CB8B424793ae03F870aa7D0ac7f77")
+    });
+    generate_contract_with_config("UniswapV2Factory", |builder| {
+        builder
+            .add_deployment_str(1, "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f")
+            .add_deployment_str(4, "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f")
+            .add_deployment_str(100, "0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7")
+    });
+    generate_contract("UniswapV2Pair");
     // This is done to have a common interface for Sushiswap, Uniswap & Honeyswap
-    generate_contract("IUniswapLikeRouter", hashmap! {});
-    generate_contract("IUniswapLikePair", hashmap! {});
-    generate_contract(
-        "SushiswapV2Router02",
-        hashmap! {
-            1 => (Address::from_str("d9e1cE17f2641f24aE83637ab66a2cca9C378B9F").unwrap(), None),
-            4 => (Address::from_str("1b02dA8Cb0d097eB8D57A175b88c7D8b47997506").unwrap(), None),
-            100 => (Address::from_str("1b02dA8Cb0d097eB8D57A175b88c7D8b47997506").unwrap(), None),
-        },
-    );
-    generate_contract(
-        "SushiswapV2Factory",
-        hashmap! {
-            1 => (Address::from_str("C0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac").unwrap(), None),
-            4 => (Address::from_str("c35DADB65012eC5796536bD9864eD8773aBc74C4").unwrap(), None),
-            100 => (Address::from_str("c35DADB65012eC5796536bD9864eD8773aBc74C4").unwrap(), None),
-        },
-    );
-    generate_contract("SushiswapV2Pair", hashmap! {});
-    generate_contract(
-        "GPv2Settlement",
-        hashmap! {
-            1 => (Address::from_str("0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf").unwrap(), Some("0x34b7f9a340e663df934fcc662b3ec5fcd7cd0c93d3c46f8ce612e94fff803909".parse().unwrap())),
-            4 => (Address::from_str("0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf").unwrap(), Some("0x52badda922fd91052e6682d125daa59dea3ce5c57add5a9d362bec2d6ccfd2b1".parse().unwrap())),
-            100 => (Address::from_str("0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf").unwrap(), Some("0x95bbefbca7162435eeb71bac6960aae4d7112abce87a51ad3952d7b7af0279e3".parse().unwrap())),
-        },
-    );
-    generate_contract("GPv2AllowListAuthentication", hashmap! {});
-    generate_contract(
-        "WETH9",
-        hashmap! {
-            // Rinkeby & Mainnet Addresses are part of the artefact
-            100 => (Address::from_str("e91D153E0b41518A2Ce8Dd3D7944Fa863463a97d").unwrap(), None),
-        },
-    );
+    generate_contract("IUniswapLikeRouter");
+    generate_contract("IUniswapLikePair");
+    generate_contract_with_config("SushiswapV2Router02", |builder| {
+        builder
+            .add_deployment_str(1, "0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F")
+            .add_deployment_str(4, "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506")
+            .add_deployment_str(100, "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506")
+    });
+    generate_contract_with_config("SushiswapV2Factory", |builder| {
+        builder
+            .add_deployment_str(1, "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac")
+            .add_deployment_str(4, "0xc35DADB65012eC5796536bD9864eD8773aBc74C4")
+            .add_deployment_str(100, "0xc35DADB65012eC5796536bD9864eD8773aBc74C4")
+    });
+    generate_contract("SushiswapV2Pair");
+    generate_contract_with_config("GPv2Settlement", |builder| {
+        builder
+            .with_contract_mod_override(Some("gpv2_settlement"))
+            .add_deployment(
+                1,
+                addr("0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf"),
+                Some(tx(
+                    "0x34b7f9a340e663df934fcc662b3ec5fcd7cd0c93d3c46f8ce612e94fff803909",
+                )),
+            )
+            .add_deployment(
+                4,
+                addr("0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf"),
+                Some(tx(
+                    "0x52badda922fd91052e6682d125daa59dea3ce5c57add5a9d362bec2d6ccfd2b1",
+                )),
+            )
+            .add_deployment(
+                100,
+                addr("0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf"),
+                Some(tx(
+                    "0x95bbefbca7162435eeb71bac6960aae4d7112abce87a51ad3952d7b7af0279e3",
+                )),
+            )
+    });
+    generate_contract("GPv2AllowListAuthentication");
+    generate_contract_with_config("WETH9", |builder| {
+        builder.add_deployment_str(100, "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d")
+    });
 }
 
-fn generate_contract(
-    name: &str,
-    deployment_overrides: HashMap<u32, (Address, Option<TransactionHash>)>,
-) {
+fn generate_contract(name: &str) {
+    generate_contract_with_config(name, |builder| builder)
+}
+
+fn generate_contract_with_config(name: &str, config: impl FnOnce(Builder) -> Builder) {
     let artifact = paths::contract_artifacts_dir().join(format!("{}.json", name));
     let address_file = paths::contract_address_file(name);
     let dest = env::var("OUT_DIR").unwrap();
@@ -93,17 +98,17 @@ fn generate_contract(
         builder = builder.add_deployment_str(5777, address.trim());
     }
 
-    for (network_id, (address, transaction_hash)) in deployment_overrides.into_iter() {
-        builder = builder.add_deployment(
-            network_id,
-            address,
-            transaction_hash.map(DeploymentInformation::TransactionHash),
-        );
-    }
-
-    builder
+    config(builder)
         .generate()
         .unwrap()
         .write_to_file(Path::new(&dest).join(format!("{}.rs", name)))
         .unwrap();
+}
+
+fn addr(s: &str) -> Address {
+    s.parse().unwrap()
+}
+
+fn tx(s: &str) -> DeploymentInformation {
+    DeploymentInformation::TransactionHash(s.parse().unwrap())
 }

--- a/contracts/build.rs
+++ b/contracts/build.rs
@@ -73,6 +73,7 @@ fn main() {
     });
     generate_contract("GPv2AllowListAuthentication");
     generate_contract_with_config("WETH9", |builder| {
+        // Rinkeby & Mainnet Addresses are part of the artefact
         builder.add_deployment_str(100, "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d")
     });
 }

--- a/orderbook/src/database/events.rs
+++ b/orderbook/src/database/events.rs
@@ -1,7 +1,7 @@
 use super::Database;
 use crate::conversions::*;
 use anyhow::{anyhow, Context, Result};
-use contracts::g_pv_2_settlement::{
+use contracts::gpv2_settlement::{
     event_data::{
         OrderInvalidated as ContractInvalidation, Settlement as ContractSettlement,
         Trade as ContractTrade,

--- a/orderbook/src/event_updater.rs
+++ b/orderbook/src/event_updater.rs
@@ -1,7 +1,7 @@
 use crate::database::Database;
 use anyhow::{Context, Result};
 use contracts::{
-    g_pv_2_settlement::{self, Event as ContractEvent},
+    gpv2_settlement::{self, Event as ContractEvent},
     GPv2Settlement,
 };
 use ethcontract::{dyns::DynWeb3, Event};
@@ -65,7 +65,7 @@ impl EventStoring<ContractEvent> for Database {
 }
 
 impl_event_retrieving! {
-    pub GPv2SettlementContract for g_pv_2_settlement
+    pub GPv2SettlementContract for gpv2_settlement
 }
 
 impl EventUpdater {


### PR DESCRIPTION
This PR refactors the build script to allow arbitrary builder configuration overrides per contract.

This allows us to generate code for the `GPv2Settlement` contract in a `gpv2_settlement` module (instead of the automatically configured `g_pv_2_settlement` module).

### Test Plan

More careful review :see_no_evil:. Shouldn't bring down staging.

Run the solver on xDAI and make sure it doesn't crash anymore:
```
$ cargo run -q -p solver -- --node-url https://rpc.xdaichain.com
2021-05-20T09:07:14.423Z  INFO solver: running solver with Arguments { ... }
2021-05-20T09:07:16.386Z  INFO shared::metrics: serving metrics address=0.0.0.0:9587
2021-05-20T09:07:16.386Z DEBUG solver::driver: starting single run
2021-05-20T09:07:16.528Z DEBUG solver::liquidity_collector: got 0 orders
2021-05-20T09:07:16.528Z DEBUG solver::liquidity_collector: got 0 AMMs
2021-05-20T09:07:16.827Z DEBUG solver::driver: solving with gas price of 20000000000
2021-05-20T09:07:16.828Z  INFO solver::driver: 0 settlements passed simulation and 0 failed
2021-05-20T09:07:16.828Z DEBUG solver::driver: single run finished ok
```
