### PR TITLE
Remove FilteredPoolFetcher

### DIFF
--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -15,7 +15,7 @@ use prometheus::Registry;
 use shared::{
     current_block::{current_block_stream, CurrentBlockStream},
     pool_aggregating::{self, PoolAggregator},
-    pool_fetching::{CachedPoolFetcher, FilteredPoolFetcher},
+    pool_fetching::CachedPoolFetcher,
     price_estimate::BaselinePriceEstimator,
     transport::LoggingTransport,
 };
@@ -178,10 +178,8 @@ async fn main() {
         pool_aggregating::pair_providers(&args.shared.baseline_sources, chain_id, &web3).await;
 
     let pool_aggregator = PoolAggregator::from_providers(&pair_providers, &web3).await;
-    let cached_pool_fetcher =
-        CachedPoolFetcher::new(Box::new(pool_aggregator), current_block_stream.clone());
     let pool_fetcher =
-        FilteredPoolFetcher::new(Box::new(cached_pool_fetcher), unsupported_tokens.clone());
+        CachedPoolFetcher::new(Box::new(pool_aggregator), current_block_stream.clone());
 
     let price_estimator = Arc::new(BaselinePriceEstimator::new(
         Box::new(pool_fetcher),

--- a/shared/src/pool_fetching.rs
+++ b/shared/src/pool_fetching.rs
@@ -23,31 +23,6 @@ pub trait PoolFetching: Send + Sync {
     async fn fetch(&self, token_pairs: HashSet<TokenPair>) -> Vec<Pool>;
 }
 
-pub struct FilteredPoolFetcher {
-    inner: Box<dyn PoolFetching>,
-    unsupported_tokens: HashSet<H160>,
-}
-
-impl FilteredPoolFetcher {
-    pub fn new(inner: Box<dyn PoolFetching>, unsupported_tokens: HashSet<H160>) -> Self {
-        Self {
-            inner,
-            unsupported_tokens,
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl PoolFetching for FilteredPoolFetcher {
-    async fn fetch(&self, token_pairs: HashSet<TokenPair>) -> Vec<Pool> {
-        let filtered_pairs = token_pairs
-            .into_iter()
-            .filter(|pair| !self.unsupported_tokens.iter().any(|t| pair.contains(t)))
-            .collect();
-        self.inner.fetch(filtered_pairs).await
-    }
-}
-
 #[derive(Clone, Hash, PartialEq, Debug)]
 pub struct Pool {
     pub tokens: TokenPair,


### PR DESCRIPTION
The main component (PriceEstimator) using the pool fetcher already
checks for deny listed tokens so there is no need for it anymore.

The other use is for fetching uniswap liquidity in the driver in
solver/src/liquidity/uniswap.rs:82 which is fine too as we only consider
base_tokens as path candidates and the original orders have already been
filtered by the order book.

This came up in #618  . I think the historical reason for the filtered pool fetcher is that it used to be the only place where we filtered unsupported tokens and eventually we introduced the filtering directly into price estimator and fee calculation.

### Test Plan
adapted test