### PR TITLE
[Trivial] Error on incomming Token Deregistration event

### DIFF
--- a/shared/src/balancer_event_handler.rs
+++ b/shared/src/balancer_event_handler.rs
@@ -239,6 +239,10 @@ impl BalancerPools {
                     ContractEvent::TokensRegistered(event) => {
                         Some(convert_tokens_registered(&event, &meta))
                     }
+                    ContractEvent::TokensDeregistered(event) => {
+                        tracing::error!("unexpected Token Deregistration event {:?}", event);
+                        None
+                    }
                     _ => {
                         // TODO - Not processing other events at the moment.
                         // https://github.com/gnosis/gp-v2-services/issues/681


### PR DESCRIPTION
Simple Follow up #642 

Given that we are only interested in `WeightedPools` at the moment and from the contract code, it appears that tokens are not ever deregistered.

### Test Plan
No new tests.
