### PR TITLE
Use a custom http transport implementation

### DIFF
--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -12,7 +12,7 @@ harness = false
 [dev-dependencies]
 contracts = { path = "../contracts" }
 criterion = "0.3"
-ethcontract = { version = "0.12",  default-features = false, features = ["http"] }
+ethcontract = { version = "0.12",  default-features = false }
 hex-literal = "0.3"
 lazy_static = "1.4"
 maplit = "1.0"

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -44,7 +44,7 @@ tokio = { version = "1.6", features = ["macros", "rt-multi-thread", "sync", "tim
 tracing = "0.1"
 url = "2.2"
 warp = "0.3"
-web3 = { version = "0.16", default-features = false, features = ["http-tls"] }
+web3 = { version = "0.16", default-features = false }
 
 [dev-dependencies]
 secp256k1 = "0.20"

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -21,6 +21,7 @@ use shared::{
         trace_call::TraceCallDetector,
     },
     current_block::current_block_stream,
+    http_transport::HttpTransport,
     maintenance::ServiceMaintenance,
     pool_aggregating::{self, PoolAggregator},
     pool_fetching::CachedPoolFetcher,
@@ -121,11 +122,8 @@ async fn main() {
     let registry = Registry::default();
     let metrics = Arc::new(Metrics::new(&registry).unwrap());
 
-    let transport = create_instrumented_transport(
-        web3::transports::Http::new(args.shared.node_url.as_str())
-            .expect("transport creation failed"),
-        metrics.clone(),
-    );
+    let transport =
+        create_instrumented_transport(HttpTransport::new(args.shared.node_url), metrics.clone());
     let web3 = web3::Web3::new(transport);
     let settlement_contract = GPv2Settlement::deployed(&web3)
         .await

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -32,7 +32,7 @@ tracing = "0.1"
 tracing-subscriber = "0.2"
 url = "2.2"
 warp = "0.3"
-web3 = { version = "0.16", default-features = false, features = ["http-tls"] }
+web3 = { version = "0.16", default-features = false }
 num-bigint = "0.3"
 mockall = "0.9"
 thiserror = "1.0"

--- a/shared/src/http_transport.rs
+++ b/shared/src/http_transport.rs
@@ -1,0 +1,187 @@
+use ethcontract::jsonrpc as jsonrpc_core;
+use futures::{future::BoxFuture, FutureExt};
+use jsonrpc_core::types::{Call, Output, Request, Value};
+use reqwest::{Client, Url};
+use serde::de::DeserializeOwned;
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+use web3::{error::Error as Web3Error, helpers, BatchTransport, RequestId, Transport};
+
+#[derive(Clone, Debug)]
+pub struct HttpTransport {
+    client: Client,
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    url: Url,
+    id: AtomicUsize,
+}
+
+impl HttpTransport {
+    pub fn new(url: Url) -> Self {
+        Self::with_client(Client::new(), url)
+    }
+
+    pub fn with_client(client: Client, url: Url) -> Self {
+        Self {
+            client,
+            inner: Arc::new(Inner {
+                url,
+                id: AtomicUsize::new(0),
+            }),
+        }
+    }
+
+    pub fn next_id(&self) -> RequestId {
+        self.inner.id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    pub fn new_request(&self) -> (Client, Url) {
+        (self.client.clone(), self.inner.url.clone())
+    }
+}
+
+// Id is only used for logging.
+async fn execute_rpc<T: DeserializeOwned>(
+    client: Client,
+    url: Url,
+    id: RequestId,
+    request: &Request,
+) -> Result<T, Web3Error> {
+    tracing::debug!(
+        "[id:{}] sending request: {:?}",
+        id,
+        serde_json::to_string(&request)?
+    );
+    let response = client.post(url).json(request).send().await.map_err(|err| {
+        let message = format!("failed to send request: {}", err);
+        tracing::debug!("[id:{}] {}", id, message);
+        Web3Error::Transport(message)
+    })?;
+    let status = response.status();
+    let text = response.text().await.map_err(|err| {
+        let message = format!("failed to get response body: {}", err);
+        tracing::debug!("[id:{}] {}", id, message);
+        Web3Error::Transport(message)
+    })?;
+    // Log the raw text before decoding to get more information on responses that aren't valid
+    // json. Debug encoding so we don't get control characters like newlines in the output.
+    tracing::debug!("[id:{}] received response: {:?}", id, text.trim());
+    if !status.is_success() {
+        return Err(Web3Error::Transport(format!(
+            "response status code is not success: {}",
+            status
+        )));
+    }
+    jsonrpc_core::serde_from_str(&text).map_err(Into::into)
+}
+
+type RpcResult = Result<Value, Web3Error>;
+
+impl Transport for HttpTransport {
+    type Out = BoxFuture<'static, RpcResult>;
+
+    fn prepare(&self, method: &str, params: Vec<Value>) -> (RequestId, Call) {
+        let id = self.next_id();
+        let request = helpers::build_request(id, method, params);
+        (id, request)
+    }
+
+    fn send(&self, id: RequestId, call: Call) -> Self::Out {
+        let (client, url) = self.new_request();
+        async move {
+            let output = execute_rpc(client, url, id, &Request::Single(call)).await?;
+            helpers::to_result_from_output(output)
+        }
+        .boxed()
+    }
+}
+
+impl BatchTransport for HttpTransport {
+    type Batch = BoxFuture<'static, Result<Vec<RpcResult>, Web3Error>>;
+
+    fn send_batch<T>(&self, requests: T) -> Self::Batch
+    where
+        T: IntoIterator<Item = (RequestId, Call)>,
+    {
+        // Batch calls don't need an id but it helps associate the response log to the request log.
+        let id = self.next_id();
+        let (client, url) = self.new_request();
+        let (ids, calls): (Vec<_>, Vec<_>) = requests.into_iter().unzip();
+        async move {
+            let outputs = execute_rpc(client, url, id, &Request::Batch(calls)).await?;
+            handle_batch_response(&ids, outputs)
+        }
+        .boxed()
+    }
+}
+
+fn handle_batch_response(
+    ids: &[RequestId],
+    outputs: Vec<Output>,
+) -> Result<Vec<RpcResult>, Web3Error> {
+    let mut outputs = outputs
+        .into_iter()
+        .map(|output| {
+            Ok((
+                id_of_output(&output)?,
+                helpers::to_result_from_output(output),
+            ))
+        })
+        .collect::<Result<HashMap<_, _>, Web3Error>>()?;
+    ids.iter()
+        .map(|id| {
+            outputs.remove(id).ok_or_else(|| {
+                Web3Error::InvalidResponse(format!("batch response is missing id {}", id))
+            })
+        })
+        .collect()
+}
+
+fn id_of_output(output: &Output) -> Result<RequestId, Web3Error> {
+    let id = match output {
+        Output::Success(success) => &success.id,
+        Output::Failure(failure) => &failure.id,
+    };
+    match id {
+        jsonrpc_core::Id::Num(num) => Ok(*num as RequestId),
+        _ => Err(Web3Error::InvalidResponse(
+            "response id is not u64".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handles_batch_response_being_in_different_order_than_input() {
+        let ids = vec![0, 1, 2];
+        // This order is different from the ids.
+        let outputs = [1u64, 0, 2]
+            .iter()
+            .map(|&id| {
+                Output::Success(jsonrpc_core::Success {
+                    jsonrpc: None,
+                    result: id.into(),
+                    id: jsonrpc_core::Id::Num(id),
+                })
+            })
+            .collect();
+        let results = handle_batch_response(&ids, outputs)
+            .unwrap()
+            .into_iter()
+            .map(|result| result.unwrap().as_u64().unwrap() as usize)
+            .collect::<Vec<_>>();
+        // The order of the ids should have been restored.
+        assert_eq!(ids, results);
+    }
+}

--- a/shared/src/http_transport.rs
+++ b/shared/src/http_transport.rs
@@ -127,6 +127,11 @@ fn handle_batch_response(
     ids: &[RequestId],
     outputs: Vec<Output>,
 ) -> Result<Vec<RpcResult>, Web3Error> {
+    if ids.len() != outputs.len() {
+        return Err(Web3Error::InvalidResponse(
+            "unexpected number of responses".to_string(),
+        ));
+    }
     let mut outputs = outputs
         .into_iter()
         .map(|output| {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -11,6 +11,7 @@ pub mod bad_token;
 pub mod balancer_event_handler;
 pub mod ethcontract_error;
 pub mod event_handling;
+pub mod http_transport;
 pub mod maintenance;
 pub mod metrics;
 pub mod network;
@@ -24,7 +25,4 @@ pub mod trace_many;
 pub mod tracing;
 pub mod transport;
 
-pub type Web3 =
-    web3::Web3<transport::LoggingTransport<transport::MetricTransport<web3::transports::Http>>>;
-
-extern crate derivative;
+pub type Web3 = web3::Web3<transport::MetricTransport<crate::http_transport::HttpTransport>>;

--- a/shared/src/transport.rs
+++ b/shared/src/transport.rs
@@ -1,129 +1,33 @@
+use crate::http_transport::HttpTransport;
+use derivative::Derivative;
+use ethcontract::jsonrpc::types::{Call, Value};
+use ethcontract::web3::{error, BatchTransport, RequestId, Transport};
+use futures::future::BoxFuture;
+use futures::FutureExt;
 use std::{
+    convert::TryInto,
     sync::Arc,
     time::{Duration, Instant},
 };
-
-use derivative::Derivative;
-use ethcontract::web3::{error, RequestId, Transport};
-use ethcontract::{
-    jsonrpc::types::{Call, Value},
-    Http,
-};
-use futures::future::BoxFuture;
-use futures::FutureExt;
-use web3::BatchTransport;
 
 /// Convenience method to create our standard instrumented transport
 pub fn create_instrumented_transport<T>(
     transport: T,
     metrics: Arc<dyn TransportMetrics>,
-) -> LoggingTransport<MetricTransport<T>>
+) -> MetricTransport<T>
 where
     T: Transport,
     <T as Transport>::Out: Send + 'static,
 {
-    LoggingTransport::new(MetricTransport::new(transport, metrics))
+    MetricTransport::new(transport, metrics)
 }
 
 /// Convenience method to create a compatible transport without metrics (noop)
-pub fn create_test_transport(url: &str) -> LoggingTransport<MetricTransport<Http>>
+pub fn create_test_transport(url: &str) -> MetricTransport<HttpTransport>
 where
 {
-    let transport = Http::new(url).expect("transport failure");
-    LoggingTransport::new(MetricTransport::new(
-        transport,
-        Arc::new(NoopTransportMetrics),
-    ))
-}
-
-#[derive(Debug, Clone)]
-pub struct LoggingTransport<T: Transport> {
-    inner: T,
-}
-
-impl<T: Transport> LoggingTransport<T> {
-    pub fn new(inner: T) -> LoggingTransport<T> {
-        Self { inner }
-    }
-}
-
-impl<T> Transport for LoggingTransport<T>
-where
-    T: Transport,
-    <T as Transport>::Out: Send + 'static,
-{
-    type Out = BoxFuture<'static, error::Result<Value>>;
-
-    fn prepare(&self, method: &str, params: Vec<Value>) -> (RequestId, Call) {
-        self.inner.prepare(method, params)
-    }
-
-    fn send(&self, id: RequestId, request: Call) -> Self::Out {
-        if let Ok(serialized) = serde_json::to_string(&request) {
-            tracing::debug!("[id:{}] sending request: '{}'", id, &serialized);
-        }
-        self.inner
-            .send(id, request)
-            .inspect(move |response| {
-                match response {
-                    Ok(value) => tracing::debug!("[id:{}] received response: '{}'", id, value),
-                    Err(err) => tracing::debug!("[id:{}] returned an error: '{}'", id, err),
-                };
-            })
-            .boxed()
-    }
-}
-
-impl<T> BatchTransport for LoggingTransport<T>
-where
-    T: BatchTransport,
-    T::Batch: Send + 'static,
-    <T as Transport>::Out: Send + 'static,
-{
-    type Batch = BoxFuture<'static, error::Result<Vec<error::Result<Value>>>>;
-
-    fn send_batch<I>(&self, requests: I) -> Self::Batch
-    where
-        I: IntoIterator<Item = (RequestId, Call)>,
-    {
-        let requests: Vec<_> = requests.into_iter().collect();
-        // Empty batches are pointless and can therefore have a 0 id, otherwise we use the ID of the first request.
-        let batch_id = requests.first().map(|(id, _)| *id).unwrap_or_default();
-        tracing::debug!(
-            "[batch_id:{}] sending Batch:\n{}",
-            batch_id,
-            requests
-                .iter()
-                .filter_map(|(_, call)| Some(format!("  {}", serde_json::to_string(call).ok()?)))
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
-        self.inner
-            .send_batch(requests.clone())
-            .inspect(move |response| {
-                match response {
-                    Ok(responses) => tracing::debug!(
-                        "[batch_id:{}] received response:\n{}",
-                        batch_id,
-                        responses
-                            .iter()
-                            .zip(requests.iter())
-                            .map(|(response, request)| {
-                                match response {
-                                    Ok(v) => format!("  [id:{}]: {}", request.0, v),
-                                    Err(e) => format!("  [id:{}]: {}", request.0, e),
-                                }
-                            })
-                            .collect::<Vec<_>>()
-                            .join("\n")
-                    ),
-                    Err(err) => {
-                        tracing::debug!("[batch_id:{}] returned an error: '{}'", batch_id, err)
-                    }
-                };
-            })
-            .boxed()
-    }
+    let transport = HttpTransport::new(url.try_into().unwrap());
+    MetricTransport::new(transport, Arc::new(NoopTransportMetrics))
 }
 
 pub trait TransportMetrics: Send + Sync {

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -43,7 +43,7 @@ strum_macros = "0.20"
 tokio = { version = "1.6", features = ["macros", "rt-multi-thread", "time"] }
 tracing = "0.1"
 transaction-retry = { git = "https://github.com/gnosis/gp-transaction-retry.git", tag = "v0.1.1" }
-web3 = { version = "0.16", default-features = false, features = ["http-tls"] }
+web3 = { version = "0.16", default-features = false }
 
 [dev-dependencies]
 tracing-subscriber = "0.2"

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -5,6 +5,7 @@ use reqwest::Url;
 use shared::{
     amm_pair_provider::{SushiswapPairProvider, UniswapPairProvider},
     bad_token::list_based::ListBasedDetector,
+    http_transport::HttpTransport,
     metrics::serve_metrics,
     network::network_name,
     pool_aggregating::{self, BaselineSources, PoolAggregator},
@@ -154,11 +155,8 @@ async fn main() {
     let metrics = Arc::new(Metrics::new(&registry).expect("Couldn't register metrics"));
 
     // TODO: custom transport that allows setting timeout
-    let transport = create_instrumented_transport(
-        web3::transports::Http::new(args.shared.node_url.as_str())
-            .expect("transport creation failed"),
-        metrics.clone(),
-    );
+    let transport =
+        create_instrumented_transport(HttpTransport::new(args.shared.node_url), metrics.clone());
     let web3 = web3::Web3::new(transport);
     let chain_id = web3
         .eth()


### PR DESCRIPTION
This allows us to log raw responses before decoding to json and
customize the transport for example by setting a timeout (not in this
PR).

For the implementation I used our gpv1 custom transport and rust-web3's
default transport as references and read the jsonrpc specification.
I discovered that that neither previous implementation takes into
account that the server is allowed to reorder responses for batch
requests. This is fixed here and something we might want to upstream
into rust-web3.

Related https://github.com/gnosis/gp-v2-services/issues/664

### Test Plan
existing tests, manual tests with staging node (TODO)
