### PR TITLE
Split up PoolFetching trait

### DIFF
--- a/shared/src/pool_fetching.rs
+++ b/shared/src/pool_fetching.rs
@@ -33,6 +33,22 @@ pub trait PoolFetching: Send + Sync {
     ) -> Result<Vec<Pool>>;
 }
 
+#[async_trait::async_trait]
+pub trait LatestPoolFetching: Send + Sync {
+    /// Like PoolFetching::fetch but only for the current block.
+    async fn fetch_latest(&self, token_pairs: HashSet<TokenPair>) -> Result<Vec<Pool>>;
+}
+
+#[async_trait::async_trait]
+impl<T> LatestPoolFetching for T
+where
+    T: PoolFetching,
+{
+    async fn fetch_latest(&self, token_pairs: HashSet<TokenPair>) -> Result<Vec<Pool>> {
+        self.fetch(token_pairs, BlockNumber::Latest).await
+    }
+}
+
 #[derive(Clone, Hash, PartialEq, Debug)]
 pub struct Pool {
     pub tokens: TokenPair,


### PR DESCRIPTION
When working on the cache I found that I can simplify the implementation
significantly by making use of the fact that we only care about the
latest state of the pools in the order book.
To encode this in the type system I introduce a new trait
LatestPoolFetching that works just like PoolFetching but always operates
on the latest block.

This trait will be used in the following PR.

### Test Plan
not needed
