### PR TITLE
Reject orders with receivers as SC wallets

### DIFF
--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -183,6 +183,7 @@ impl OrderbookServices {
             fee_calculator.clone(),
             Duration::from_secs(120),
             bad_token_detector,
+            Box::new(web3.clone()),
         ));
         let maintenance = ServiceMaintenance {
             maintainers: vec![orderbook.clone(), Arc::new(db.clone()), event_updater],

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -65,6 +65,15 @@ impl Order {
         token_list.contains(&self.order_creation.buy_token)
             || token_list.contains(&self.order_creation.sell_token)
     }
+
+    pub fn actual_receiver(&self) -> H160 {
+        let receiver = self.order_creation.receiver.unwrap_or_default();
+        if receiver == H160::zero() {
+            self.order_meta_data.owner
+        } else {
+            receiver
+        }
+    }
 }
 
 #[derive(Default)]

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -561,6 +561,7 @@ components:
           type: string
           enum:
             [
+              WrongOwner,
               DuplicateOrder,
               InvalidSignature,
               MissingOrderData,
@@ -568,7 +569,7 @@ components:
               InsufficientFunds,
               InsufficientFee,
               UnsupportedToken,
-              WrongOwner,
+              TransferEthToContract,
             ]
         description:
           type: string

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -561,15 +561,15 @@ components:
           type: string
           enum:
             [
-              WrongOwner,
               DuplicateOrder,
+              InsufficientFee,
+              InsufficientFunds,
+              InsufficientValidTo,
               InvalidSignature,
               MissingOrderData,
-              InsufficientValidTo,
-              InsufficientFunds,
-              InsufficientFee,
-              UnsupportedToken,
               TransferEthToContract,
+              UnsupportedToken,
+              WrongOwner,
             ]
         description:
           type: string

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -66,6 +66,14 @@ pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
             super::error("InsufficientFee", "Order does not include sufficient fee"),
             StatusCode::BAD_REQUEST,
         ),
