### PR TITLE
[Trivial] Make volume filtering solver use it's inner name

### DIFF
--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -179,6 +179,10 @@ impl<S: Solver + Send + Sync> Solver for SellVolumeFilteringSolver<S> {
         );
         self.inner.solve(filtered_liquidity, gas_price).await
     }
+
+    fn name(&self) -> &'static str {
+        self.inner.name()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
To make it more readable in the metrics:

![image](https://user-images.githubusercontent.com/1200333/118995383-63bd3580-b987-11eb-866c-0ec55483edf0.png)


### Test Plan
🤷 
