### PR TITLE
Make pool fetching error if communication with node fails

### DIFF
--- a/shared/src/ethcontract_error.rs
+++ b/shared/src/ethcontract_error.rs
@@ -1,0 +1,55 @@
+use ethcontract::errors::{ExecutionError, MethodError};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum EthcontractErrorType {
+    // The error stems from communicating with the node.
+    Node,
+    // Communication was successful but the contract on chain errored.
+    Contract,
+}
+
+impl EthcontractErrorType {
+    pub fn classify(err: &MethodError) -> Self {
+        match &err.inner {
+            ExecutionError::Web3(_) => Self::Node,
+            _ => Self::Contract,
+        }
+    }
+}
+
+// Create an arbitrary error. Useful for testing.
+pub fn testing_node_error() -> MethodError {
+    MethodError {
+        signature: String::new(),
+        inner: ExecutionError::Web3(web3::Error::Internal),
+    }
+}
+
+// Create an arbitrary error. Useful for testing.
+pub fn testing_contract_error() -> MethodError {
+    MethodError {
+        signature: String::new(),
+        inner: ExecutionError::InvalidOpcode,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_error() {
+        assert_eq!(
+            EthcontractErrorType::classify(&testing_node_error()),
+            EthcontractErrorType::Node
+        );
+    }
+
+    #[test]
+    fn contract_error() {
+        assert_eq!(
+            EthcontractErrorType::classify(&testing_contract_error()),
+            EthcontractErrorType::Contract
+        );
+    }
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -8,6 +8,7 @@ pub mod http;
 #[macro_use]
 pub mod macros;
 pub mod bad_token;
+pub mod ethcontract_error;
 pub mod event_handling;
 pub mod maintenance;
 pub mod metrics;

--- a/shared/src/price_estimate.rs
+++ b/shared/src/price_estimate.rs
@@ -321,7 +321,7 @@ impl BaselinePriceEstimator {
         let pools = self
             .pool_fetcher
             .fetch(all_pairs, BlockNumber::Latest)
-            .await
+            .await?
             .into_iter()
             .fold(HashMap::<_, Vec<Pool>>::new(), |mut pools, pool| {
                 pools.entry(pool.tokens).or_default().push(pool);
@@ -415,12 +415,17 @@ mod tests {
     struct FakePoolFetcher(Vec<Pool>);
     #[async_trait::async_trait]
     impl PoolFetching for FakePoolFetcher {
-        async fn fetch(&self, token_pairs: HashSet<TokenPair>, _: BlockNumber) -> Vec<Pool> {
-            self.0
+        async fn fetch(
+            &self,
+            token_pairs: HashSet<TokenPair>,
+            _: BlockNumber,
+        ) -> Result<Vec<Pool>> {
+            Ok(self
+                .0
                 .clone()
                 .into_iter()
                 .filter(|pool| token_pairs.contains(&pool.tokens))
-                .collect()
+                .collect())
         }
     }
 

--- a/solver/src/liquidity/uniswap.rs
+++ b/solver/src/liquidity/uniswap.rs
@@ -80,7 +80,7 @@ impl UniswapLikeLiquidity {
 
         let mut tokens = HashSet::new();
         let mut result = Vec::new();
-        for pool in self.pool_fetcher.fetch(pools, at_block).await {
+        for pool in self.pool_fetcher.fetch(pools, at_block).await? {
             tokens.insert(pool.tokens.get().0);
             tokens.insert(pool.tokens.get().1);
 


### PR DESCRIPTION
The current code skips all pools for which a future has errored. This
makes sense when the contract call reverted becauase the pool is
unusuable in this case.
It does not make sense when communication with the node failed. In that
case it is likely that all futures are errors so the function would
return an empty vector which would then be part of the cache.

In order to test this I had to split up PoolFetcher::fetch.

### Test Plan
existing tests and added new one
