### PR TITLE
Make BlockStream poll interval configurable

### DIFF
--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -131,7 +131,9 @@ impl OrderbookServices {
         let db = Database::new("postgresql://").unwrap();
         db.clear().await.unwrap();
         let event_updater = Arc::new(EventUpdater::new(gpv2.settlement.clone(), db.clone(), None));
-        let current_block_stream = current_block_stream(web3.clone()).await.unwrap();
+        let current_block_stream = current_block_stream(web3.clone(), Duration::from_secs(1))
+            .await
+            .unwrap();
         let pair_provider = Arc::new(UniswapPairProvider {
             factory: uniswap_factory.clone(),
             chain_id,

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -91,11 +91,11 @@ struct Arguments {
     /// The amount of time a classification of a token into good or bad is valid for.
     #[structopt(
         long,
-        env = "BLOCK_STREAM_POLL_INTERVAL_SECONDS",
+        env,
         default_value = "5",
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
-    block_stream_poll_interval: Duration,
+    block_stream_poll_interval_seconds: Duration,
 }
 
 pub async fn database_metrics(metrics: Arc<Metrics>, database: Database) -> ! {
@@ -204,9 +204,10 @@ async fn main() {
         },
     ));
 
-    let current_block_stream = current_block_stream(web3.clone(), args.block_stream_poll_interval)
-        .await
-        .unwrap();
+    let current_block_stream =
+        current_block_stream(web3.clone(), args.block_stream_poll_interval_seconds)
+            .await
+            .unwrap();
 
     let pool_aggregator = PoolAggregator::from_providers(&pair_providers, &web3).await;
     let pool_fetcher =

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -87,6 +87,15 @@ struct Arguments {
     /// thinks they are bad. Base tokens are automatically allowed.
     #[structopt(long, env = "ALLOWED_TOKENS", use_delimiter = true)]
     pub allowed_tokens: Vec<H160>,
+
+    /// The amount of time a classification of a token into good or bad is valid for.
+    #[structopt(
+        long,
+        env = "BLOCK_STREAM_POLL_INTERVAL_SECONDS",
+        default_value = "5",
+        parse(try_from_str = shared::arguments::duration_from_seconds),
+    )]
+    block_stream_poll_interval: Duration,
 }
 
 pub async fn database_metrics(metrics: Arc<Metrics>, database: Database) -> ! {
@@ -195,7 +204,9 @@ async fn main() {
         },
     ));
 
-    let current_block_stream = current_block_stream(web3.clone()).await.unwrap();
+    let current_block_stream = current_block_stream(web3.clone(), args.block_stream_poll_interval)
+        .await
+        .unwrap();
 
     let pool_aggregator = PoolAggregator::from_providers(&pair_providers, &web3).await;
     let pool_fetcher =

--- a/shared/src/current_block.rs
+++ b/shared/src/current_block.rs
@@ -18,8 +18,6 @@ use web3::{
 
 pub type Block = web3::types::Block<H256>;
 
-const POLL_INTERVAL: Duration = Duration::from_secs(1);
-
 /// Creates a cloneable stream that yields the current block whenever it changes.
 ///
 /// The stream is not guaranteed to yield *every* block individually without gaps but it does yield
@@ -30,7 +28,10 @@ const POLL_INTERVAL: Duration = Duration::from_secs(1);
 /// The stream is cloneable so that we only have to poll the node once while being able to share the
 /// result with several consumers. Calling this function again would create a new poller so it is
 /// preferable to clone an existing stream instead.
-pub async fn current_block_stream(web3: Web3) -> Result<CurrentBlockStream> {
+pub async fn current_block_stream(
+    web3: Web3,
+    poll_interval: Duration,
+) -> Result<CurrentBlockStream> {
     let first_block = web3.current_block().await?;
     let first_hash = first_block.hash.ok_or_else(|| anyhow!("missing hash"))?;
 
@@ -42,7 +43,7 @@ pub async fn current_block_stream(web3: Web3) -> Result<CurrentBlockStream> {
     let update_future = async move {
         let mut previous_hash = first_hash;
         loop {
-            tokio::time::delay_for(POLL_INTERVAL).await;
+            tokio::time::delay_for(poll_interval).await;
             let block = match web3.current_block().await {
                 Ok(block) => block,
                 Err(err) => {
@@ -198,7 +199,9 @@ mod tests {
         let node = "https://dev-openethereum.mainnet.gnosisdev.com";
         let transport = LoggingTransport::new(web3::transports::Http::new(node).unwrap());
         let web3 = Web3::new(transport);
-        let mut stream = current_block_stream(web3).await.unwrap();
+        let mut stream = current_block_stream(web3, Duration::from_secs(1))
+            .await
+            .unwrap();
         for _ in 0..3 {
             let block = stream.next().await.unwrap();
             println!("new block number {}", block.number.unwrap().as_u64());


### PR DESCRIPTION
My benchmarks showed that our prod environment has much larger outliers when it comes to querying the API than staging. After investigating a few isolated instances, it looks like prod is much more sensitive to reorgs and therefore running maintenance (and thus cache eviction) much more frequently than staging.

This PR allows us to configure the polling interval which we use for the new block stream (and sets the default from 1s to 5s)

It may be that #650 becomes more frequent as a consequence since we will be updating our trade table less frequently

### Test Plan
I didn't see significant improvements on the benchmarks (locally my times are much better than on prod however).