+        Ok(AddOrderResult::TransferEthToContract) => (
+            super::error(
+                "TransferEthToContract",
+                "Setting receiver to a smart contract wallet when buying Ether \
+                 is currently not supported",
+            ),
+            StatusCode::BAD_REQUEST,
+        ),
         Err(_) => (super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR),
     };
     warp::reply::with_status(body, status_code)

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -242,6 +242,7 @@ async fn main() {
         fee_calculator.clone(),
         args.min_order_validity_period,
         bad_token_detector,
+        Box::new(web3.clone()),
     ));
     let service_maintainer = ServiceMaintenance {
         maintainers: vec![

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -14,8 +14,8 @@ use model::{
 };
 use primitive_types::{H160, U256};
 use shared::{
-    bad_token::BadTokenDetecting, code::CodeFetching, maintenance::Maintaining,
-    time::now_in_epoch_seconds,
+    bad_token::BadTokenDetecting, maintenance::Maintaining, time::now_in_epoch_seconds,
+    web3_traits::CodeFetching,
 };
 use std::{
     collections::{HashMap, HashSet},

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -9,11 +9,14 @@ use chrono::Utc;
 use futures::TryStreamExt;
 use model::order::{OrderCancellation, OrderCreationPayload};
 use model::{
-    order::{Order, OrderUid},
+    order::{Order, OrderUid, BUY_ETH_ADDRESS},
     DomainSeparator,
 };
 use primitive_types::{H160, U256};
-use shared::{bad_token::BadTokenDetecting, maintenance::Maintaining, time::now_in_epoch_seconds};
+use shared::{
+    bad_token::BadTokenDetecting, code::CodeFetching, maintenance::Maintaining,
+    time::now_in_epoch_seconds,
+};
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -32,6 +35,7 @@ pub enum AddOrderResult {
     InsufficientFunds,
     InsufficientFee,
     UnsupportedToken(H160),
+    TransferEthToContract,
 }
 
 #[derive(Debug)]
@@ -49,6 +53,7 @@ pub struct Orderbook {
     fee_validator: Arc<EthAwareMinFeeCalculator>,
     min_order_validity_period: Duration,
     bad_token_detector: Arc<dyn BadTokenDetecting>,
+    code_fetcher: Box<dyn CodeFetching>,
 }
 
 impl Orderbook {
@@ -59,6 +64,7 @@ impl Orderbook {
         fee_validator: Arc<EthAwareMinFeeCalculator>,
         min_order_validity_period: Duration,
         bad_token_detector: Arc<dyn BadTokenDetecting>,
+        code_fetcher: Box<dyn CodeFetching>,
     ) -> Self {
         Self {
             domain_separator,
@@ -67,6 +73,7 @@ impl Orderbook {
             fee_validator,
             min_order_validity_period,
             bad_token_detector,
+            code_fetcher,
         }
     }
 
@@ -116,6 +123,17 @@ impl Orderbook {
             .unwrap_or(false)
         {
             return Ok(AddOrderResult::InsufficientFunds);
+        }
+
+        if order.order_creation.buy_token == BUY_ETH_ADDRESS {
+            let code_size = self
+                .code_fetcher
+                .code_size(order.actual_receiver())
+                .await
+                .unwrap_or(1);
+            if code_size != 0 {
+                return Ok(AddOrderResult::TransferEthToContract);
+            }
         }
 
         match self.database.insert_order(&order).await {

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -129,8 +129,7 @@ impl Orderbook {
             let code_size = self
                 .code_fetcher
                 .code_size(order.actual_receiver())
-                .await
-                .unwrap_or(1);
+                .await?;
             if code_size != 0 {
                 return Ok(AddOrderResult::TransferEthToContract);
             }

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -126,10 +126,7 @@ impl Orderbook {
         }
 
         if order.order_creation.buy_token == BUY_ETH_ADDRESS {
-            let code_size = self
-                .code_fetcher
-                .code_size(order.actual_receiver())
-                .await?;
+            let code_size = self.code_fetcher.code_size(order.actual_receiver()).await?;
             if code_size != 0 {
                 return Ok(AddOrderResult::TransferEthToContract);
             }

--- a/shared/src/code.rs
+++ b/shared/src/code.rs
@@ -1,0 +1,17 @@
+use crate::Web3;
+use anyhow::Result;
+use ethcontract::H160;
+
+#[mockall::automock]
+#[async_trait::async_trait]
+pub trait CodeFetching: Send + Sync {
+    /// Fethces the code size at the specified address.
+    async fn code_size(&self, address: H160) -> Result<usize>;
+}
+
+#[async_trait::async_trait]
+impl CodeFetching for Web3 {
+    async fn code_size(&self, address: H160) -> Result<usize> {
+        Ok(self.eth().code(address, None).await?.0.len())
+    }
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod amm_pair_provider;
 pub mod arguments;
 pub mod baseline_solver;
+pub mod code;
 pub mod conversions;
 pub mod current_block;
 pub mod gas_price_estimation;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,17 +1,17 @@
-pub mod amm_pair_provider;
-pub mod arguments;
-pub mod baseline_solver;
-pub mod code;
-pub mod conversions;
-pub mod current_block;
-pub mod gas_price_estimation;
-pub mod http;
 #[macro_use]
 pub mod macros;
+
+pub mod amm_pair_provider;
+pub mod arguments;
 pub mod bad_token;
 pub mod balancer_event_handler;
+pub mod baseline_solver;
+pub mod conversions;
+pub mod current_block;
 pub mod ethcontract_error;
 pub mod event_handling;
+pub mod gas_price_estimation;
+pub mod http;
 pub mod http_transport;
 pub mod maintenance;
 pub mod metrics;
@@ -26,5 +26,6 @@ pub mod token_list;
 pub mod trace_many;
 pub mod tracing;
 pub mod transport;
+pub mod web3_traits;
 
 pub type Web3 = web3::Web3<transport::MetricTransport<crate::http_transport::HttpTransport>>;

--- a/shared/src/web3_traits.rs
+++ b/shared/src/web3_traits.rs
@@ -1,3 +1,6 @@
+//! Module containting traits for abstracting Web3 operations so components can
+//! more easily be tested with mocked versions of these behaviours.
+
 use crate::Web3;
 use anyhow::Result;
 use ethcontract::H160;


### PR DESCRIPTION
This PR rejects orders with a receiver address as an SC wallet when buying ETH.

This should be removed once we implement access list support and SC wallets can be supported.

Created #685 to capture the work required to support this properly with the current contracts.

### Test Plan

<details><summary>Did some manual testing.</summary>

After spinning up a local orderbook, find a SC that can receive ETH (I just used the GPv2 Settlement contract as if it were  an SC wallet :stuck_out_tongue:). Verify that the address has code:
```
$ curl -s 'http://localhost:8545' \
  -H 'Content-Type: application/json' \
  --data-raw '{"jsonrpc":"2.0","id":1,"method":"eth_getCode","params":["0x9561c133dd8580860b6b7e504bc5aa500f0f06a7","latest"]}' \
  | jq '.result | length'
22352
```

Now author an order that transfers to the SC and see that it succeeds.
```
$ curl -s 'http://localhost:8080/api/v1/orders' \
  -H 'Content-Type: application/json' \
  --data-raw "$(cat << EOF
    {
      "sellToken": "0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab",
      "buyToken": "0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab",
      "receiver": "0x9561c133dd8580860b6b7e504bc5aa500f0f06a7",
      "sellAmount": "1234567890",
      "buyAmount": "1234567890",
      "validTo": 1622725574,
      "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "feeAmount": "1234568890",
      "kind": "buy",
      "partiallyFillable": true,
      "signature": "0xdaec39dbdce62a1f4ed138cab5333a358277373debd71e4b52aeae9e807bac58241ceca6730bf9ebd13314424ea3e787d841c101c56e3f090d6474008b9f5efa1c",
      "signingScheme": "eip712",
      "from": "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1"
    }
EOF
)"
"0x3cc0d4ec51ab940dcdec4c9b9a66c2fe28f7334195ca98227427cb2ced3332ce90f8bf6a479f320ead074411a4b0e7944ea8c9c160b8d3c6"
```

Author the same order, but instead buy native token and see that it fails with the expected message:
```
$ curl -s 'http://localhost:8080/api/v1/orders' \
  -H 'Content-Type: application/json' \
  --data-raw "$(cat << EOF
    {
      "sellToken": "0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab",
      "buyToken": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
      "receiver": "0x9561c133dd8580860b6b7e504bc5aa500f0f06a7",
      "sellAmount": "1234567890",
      "buyAmount": "1234567890",
      "validTo": 1622726574,
      "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "feeAmount": "1234568890",
      "kind": "buy",
      "partiallyFillable": true,
      "signature": "0x84d7cb9e0ccf2e2af129b23b03591f62ff5af0f5367c7f54e6e14946d4bae0197aa22192c5709581168bd80dcc5c3bda626ae37546cd0dfdb0108e3c025d3d201c",
      "signingScheme": "eip712",
      "from": "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1"
    }
EOF
)" | jq
{
  "errorType": "TransferEthToContract",
  "description": "Setting receiver to a smart contract wallet when buying Ether is currently not supported"
}
```

</details>
