### PR TITLE
[Easy] Propogate EventHandler Maintenance Failure Logs

### DIFF
--- a/orderbook/src/event_updater.rs
+++ b/orderbook/src/event_updater.rs
@@ -24,7 +24,7 @@ impl EventStoring<ContractEvent> for Database {
     ) -> Result<()> {
         let db_events = self
             .contract_to_db_events(events)
-            .context("failed to get event")?;
+            .context("replace - failed to convert events")?;
         tracing::debug!(
             "replacing {} events from block number {}",
             db_events.len(),
@@ -39,7 +39,7 @@ impl EventStoring<ContractEvent> for Database {
     async fn append_events(&self, events: Vec<Event<ContractEvent>>) -> Result<()> {
         let db_events = self
             .contract_to_db_events(events)
-            .context("failed to get event")?;
+            .context("append - failed to convert events")?;
         tracing::debug!("inserting {} new events", db_events.len());
         self.insert_events(db_events)
             .await

--- a/shared/src/event_handling.rs
+++ b/shared/src/event_handling.rs
@@ -174,7 +174,6 @@ where
             .await
             .update_events()
             .await
-            .context("event update error")
     }
 }
 

--- a/shared/src/event_handling.rs
+++ b/shared/src/event_handling.rs
@@ -131,7 +131,7 @@ where
         // in one transaction.
         let mut have_deleted_old_events = false;
         while let Some(events_chunk) = events.next().await {
-            let unwrapped_events = events_chunk.context("Failed to get next chunk of events")?;
+            let unwrapped_events = events_chunk.context("failed to get next chunk of events")?;
             if !have_deleted_old_events {
                 self.store
                     .replace_events(unwrapped_events, range.clone())

--- a/shared/src/event_handling.rs
+++ b/shared/src/event_handling.rs
@@ -170,10 +170,7 @@ where
     S: EventStoring<C::Event> + Send + Sync,
 {
     async fn run_maintenance(&self) -> Result<()> {
-        self.lock()
-            .await
-            .update_events()
-            .await
+        self.lock().await.update_events().await
     }
 }
 

--- a/shared/src/maintenance.rs
+++ b/shared/src/maintenance.rs
@@ -19,7 +19,7 @@ impl Maintaining for ServiceMaintenance {
     async fn run_maintenance(&self) -> Result<()> {
         for result in join_all(self.maintainers.iter().map(|m| m.run_maintenance())).await {
             if let Err(err) = result {
-                tracing::error!("Service Maintenance failed with: {}", err);
+                tracing::error!("Service Maintenance Error: {}", err);
             }
         }
         Ok(())

--- a/shared/src/maintenance.rs
+++ b/shared/src/maintenance.rs
@@ -19,7 +19,7 @@ impl Maintaining for ServiceMaintenance {
     async fn run_maintenance(&self) -> Result<()> {
         for result in join_all(self.maintainers.iter().map(|m| m.run_maintenance())).await {
             if let Err(err) = result {
-                tracing::error!("Service Maintenance Error: {}", err);
+                tracing::error!("Service Maintenance Error: {:?}", err);
             }
         }
         Ok(())

--- a/shared/src/maintenance.rs
+++ b/shared/src/maintenance.rs
@@ -19,7 +19,7 @@ impl Maintaining for ServiceMaintenance {
     async fn run_maintenance(&self) -> Result<()> {
         for result in join_all(self.maintainers.iter().map(|m| m.run_maintenance())).await {
             if let Err(err) = result {
-                tracing::error!("failed with: {}", err);
+                tracing::error!("Service Maintenance failed with: {}", err);
             }
         }
         Ok(())


### PR DESCRIPTION
Fixes #656
Attempting to propagate a more descriptive error out of failed `EventHandler` maintenance. Currently we are getting:

```
shared::maintenance: failed with: event update error
```

Note that this is also being emitted from the other file that was touched which has been updated a bit to be more specific

So, what we would expect to see now for similar occurrences of an error could be any of 

```
shared::maintenance: Service Maintenance Error: failed to get past events
shared::maintenance: Service Maintenance Error: failed to get next chunk of events
shared::maintenance: Service Maintenance Error: replace - failed to convert events
shared::maintenance: Service Maintenance Error: append - failed to convert events
shared::maintenance: Service Maintenance Error: failed to insert trades
shared::maintenance: Service Maintenance Error: failed to replace trades
```

and possibly more.

### Test Plan
This trait implementation for `Mutex<EventHandler<B, C, S>>` seems like quite an elaborate construct I am not sure if it can easily be mocked. Happy to try if reviewers think it should be.
