### PR TITLE
Use camel case for order cancellation serialization

### DIFF
--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -255,7 +255,7 @@ impl OrderCreation {
 
 /// An order cancellation as provided to the orderbook by the frontend.
 #[serde_as]
-#[derive(Eq, PartialEq, Clone, Copy, Debug, Deserialize, Serialize, Hash)]
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 pub struct OrderCancellation {
     pub order_uid: OrderUid,
     pub signature: Signature,


### PR DESCRIPTION
This PR fixes the order cancellation JSON (de)serialization to use camel case like the rest of the API and as documented in the OpenAPI specification.

Previously, it was looking for a field name `signing_scheme` instead of `signingScheme`.

### Test Plan

Added new unit test.
