### PR TITLE
[Objective Criterion] Add solver fees to objective value

### DIFF
--- a/e2e/tests/eth_integration.rs
+++ b/e2e/tests/eth_integration.rs
@@ -210,6 +210,7 @@ async fn eth_integration(web3: Web3) {
         f64::MAX,
         None,
         block_stream,
+        1.0,
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -184,6 +184,7 @@ async fn onchain_settlement(web3: Web3) {
         f64::MAX,
         None,
         block_stream,
+        1.0,
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -185,6 +185,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         f64::MAX,
         Some(market_makable_token_list),
         block_stream,
+        1.0,
     );
     driver.single_run().await.unwrap();
 

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -52,6 +52,7 @@ pub struct Driver {
     market_makable_token_list: Option<TokenList>,
     inflight_trades: HashSet<OrderUid>,
     block_stream: CurrentBlockStream,
+    fee_discount_factor: f64,
 }
 impl Driver {
     #[allow(clippy::too_many_arguments)]
@@ -73,6 +74,7 @@ impl Driver {
         gas_price_cap: f64,
         market_makable_token_list: Option<TokenList>,
         block_stream: CurrentBlockStream,
+        fee_discount_factor: f64,
     ) -> Self {
         Self {
             settlement_contract,
@@ -93,6 +95,7 @@ impl Driver {
             market_makable_token_list,
             inflight_trades: HashSet::new(),
             block_stream,
+            fee_discount_factor,
         }
     }
 
@@ -309,6 +312,9 @@ impl Driver {
         futures::stream::iter(settlements)
             .filter_map(|settlement| async {
                 let surplus = settlement.settlement.total_surplus(prices);
+                // Given the fee discount the solver fees by themselves may not be sufficient to make a solution economically viable (leading to a negative objective value)
+                // We therefore reverse apply the fee discount to simulate unsubsidized fees for ranking.
+                let solver_fees = settlement.settlement.total_fees(prices) / BigRational::from_float(self.fee_discount_factor).expect("Discount factor is not a rational");
                 let gas_estimate = settlement_submission::estimate_gas(
                     &self.settlement_contract,
                     &settlement.settlement.clone().into(),
@@ -319,6 +325,7 @@ impl Driver {
                 let rated_settlement = RatedSettlement {
                     settlement,
                     surplus,
+                    solver_fees,
                     gas_estimate,
                     gas_price: gas_price_wei.clone(),
                 };

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -312,9 +312,9 @@ impl Driver {
         futures::stream::iter(settlements)
             .filter_map(|settlement| async {
                 let surplus = settlement.settlement.total_surplus(prices);
-                // Given the fee discount the solver fees by themselves may not be sufficient to make a solution economically viable (leading to a negative objective value)
+                // Because of a potential fee discount, the solver fees may by themselves not be sufficient to make a solution economically viable (leading to a negative objective value)
                 // We therefore reverse apply the fee discount to simulate unsubsidized fees for ranking.
-                let solver_fees = settlement.settlement.total_fees(prices) / BigRational::from_float(self.fee_discount_factor).expect("Discount factor is not a rational");
+                let unsubsidized_solver_fees = settlement.settlement.total_fees(prices) / BigRational::from_float(self.fee_discount_factor).expect("Discount factor is not a rational");
                 let gas_estimate = settlement_submission::estimate_gas(
                     &self.settlement_contract,
                     &settlement.settlement.clone().into(),
@@ -325,7 +325,7 @@ impl Driver {
                 let rated_settlement = RatedSettlement {
                     settlement,
                     surplus,
-                    solver_fees,
+                    solver_fees: unsubsidized_solver_fees,
                     gas_estimate,
                     gas_price: gas_price_wei.clone(),
                 };

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -286,6 +286,7 @@ async fn main() {
         args.gas_price_cap,
         market_makable_token_list,
         current_block_stream.clone(),
+        args.shared.fee_discount_factor,
     );
 
     let maintainer = ServiceMaintenance {

--- a/solver/src/settlement.rs
+++ b/solver/src/settlement.rs
@@ -46,6 +46,20 @@ impl Trade {
         }
     }
 
+    // Returns the relative fee amount given the executed amount
+    // cf. https://github.com/gnosis/gp-v2-contracts/blob/964f1eb76f366f652db7f4c2cb5ff9bfa26eb2cd/src/contracts/GPv2Settlement.sol#L370-L371
+    pub fn fee(&self) -> U256 {
+        let order = self.order.order_creation;
+        match order.kind {
+            model::order::OrderKind::Buy => {
+                order.fee_amount * self.executed_amount / order.buy_amount
+            }
+            model::order::OrderKind::Sell => {
+                order.fee_amount * self.executed_amount / order.sell_amount
+            }
+        }
+    }
+
     /// Encodes the settlement trade as a tuple, as expected by the smart
     /// contract.
     pub fn encode(&self) -> EncodedTrade {
@@ -135,7 +149,7 @@ impl Settlement {
         &self.encoder.trades()
     }
 
-    // For now this computes the total surplus of all EOA trades.
+    // Computes the total surplus of all protocol trades (in wei ETH).
     pub fn total_surplus(&self, external_prices: &HashMap<H160, BigRational>) -> BigRational {
         match self.encoder.total_surplus(&external_prices) {
             Some(value) => value,
@@ -144,6 +158,19 @@ impl Settlement {
                 num::zero()
             }
         }
+    }
+
+    // Computes the total fee of all protocol trades (in wei ETH).
+    pub fn total_fees(&self, external_prices: &HashMap<H160, BigRational>) -> BigRational {
+        self.encoder
+            .trades()
+            .iter()
+            .filter_map(|trade| {
+                let fee_token_price =
+                    external_prices.get(&trade.order.order_creation.sell_token)?;
+                Some(trade.fee().to_big_rational() * fee_token_price)
+            })
+            .sum()
     }
 
     /// See SettlementEncoder::merge
@@ -507,6 +534,118 @@ pub mod tests {
         assert_eq!(
             buy_order_surplus(&r(100), &r(200), &r(60), &r(20), &r(20)),
             Some(r(2000))
+        );
+    }
+
+    #[test]
+    fn test_trade_fee() {
+        let fully_filled_sell = Trade {
+            order: Order {
+                order_creation: OrderCreation {
+                    sell_amount: 100.into(),
+                    fee_amount: 5.into(),
+                    kind: OrderKind::Sell,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            executed_amount: 100.into(),
+            ..Default::default()
+        };
+        assert_eq!(fully_filled_sell.fee(), 5.into());
+
+        let partially_filled_sell = Trade {
+            order: Order {
+                order_creation: OrderCreation {
+                    sell_amount: 100.into(),
+                    fee_amount: 5.into(),
+                    kind: OrderKind::Sell,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            executed_amount: 50.into(),
+            ..Default::default()
+        };
+        assert_eq!(partially_filled_sell.fee(), 2.into());
+
+        let fully_filled_buy = Trade {
+            order: Order {
+                order_creation: OrderCreation {
+                    buy_amount: 100.into(),
+                    fee_amount: 5.into(),
+                    kind: OrderKind::Buy,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            executed_amount: 100.into(),
+            ..Default::default()
+        };
+        assert_eq!(fully_filled_buy.fee(), 5.into());
+
+        let partially_filled_buy = Trade {
+            order: Order {
+                order_creation: OrderCreation {
+                    buy_amount: 100.into(),
+                    fee_amount: 5.into(),
+                    kind: OrderKind::Buy,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            executed_amount: 50.into(),
+            ..Default::default()
+        };
+        assert_eq!(partially_filled_buy.fee(), 2.into());
+    }
+
+    #[test]
+    fn total_fees_normalizes_individual_fees_into_eth() {
+        let token0 = H160::from_low_u64_be(0);
+        let token1 = H160::from_low_u64_be(1);
+
+        let trade0 = Trade {
+            order: Order {
+                order_creation: OrderCreation {
+                    sell_token: token0,
+                    sell_amount: 10.into(),
+                    fee_amount: 5.into(),
+                    kind: OrderKind::Sell,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            executed_amount: 10.into(),
+            ..Default::default()
+        };
+        let trade1 = Trade {
+            order: Order {
+                order_creation: OrderCreation {
+                    sell_token: token1,
+                    sell_amount: 10.into(),
+                    fee_amount: 2.into(),
+                    kind: OrderKind::Sell,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            executed_amount: 10.into(),
+            ..Default::default()
+        };
+
+        let clearing_prices = maplit::hashmap! {token0 => 5.into(), token1 => 10.into()};
+        let external_prices = maplit::hashmap! {token0 => BigRational::from_integer(5.into()), token1 => BigRational::from_integer(10.into())};
+
+        // Fee in sell tokens
+        assert_eq!(trade0.fee(), 5.into());
+        assert_eq!(trade1.fee(), 2.into());
+
+        // Fee in wei of ETH
+        let settlement = test_settlement(clearing_prices, vec![trade0, trade1]);
+        assert_eq!(
+            settlement.total_fees(&external_prices),
+            BigRational::from_integer(45.into())
         );
     }
 }


### PR DESCRIPTION
Our current objective value deducts the costs (gas) from the achieved surplus but doesn't offset its cost by the accrued fees. This may lead to batches where the objective criterion is actually negative (for smaller amounts the surplus tends to be much smaller than the gas costs).

This may lead to weird behaviour that simpler, single trade solutions are picked over complex CoW solutions, because the single trade solution is less negative (and therefore better) than matching many negative trades at once.

This PR adds the solver_fees to the objective value and also scales them by the discount factor (pretending users were paying the real min fee)

### Test Plan
Added a unit test for both individual trade fee computation as well as the total fee computation for a settlement (containing normalizing prices).
