### PR TITLE
Add new bad token

### DIFF
--- a/shared/src/bad_token/trace_call.rs
+++ b/shared/src/bad_token/trace_call.rs
@@ -381,7 +381,7 @@ mod tests {
         println!("{:?}", TraceCallDetector::arbitrary_recipient());
     }
 
-    // cargo test -p orderbook mainnet_tokens -- --nocapture
+    // cargo test -p shared mainnet_tokens -- --nocapture --ignored
     #[tokio::test]
     #[ignore]
     async fn mainnet_tokens() {
@@ -492,6 +492,7 @@ mod tests {
             H160(hex!("2b1fe2cea92436e8c34b7c215af66aaa2932a8b2")),
             H160(hex!("c7c24fe893c21e8a4ef46eaf31badcab9f362841")),
             H160(hex!("ef5b32486ed432b804a51d129f4d2fbdf18057ec")),
+            H160(hex!("2129ff6000b95a973236020bcd2b2006b0d8e019")),
         ];
 
         // Of the deny listed tokens the following are detected as good:


### PR DESCRIPTION
Before I was aware that we aren't using the tracing bad token detector and ran into some bad-token specific alerts, I went down the path of trying to figure out why a new token wasn't detected. It in, in fact, being detected, so no fixes were required. This PR just adds the token to our test list to, maybe, help catch regressions. Additionally, the comment with the command line for running the test was fixed.
