### PR TITLE
Update price stream logic and pass in cap as command line arg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2989,7 +2989,7 @@ dependencies = [
 [[package]]
 name = "transaction-retry"
 version = "0.1.0"
-source = "git+https://github.com/gnosis/gp-transaction-retry.git?tag=v0.1.0#31b32869dbc773d62c11e91dac4d66aaa691faa2"
+source = "git+https://github.com/gnosis/gp-transaction-retry.git?tag=v0.1.1#6c94d9d2e2a8314f85b5aec4ca0a96185110bd98"
 dependencies = [
  "async-trait",
  "futures",

--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -179,6 +179,7 @@ async fn onchain_settlement(web3: Web3) {
         network_id,
         1,
         Duration::from_secs(30),
+        f64::MAX,
         None,
     );
     driver.single_run().await.unwrap();

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -180,6 +180,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         network_id,
         1,
         Duration::from_secs(10),
+        f64::MAX,
         Some(market_makable_token_list),
     );
     driver.single_run().await.unwrap();

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -74,3 +74,8 @@ pub fn duration_from_seconds(s: &str) -> Result<Duration, ParseFloatError> {
 pub fn wei_from_base_unit(s: &str) -> anyhow::Result<U256> {
     Ok(U256::from_dec_str(s)? * U256::exp10(18))
 }
+
+pub fn wei_from_gwei(s: &str) -> anyhow::Result<f64> {
+    let in_gwei: f64 = s.parse()?;
+    Ok(in_gwei * 10e9)
+}

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -20,7 +20,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 contracts = { path = "../contracts" }
 ethcontract = { version = "0.11", default-features = false }
 futures = "0.3"
-transaction-retry = { git = "https://github.com/gnosis/gp-transaction-retry.git", tag = "v0.1.0" }
+transaction-retry = { git = "https://github.com/gnosis/gp-transaction-retry.git", tag = "v0.1.1" }
 gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.1", features = ["web3_"] }
 hex = "0.4"
 hex-literal = "0.3"

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -27,10 +27,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-// There is no economic viability calculation yet so we're using an arbitrary very high cap to
-// protect against a gas estimator giving bogus results that would drain all our funds.
-const GAS_PRICE_CAP: f64 = 500e9;
-
 pub struct Driver {
     settlement_contract: GPv2Settlement,
     liquidity_collector: LiquidityCollector,
@@ -46,6 +42,7 @@ pub struct Driver {
     network_id: String,
     max_merged_settlements: usize,
     solver_time_limit: Duration,
+    gas_price_cap: f64,
     market_makable_token_list: Option<TokenList>,
 }
 impl Driver {
@@ -65,6 +62,7 @@ impl Driver {
         network_id: String,
         max_merged_settlements: usize,
         solver_time_limit: Duration,
+        gas_price_cap: f64,
         market_makable_token_list: Option<TokenList>,
     ) -> Self {
         Self {
@@ -82,6 +80,7 @@ impl Driver {
             network_id,
             max_merged_settlements,
             solver_time_limit,
+            gas_price_cap,
             market_makable_token_list,
         }
     }
@@ -131,7 +130,7 @@ impl Driver {
             &self.settlement_contract,
             self.gas_price_estimator.as_ref(),
             self.target_confirm_time,
-            GAS_PRICE_CAP,
+            self.gas_price_cap,
             rated_settlement,
         )
         .await

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -127,6 +127,15 @@ struct Arguments {
         default_value = "https://tokens.coingecko.com/uniswap/all.json"
     )]
     market_makable_token_list: String,
+
+    /// The maximum gas price the solver is willing to pay in a settlement
+    #[structopt(
+        long,
+        env = "GAS_PRICE_CAP_GWEI",
+        default_value = "1500",
+        parse(try_from_str = shared::arguments::wei_from_gwei)
+    )]
+    gas_price_cap: f64,
 }
 
 #[tokio::main]
@@ -244,6 +253,7 @@ async fn main() {
         network_id,
         args.max_merged_settlements,
         args.solver_time_limit,
+        args.gas_price_cap,
         market_makable_token_list,
     );
 


### PR DESCRIPTION
Fixes #617 by updating to the latest version of dependency and allowing to configure gas price cap via command line (default being 1500 gwei)

### Test Plan
CI
