### PR TITLE
Use pool cache in driver

### DIFF
--- a/e2e/tests/eth_integration.rs
+++ b/e2e/tests/eth_integration.rs
@@ -102,6 +102,7 @@ async fn eth_integration(web3: Web3) {
     let OrderbookServices {
         maintenance,
         price_estimator,
+        block_stream,
         ..
     } = OrderbookServices::new(&web3, &gpv2, &uniswap_factory, native_token).await;
 
@@ -208,6 +209,7 @@ async fn eth_integration(web3: Web3) {
         Duration::from_secs(30),
         f64::MAX,
         None,
+        block_stream,
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -101,6 +101,7 @@ async fn onchain_settlement(web3: Web3) {
     let OrderbookServices {
         price_estimator,
         maintenance,
+        block_stream,
     } = OrderbookServices::new(&web3, &gpv2, &uniswap_factory, native_token).await;
 
     let client = reqwest::Client::new();
@@ -182,6 +183,7 @@ async fn onchain_settlement(web3: Web3) {
         Duration::from_secs(30),
         f64::MAX,
         None,
+        block_stream,
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -10,9 +10,14 @@ use orderbook::{
 };
 use prometheus::Registry;
 use shared::{
-    amm_pair_provider::UniswapPairProvider, bad_token::list_based::ListBasedDetector,
-    current_block::current_block_stream, maintenance::ServiceMaintenance, pool_cache::PoolCache,
-    pool_fetching::PoolFetcher, price_estimate::BaselinePriceEstimator, Web3,
+    amm_pair_provider::UniswapPairProvider,
+    bad_token::list_based::ListBasedDetector,
+    current_block::{current_block_stream, CurrentBlockStream},
+    maintenance::ServiceMaintenance,
+    pool_cache::PoolCache,
+    pool_fetching::PoolFetcher,
+    price_estimate::BaselinePriceEstimator,
+    Web3,
 };
 use solver::orderbook::OrderBookApi;
 use std::{collections::HashSet, num::NonZeroU64, str::FromStr, sync::Arc, time::Duration};
@@ -111,6 +116,7 @@ pub async fn deploy_mintable_token(web3: &Web3) -> ERC20Mintable {
 pub struct OrderbookServices {
     pub price_estimator: Arc<BaselinePriceEstimator>,
     pub maintenance: ServiceMaintenance,
+    pub block_stream: CurrentBlockStream,
 }
 impl OrderbookServices {
     pub async fn new(
@@ -145,7 +151,7 @@ impl OrderbookServices {
                 pair_provider,
                 web3: web3.clone(),
             }),
-            current_block_stream,
+            current_block_stream.clone(),
             metrics.clone(),
         )
         .unwrap();
@@ -194,6 +200,7 @@ impl OrderbookServices {
         Self {
             price_estimator,
             maintenance,
+            block_stream: current_block_stream,
         }
     }
 }

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -114,6 +114,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
     let OrderbookServices {
         price_estimator,
         maintenance,
+        block_stream,
     } = OrderbookServices::new(&web3, &gpv2, &uniswap_factory, native_token).await;
 
     let client = reqwest::Client::new();
@@ -183,6 +184,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         Duration::from_secs(10),
         f64::MAX,
         Some(market_makable_token_list),
+        block_stream,
     );
     driver.single_run().await.unwrap();
 

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -89,14 +89,9 @@ struct Arguments {
     #[structopt(long, env = "ALLOWED_TOKENS", use_delimiter = true)]
     pub allowed_tokens: Vec<H160>,
 
-    /// The amount of time a classification of a token into good or bad is valid for.
-    #[structopt(
-        long,
-        env,
-        default_value = "5",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
-    )]
-    block_stream_poll_interval_seconds: Duration,
+    /// The number of pairs that are automatically updated in the pool cache.
+    #[structopt(long, env, default_value = "200")]
+    pub pool_cache_lru_size: usize,
 }
 
 pub async fn database_metrics(metrics: Arc<Metrics>, database: Database) -> ! {
@@ -207,7 +202,7 @@ async fn main() {
     ));
 
     let current_block_stream =
-        current_block_stream(web3.clone(), args.block_stream_poll_interval_seconds)
+        current_block_stream(web3.clone(), args.shared.block_stream_poll_interval_seconds)
             .await
             .unwrap();
 
@@ -215,7 +210,7 @@ async fn main() {
     let pool_fetcher = Arc::new(
         PoolCache::new(
             args.shared.pool_cache_blocks,
-            args.shared.pool_cache_lru_size,
+            args.pool_cache_lru_size,
             args.shared.pool_cache_maximum_recent_block_age,
             Box::new(pool_aggregator),
             current_block_stream.clone(),

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -70,12 +70,17 @@ pub struct Arguments {
     pub pool_cache_blocks: NonZeroU64,
 
     /// The number of pairs that are automatically updated in the pool cache.
-    #[structopt(long, env, default_value = "200")]
-    pub pool_cache_lru_size: usize,
-
-    /// The number of pairs that are automatically updated in the pool cache.
     #[structopt(long, env, default_value = "4")]
     pub pool_cache_maximum_recent_block_age: u64,
+
+    /// How often we poll the node to check if the current block has changed.
+    #[structopt(
+        long,
+        env,
+        default_value = "5",
+        parse(try_from_str = duration_from_seconds),
+    )]
+    pub block_stream_poll_interval_seconds: Duration,
 }
 
 pub fn duration_from_seconds(s: &str) -> Result<Duration, ParseFloatError> {

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -5,8 +5,8 @@ use reqwest::Url;
 use shared::{
     amm_pair_provider::{SushiswapPairProvider, UniswapPairProvider},
     bad_token::list_based::ListBasedDetector,
-    http_transport::HttpTransport,
     current_block::current_block_stream,
+    http_transport::HttpTransport,
     maintenance::ServiceMaintenance,
     metrics::serve_metrics,
     network::network_name,
@@ -217,6 +217,7 @@ async fn main() {
             args.shared.pool_cache_maximum_recent_block_age,
             Box::new(pool_aggregator),
             current_block_stream.clone(),
+            metrics.clone(),
         )
         .expect("failed to create pool cache"),
     );

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -6,9 +6,12 @@ use shared::{
     amm_pair_provider::{SushiswapPairProvider, UniswapPairProvider},
     bad_token::list_based::ListBasedDetector,
     http_transport::HttpTransport,
+    current_block::current_block_stream,
+    maintenance::ServiceMaintenance,
     metrics::serve_metrics,
     network::network_name,
     pool_aggregating::{self, BaselineSources, PoolAggregator},
+    pool_cache::PoolCache,
     price_estimate::BaselinePriceEstimator,
     token_info::{CachedTokenInfoFetcher, TokenInfoFetcher},
     token_list::TokenList,
@@ -199,14 +202,27 @@ async fn main() {
         .expect("failed to create gas price estimator"),
     );
 
+    let current_block_stream =
+        current_block_stream(web3.clone(), args.shared.block_stream_poll_interval_seconds)
+            .await
+            .unwrap();
+
     let pair_providers =
         pool_aggregating::pair_providers(&args.shared.baseline_sources, chain_id, &web3).await;
-
     let pool_aggregator = PoolAggregator::from_providers(&pair_providers, &web3).await;
+    let pool_fetcher = Arc::new(
+        PoolCache::new(
+            args.shared.pool_cache_blocks,
+            0,
+            args.shared.pool_cache_maximum_recent_block_age,
+            Box::new(pool_aggregator),
+            current_block_stream.clone(),
+        )
+        .expect("failed to create pool cache"),
+    );
 
-    // TODO: use caching pool fetcher
     let price_estimator = Arc::new(BaselinePriceEstimator::new(
-        Arc::new(pool_aggregator),
+        pool_fetcher.clone(),
         gas_price_estimator.clone(),
         base_tokens.clone(),
         // Order book already filters bad tokens
@@ -262,7 +278,13 @@ async fn main() {
         args.solver_time_limit,
         args.gas_price_cap,
         market_makable_token_list,
+        current_block_stream.clone(),
     );
+
+    let maintainer = ServiceMaintenance {
+        maintainers: vec![pool_fetcher],
+    };
+    tokio::task::spawn(maintainer.run_maintenance_on_new_block(current_block_stream));
 
     serve_metrics(registry, ([0, 0, 0, 0], args.metrics_port).into());
     driver.run_forever().await;


### PR DESCRIPTION
Enable the pool cache in the driver. I decided to move the lru_size argument into the order book and have the lru be always turned off in the driver. This makes sense to me as in the driver we should be able to fetch all of the needed pools up front together which is less wasteful than auto updating.

### Test Plan
manually checked that maintenance runs, e2e tests otherwise