### PR TITLE
Retry failed requests in cached pool fetcher

### DIFF
--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -14,7 +14,7 @@ use shared::{
     bad_token::list_based::ListBasedDetector,
     current_block::{current_block_stream, CurrentBlockStream},
     maintenance::ServiceMaintenance,
-    pool_cache::PoolCache,
+    pool_cache::{PoolCache, PoolCacheConfig},
     pool_fetching::PoolFetcher,
     price_estimate::BaselinePriceEstimator,
     Web3,
@@ -144,9 +144,12 @@ impl OrderbookServices {
             .await
             .unwrap();
         let pool_fetcher = PoolCache::new(
-            NonZeroU64::new(10).unwrap(),
-            20,
-            4,
+            PoolCacheConfig {
+                number_of_blocks_to_cache: NonZeroU64::new(10).unwrap(),
+                number_of_pairs_to_auto_update: 20,
+                maximum_recent_block_age: 4,
+                ..Default::default()
+            },
             Box::new(PoolFetcher {
                 pair_provider,
                 web3: web3.clone(),

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -24,7 +24,7 @@ use shared::{
     http_transport::HttpTransport,
     maintenance::ServiceMaintenance,
     pool_aggregating::{self, PoolAggregator},
-    pool_cache::PoolCache,
+    pool_cache::{PoolCache, PoolCacheConfig},
     price_estimate::BaselinePriceEstimator,
     transport::create_instrumented_transport,
 };
@@ -209,9 +209,13 @@ async fn main() {
     let pool_aggregator = PoolAggregator::from_providers(&pair_providers, &web3).await;
     let pool_fetcher = Arc::new(
         PoolCache::new(
-            args.shared.pool_cache_blocks,
-            args.pool_cache_lru_size,
-            args.shared.pool_cache_maximum_recent_block_age,
+            PoolCacheConfig {
+                number_of_blocks_to_cache: args.shared.pool_cache_blocks,
+                number_of_pairs_to_auto_update: args.pool_cache_lru_size,
+                maximum_recent_block_age: args.shared.pool_cache_maximum_recent_block_age,
+                max_retries: args.shared.pool_cache_maximum_retries,
+                delay_between_retries: args.shared.pool_cache_delay_between_retries_seconds,
+            },
             Box::new(pool_aggregator),
             current_block_stream.clone(),
             metrics.clone(),

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -73,6 +73,14 @@ pub struct Arguments {
     #[structopt(long, env, default_value = "4")]
     pub pool_cache_maximum_recent_block_age: u64,
 
+    /// How often to retry requests in the pool cache.
+    #[structopt(long, env, default_value = "5")]
+    pub pool_cache_maximum_retries: u32,
+
+    /// How long to sleep between retries in the pool cache.
+    #[structopt(long, env, default_value = "1", parse(try_from_str = duration_from_seconds))]
+    pub pool_cache_delay_between_retries_seconds: Duration,
+
     /// How often we poll the node to check if the current block has changed.
     #[structopt(
         long,


### PR DESCRIPTION
to get rid of annoying alerts as an interim solution.

Also turned the pool cache config into a struct because clippy
complained and I agree with it that this is easier to read and less
likely to have order of arguments errors.

### Test Plan
Manually tested that price estimation still works. Didn't write a test for retry logic because it is simple and uses sleep so I didn't want all the boilerplate for testing.
