### PR TITLE
Instrument Web3 Transport to record round trip times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,6 +471,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,6 +2462,7 @@ dependencies = [
  "async-trait",
  "atty",
  "contracts",
+ "derivative",
  "ethcontract",
  "futures",
  "gas-estimation",

--- a/e2e/tests/ganache.rs
+++ b/e2e/tests/ganache.rs
@@ -1,7 +1,7 @@
 use ethcontract::futures::FutureExt;
-use ethcontract::{Http, U256};
+use ethcontract::U256;
 use lazy_static::lazy_static;
-use shared::{transport::LoggingTransport, Web3};
+use shared::{transport::create_test_transport, Web3};
 use std::{
     fmt::Debug,
     future::Future,
@@ -33,7 +33,7 @@ where
     // it but rather in the locked state.
     let _lock = GANACHE_MUTEX.lock();
 
-    let http = LoggingTransport::new(Http::new(NODE_HOST).expect("transport failure"));
+    let http = create_test_transport(NODE_HOST);
     let web3 = Web3::new(http);
     let resetter = Resetter::new(&web3).await;
 

--- a/orderbook/src/account_balances.rs
+++ b/orderbook/src/account_balances.rs
@@ -189,16 +189,14 @@ fn is_empty_or_truthy(bytes: &[u8]) -> bool {
 mod tests {
     use super::*;
     use contracts::ERC20Mintable;
-    use ethcontract::{prelude::Account, Http};
+    use ethcontract::prelude::Account;
     use hex_literal::hex;
-    use shared::transport::LoggingTransport;
+    use shared::transport::create_test_transport;
 
     #[tokio::test]
     #[ignore]
     async fn mainnet_can_transfer() {
-        let http = LoggingTransport::new(
-            Http::new("https://dev-openethereum.mainnet.gnosisdev.com/").unwrap(),
-        );
+        let http = create_test_transport("http://127.0.0.1:8545");
         let web3 = Web3::new(http);
         let settlement = contracts::GPv2Settlement::deployed(&web3).await.unwrap();
         let allowance = settlement.allowance_manager().call().await.unwrap();
@@ -216,9 +214,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn mainnet_cannot_transfer() {
-        let http = LoggingTransport::new(
-            Http::new("https://dev-openethereum.mainnet.gnosisdev.com/").unwrap(),
-        );
+        let http = create_test_transport("http://127.0.0.1:8545");
         let web3 = Web3::new(http);
         let settlement = contracts::GPv2Settlement::deployed(&web3).await.unwrap();
         let allowance = settlement.allowance_manager().call().await.unwrap();
@@ -238,8 +234,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn watch_testnet_balance() {
-        let http =
-            LoggingTransport::new(Http::new("http://127.0.0.1:8545").expect("transport failure"));
+        let http = create_test_transport("http://127.0.0.1:8545");
         let web3 = Web3::new(http);
 
         let accounts: Vec<H160> = web3.eth().accounts().await.expect("get accounts failed");

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -25,7 +25,7 @@ use shared::{
     pool_aggregating::{self, PoolAggregator},
     pool_fetching::CachedPoolFetcher,
     price_estimate::BaselinePriceEstimator,
-    transport::LoggingTransport,
+    transport::create_instrumented_transport,
 };
 use std::{
     collections::HashSet, iter::FromIterator as _, net::SocketAddr, sync::Arc, time::Duration,
@@ -109,9 +109,13 @@ async fn main() {
     shared::tracing::initialize(args.shared.log_filter.as_str());
     tracing::info!("running order book with {:#?}", args);
 
-    let transport = LoggingTransport::new(
+    let registry = Registry::default();
+    let metrics = Arc::new(Metrics::new(&registry).unwrap());
+
+    let transport = create_instrumented_transport(
         web3::transports::Http::new(args.shared.node_url.as_str())
             .expect("transport creation failed"),
+        metrics.clone(),
     );
     let web3 = web3::Web3::new(transport);
     let settlement_contract = GPv2Settlement::deployed(&web3)
@@ -233,9 +237,6 @@ async fn main() {
         ],
     };
     check_database_connection(orderbook.as_ref()).await;
-
-    let registry = Registry::default();
-    let metrics = Arc::new(Metrics::new(&registry).unwrap());
 
     let serve_task = serve_task(
         database.clone(),

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -11,6 +11,7 @@ assert_approx_eq = "1.1"
 async-trait = "0.1"
 atty = "0.2"
 contracts = { path = "../contracts" }
+derivative = "2.2"
 ethcontract = { version = "0.11", default-features = false }
 futures = "0.3"
 gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.1.2", features = ["web3_"] }

--- a/shared/src/bad_token/trace_call.rs
+++ b/shared/src/bad_token/trace_call.rs
@@ -285,12 +285,11 @@ mod tests {
     use super::*;
     use crate::{
         amm_pair_provider::{SushiswapPairProvider, UniswapPairProvider},
-        transport::LoggingTransport,
+        transport::create_test_transport,
     };
     use hex_literal::hex;
-    use web3::{
-        transports::Http,
-        types::{Action, ActionType, Bytes, Call, CallResult, CallType, Res, TransactionTrace},
+    use web3::types::{
+        Action, ActionType, Bytes, Call, CallResult, CallType, Res, TransactionTrace,
     };
 
     fn encode_u256(u256: U256) -> Bytes {
@@ -402,9 +401,7 @@ mod tests {
     #[ignore]
     async fn mainnet_tokens() {
         // shared::tracing::initialize("orderbook::bad_token=debug,shared::transport=debug");
-        let http = LoggingTransport::new(
-            Http::new("https://dev-openethereum.mainnet.gnosisdev.com/").unwrap(),
-        );
+        let http = create_test_transport("https://dev-openethereum.mainnet.gnosisdev.com/");
         let web3 = Web3::new(http);
 
         let base_tokens = &[

--- a/shared/src/current_block.rs
+++ b/shared/src/current_block.rs
@@ -160,7 +160,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::transport::LoggingTransport;
+    use crate::transport::create_test_transport;
 
     use super::*;
     use futures::FutureExt;
@@ -196,7 +196,7 @@ mod tests {
     #[ignore]
     async fn mainnet() {
         let node = "https://dev-openethereum.mainnet.gnosisdev.com";
-        let transport = LoggingTransport::new(web3::transports::Http::new(node).unwrap());
+        let transport = create_test_transport(node);
         let web3 = Web3::new(transport);
         let mut stream = current_block_stream(web3).await.unwrap();
         for _ in 0..3 {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -22,4 +22,7 @@ pub mod trace_many;
 pub mod tracing;
 pub mod transport;
 
-pub type Web3 = web3::Web3<transport::LoggingTransport<web3::transports::Http>>;
+pub type Web3 =
+    web3::Web3<transport::LoggingTransport<transport::MetricTransport<web3::transports::Http>>>;
+
+extern crate derivative;

--- a/shared/src/transport.rs
+++ b/shared/src/transport.rs
@@ -1,8 +1,40 @@
-use ethcontract::jsonrpc::types::{Call, Value};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use derivative::Derivative;
 use ethcontract::web3::{error, RequestId, Transport};
+use ethcontract::{
+    jsonrpc::types::{Call, Value},
+    Http,
+};
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use web3::BatchTransport;
+
+/// Convenience method to create our standard instrumented transport
+pub fn create_instrumented_transport<T>(
+    transport: T,
+    metrics: Arc<dyn TransportMetrics>,
+) -> LoggingTransport<MetricTransport<T>>
+where
+    T: Transport,
+    <T as Transport>::Out: Send + 'static,
+{
+    LoggingTransport::new(MetricTransport::new(transport, metrics))
+}
+
+/// Convenience method to create a compatible transport without metrics (noop)
+pub fn create_test_transport(url: &str) -> LoggingTransport<MetricTransport<Http>>
+where
+{
+    let transport = Http::new(url).expect("transport failure");
+    LoggingTransport::new(MetricTransport::new(
+        transport,
+        Arc::new(NoopTransportMetrics),
+    ))
+}
 
 #[derive(Debug, Clone)]
 pub struct LoggingTransport<T: Transport> {
@@ -92,4 +124,75 @@ where
             })
             .boxed()
     }
+}
+
+pub trait TransportMetrics: Send + Sync {
+    fn report_query(&self, label: &str, elapsed: Duration);
+}
+#[derive(Clone, Derivative)]
+#[derivative(Debug)]
+pub struct MetricTransport<T: Transport> {
+    inner: T,
+    #[derivative(Debug = "ignore")]
+    metrics: Arc<dyn TransportMetrics>,
+}
+
+impl<T: Transport> MetricTransport<T> {
+    pub fn new(inner: T, metrics: Arc<dyn TransportMetrics>) -> MetricTransport<T> {
+        Self { inner, metrics }
+    }
+}
+
+impl<T> Transport for MetricTransport<T>
+where
+    T: Transport,
+    <T as Transport>::Out: Send + 'static,
+{
+    type Out = BoxFuture<'static, error::Result<Value>>;
+
+    fn prepare(&self, method: &str, params: Vec<Value>) -> (RequestId, Call) {
+        self.inner.prepare(method, params)
+    }
+
+    fn send(&self, id: RequestId, request: Call) -> Self::Out {
+        let metrics = self.metrics.clone();
+        let start = Instant::now();
+        self.inner
+            .send(id, request.clone())
+            .inspect(move |_| {
+                let label = match request {
+                    Call::MethodCall(method) => method.method,
+                    Call::Notification(notification) => notification.method,
+                    Call::Invalid { .. } => "invalid".into(),
+                };
+                metrics.report_query(&label, start.elapsed());
+            })
+            .boxed()
+    }
+}
+
+impl<T> BatchTransport for MetricTransport<T>
+where
+    T: BatchTransport,
+    T::Batch: Send + 'static,
+    <T as Transport>::Out: Send + 'static,
+{
+    type Batch = BoxFuture<'static, error::Result<Vec<error::Result<Value>>>>;
+
+    fn send_batch<I>(&self, requests: I) -> Self::Batch
+    where
+        I: IntoIterator<Item = (RequestId, Call)>,
+    {
+        let metrics = self.metrics.clone();
+        let start = Instant::now();
+        self.inner
+            .send_batch(requests)
+            .inspect(move |_| metrics.report_query(&"batch", start.elapsed()))
+            .boxed()
+    }
+}
+
+struct NoopTransportMetrics;
+impl TransportMetrics for NoopTransportMetrics {
+    fn report_query(&self, _: &str, _: Duration) {}
 }

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -11,7 +11,7 @@ use shared::{
     price_estimate::BaselinePriceEstimator,
     token_info::{CachedTokenInfoFetcher, TokenInfoFetcher},
     token_list::TokenList,
-    transport::LoggingTransport,
+    transport::create_instrumented_transport,
 };
 use solver::{
     driver::Driver, liquidity::uniswap::UniswapLikeLiquidity,
@@ -20,7 +20,6 @@ use solver::{
 use std::iter::FromIterator as _;
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use structopt::StructOpt;
-use web3::transports::Http;
 
 #[derive(Debug, StructOpt)]
 struct Arguments {
@@ -149,9 +148,10 @@ async fn main() {
     let metrics = Arc::new(Metrics::new(&registry).expect("Couldn't register metrics"));
 
     // TODO: custom transport that allows setting timeout
-    let transport = LoggingTransport::new(
+    let transport = create_instrumented_transport(
         web3::transports::Http::new(args.shared.node_url.as_str())
             .expect("transport creation failed"),
+        metrics.clone(),
     );
     let web3 = web3::Web3::new(transport);
     let chain_id = web3
@@ -268,7 +268,7 @@ async fn build_amm_artifacts(
     chain_id: u64,
     settlement_contract: contracts::GPv2Settlement,
     base_tokens: HashSet<H160>,
-    web3: web3::Web3<LoggingTransport<Http>>,
+    web3: shared::Web3,
 ) -> Vec<UniswapLikeLiquidity> {
     let mut res = vec![];
     for source in sources {

--- a/solver/src/settlement_simulation.rs
+++ b/solver/src/settlement_simulation.rs
@@ -77,7 +77,7 @@ pub fn tenderly_link(
 mod tests {
     use super::*;
     use ethcontract::{Account, PrivateKey};
-    use shared::transport::LoggingTransport;
+    use shared::transport::create_test_transport;
 
     // cargo test -p solver settlement_simulation::tests::mainnet -- --ignored --nocapture
     #[tokio::test]
@@ -85,7 +85,7 @@ mod tests {
     async fn mainnet() {
         // Create some bogus settlements to see that the simulation returns an error.
         let node = "https://dev-openethereum.mainnet.gnosisdev.com";
-        let transport = LoggingTransport::new(web3::transports::Http::new(node).unwrap());
+        let transport = create_test_transport(node);
         let web3 = Web3::new(transport);
         let block = web3.eth().block_number().await.unwrap().as_u64();
         let network_id = web3.net().version().await.unwrap();

--- a/solver/src/testutil.rs
+++ b/solver/src/testutil.rs
@@ -1,8 +1,8 @@
 use contracts::WETH9;
 use jsonrpc_core::Call as RpcCall;
 use serde_json::Value;
-use shared::transport::LoggingTransport;
-use web3::{api::Web3, transports::Http, types::H160, Transport};
+use shared::transport::create_test_transport;
+use web3::{api::Web3, types::H160, Transport};
 
 // To create an ethcontract instance we need to provide a web3 even though we never use it. This
 // module provides a dummy transport and web3.
@@ -35,7 +35,5 @@ pub fn infura(network: impl AsRef<str>) -> shared::Web3 {
         infura_project_id
     );
 
-    Web3::new(LoggingTransport::new(
-        Http::new(&node_url).expect("transport creation failed"),
-    ))
+    Web3::new(create_test_transport(&node_url))
 }


### PR DESCRIPTION
Adding another implementation of Transport and BatchTransport which reports the roundtrip time to prometheus. This should 
help us verify if our bad response times are due to node slowness or not.

Note, that something like a DynTransport would probably be nice so that our components can be agnostic as to whether they have a LoggingTransport a MetricTransport or a mix/match. However, this doesn't seem trivial and was out of scope for this more important change.

### Test Plan
Run orderbook locally, make a fee request, then check metrics under `http://localhost:9586/metrics`
