### PR TITLE
Benchmark API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.DS_Store
+
 /target
 /.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,6 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
- "futures",
  "itertools 0.10.0",
  "lazy_static",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,6 @@ dependencies = [
  "contracts",
  "criterion",
  "ethcontract",
- "futures",
  "hex-literal",
  "lazy_static",
  "maplit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "bstr"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "buf_redux"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +283,15 @@ dependencies = [
  "semver-parser",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "cast"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57cdfa5d50aad6cb4d44dcab6101a7f79925bd59d82ca42f38a9856a28865374"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -359,6 +380,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
+name = "criterion"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "futures",
+ "itertools 0.10.0",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+dependencies = [
+ "cast",
+ "itertools 0.9.0",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +424,31 @@ checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60ab4a8dba064f2fbb5aa270c28da5cf4bbd0e72dae1140a6b0353a779dbe00"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "loom",
+ "memoffset",
+ "scopeguard",
 ]
 
 [[package]]
@@ -403,6 +486,28 @@ checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -519,13 +624,16 @@ name = "e2e"
 version = "1.0.0"
 dependencies = [
  "contracts",
+ "criterion",
  "ethcontract",
+ "futures",
  "hex-literal",
  "lazy_static",
  "maplit",
  "model",
  "orderbook",
  "prometheus",
+ "rand 0.8.3",
  "reqwest",
  "secp256k1",
  "serde_json",
@@ -915,6 +1023,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061d3be1afec479d56fa3bd182bf966c7999ec175fcfdb87ac14d417241366c6"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +1092,12 @@ dependencies = [
  "tracing",
  "tracing-futures",
 ]
+
+[[package]]
+name = "half"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hashbrown"
@@ -1238,6 +1365,15 @@ checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
@@ -1253,9 +1389,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.46"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1345,6 +1481,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27a6650b2f722ae8c0e2ebc46d07f80c9923464fc206d962332f1eff83143530"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
+]
+
+[[package]]
 name = "lru"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,6 +1537,15 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "memoffset"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1681,6 +1837,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,6 +2035,34 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "plotters"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07fffcddc1cb3a1de753caa4e4df03b79922ba43cf882acc1bdd7e8df9f4590"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38a02e23bd9604b842a812063aec4ef702b57989c37b655254bb61c471ad211"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -2097,6 +2287,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,6 +2422,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,6 +2447,15 @@ name = "safemem"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2313,6 +2546,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -2512,7 +2755,7 @@ dependencies = [
  "gas-estimation",
  "hex",
  "hex-literal",
- "itertools",
+ "itertools 0.10.0",
  "jsonrpc-core",
  "maplit",
  "mockall",
@@ -2808,6 +3051,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3176,6 +3429,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3226,9 +3490,9 @@ checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.69"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3238,9 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.69"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3265,9 +3529,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.69"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3275,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.69"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3288,15 +3552,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.69"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.46"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -5,16 +5,23 @@ authors = ["Gnosis Developers <developers@gnosis.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 
+[[bench]]
+name = "bench"
+harness = false
+
 [dev-dependencies]
 contracts = { path = "../contracts" }
+criterion = { version = "0.3", features = ["async_futures"] }
 ethcontract = { version = "0.11",  default-features = false, features = ["http"] }
+futures = "0.3"
 hex-literal = "0.3"
 lazy_static = "1.4"
 maplit = "1.0"
 model = { path = "../model" }
 orderbook = { path = "../orderbook" }
 prometheus = "0.12"
-reqwest = "0.10"
+rand = "0.8"
+reqwest = { version = "0.10", features = ["blocking"] }
 secp256k1 = "0.20"
 serde_json = "1.0"
 shared = { path = "../shared" }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -13,7 +13,6 @@ harness = false
 contracts = { path = "../contracts" }
 criterion = { version = "0.3", features = ["async_futures"] }
 ethcontract = { version = "0.11",  default-features = false, features = ["http"] }
-futures = "0.3"
 hex-literal = "0.3"
 lazy_static = "1.4"
 maplit = "1.0"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -11,7 +11,7 @@ harness = false
 
 [dev-dependencies]
 contracts = { path = "../contracts" }
-criterion = { version = "0.3", features = ["async_futures"] }
+criterion = "0.3"
 ethcontract = { version = "0.11",  default-features = false, features = ["http"] }
 hex-literal = "0.3"
 lazy_static = "1.4"

--- a/e2e/benches/bench.rs
+++ b/e2e/benches/bench.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use criterion::async_executor::FuturesExecutor;
 use criterion::{criterion_group, criterion_main, Criterion};
 use ethcontract::U256;
 use rand::seq::SliceRandom as _;
@@ -20,13 +19,12 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     group
         .measurement_time(Duration::from_secs(300))
         .bench_function("Estimate Price", |b| {
-            b.to_async(FuturesExecutor)
-                .iter(|| estimate_fee_and_price_estimate(&token_list));
+            b.iter(|| estimate_fee_and_price_estimate(&token_list));
         });
     group.finish();
 }
 
-async fn estimate_fee_and_price_estimate(token_list: &TokenList) {
+fn estimate_fee_and_price_estimate(token_list: &TokenList) {
     let mut rng = rand::thread_rng();
     let base_token = token_list
         .all()

--- a/e2e/benches/bench.rs
+++ b/e2e/benches/bench.rs
@@ -1,0 +1,67 @@
+use std::time::Duration;
+
+use criterion::async_executor::FuturesExecutor;
+use criterion::{criterion_group, criterion_main, Criterion};
+use ethcontract::U256;
+use rand::seq::SliceRandom as _;
+use shared::token_list::TokenList;
+use tokio::runtime::Runtime;
+
+const TOKEN_LIST: &str = "https://gateway.ipfs.io/ipns/tokens.uniswap.org";
+const BASE_URL: &str = "https://protocol-mainnet.dev.gnosisdev.com/api/v1";
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let mut rt = Runtime::new().unwrap();
+    let token_list = rt
+        .block_on(TokenList::from_url(TOKEN_LIST, 1))
+        .expect("Failed to fetch token list");
+
+    let mut group = c.benchmark_group("e2e API requests");
+    group
+        .measurement_time(Duration::from_secs(300))
+        .sample_size(500)
+        .bench_function("Estimate Price", |b| {
+            b.to_async(FuturesExecutor)
+                .iter(|| estimate_fee_and_price_estimate(&token_list));
+        });
+    group.finish();
+}
+
+async fn estimate_fee_and_price_estimate(token_list: &TokenList) {
+    let mut rng = rand::thread_rng();
+    let base_token = token_list
+        .all()
+        .choose(&mut rng)
+        .expect("Empty token list")
+        .clone();
+    let quote_token = token_list
+        .all()
+        .choose(&mut rng)
+        .expect("Empty token list")
+        .clone();
+    let order_type = &["sell", "buy"].choose(&mut rng).unwrap();
+    let amount = U256::exp10(base_token.decimals as usize);
+    let estimate_amount = format!(
+        "{}/markets/{:#x}-{:#x}/{}/{}",
+        BASE_URL, base_token.address, quote_token.address, order_type, amount
+    );
+    let estimate_fee = format!(
+        "{}/fee?sellToken={:#x}&buyToken={:#x}&kind={}&amount={}",
+        BASE_URL, base_token.address, quote_token.address, order_type, amount
+    );
+
+    for request_url in &[estimate_amount, estimate_fee] {
+        let result = reqwest::blocking::get(request_url).expect("Query failed");
+        if !result.status().is_success() {
+            println!(
+                "Request: {}, Status: {}, Response: {}",
+                request_url,
+                result.status(),
+                result.text().expect("No text")
+            );
+        }
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/e2e/benches/bench.rs
+++ b/e2e/benches/bench.rs
@@ -8,7 +8,7 @@ use shared::token_list::TokenList;
 use tokio::runtime::Runtime;
 
 const TOKEN_LIST: &str = "https://gateway.ipfs.io/ipns/tokens.uniswap.org";
-const BASE_URL: &str = "https://protocol-mainnet.dev.gnosisdev.com/api/v1";
+const BASE_URL: &str = "http://localhost:8080/api/v1";
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let mut rt = Runtime::new().unwrap();
@@ -19,7 +19,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("e2e API requests");
     group
         .measurement_time(Duration::from_secs(300))
-        .sample_size(500)
         .bench_function("Estimate Price", |b| {
             b.to_async(FuturesExecutor)
                 .iter(|| estimate_fee_and_price_estimate(&token_list));

--- a/shared/src/token_list.rs
+++ b/shared/src/token_list.rs
@@ -43,6 +43,10 @@ impl TokenList {
     pub fn get(&self, address: &H160) -> Option<&Token> {
         self.tokens.get(address)
     }
+
+    pub fn all(&self) -> Vec<Token> {
+        self.tokens.values().cloned().collect()
+    }
 }
 
 /// Relevant parts of TokenList schema as defined in https://uniswap.org/tokenlist.schema.json


### PR DESCRIPTION
Related to #638 

This PR is introducing a benchmark for the price/fee estimation API into the repo. I used Criterion, even though it's usually better suited for micro-benchmarking in order to repurpose the rust benchmarking support.

A disadvantage is that I don't seem to be able to do multiple parallel requests (which even with autocannon was problematic as the backend started rate limiting us)

### Test Plan
`cargo bench -p e2e`
