### PR TITLE
No longer escape complexity level

### DIFF
--- a/solver/src/oneinch_solver/api.rs
+++ b/solver/src/oneinch_solver/api.rs
@@ -127,9 +127,8 @@ impl SwapQuery {
                 .append_pair("disableEstimate", &disable_estimate.to_string());
         }
         if let Some(complexity_level) = self.complexity_level {
-            // complexity level needs to be encoded as a string despite being an in (https://docs.1inch.io/api/quote-swap)
             url.query_pairs_mut()
-                .append_pair("complexityLevel", &format!("'{}'", complexity_level));
+                .append_pair("complexityLevel", &complexity_level.to_string());
         }
         if let Some(gas_limit) = self.gas_limit {
             url.query_pairs_mut()
@@ -357,7 +356,7 @@ mod tests {
                 &fromAddress=0x00000000219ab540356cbb839cbe05303d7705fa\
                 &slippage=0.5\
                 &disableEstimate=true\
-                &complexityLevel=%271%27\
+                &complexityLevel=1\
                 &gasLimit=133700\
                 &mainRouteParts=28\
                 &parts=42",


### PR DESCRIPTION
This PR removes the string escaping from the 1Inch API call.

I'm not 100% sure which one it should be, but my unscientific testing suggests that escaping is not only not necessary, but makes it so the parameter is ignored:

```bash
#!/usr/bin/env bash

swap () {
  url="https://api.1inch.exchange/v3.0/1/quote?fromTokenAddress=0x6810e776880c02933d47db1b9fc05908e5386b96&toTokenAddress=0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2&amount=10000000000000000000000$1"
  curl -s \
    -X GET \
    -H  "accept: application/json" \
    "$url" \
    | jq -r ".estimatedGas"
}

base_line=$(swap)
for n in $(seq 0 3); do
  for p in $n "%22$n%22" "%27$n%27"; do
    ext="&complexityLevel=$p"
    result="$(swap $ext)"
    echo "### $p"
    diff <(echo $base_line) <(echo $result)
  done
done
```

Executing this, only "unescaped" integers ever produce different results than omitting the parameter altogether:
```
### 0
### %220%22
### %270%27
### 1
1c1
< 1863546
---
> 1512574
### %221%22
### %271%27
### 2
### %222%22
### %272%27
### 3
1c1
< 1863546
---
> 2052969
### %223%22
### %273%27
```

To me, this suggests that the escaping here is not working as intended. Additionally, the 1Inch documentation and swagger page both suggest that this shouldn't escaped.

### Test Plan

:point_up: 
