### PR TITLE
[Easy] Include Solver Name in Simulation Failure

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -249,7 +249,9 @@ impl Driver {
             };
             tracing::error!(
                 "{} settlement simulation failed at submission and block {}:\n{:?}",
-                settlement.name, current_block_during_liquidity_fetch, error_at_earlier_block
+                settlement.name,
+                current_block_during_liquidity_fetch,
+                error_at_earlier_block
             );
             // This is an additional debug log so that the log message doesn't get too long as
             // settlement information is recoverable through tenderly anyway.

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -248,8 +248,8 @@ impl Driver {
                 Err(err) => err,
             };
             tracing::error!(
-                "settlement simulation failed right before submission AND for block {} which was current when liquidity was fetched:\n{:?}",
-                current_block_during_liquidity_fetch, error_at_earlier_block
+                "settlement simulation for {} solver failed right before submission AND for block {} which was current when liquidity was fetched:\n{:?}",
+                settlement.name, current_block_during_liquidity_fetch, error_at_earlier_block
             );
             // This is an additional debug log so that the log message doesn't get too long as
             // settlement information is recoverable through tenderly anyway.

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -248,7 +248,7 @@ impl Driver {
                 Err(err) => err,
             };
             tracing::error!(
-                "settlement simulation for {} solver failed right before submission AND for block {} which was current when liquidity was fetched:\n{:?}",
+                "{} settlement simulation failed at submission and block {}:\n{:?}",
                 settlement.name, current_block_during_liquidity_fetch, error_at_earlier_block
             );
             // This is an additional debug log so that the log message doesn't get too long as


### PR DESCRIPTION
Based on several alerts of the form:

```
ERROR solver::driver: settlement simulation failed right before submission AND for block 12527827 which was current when liquidity was fetched:
```

It would be nice to know which solver is failing (given that many of them are rounding errors from HTTP solver)
