### PR TITLE
Fix price estimation

### DIFF
--- a/shared/src/baseline_solver.rs
+++ b/shared/src/baseline_solver.rs
@@ -115,6 +115,8 @@ pub fn estimate_sell_amount<'a, L: BaselineSolvable>(
         })
 }
 
+/// Maximum amount of units of the last token of the path you get when selling 1 unit of the first
+/// token along the path.
 pub fn estimate_spot_price<'a, L: BaselineSolvable>(
     path: &[H160],
     liquidity: &'a HashMap<TokenPair, Vec<L>>,


### PR DESCRIPTION
A user reported a bug that the price we give was wrong. For the pair [SushiToken](https://etherscan.io/token/0x6B3595068778DD592e39A122f4f5a5cF09C90fE2) - [USDC](https://etherscan.io/token/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48) the 1 sushi should be worth  roughly 10 usdc as seen on the etherscsan links.

```
curl "https://protocol-mainnet.dev.gnosisdev.com/api/v1/markets/0x6B3595068778DD592e39A122f4f5a5cF09C90fE2-0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/sell/100000000000000000000"
{"amount":"540263517","token":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"}
```

Taking the decimals into account: `(540263517 * 1e-6) / (100000000000000000000 * 1e-18) == 5.4` so indeed the price is off.

When debugging this I noticed that `sell_token_price_in_eth` seemed off because `cost_in_native_token` (which is the final buy amount in the native token) was many orders of magnitudes lower than `tx_cost_in_native_token` when intuitively it should be a little larger as we are selling roughly a 1000 dollars worth of sushi. This made the the gas cost effectively the only criteria so the direct connection was always preferred even with a much worse price.

The reason for this is that `estimate_price` returns different units when calculating with 0 input amount (spot price) versus some input amount. I fixed the documentation and swapped the order of the tokens in the native token spot price calculation and changed the test so that it would fail without this commit.

In a future PR it probably makes sense to make this more clear in the names of the functions and also have a separate spot_price function rather than mixing this behavior in the same estimate_price function.

### Test Plan
new unit test and ran the same curl command locally: 

```
curl "http://localhost:8080/api/v1/markets/0x6B3595068778DD592e39A122f4f5a5cF09C90fE2-0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/sell/100000000000000000000"
{"amount":"928545308","token":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"}
```

`(928545308 * 1e-6) / (100000000000000000000 * 1e-18) == 9.3`
