### PR TITLE
Fix cached pool fetcher

### DIFF
--- a/shared/src/pool_fetching.rs
+++ b/shared/src/pool_fetching.rs
@@ -165,10 +165,12 @@ impl BaselineSolvable for Pool {
     }
 }
 
+type TokenPoolsMap = HashMap<TokenPair, Vec<Pool>>;
+
 // Read though Pool Fetcher that keeps previously fetched pools in a cache, which get invalidated whenever there is a new block
 pub struct CachedPoolFetcher {
     inner: Box<dyn PoolFetching>,
-    cache: Arc<Mutex<(Block, HashMap<TokenPair, Vec<Pool>>)>>,
+    cache: Arc<Mutex<(Block, TokenPoolsMap)>>,
     block_stream: CurrentBlockStream,
 }
 

--- a/shared/src/pool_fetching.rs
+++ b/shared/src/pool_fetching.rs
@@ -168,7 +168,7 @@ impl BaselineSolvable for Pool {
 // Read though Pool Fetcher that keeps previously fetched pools in a cache, which get invalidated whenever there is a new block
 pub struct CachedPoolFetcher {
     inner: Box<dyn PoolFetching>,
-    cache: Arc<Mutex<(Block, HashMap<TokenPair, Pool>)>>,
+    cache: Arc<Mutex<(Block, HashMap<TokenPair, Vec<Pool>>)>>,
     block_stream: CurrentBlockStream,
 }
 
@@ -189,12 +189,13 @@ impl CachedPoolFetcher {
         let cache_results: Vec<_> = cache_hits
             .iter()
             .filter_map(|pair| cache.1.get(pair))
+            .flatten()
             .cloned()
             .collect();
 
         let mut inner_results = self.inner.fetch(cache_misses).await;
         for miss in &inner_results {
-            cache.1.insert(miss.tokens, miss.clone());
+            cache.1.entry(miss.tokens).or_default().push(miss.clone());
         }
         inner_results.extend(cache_results);
         inner_results
@@ -410,7 +411,10 @@ mod tests {
         let token_b = H160::from_low_u64_be(2);
         let pair = TokenPair::new(token_a, token_b).unwrap();
 
-        let pools = Arc::new(Mutex::new(vec![Pool::uniswap(pair, (1, 1))]));
+        let pools = Arc::new(Mutex::new(vec![
+            Pool::uniswap(pair, (1, 1)),
+            Pool::uniswap(pair, (2, 2)),
+        ]));
 
         let current_block = Arc::new(std::sync::Mutex::new(Block::default()));
 
@@ -423,14 +427,14 @@ mod tests {
         // Read Through
         assert_eq!(
             instance.fetch(hashset!(pair)).await,
-            vec![Pool::uniswap(pair, (1, 1))]
+            vec![Pool::uniswap(pair, (1, 1)), Pool::uniswap(pair, (2, 2))]
         );
 
         // clear inner to test caching
         pools.lock().await.clear();
         assert_eq!(
             instance.fetch(hashset!(pair)).await,
-            vec![Pool::uniswap(pair, (1, 1))]
+            vec![Pool::uniswap(pair, (1, 1)), Pool::uniswap(pair, (2, 2)),]
         );
 
         // invalidate cache


### PR DESCRIPTION
Fixes #632

The CachedPoolFetcher was only caching a single pool per token pair even if multiple pools were fetched by inner. Components relying ont he Cache (e.g. the price estimate) would therefore only get a single pool on cache hits leading to suboptimal price estimates.

### Test Plan
Adjusted the unit test (failed before this change) and made sure we are now getting the best Uniswap price when trying to sell 100 WETH for UNI:

http://localhost:8080/api/v1/markets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2-0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/sell/99995000000000000000

And the best Sushiswap price when trying to sell 100 WETH for SUSHI

http://localhost:8080/api/v1/markets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2-0x6B3595068778DD592e39A122f4f5a5cF09C90fE2/sell/99992840000000000000

Compared to expected values by using https://swap.archerdao.io/#/swap
