### PR TITLE
Make caching pool fetcher block aware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,6 +1345,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,6 +2455,7 @@ dependencies = [
  "futures",
  "gas-estimation",
  "hex-literal",
+ "lru",
  "maplit",
  "mockall",
  "model",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -15,6 +15,7 @@ ethcontract = { version = "0.11", default-features = false }
 futures = "0.3"
 gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.2", features = ["web3_"] }
 hex-literal = "0.3"
+lru = "0.6"
 maplit = "1.0"
 model = { path = "../model" }
 num = "0.4"

--- a/shared/src/pool_fetching.rs
+++ b/shared/src/pool_fetching.rs
@@ -220,7 +220,7 @@ impl CachedPoolFetcher {
     ) -> Vec<Pool> {
         let mut cache = self.cache.lock().await;
         let block: Block = at_block.into();
-        let mut cached_pools = cache.pools.pop(&block).unwrap_or_else(|| HashMap::new());
+        let mut cached_pools = cache.pools.pop(&block).unwrap_or_else(HashMap::new);
 
         let (cache_hits, cache_misses) = token_pairs
             .into_iter()


### PR DESCRIPTION
Following up un #626 the caching pool fetcher should now differentiate at what block its information was fetched (and not e.g. return the Latest state when queried for a past block).

This is achieved by allowing it to store cached pool information for multiple blocks (stored in an LRU cache).

### Test Plan
Added a unit test
