### PR TITLE
Pass fixed block number into liquidity fetcher

### DIFF
--- a/shared/src/pool_aggregating.rs
+++ b/shared/src/pool_aggregating.rs
@@ -1,6 +1,7 @@
 use crate::amm_pair_provider::{AmmPairProvider, SushiswapPairProvider, UniswapPairProvider};
 use crate::pool_fetching::{Pool, PoolFetcher, PoolFetching};
 use crate::Web3;
+use ethcontract::BlockNumber;
 use model::TokenPair;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -58,10 +59,10 @@ impl PoolAggregator {
 
 #[async_trait::async_trait]
 impl PoolFetching for PoolAggregator {
-    async fn fetch(&self, token_pairs: HashSet<TokenPair>) -> Vec<Pool> {
+    async fn fetch(&self, token_pairs: HashSet<TokenPair>, at_block: BlockNumber) -> Vec<Pool> {
         let mut pools = vec![];
         for fetcher in self.pool_fetchers.iter() {
-            pools.extend(fetcher.fetch(token_pairs.clone()).await);
+            pools.extend(fetcher.fetch(token_pairs.clone(), at_block).await);
         }
         pools
     }

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -325,7 +325,6 @@ impl Driver {
 
     pub async fn single_run(&mut self) -> Result<()> {
         tracing::debug!("starting single run");
-        let liquidity = self.liquidity_collector.get_liquidity().await?;
         let current_block_during_liquidity_fetch = self
             .web3
             .eth()
@@ -333,6 +332,10 @@ impl Driver {
             .await
             .context("failed to get current block")?
             .as_u64();
+        let liquidity = self
+            .liquidity_collector
+            .get_liquidity(current_block_during_liquidity_fetch.into())
+            .await?;
 
         let estimated_prices =
             collect_estimated_prices(self.price_estimator.as_ref(), self.native_token, &liquidity)

--- a/solver/src/liquidity/uniswap.rs
+++ b/solver/src/liquidity/uniswap.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use contracts::{GPv2Settlement, IUniswapLikeRouter, ERC20};
-use ethcontract::batch::CallBatch;
+use ethcontract::{batch::CallBatch, BlockNumber};
 use primitive_types::{H160, U256};
 use shared::{
     baseline_solver::{path_candidates, token_path_to_pair_path},
@@ -60,6 +60,7 @@ impl UniswapLikeLiquidity {
     pub async fn get_liquidity(
         &self,
         offchain_orders: impl Iterator<Item = &LimitOrder> + Send + Sync,
+        at_block: BlockNumber,
     ) -> Result<Vec<AmmOrder>> {
         let mut pools = HashSet::new();
 
@@ -79,7 +80,7 @@ impl UniswapLikeLiquidity {
 
         let mut tokens = HashSet::new();
         let mut result = Vec::new();
-        for pool in self.pool_fetcher.fetch(pools).await {
+        for pool in self.pool_fetcher.fetch(pools, at_block).await {
             tokens.insert(pool.tokens.get().0);
             tokens.insert(pool.tokens.get().1);
 

--- a/solver/src/liquidity_collector.rs
+++ b/solver/src/liquidity_collector.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use ethcontract::BlockNumber;
 
 use crate::{
     liquidity::uniswap::UniswapLikeLiquidity, liquidity::Liquidity, orderbook::OrderBookApi,
@@ -10,7 +11,7 @@ pub struct LiquidityCollector {
 }
 
 impl LiquidityCollector {
-    pub async fn get_liquidity(&self) -> Result<Vec<Liquidity>> {
+    pub async fn get_liquidity(&self, at_block: BlockNumber) -> Result<Vec<Liquidity>> {
         let limit_orders = self
             .orderbook_api
             .get_liquidity()
@@ -22,7 +23,7 @@ impl LiquidityCollector {
         for liquidity in self.uniswap_like_liquidity.iter() {
             amms.extend(
                 liquidity
-                    .get_liquidity(limit_orders.iter())
+                    .get_liquidity(limit_orders.iter(), at_block)
                     .await
                     .context("failed to get pool")?,
             );


### PR DESCRIPTION
Fixes #545

Some of the alerts regarding settlements that failed both on the Latest block as well as on the block that liquidity was fetched are incorrect, because we don't enforce that liquidity is actually fully fetched on a given block. It is possible that e.g. Uniswap pools are fetched on block t and Sushiswap pools on block t+1.

As we add more Baseline Liquidity sources the chance for seeing inconsistent state increases.

This PR makes it so that we can "fix" a BlockNumber into our liquidity fetcher to make sure at least the baseline solver is working only with state that comes from one coherent block. Technically we could still run into issues with reorgs, but I'm not sure there is something we can do about.

Theoretically we should also fetch the off-chain orderbook at a specific block (so that balance checks, etc are in line with the remaining path finding). We can add that if we see failures with regards to that.

### Test Plan
CI as this is mainly just propagating a new argument into all implementations of the PoolFetching trait.
