### PR TITLE
Multi-Contract Event Handling

### DIFF
--- a/shared/src/event_handling.rs
+++ b/shared/src/event_handling.rs
@@ -18,10 +18,10 @@ pub struct EventHandler<B, C, S>
 where
     B: BlockRetrieving,
     C: EventRetrieving,
-    S: EventStoring<C::Event>,
+    S: EventStoring<C::Event, String>,
 {
     block_retriever: B,
-    contract: C,
+    named_contracts: Vec<(C, String)>,
     store: S,
     last_handled_block: Option<u64>,
 }
@@ -33,23 +33,30 @@ where
 /// Databases: might transform, filter and classify which events are inserted
 /// HashSet: For less persistent (in memory) storing, insert events into a set.
 #[async_trait::async_trait]
-pub trait EventStoring<T> {
+pub trait EventStoring<T, U> {
     /// Returns ok, on successful execution, otherwise an appropriate error
     ///
     /// # Arguments
     /// * `events` the contract events to be replaced by the implementer
     /// * `range` indicates a particular range of blocks on which to operate.
+    /// * `context` used by the multi-receiver to pass information like which receiver it came from
     async fn replace_events(
         &mut self,
         events: Vec<EthcontractEvent<T>>,
         range: RangeInclusive<BlockNumber>,
+        context: Option<U>,
     ) -> Result<()>;
 
     /// Returns ok, on successful execution, otherwise an appropriate error
     ///
     /// # Arguments
     /// * `events` the contract events to be appended by the implementer
-    async fn append_events(&mut self, events: Vec<EthcontractEvent<T>>) -> Result<()>;
+    /// * `context` used by the multi-receiver to pass information like which receiver it came from
+    async fn append_events(
+        &mut self,
+        events: Vec<EthcontractEvent<T>>,
+        context: Option<U>,
+    ) -> Result<()>;
 
     async fn last_event_block(&self) -> Result<u64>;
 }
@@ -63,17 +70,17 @@ impl<B, C, S> EventHandler<B, C, S>
 where
     B: BlockRetrieving,
     C: EventRetrieving,
-    S: EventStoring<C::Event>,
+    S: EventStoring<C::Event, String>,
 {
     pub fn new(
         block_retriever: B,
-        contract: C,
+        named_contracts: Vec<(C, String)>,
         store: S,
         start_sync_at_block: Option<u64>,
     ) -> Self {
         Self {
             block_retriever,
-            contract,
+            named_contracts,
             store,
             last_handled_block: start_sync_at_block,
         }
@@ -100,59 +107,66 @@ where
         Ok(BlockNumber::Specific(from_block)..=BlockNumber::Latest(current_block))
     }
 
-    /// Get new events from the contract and insert them into the database.
+    /// Get new events from the each contract and insert them into the database.
     pub async fn update_events(&mut self) -> Result<()> {
         let range = self.event_block_range().await?;
         tracing::debug!("updating events in block range {:?}", range);
-        let events = self
-            .past_events(&range)
-            .await
-            .context("failed to get past events")?
-            .ready_chunks(INSERT_EVENT_BATCH_SIZE)
-            .map(|chunk| chunk.into_iter().collect::<Result<Vec<_>, _>>());
-        futures::pin_mut!(events);
-        // We intentionally do not go with the obvious approach of deleting old events first and
-        // then inserting new ones. Instead, we make sure that the deletion and the insertion of the
-        // first batch of events happen in one transaction.
-        // This is important for two reasons:
-        // 1. It ensures that we only delete if we really have new events. Otherwise if fetching new
-        //    events from the node fails for whatever reason we might keep deleting events over and
-        //    over without inserting new ones resulting in the database table getting cleared.
-        // 2. It ensures that other users of the database are unlikely to see an inconsistent state
-        //    some events have been deleted but new ones not yet inserted. This is important in case
-        //    for example another part of the code calculates the total executed amount of an order.
-        //    If this happened right after deletion but before insertion, then the result would be
-        //    wrong. In theory this could still happen if the last MAX_REORG_BLOCK_COUNT blocks had
-        //    more than INSERT_TRADE_BATCH_SIZE trade events but this is unlikely.
-        // There alternative solutions for 2. but this one is the most practical. For example, we
-        // could keep all reorg-able events in this struct and only store ones that are older than
-        // MAX_REORG_BLOCK_COUNT in the database but then any code using trade events would have to
-        // go through this class instead of being able to work with the database directly.
-        // Or we could make the batch size unlimited but this runs into problems when we have not
-        // updated it in a long time resulting in many missing events which we would all have to
-        // in one transaction.
-        let mut have_deleted_old_events = false;
-        while let Some(events_chunk) = events.next().await {
-            let unwrapped_events = events_chunk.context("failed to get next chunk of events")?;
-            if !have_deleted_old_events {
-                self.store
-                    .replace_events(unwrapped_events, range.clone())
-                    .await?;
-                have_deleted_old_events = true;
-            } else {
-                self.store.append_events(unwrapped_events).await?;
-            };
+        for (contract, name) in &self.named_contracts {
+            let events = self
+                .past_events(&range, contract)
+                .await
+                .context("failed to get past events")?
+                .ready_chunks(INSERT_EVENT_BATCH_SIZE)
+                .map(|chunk| chunk.into_iter().collect::<Result<Vec<_>, _>>());
+            futures::pin_mut!(events);
+            // We intentionally do not go with the obvious approach of deleting old events first and
+            // then inserting new ones. Instead, we make sure that the deletion and the insertion of the
+            // first batch of events happen in one transaction.
+            // This is important for two reasons:
+            // 1. It ensures that we only delete if we really have new events. Otherwise if fetching new
+            //    events from the node fails for whatever reason we might keep deleting events over and
+            //    over without inserting new ones resulting in the database table getting cleared.
+            // 2. It ensures that other users of the database are unlikely to see an inconsistent state
+            //    some events have been deleted but new ones not yet inserted. This is important in case
+            //    for example another part of the code calculates the total executed amount of an order.
+            //    If this happened right after deletion but before insertion, then the result would be
+            //    wrong. In theory this could still happen if the last MAX_REORG_BLOCK_COUNT blocks had
+            //    more than INSERT_TRADE_BATCH_SIZE trade events but this is unlikely.
+            // There alternative solutions for 2. but this one is the most practical. For example, we
+            // could keep all reorg-able events in this struct and only store ones that are older than
+            // MAX_REORG_BLOCK_COUNT in the database but then any code using trade events would have to
+            // go through this class instead of being able to work with the database directly.
+            // Or we could make the batch size unlimited but this runs into problems when we have not
+            // updated it in a long time resulting in many missing events which we would all have to
+            // in one transaction.
+            let mut have_deleted_old_events = false;
+            while let Some(events_chunk) = events.next().await {
+                let unwrapped_events =
+                    events_chunk.context("failed to get next chunk of events")?;
+                if !have_deleted_old_events {
+                    self.store
+                        .replace_events(unwrapped_events, range.clone(), Some(name.clone()))
+                        .await?;
+                    have_deleted_old_events = true;
+                } else {
+                    self.store
+                        .append_events(unwrapped_events, Some(name.clone()))
+                        .await?;
+                };
+            }
         }
         self.last_handled_block = Some(range.end().to_u64());
         Ok(())
     }
 
+    // TODO - This should ideally be a method on the contract itself,
+    // but we use a marco to generate implementation of EventRetrieving for contracts.
     async fn past_events(
         &self,
         block_range: &RangeInclusive<BlockNumber>,
+        contract: &C,
     ) -> Result<impl Stream<Item = Result<EthcontractEvent<C::Event>>>, ExecutionError> {
-        Ok(self
-            .contract
+        Ok(contract
             .get_events()
             .from_block((*block_range.start()).block_number())
             .to_block((*block_range.end()).block_number())
@@ -169,7 +183,7 @@ where
     B: BlockRetrieving + Send + Sync,
     C: EventRetrieving + Send + Sync,
     C::Event: Send,
-    S: EventStoring<C::Event> + Send + Sync,
+    S: EventStoring<C::Event, String> + Send + Sync,
 {
     async fn run_maintenance(&self) -> Result<()> {
         self.lock().await.update_events().await


### PR DESCRIPTION
As a first step to Receiving and Storing multiple pool types for the Balancer integration, we must first implement some way Streaming Events from multiple contracts into the same Storage. This naive first approach extends the event handler to accept a vector of Event Receivers coupled with some additional context which the EventStoring uses to distinguish where the events came from. This adaption is used for our existing single contract event handlers passing along the contract name as a String.

For event updates, this implementation simply loops over each receiver, and handles the events sequentially. This may be something can could be parallelized perhaps with a mutex but it seems we will be fetching the same blocks multiple times   regardless. Happy to get suggestions on this

### Test Plan
No tests introduced here.
