### PR TITLE
Don't use deny list in driver

### DIFF
--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -12,6 +12,7 @@ use orderbook::{
     orderbook::Orderbook,
     serve_task, verify_deployed_contract_constants,
 };
+use primitive_types::H160;
 use prometheus::Registry;
 use shared::{
     bad_token::{
@@ -77,6 +78,15 @@ struct Arguments {
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
     token_quality_cache_expiry: Duration,
+
+    /// List of token addresses to be ignored throughout service
+    #[structopt(long, env = "UNSUPPORTED_TOKENS", use_delimiter = true)]
+    pub unsupported_tokens: Vec<H160>,
+
+    /// List of token addresses that shoud be allowed regardless of whether the bad token detector
+    /// thinks they are bad. Base tokens are automatically allowed.
+    #[structopt(long, env = "ALLOWED_TOKENS", use_delimiter = true)]
+    pub allowed_tokens: Vec<H160>,
 }
 
 pub async fn database_metrics(metrics: Arc<Metrics>, database: Database) -> ! {
@@ -160,10 +170,10 @@ async fn main() {
     let mut base_tokens = HashSet::from_iter(args.shared.base_tokens);
     // We should always use the native token as a base token.
     base_tokens.insert(native_token.address());
-    let mut allowed_tokens = args.shared.allowed_tokens;
+    let mut allowed_tokens = args.allowed_tokens;
     allowed_tokens.extend(base_tokens.iter().copied());
     allowed_tokens.push(BUY_ETH_ADDRESS);
-    let unsupported_tokens = args.shared.unsupported_tokens;
+    let unsupported_tokens = args.unsupported_tokens;
 
     let trace_call_detector = TraceCallDetector {
         web3: web3.clone(),

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -47,15 +47,6 @@ pub struct Arguments {
     #[structopt(long, env = "BASE_TOKENS", use_delimiter = true)]
     pub base_tokens: Vec<H160>,
 
-    /// List of token addresses to be ignored throughout service
-    #[structopt(long, env = "UNSUPPORTED_TOKENS", use_delimiter = true)]
-    pub unsupported_tokens: Vec<H160>,
-
-    /// List of token addresses that shoud be allowed regardless of whether the bad token detector
-    /// thinks they are bad. Base tokens are automatically allowed.
-    #[structopt(long, env = "ALLOWED_TOKENS", use_delimiter = true)]
-    pub allowed_tokens: Vec<H160>,
-
     /// Fee discount factor: 1 means no discount, 0.9 means 10% discount.
     #[structopt(long, env = "FEE_DISCOUNT_FACTOR", default_value = "1")]
     pub fee_discount_factor: f64,

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -205,6 +205,7 @@ async fn main() {
         Box::new(pool_aggregator),
         gas_price_estimator.clone(),
         base_tokens.clone(),
+        // Order book already filters bad tokens
         Arc::new(ListBasedDetector::deny_list(Vec::new())),
         native_token_contract.address(),
     ));

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -200,12 +200,12 @@ async fn main() {
 
     let pool_aggregator = PoolAggregator::from_providers(&pair_providers, &web3).await;
 
-    // TODO - use Filtered-Cached PoolFetchers here too.
+    // TODO: use caching pool fetcher
     let price_estimator = Arc::new(BaselinePriceEstimator::new(
         Box::new(pool_aggregator),
         gas_price_estimator.clone(),
         base_tokens.clone(),
-        Arc::new(ListBasedDetector::deny_list(args.shared.unsupported_tokens)),
+        Arc::new(ListBasedDetector::deny_list(Vec::new())),
         native_token_contract.address(),
     ));
     let uniswap_like_liquidity = build_amm_artifacts(


### PR DESCRIPTION
The deny list is only needed for the order book. To avoid confusion
let's not use it in the driver at all.

This came up on the staging config update to clear the deny listed tokens.

### Test Plan
existing tests, shouldn't affect anything
