### PR TITLE
Fix nonce too low error

### DIFF
--- a/solver/src/settlement_submission/retry.rs
+++ b/solver/src/settlement_submission/retry.rs
@@ -103,11 +103,17 @@ mod tests {
 
     #[test]
     fn test_submission_result_was_mined() {
-        let transaction_error = ExecutionError::Web3(Web3Error::Rpc(RpcError {
+        let transaction_error_open_ethereum = ExecutionError::Web3(Web3Error::Rpc(RpcError {
             code: ErrorCode::from(-32010),
             message: "".into(),
             data: None,
         }));
+        let transaction_error_geth = ExecutionError::Web3(Web3Error::Rpc(RpcError {
+            code: ErrorCode::from(-32000),
+            message: "nonce too low".into(),
+            data: None,
+        }));
+
         let result = SettleResult(Ok(()));
         assert!(result.was_mined());
 
@@ -117,7 +123,16 @@ mod tests {
         )));
         assert!(result.was_mined());
 
-        let result = SettleResult(Err(MethodError::from_parts("".into(), transaction_error)));
+        let result = SettleResult(Err(MethodError::from_parts(
+            "".into(),
+            transaction_error_open_ethereum,
+        )));
+        assert!(!result.was_mined());
+
+        let result = SettleResult(Err(MethodError::from_parts(
+            "".into(),
+            transaction_error_geth,
+        )));
         assert!(!result.was_mined());
     }
 


### PR DESCRIPTION
Looking at the logs we can see that these logs are benign race conditions when we try to resubmit a transaction with a higher gas price but it got mined at the old gas price in the meantime (in this case reusing the same nonce is invalid)

E.g. https://logs.gnosis.io/goto/e9a936cc179067417b7853c06ac733ed

```
2021-05-21T09:29:31.941Z ERROR solver::driver: Failed to submit settlement: settlement transaction failed
  Caused by:
    ...
    1: web3 error: RPC error: Error { code: ServerError(-32000), message: "nonce too low", data: None }
2021-05-21T09:29:31.455Z DEBUG shared::transport: [id:1340150] sending request: '{"jsonrpc":"2.0","method":"eth_sendRawTransaction" ...}'
...
2021-05-21T09:29:31.452Z  INFO solver::settlement_submission::retry: submitting solution transaction at gas price 56624999873
...
2021-05-21T09:29:16.246Z DEBUG shared::transport: [id:1340144] received response: '"0x2621b58bea6099f34341ef64d1fe29fd44afd7c9b8d0db057750478fd10ca495"'
2021-05-21T09:29:16.125Z DEBUG shared::transport: [id:1340144] sending request: '{"jsonrpc":"2.0","method":"eth_sendRawTransaction" ...}'
2021-05-21T09:29:16.122Z  INFO solver::settlement_submission::retry: submitting solution transaction at gas price 50333333219.55556
```

And https://etherscan.io/tx/0x2621b58bea6099f34341ef64d1fe29fd44afd7c9b8d0db057750478fd10ca495 was the mined transaction

This started happening after switching to geth, because for OpenEthereum nodes we were correctly classifying these errors as benign. The fix therefore is to add correct geth classification.

I'm not entirely sure if this is the best way, because geth uses a very generic default error code and it's not clear that this might not miss some real errors. We could also match on the error message "nonce too low" however this feels a bit more brittle overall.

### Test Plan
Adjusted unit test. Hard to test in real life because this relies on race conditions happening.
