### PR TITLE
Makes sure instance_name is generated on every http solve.

### DIFF
--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -85,12 +85,12 @@ pub fn create(
                 SolverConfig {
                     max_nr_exec_orders: 100,
                     time_limit: time_limit.as_secs() as u32,
-                    instance_name: HttpSolver::generate_instance_name(&network_id, chain_id),
                 },
                 native_token,
                 token_info_fetcher.clone(),
                 price_estimator.clone(),
                 network_id.clone(),
+                chain_id,
                 fee_discount_factor,
             )),
             SolverType::OneInch => {


### PR DESCRIPTION
Previously instance_name passed to http solver was being generated at program startup instead of every time the solver is called. This PR fixes that.