### PR TITLE
[Trivial] inconsistency in runtime arguments

### DIFF
--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -124,7 +124,7 @@ struct Arguments {
     /// without external liquidity
     #[structopt(
         long,
-        env = "MARKET_MAKEABLE_TOKEN_LIST",
+        env = "MARKET_MAKABLE_TOKEN_LIST",
         default_value = "https://tokens.coingecko.com/uniswap/all.json"
     )]
     market_makable_token_list: String,


### PR DESCRIPTION
Not sure how much this matters, but the capitalized name was different with the argument name. Given that neither spellings are actually real words I chose the one I thought looked more appealing.
