### PR TITLE
Logging http solver instance name for cross referencing.

### DIFF
--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -387,10 +387,7 @@ impl Solver for HttpSolver {
             return Ok(Vec::new());
         };
         let (model, context) = self.prepare_model(liquidity, gas_price).await?;
-        tracing::info!(
-            "http solver instance name is {}",
-            self.config.instance_name
-        );
+        tracing::info!("http solver instance name is {}", self.config.instance_name);
         let settled = self.send(&model).await?;
         tracing::trace!(?settled);
         if !settled.has_execution_plan() {

--- a/solver/src/http_solver.rs
+++ b/solver/src/http_solver.rs
@@ -387,6 +387,10 @@ impl Solver for HttpSolver {
             return Ok(Vec::new());
         };
         let (model, context) = self.prepare_model(liquidity, gas_price).await?;
+        tracing::info!(
+            "http solver instance name is {}",
+            self.config.instance_name
+        );
         let settled = self.send(&model).await?;
         tracing::trace!(?settled);
         if !settled.has_execution_plan() {


### PR DESCRIPTION
For convenience. If we wanted to also log an address to the instance.json file in the S3 bucket we would need a way to know if we're in staging or prod from rust, or just create another parameter with the s3 url.
