### PR TITLE
Driver friendly pool cache

### DIFF
--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -138,6 +138,7 @@ impl OrderbookServices {
         let pool_fetcher = PoolCache::new(
             NonZeroU64::new(10).unwrap(),
             20,
+            4,
             Box::new(PoolFetcher {
                 pair_provider,
                 web3: web3.clone(),

--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -10,16 +10,12 @@ use orderbook::{
 };
 use prometheus::Registry;
 use shared::{
-    amm_pair_provider::UniswapPairProvider,
-    bad_token::list_based::ListBasedDetector,
-    current_block::current_block_stream,
-    maintenance::ServiceMaintenance,
-    pool_fetching::{CachedPoolFetcher, PoolFetcher},
-    price_estimate::BaselinePriceEstimator,
-    Web3,
+    amm_pair_provider::UniswapPairProvider, bad_token::list_based::ListBasedDetector,
+    current_block::current_block_stream, maintenance::ServiceMaintenance, pool_cache::PoolCache,
+    pool_fetching::PoolFetcher, price_estimate::BaselinePriceEstimator, Web3,
 };
 use solver::orderbook::OrderBookApi;
-use std::{collections::HashSet, str::FromStr, sync::Arc, time::Duration};
+use std::{collections::HashSet, num::NonZeroU64, str::FromStr, sync::Arc, time::Duration};
 
 pub const API_HOST: &str = "http://127.0.0.1:8080";
 
@@ -132,24 +128,27 @@ impl OrderbookServices {
         let db = Database::new("postgresql://").unwrap();
         db.clear().await.unwrap();
         let event_updater = Arc::new(EventUpdater::new(gpv2.settlement.clone(), db.clone(), None));
-        let current_block_stream = current_block_stream(web3.clone(), Duration::from_secs(1))
-            .await
-            .unwrap();
         let pair_provider = Arc::new(UniswapPairProvider {
             factory: uniswap_factory.clone(),
             chain_id,
         });
-        let pool_fetcher = CachedPoolFetcher::new(
+        let current_block_stream = current_block_stream(web3.clone(), Duration::from_secs(5))
+            .await
+            .unwrap();
+        let pool_fetcher = PoolCache::new(
+            NonZeroU64::new(10).unwrap(),
+            20,
             Box::new(PoolFetcher {
                 pair_provider,
                 web3: web3.clone(),
             }),
             current_block_stream,
-        );
+        )
+        .unwrap();
         let gas_estimator = Arc::new(web3.clone());
         let bad_token_detector = Arc::new(ListBasedDetector::deny_list(Vec::new()));
         let price_estimator = Arc::new(BaselinePriceEstimator::new(
-            Box::new(pool_fetcher),
+            Arc::new(pool_fetcher),
             gas_estimator.clone(),
             HashSet::new(),
             bad_token_detector.clone(),

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -192,6 +192,14 @@ impl TokenPair {
     pub fn get(&self) -> (H160, H160) {
         (self.0, self.1)
     }
+
+    /// Lowest element according to Ord trait.
+    pub fn first_ord() -> Self {
+        Self(
+            H160([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            H160([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+        )
+    }
 }
 
 impl Default for TokenPair {

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -218,6 +218,7 @@ async fn main() {
         PoolCache::new(
             args.shared.pool_cache_blocks,
             args.shared.pool_cache_lru_size,
+            args.shared.pool_cache_maximum_recent_block_age,
             Box::new(pool_aggregator),
             current_block_stream.clone(),
         )

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -23,7 +23,7 @@ use shared::{
     current_block::current_block_stream,
     maintenance::ServiceMaintenance,
     pool_aggregating::{self, PoolAggregator},
-    pool_fetching::CachedPoolFetcher,
+    pool_cache::PoolCache,
     price_estimate::BaselinePriceEstimator,
     transport::create_instrumented_transport,
 };
@@ -214,11 +214,18 @@ async fn main() {
             .unwrap();
 
     let pool_aggregator = PoolAggregator::from_providers(&pair_providers, &web3).await;
-    let pool_fetcher =
-        CachedPoolFetcher::new(Box::new(pool_aggregator), current_block_stream.clone());
+    let pool_fetcher = Arc::new(
+        PoolCache::new(
+            args.shared.pool_cache_blocks,
+            args.shared.pool_cache_lru_size,
+            Box::new(pool_aggregator),
+            current_block_stream.clone(),
+        )
+        .expect("failed to create pool cache"),
+    );
 
     let price_estimator = Arc::new(BaselinePriceEstimator::new(
-        Box::new(pool_fetcher),
+        pool_fetcher.clone(),
         gas_price_estimator.clone(),
         base_tokens,
         bad_token_detector.clone(),
@@ -246,6 +253,7 @@ async fn main() {
             orderbook.clone(),
             Arc::new(database.clone()),
             Arc::new(event_updater),
+            pool_fetcher,
         ],
     };
     check_database_connection(orderbook.as_ref()).await;

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -1,7 +1,10 @@
 //! Contains command line arguments and related helpers that are shared between the binaries.
 use crate::{gas_price_estimation::GasEstimatorType, pool_aggregating::BaselineSources};
 use ethcontract::{H160, U256};
-use std::{num::ParseFloatError, time::Duration};
+use std::{
+    num::{NonZeroU64, ParseFloatError},
+    time::Duration,
+};
 use url::Url;
 
 #[derive(Debug, structopt::StructOpt)]
@@ -61,6 +64,14 @@ pub struct Arguments {
         use_delimiter = true
     )]
     pub baseline_sources: Vec<BaselineSources>,
+
+    /// The number of blocks kept in the pool cache.
+    #[structopt(long, env, default_value = "10")]
+    pub pool_cache_blocks: NonZeroU64,
+
+    /// The number of pairs that are automatically updated in the pool cache.
+    #[structopt(long, env, default_value = "200")]
+    pub pool_cache_lru_size: usize,
 }
 
 pub fn duration_from_seconds(s: &str) -> Result<Duration, ParseFloatError> {

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -72,6 +72,10 @@ pub struct Arguments {
     /// The number of pairs that are automatically updated in the pool cache.
     #[structopt(long, env, default_value = "200")]
     pub pool_cache_lru_size: usize,
+
+    /// The number of pairs that are automatically updated in the pool cache.
+    #[structopt(long, env, default_value = "4")]
+    pub pool_cache_maximum_recent_block_age: u64,
 }
 
 pub fn duration_from_seconds(s: &str) -> Result<Duration, ParseFloatError> {

--- a/shared/src/baseline_solver.rs
+++ b/shared/src/baseline_solver.rs
@@ -273,7 +273,7 @@ mod tests {
             (100, 100),
         )];
         let pools = hashmap! {
-            pools[0].tokens => vec![pools[0].clone()],
+            pools[0].tokens => vec![pools[0]],
         };
 
         assert!(estimate_buy_amount(1.into(), &path, &pools).is_none());
@@ -292,8 +292,8 @@ mod tests {
             Pool::uniswap(TokenPair::new(path[1], path[2]).unwrap(), (200, 50)),
         ];
         let pools = hashmap! {
-            pools[0].tokens => vec![pools[0].clone()],
-            pools[1].tokens => vec![pools[1].clone()],
+            pools[0].tokens => vec![pools[0]],
+            pools[1].tokens => vec![pools[1]],
         };
 
         assert_eq!(
@@ -321,8 +321,8 @@ mod tests {
             Pool::uniswap(TokenPair::new(path[1], path[2]).unwrap(), (200, 50)),
         ];
         let pools = hashmap! {
-            pools[0].tokens => vec![pools[0].clone()],
-            pools[1].tokens => vec![pools[1].clone()],
+            pools[0].tokens => vec![pools[0]],
+            pools[1].tokens => vec![pools[1]],
         };
 
         assert!(estimate_sell_amount(100.into(), &path, &pools).is_none());
@@ -340,8 +340,8 @@ mod tests {
             Pool::uniswap(TokenPair::new(path[1], path[2]).unwrap(), (200, 50)),
         ];
         let pools = hashmap! {
-            pools[0].tokens => vec![pools[0].clone()],
-            pools[1].tokens => vec![pools[1].clone()]
+            pools[0].tokens => vec![pools[0]],
+            pools[1].tokens => vec![pools[1]]
         };
 
         assert_eq!(
@@ -365,8 +365,8 @@ mod tests {
         let second_hop_high_slippage = Pool::uniswap(second_pair, (200_000, 50_000));
         let second_hop_low_slippage = Pool::uniswap(second_pair, (200_000_000, 50_000_000));
         let pools = hashmap! {
-            first_pair => vec![first_hop_high_price.clone(), first_hop_low_price.clone()],
-            second_pair => vec![second_hop_high_slippage, second_hop_low_slippage.clone()],
+            first_pair => vec![first_hop_high_price, first_hop_low_price],
+            second_pair => vec![second_hop_high_slippage, second_hop_low_slippage],
         };
 
         let buy_estimate = estimate_buy_amount(1000.into(), &path, &pools).unwrap();
@@ -418,7 +418,7 @@ mod tests {
         let valid_pool = Pool::uniswap(pair, (100_000, 100_000));
         let invalid_pool = Pool::uniswap(pair, (0, 0));
         let pools = hashmap! {
-            pair => vec![valid_pool.clone(), invalid_pool],
+            pair => vec![valid_pool, invalid_pool],
         };
 
         let buy_estimate = estimate_buy_amount(1000.into(), &path, &pools).unwrap();

--- a/shared/src/current_block.rs
+++ b/shared/src/current_block.rs
@@ -68,6 +68,13 @@ pub fn into_stream(receiver: watch::Receiver<Block>) -> WatchStream<Block> {
     WatchStream::new(receiver)
 }
 
+pub fn block_number(block: &Block) -> Result<u64> {
+    block
+        .number
+        .map(|number| number.as_u64())
+        .ok_or_else(|| anyhow!("no block number"))
+}
+
 /// Trait for abstracting the retrieval of the block information such as the
 /// latest block number.
 #[async_trait::async_trait]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -15,6 +15,7 @@ pub mod maintenance;
 pub mod metrics;
 pub mod network;
 pub mod pool_aggregating;
+pub mod pool_cache;
 pub mod pool_fetching;
 pub mod price_estimate;
 pub mod time;

--- a/shared/src/pool_cache.rs
+++ b/shared/src/pool_cache.rs
@@ -120,12 +120,6 @@ impl PoolFetching for PoolCache {
             last_update_block = mutexed.last_update_block;
         }
 
-        tracing::debug!(
-            "{} cache misses out of {} total",
-            cache_misses.len(),
-            pairs.len()
-        );
-
         if cache_misses.is_empty() {
             return Ok(cache_hits);
         }

--- a/shared/src/pool_cache.rs
+++ b/shared/src/pool_cache.rs
@@ -26,7 +26,7 @@ pub struct PoolCache {
 // Design:
 // The design of this module is driven by the need to always return pools quickly so that end users
 // going through the api do not have to wait longer than necessary:
-// - The mutex is never held while waiting on an async operation (getting pools from the node).
+// - The mutex is never locked while waiting on an async operation (getting pools from the node).
 // - Automatically updating the cache is decoupled from normal pool fetches.
 // A result of this is that it is possible that the same uncached pair is requested multiple times
 // simultaneously and some work is wasted. This is unlikely to happen in practice and the pool is
@@ -96,9 +96,6 @@ impl PoolCache {
 #[async_trait::async_trait]
 impl PoolFetching for PoolCache {
     async fn fetch(&self, pairs: HashSet<TokenPair>, block: Block) -> Result<Vec<Pool>> {
-        // We assume that if "Latest" is used it is okay to return an earlier cached version even if
-        // it is not exactly latest. This should be reflected in the block enum parameter in the
-        // future.
         let block = match block {
             Block::Recent => None,
             Block::Number(number) => Some(number),

--- a/shared/src/pool_cache.rs
+++ b/shared/src/pool_cache.rs
@@ -1,0 +1,428 @@
+use crate::{
+    current_block::{self, CurrentBlockStream},
+    maintenance::Maintaining,
+    pool_fetching::{Block, Pool, PoolFetching},
+};
+use anyhow::{Context, Result};
+use lru::LruCache;
+use model::TokenPair;
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    num::NonZeroU64,
+    sync::Mutex,
+};
+
+/// Caching pool fetcher
+///
+/// Caches all requests for a specific number of blocks and automatically updates the N most
+/// recently used pools automatically when a new block arrives.
+pub struct PoolCache {
+    mutexed: Mutex<Mutexed>,
+    number_of_blocks_to_cache: NonZeroU64,
+    inner: Box<dyn PoolFetching>,
+    block_stream: CurrentBlockStream,
+}
+
+// Design:
+// The design of this module is driven by the need to always return pools quickly so that end users
+// going through the api do not have to wait longer than necessary:
+// - The mutex is never held while waiting on an async operation (getting pools from the node).
+// - Automatically updating the cache is decoupled from normal pool fetches.
+// A result of this is that it is possible that the same uncached pair is requested multiple times
+// simultaneously and some work is wasted. This is unlikely to happen in practice and the pool is
+// going to be cached the next time it is needed.
+// When pools are requested we mark all those pools as recently used which potentially evicts other
+// pairs from the pair lru cache. Cache misses are fetched and inserted into the cache.
+// Then when the automatic update runs the next time, we request and cache all recently used pairs.
+// For the order book we only care about the "recent" state of the pools. So we can return any
+// result from the cache even if it comes from previous blocks.
+// On the other hand for the driver we need to get the pool at exact blocks which is why we keep a
+// cache of previous blocks in the first place as we could simplify this module if it was only used
+// by the order book.
+
+impl PoolCache {
+    /// number_of_blocks_to_cache: Previous blocks stay cached until the block is this much older
+    /// than the current block.
+    /// number_of_pairs_to_auto_update: The number of most recently used pools to keep track of and
+    /// auto update when the current block changes.
+    pub fn new(
+        number_of_blocks_to_cache: NonZeroU64,
+        number_of_pairs_to_auto_update: usize,
+        inner: Box<dyn PoolFetching>,
+        block_stream: CurrentBlockStream,
+    ) -> Result<Self> {
+        let block = current_block::block_number(&block_stream.borrow())?;
+        Ok(Self {
+            mutexed: Mutex::new(Mutexed::new(number_of_pairs_to_auto_update, block)),
+            number_of_blocks_to_cache,
+            inner,
+            block_stream,
+        })
+    }
+
+    pub async fn update_cache(&self, new_block: u64) -> Result<()> {
+        let pairs = self
+            .mutexed
+            .lock()
+            .unwrap()
+            .recently_used_pairs()
+            .collect::<HashSet<_>>();
+        tracing::debug!("automatically updating {} pair pools", pairs.len());
+        let pools = self
+            .inner
+            .fetch(pairs.clone(), Block::Number(new_block))
+            .await?;
+        {
+            let mut mutexed = self.mutexed.lock().unwrap();
+            mutexed.insert(new_block, pairs.into_iter(), &pools);
+            let oldest_to_keep = new_block.saturating_sub(self.number_of_blocks_to_cache.get() - 1);
+            mutexed.remove_cached_blocks_older_than(oldest_to_keep);
+            mutexed.last_update_block = new_block;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl PoolFetching for PoolCache {
+    async fn fetch(&self, pairs: HashSet<TokenPair>, block: Block) -> Result<Vec<Pool>> {
+        // We assume that if "Latest" is used it is okay to return an earlier cached version even if
+        // it is not exactly latest. This should be reflected in the block enum parameter in the
+        // future.
+        let block = match block {
+            Block::Recent => None,
+            Block::Number(number) => Some(number),
+        };
+
+        let mut cache_hits = Vec::new();
+        let mut cache_misses = HashSet::new();
+        let last_update_block;
+        {
+            let mut mutexed = self.mutexed.lock().unwrap();
+            for &pair in &pairs {
+                match mutexed.get(pair, block) {
+                    Some(pools) => cache_hits.extend_from_slice(&pools),
+                    None => {
+                        cache_misses.insert(pair);
+                    }
+                }
+            }
+            last_update_block = mutexed.last_update_block;
+        }
+
+        tracing::debug!(
+            "{} cache misses out of {} total",
+            cache_misses.len(),
+            pairs.len()
+        );
+
+        if cache_misses.is_empty() {
+            return Ok(cache_hits);
+        }
+
+        let cache_miss_block = block.unwrap_or(last_update_block);
+        let uncached_pools = self
+            .inner
+            .fetch(cache_misses.clone(), Block::Number(cache_miss_block))
+            .await?;
+        {
+            let mut mutexed = self.mutexed.lock().unwrap();
+            mutexed.insert(cache_miss_block, pairs.iter().copied(), &uncached_pools);
+        }
+
+        cache_hits.extend_from_slice(&uncached_pools);
+        Ok(cache_hits)
+    }
+}
+
+#[async_trait::async_trait]
+impl Maintaining for PoolCache {
+    async fn run_maintenance(&self) -> Result<()> {
+        let block = current_block::block_number(&self.block_stream.borrow())?;
+        self.update_cache(block)
+            .await
+            .context("failed to update pool cache")
+    }
+}
+
+#[derive(Debug)]
+struct Mutexed {
+    recently_used: LruCache<TokenPair, ()>,
+    // For quickly finding at which block a pair is cached.
+    cached_most_recently_at_block: HashMap<TokenPair, u64>,
+    // Tuple ordering allows us to efficiently construct range queries by block.
+    pools: BTreeMap<(u64, TokenPair), Vec<Pool>>,
+    // The last block at which the automatic cache updating happened.
+    last_update_block: u64,
+}
+
+impl Mutexed {
+    fn new(pairs_lru_size: usize, current_block: u64) -> Mutexed {
+        Self {
+            recently_used: LruCache::new(pairs_lru_size),
+            cached_most_recently_at_block: HashMap::new(),
+            pools: BTreeMap::new(),
+            last_update_block: current_block,
+        }
+    }
+}
+
+impl Mutexed {
+    fn get(&mut self, pair: TokenPair, block: Option<u64>) -> Option<&[Pool]> {
+        self.recently_used.put(pair, ());
+        let block = block.or_else(|| self.cached_most_recently_at_block.get(&pair).copied())?;
+        self.pools.get(&(block, pair)).map(Vec::as_slice)
+    }
+
+    fn insert(&mut self, block: u64, pairs: impl Iterator<Item = TokenPair>, pools: &[Pool]) {
+        for pair in pairs {
+            self.cached_most_recently_at_block.insert(pair, block);
+            // Make sure pairs without pools are cached.
+            self.pools.insert((block, pair), Vec::new());
+        }
+        for &pool in pools {
+            // Unwrap because previous loop guarantees all pairs have an entry.
+            self.pools
+                .get_mut(&(block, pool.tokens))
+                .unwrap()
+                .push(pool);
+        }
+    }
+
+    fn remove_cached_blocks_older_than(&mut self, oldest_to_keep: u64) {
+        tracing::debug!("dropping blocks older than {} from cache", oldest_to_keep);
+        self.pools = self
+            .pools
+            .split_off(&(oldest_to_keep, TokenPair::first_ord()));
+        self.cached_most_recently_at_block
+            .retain(|_pair, block| *block >= oldest_to_keep);
+        tracing::debug!(
+            "the cache now contains pools for {} block-pair combinations",
+            self.pools.len()
+        );
+    }
+
+    fn recently_used_pairs(&self) -> impl Iterator<Item = TokenPair> + '_ {
+        self.recently_used.iter().map(|(pair, _)| *pair)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::current_block::Block as Web3Block;
+    use futures::FutureExt;
+    use primitive_types::H160;
+    use std::sync::Arc;
+    use tokio::sync::watch;
+
+    #[derive(Default)]
+    struct FakePoolFetcher(Arc<Mutex<Vec<Pool>>>);
+    #[async_trait::async_trait]
+    impl PoolFetching for FakePoolFetcher {
+        async fn fetch(&self, _: HashSet<TokenPair>, _: Block) -> Result<Vec<Pool>> {
+            Ok(self.0.lock().unwrap().clone())
+        }
+    }
+
+    fn test_pairs() -> [TokenPair; 3] {
+        [
+            TokenPair::new(H160::from_low_u64_le(0), H160::from_low_u64_le(1)).unwrap(),
+            TokenPair::new(H160::from_low_u64_le(1), H160::from_low_u64_le(2)).unwrap(),
+            TokenPair::new(H160::from_low_u64_le(2), H160::from_low_u64_le(3)).unwrap(),
+        ]
+    }
+
+    #[test]
+    fn marks_recently_used() {
+        let inner = FakePoolFetcher::default();
+        let block_number = 10u64;
+        let block = Web3Block {
+            number: Some(block_number.into()),
+            ..Default::default()
+        };
+        let (_sender, receiver) = watch::channel(block);
+        let cache =
+            PoolCache::new(NonZeroU64::new(1).unwrap(), 2, Box::new(inner), receiver).unwrap();
+
+        cache
+            .fetch(test_pairs()[0..1].iter().copied().collect(), Block::Recent)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        cache
+            .fetch(test_pairs()[1..2].iter().copied().collect(), Block::Recent)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        let pairs = cache
+            .mutexed
+            .lock()
+            .unwrap()
+            .recently_used_pairs()
+            .collect::<HashSet<_>>();
+        assert_eq!(pairs, test_pairs()[0..2].iter().copied().collect());
+
+        // 1 is already cached, 3 isn't.
+        cache
+            .fetch(test_pairs()[1..3].iter().copied().collect(), Block::Recent)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        let pairs = cache
+            .mutexed
+            .lock()
+            .unwrap()
+            .recently_used_pairs()
+            .collect::<HashSet<_>>();
+        assert_eq!(pairs, test_pairs()[1..3].iter().copied().collect());
+    }
+
+    #[test]
+    fn auto_updates_recently_used() {
+        let inner = FakePoolFetcher::default();
+        let pools = inner.0.clone();
+        let block_number = 10u64;
+        let block = Web3Block {
+            number: Some(block_number.into()),
+            ..Default::default()
+        };
+        let (_sender, receiver) = watch::channel(block);
+        let cache =
+            PoolCache::new(NonZeroU64::new(1).unwrap(), 2, Box::new(inner), receiver).unwrap();
+
+        let result = cache
+            .fetch(test_pairs()[0..2].iter().copied().collect(), Block::Recent)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        assert!(result.is_empty());
+
+        let updated_pools = vec![
+            Pool::uniswap(test_pairs()[0], (1, 1)),
+            Pool::uniswap(test_pairs()[1], (2, 2)),
+        ];
+        *pools.lock().unwrap() = updated_pools.clone();
+        cache
+            .update_cache(block_number)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        pools.lock().unwrap().clear();
+
+        let result = cache
+            .fetch(test_pairs()[0..2].iter().copied().collect(), Block::Recent)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.len(), 2);
+        for pool in updated_pools {
+            assert!(result.contains(&pool));
+        }
+    }
+
+    #[test]
+    fn cache_hit_and_miss() {
+        let inner = FakePoolFetcher::default();
+        let pools = inner.0.clone();
+        let block_number = 10u64;
+        let block = Web3Block {
+            number: Some(block_number.into()),
+            ..Default::default()
+        };
+        let (_sender, receiver) = watch::channel(block);
+        let cache =
+            PoolCache::new(NonZeroU64::new(1).unwrap(), 2, Box::new(inner), receiver).unwrap();
+
+        // cache miss gets cached
+        cache
+            .fetch(test_pairs()[0..1].iter().copied().collect(), Block::Recent)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+
+        *pools.lock().unwrap() = vec![Pool::uniswap(test_pairs()[0], (1, 1))];
+        // cache hit does not use inner pool fetcher so result is still empty
+        let result = cache
+            .fetch(test_pairs()[0..1].iter().copied().collect(), Block::Recent)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        assert_eq!(result, vec![]);
+    }
+
+    #[test]
+    fn uses_most_recent_cached_for_latest_block() {
+        let inner = FakePoolFetcher::default();
+        let pools = inner.0.clone();
+        let block_number = 10u64;
+        let block = Web3Block {
+            number: Some(block_number.into()),
+            ..Default::default()
+        };
+        let (_sender, receiver) = watch::channel(block);
+        let cache =
+            PoolCache::new(NonZeroU64::new(1).unwrap(), 2, Box::new(inner), receiver).unwrap();
+
+        // cache at block 5
+        *pools.lock().unwrap() = vec![Pool::uniswap(test_pairs()[0], (1, 1))];
+        let result = cache
+            .fetch(
+                test_pairs()[0..1].iter().copied().collect(),
+                Block::Number(5),
+            )
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        assert_eq!(result, vec![Pool::uniswap(test_pairs()[0], (1, 1))]);
+
+        // cache at block 6
+        *pools.lock().unwrap() = vec![Pool::uniswap(test_pairs()[0], (2, 2))];
+        let result = cache
+            .fetch(
+                test_pairs()[0..1].iter().copied().collect(),
+                Block::Number(6),
+            )
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        assert_eq!(result, vec![Pool::uniswap(test_pairs()[0], (2, 2))]);
+
+        pools.lock().unwrap().clear();
+        // cache hit at block 6
+        let result = cache
+            .fetch(test_pairs()[0..1].iter().copied().collect(), Block::Recent)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        assert_eq!(result, vec![Pool::uniswap(test_pairs()[0], (2, 2))]);
+    }
+
+    #[test]
+    fn evicts_old_blocks_from_cache() {
+        let inner = FakePoolFetcher::default();
+        let block_number = 10u64;
+        let block = Web3Block {
+            number: Some(block_number.into()),
+            ..Default::default()
+        };
+        let (_sender, receiver) = watch::channel(block);
+        let cache =
+            PoolCache::new(NonZeroU64::new(5).unwrap(), 0, Box::new(inner), receiver).unwrap();
+
+        cache
+            .fetch(
+                test_pairs()[0..1].iter().copied().collect(),
+                Block::Number(10),
+            )
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(cache.mutexed.lock().unwrap().pools.len(), 1);
+        cache.update_cache(14).now_or_never().unwrap().unwrap();
+        assert_eq!(cache.mutexed.lock().unwrap().pools.len(), 1);
+        cache.update_cache(15).now_or_never().unwrap().unwrap();
+        assert!(cache.mutexed.lock().unwrap().pools.is_empty());
+    }
+}

--- a/shared/src/pool_fetching.rs
+++ b/shared/src/pool_fetching.rs
@@ -1,21 +1,13 @@
 use crate::{
-    amm_pair_provider::AmmPairProvider,
-    baseline_solver::BaselineSolvable,
-    current_block::{Block as CurrentBlock, CurrentBlockStream},
-    ethcontract_error::EthcontractErrorType,
-    Web3,
+    amm_pair_provider::AmmPairProvider, baseline_solver::BaselineSolvable,
+    ethcontract_error::EthcontractErrorType, Web3,
 };
 use anyhow::Result;
 use contracts::{IUniswapLikePair, ERC20};
 use ethcontract::{batch::CallBatch, errors::MethodError, BlockId, BlockNumber, H160, U256};
-use lru::LruCache;
 use model::TokenPair;
 use num::{rational::Ratio, BigInt, BigRational, Zero};
-use std::{
-    collections::{hash_map::Entry, HashMap, HashSet},
-    sync::Arc,
-};
-use tokio::sync::Mutex;
+use std::{collections::HashSet, sync::Arc};
 
 const MAX_BATCH_SIZE: usize = 100;
 const POOL_SWAP_GAS_COST: usize = 60_000;
@@ -47,7 +39,7 @@ pub trait PoolFetching: Send + Sync {
     async fn fetch(&self, token_pairs: HashSet<TokenPair>, at_block: Block) -> Result<Vec<Pool>>;
 }
 
-#[derive(Clone, Hash, PartialEq, Debug)]
+#[derive(Clone, Copy, Eq, Hash, PartialEq, Debug)]
 pub struct Pool {
     pub tokens: TokenPair,
     pub reserves: (u128, u128),
@@ -189,116 +181,6 @@ impl BaselineSolvable for Pool {
     }
 }
 
-const MAX_CACHED_BLOCKS: usize = 10;
-
-// Read though Pool Fetcher that keeps previously fetched pools in a LRU cache. Pools fetched for `Block::Latest` get invalidated whenever there is a new block
-pub struct CachedPoolFetcher {
-    inner: Box<dyn PoolFetching>,
-    cache: Arc<Mutex<Cache>>,
-    block_stream: CurrentBlockStream,
-}
-
-struct Cache {
-    /// Used to store details (e.g. hash) about the latest block. Needed so we know what `Block::Latest` refers to
-    latest_block: CurrentBlock,
-    pools: LruCache<u64, HashMap<TokenPair, Vec<Pool>>>,
-}
-
-impl Cache {
-    fn latest_block_number(&self) -> u64 {
-        self.latest_block
-            .number
-            .expect("Latest block always has a number")
-            .as_u64()
-    }
-}
-
-impl CachedPoolFetcher {
-    pub fn new(inner: Box<dyn PoolFetching>, block_stream: CurrentBlockStream) -> Self {
-        Self {
-            inner,
-            cache: Arc::new(Mutex::new(Cache {
-                latest_block: CurrentBlock::default(),
-                pools: LruCache::new(MAX_CACHED_BLOCKS),
-            })),
-            block_stream,
-        }
-    }
-
-    async fn fetch_inner(
-        &self,
-        token_pairs: HashSet<TokenPair>,
-        at_block: Block,
-    ) -> Result<Vec<Pool>> {
-        let mut cache = self.cache.lock().await;
-        let block = match at_block {
-            Block::Recent => cache.latest_block_number(),
-            Block::Number(number) => number,
-        };
-
-        let cached_pools = match cache.pools.get_mut(&block) {
-            Some(cache) => cache,
-            None => {
-                cache.pools.put(block, Default::default());
-                cache.pools.get_mut(&block).unwrap()
-            }
-        };
-
-        let mut cache_hits = Vec::new();
-        let mut cache_misses = HashSet::new();
-        for &pair in &token_pairs {
-            match cached_pools.entry(pair) {
-                Entry::Occupied(entry) => {
-                    cache_hits.extend_from_slice(entry.get());
-                }
-                Entry::Vacant(entry) => {
-                    cache_misses.insert(pair);
-                    // It is possible that the inner fetcher when queried below does not return any
-                    // pools for a token pair. It is important that this information itself enters
-                    // the cache so that it is remembered on next fetch and we do not attempt to
-                    // fetch pools for the token pair again (until the cache expires).
-                    entry.insert(Default::default());
-                }
-            }
-        }
-
-        if cache_misses.is_empty() {
-            return Ok(cache_hits);
-        }
-
-        let mut inner_results = self.inner.fetch(cache_misses, at_block).await?;
-        for miss in &inner_results {
-            // Unwrap because the loop above guarantees that the cache has an entry for all pairs.
-            cached_pools
-                .get_mut(&miss.tokens)
-                .unwrap()
-                .push(miss.clone());
-        }
-
-        inner_results.append(&mut cache_hits);
-        Ok(inner_results)
-    }
-
-    async fn clear_cache_if_necessary(&self) {
-        let mut cache = self.cache.lock().await;
-        let current = self.block_stream.borrow().clone();
-        if cache.latest_block != current {
-            cache.latest_block = current;
-            // Make sure we don't keep any cached data at that block around
-            let number = cache.latest_block_number();
-            cache.pools.pop(&number);
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl PoolFetching for CachedPoolFetcher {
-    async fn fetch(&self, token_pairs: HashSet<TokenPair>, at_block: Block) -> Result<Vec<Pool>> {
-        self.clear_cache_if_necessary().await;
-        self.fetch_inner(token_pairs, at_block).await
-    }
-}
-
 pub struct PoolFetcher {
     pub pair_provider: Arc<dyn AmmPairProvider>,
     pub web3: Web3,
@@ -402,13 +284,9 @@ fn handle_results(results: Vec<FetchedPool>) -> Result<Vec<Pool>> {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use crate::{conversions::big_rational_to_float, ethcontract_error};
     use assert_approx_eq::assert_approx_eq;
-    use ethcontract::H256;
-    use maplit::hashset;
-    use tokio::sync::watch;
 
     #[test]
     fn test_get_amounts_out() {
@@ -522,165 +400,6 @@ mod tests {
 
         let pool = Pool::uniswap(TokenPair::new(token_a, token_b).unwrap(), (0, 0));
         assert_eq!(pool.get_spot_price(token_a), None);
-    }
-
-    struct FakePoolFetcher(Arc<Mutex<Vec<Pool>>>);
-    #[async_trait::async_trait]
-    impl PoolFetching for FakePoolFetcher {
-        async fn fetch(&self, _: HashSet<TokenPair>, _: Block) -> Result<Vec<Pool>> {
-            Ok(self.0.lock().await.clone())
-        }
-    }
-
-    #[tokio::test]
-    async fn caching_pool_fetcher() {
-        let token_a = H160::from_low_u64_be(1);
-        let token_b = H160::from_low_u64_be(2);
-        let pair = TokenPair::new(token_a, token_b).unwrap();
-
-        let pools = Arc::new(Mutex::new(vec![
-            Pool::uniswap(pair, (1, 1)),
-            Pool::uniswap(pair, (2, 2)),
-        ]));
-
-        let starting_block = CurrentBlock {
-            hash: Some(H256::from_low_u64_be(0)),
-            number: Some(0.into()),
-            ..Default::default()
-        };
-
-        let (sender, receiver) = watch::channel(starting_block);
-        let inner = Box::new(FakePoolFetcher(pools.clone()));
-        let instance = CachedPoolFetcher::new(inner, receiver);
-
-        // Read Through
-        assert_eq!(
-            instance.fetch(hashset!(pair), Block::Recent).await.unwrap(),
-            vec![Pool::uniswap(pair, (1, 1)), Pool::uniswap(pair, (2, 2))]
-        );
-        assert_eq!(
-            instance
-                .fetch(hashset!(pair), Block::Number(42))
-                .await
-                .unwrap(),
-            vec![Pool::uniswap(pair, (1, 1)), Pool::uniswap(pair, (2, 2))]
-        );
-
-        // clear inner to test caching
-        pools.lock().await.clear();
-        assert_eq!(
-            instance.fetch(hashset!(pair), Block::Recent).await.unwrap(),
-            vec![Pool::uniswap(pair, (1, 1)), Pool::uniswap(pair, (2, 2))]
-        );
-        assert_eq!(
-            instance
-                .fetch(hashset!(pair), Block::Number(42))
-                .await
-                .unwrap(),
-            vec![Pool::uniswap(pair, (1, 1)), Pool::uniswap(pair, (2, 2))]
-        );
-
-        // invalidate cache
-        sender
-            .send(CurrentBlock {
-                hash: Some(H256::from_low_u64_be(1)),
-                number: Some(1.into()),
-                ..Default::default()
-            })
-            .unwrap();
-        assert_eq!(
-            instance.fetch(hashset!(pair), Block::Recent).await.unwrap(),
-            vec![]
-        );
-
-        // Cache entry for fixed block didn't change
-        assert_eq!(
-            instance
-                .fetch(hashset!(pair), Block::Number(42))
-                .await
-                .unwrap(),
-            vec![Pool::uniswap(pair, (1, 1)), Pool::uniswap(pair, (2, 2))]
-        );
-    }
-
-    #[tokio::test]
-    async fn caching_pool_fetcher_invalidates_if_latest_block_reorgs() {
-        let token_a = H160::from_low_u64_be(1);
-        let token_b = H160::from_low_u64_be(2);
-        let pair = TokenPair::new(token_a, token_b).unwrap();
-
-        let pools = Arc::new(Mutex::new(vec![Pool::uniswap(pair, (1, 1))]));
-
-        let starting_block = CurrentBlock {
-            hash: Some(H256::from_low_u64_be(0)),
-            number: Some(0.into()),
-            ..Default::default()
-        };
-
-        let (sender, receiver) = watch::channel(starting_block.clone());
-        let inner = Box::new(FakePoolFetcher(pools.clone()));
-        let instance = CachedPoolFetcher::new(inner, receiver);
-
-        // Read Through
-        assert_eq!(
-            instance.fetch(hashset!(pair), Block::Recent).await.unwrap(),
-            vec![Pool::uniswap(pair, (1, 1))]
-        );
-
-        // simulate reorg on latest block
-        sender
-            .send(CurrentBlock {
-                hash: Some(H256::from_low_u64_be(1)),
-                number: starting_block.number,
-                ..Default::default()
-            })
-            .unwrap();
-
-        // clear inner, to test we are not using cache
-        pools.lock().await.clear();
-        assert_eq!(
-            instance
-                .fetch(hashset!(pair), Block::Number(0))
-                .await
-                .unwrap(),
-            vec![]
-        );
-        assert_eq!(
-            instance.fetch(hashset!(pair), Block::Recent).await.unwrap(),
-            vec![]
-        );
-    }
-
-    #[tokio::test]
-    async fn caching_pool_fetcher_caches_empty() {
-        let token_a = H160::from_low_u64_be(1);
-        let token_b = H160::from_low_u64_be(2);
-        let pair = TokenPair::new(token_a, token_b).unwrap();
-
-        let pools = Arc::new(Mutex::new(vec![]));
-
-        let starting_block = CurrentBlock {
-            hash: Some(H256::from_low_u64_be(0)),
-            number: Some(0.into()),
-            ..Default::default()
-        };
-        let (_sender, receiver) = watch::channel(starting_block);
-        let inner = Box::new(FakePoolFetcher(pools.clone()));
-        let instance = CachedPoolFetcher::new(inner, receiver);
-
-        assert!(instance
-            .fetch(hashset!(pair), Block::Recent)
-            .await
-            .unwrap()
-            .is_empty());
-        // Change inner to return a new pool if it was called.
-        pools.lock().await.push(Pool::uniswap(pair, (1, 1)));
-        // Inner shouldn't get called because the previous empty result is still cached.
-        assert!(instance
-            .fetch(hashset!(pair), Block::Recent)
-            .await
-            .unwrap()
-            .is_empty());
     }
 
     #[test]

--- a/shared/src/price_estimate.rs
+++ b/shared/src/price_estimate.rs
@@ -89,7 +89,7 @@ pub trait PriceEstimating: Send + Sync {
 }
 
 pub struct BaselinePriceEstimator {
-    pool_fetcher: Box<dyn PoolFetching>,
+    pool_fetcher: Arc<dyn PoolFetching>,
     gas_estimator: Arc<dyn GasPriceEstimating>,
     base_tokens: HashSet<H160>,
     bad_token_detector: Arc<dyn BadTokenDetecting>,
@@ -98,7 +98,7 @@ pub struct BaselinePriceEstimator {
 
 impl BaselinePriceEstimator {
     pub fn new(
-        pool_fetcher: Box<dyn PoolFetching>,
+        pool_fetcher: Arc<dyn PoolFetching>,
         gas_estimator: Arc<dyn GasPriceEstimating>,
         base_tokens: HashSet<H160>,
         bad_token_detector: Arc<dyn BadTokenDetecting>,
@@ -434,7 +434,7 @@ mod tests {
             (10u128.pow(30), 10u128.pow(29)),
         );
 
-        let pool_fetcher = Box::new(FakePoolFetcher(vec![pool]));
+        let pool_fetcher = Arc::new(FakePoolFetcher(vec![pool]));
         let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(0.0))));
         let estimator = BaselinePriceEstimator::new(
             pool_fetcher,
@@ -501,7 +501,7 @@ mod tests {
             (10u128.pow(30), 10u128.pow(29)),
         );
 
-        let pool_fetcher = Box::new(FakePoolFetcher(vec![pool]));
+        let pool_fetcher = Arc::new(FakePoolFetcher(vec![pool]));
         let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(0.0))));
         let estimator = BaselinePriceEstimator::new(
             pool_fetcher,
@@ -535,7 +535,7 @@ mod tests {
             (10u128.pow(30), 10u128.pow(29)),
         );
 
-        let pool_fetcher = Box::new(FakePoolFetcher(vec![pool_ab, pool_bc]));
+        let pool_fetcher = Arc::new(FakePoolFetcher(vec![pool_ab, pool_bc]));
         let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(0.0))));
         let estimator = BaselinePriceEstimator::new(
             pool_fetcher,
@@ -560,7 +560,7 @@ mod tests {
     async fn return_error_if_no_token_found() {
         let token_a = H160::from_low_u64_be(1);
         let token_b = H160::from_low_u64_be(2);
-        let pool_fetcher = Box::new(FakePoolFetcher(vec![]));
+        let pool_fetcher = Arc::new(FakePoolFetcher(vec![]));
         let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(0.0))));
         let estimator = BaselinePriceEstimator::new(
             pool_fetcher,
@@ -584,11 +584,11 @@ mod tests {
             TokenPair::new(token_a, token_b).unwrap(),
             (10u128.pow(30), 10u128.pow(29)),
         );
-        let pool_fetcher = FakePoolFetcher(vec![pool_ab]);
+        let pool_fetcher = Arc::new(FakePoolFetcher(vec![pool_ab]));
         let bad_token = Arc::new(ListBasedDetector::deny_list(vec![token_a]));
         let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(0.0))));
         let estimator = BaselinePriceEstimator::new(
-            Box::new(pool_fetcher),
+            pool_fetcher,
             gas_estimator,
             hashset!(),
             bad_token,
@@ -619,7 +619,7 @@ mod tests {
         let token_b = H160::from_low_u64_be(2);
         let pool = Pool::uniswap(TokenPair::new(token_a, token_b).unwrap(), (0, 10));
 
-        let pool_fetcher = Box::new(FakePoolFetcher(vec![pool]));
+        let pool_fetcher = Arc::new(FakePoolFetcher(vec![pool]));
         let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(0.0))));
         let estimator = BaselinePriceEstimator::new(
             pool_fetcher,
@@ -648,7 +648,7 @@ mod tests {
             (10u128.pow(30), 10u128.pow(29)),
         );
 
-        let pool_fetcher = Box::new(FakePoolFetcher(vec![pool]));
+        let pool_fetcher = Arc::new(FakePoolFetcher(vec![pool]));
         let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(0.0))));
         let estimator = BaselinePriceEstimator::new(
             pool_fetcher,
@@ -697,7 +697,7 @@ mod tests {
             Pool::uniswap(TokenPair::new(token_a, token_b).unwrap(), (100_000, 90_000)),
         ];
 
-        let pool_fetcher = Box::new(FakePoolFetcher(pools.clone()));
+        let pool_fetcher = Arc::new(FakePoolFetcher(pools.clone()));
         let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(0.0))));
         let estimator = BaselinePriceEstimator::new(
             pool_fetcher,
@@ -735,7 +735,7 @@ mod tests {
             Pool::uniswap(TokenPair::new(intermediate, token_b).unwrap(), (900, 1000)),
         ];
 
-        let pool_fetcher = Box::new(FakePoolFetcher(pools));
+        let pool_fetcher = Arc::new(FakePoolFetcher(pools));
         let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(0.0))));
         let estimator = BaselinePriceEstimator::new(
             pool_fetcher,
@@ -773,7 +773,7 @@ mod tests {
         let supported_token = H160::from_low_u64_be(1);
         let unsupported_token = H160::from_low_u64_be(2);
 
-        let pool_fetcher = Box::new(FakePoolFetcher(Vec::new()));
+        let pool_fetcher = Arc::new(FakePoolFetcher(Vec::new()));
         let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(0.0))));
         let estimator = BaselinePriceEstimator::new(
             pool_fetcher,
@@ -835,7 +835,7 @@ mod tests {
             ),
         ];
 
-        let pool_fetcher = Box::new(FakePoolFetcher(pools.clone()));
+        let pool_fetcher = Arc::new(FakePoolFetcher(pools.clone()));
         let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(100.0))));
         let estimator = BaselinePriceEstimator::new(
             pool_fetcher,
@@ -864,7 +864,7 @@ mod tests {
         );
 
         // Now with a cheap gas price
-        let pool_fetcher = Box::new(FakePoolFetcher(pools));
+        let pool_fetcher = Arc::new(FakePoolFetcher(pools));
         let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(0.0))));
         let estimator = BaselinePriceEstimator::new(
             pool_fetcher,

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -208,7 +208,7 @@ async fn main() {
 
     // TODO: use caching pool fetcher
     let price_estimator = Arc::new(BaselinePriceEstimator::new(
-        Box::new(pool_aggregator),
+        Arc::new(pool_aggregator),
         gas_price_estimator.clone(),
         base_tokens.clone(),
         // Order book already filters bad tokens


### PR DESCRIPTION
Replaces the existing cache. Pool fetching takes a significant amount of
time in both the order book and the driver. This cache hopes to reduce
this by caching recently used tokens automatically when the current
block changes, and keeping previous results cached for a number of
blocks.

Follow ups:
- Change the block number parameter in the pool fetching trait to make it clear whether you get a best effort or exact result.
- Maybe make maintenance trait pass block number around.
- Enable it in the driver.
 
### Test Plan
new unit tests, some manual testing