### PR TITLE
Make driver use pool cache for liquidity

### DIFF
--- a/e2e/tests/eth_integration.rs
+++ b/e2e/tests/eth_integration.rs
@@ -6,7 +6,10 @@ use model::{
 };
 use secp256k1::SecretKey;
 use serde_json::json;
-use shared::{amm_pair_provider::UniswapPairProvider, maintenance::Maintaining, Web3};
+use shared::{
+    amm_pair_provider::UniswapPairProvider, maintenance::Maintaining, pool_fetching::PoolFetcher,
+    Web3,
+};
 use solver::{
     liquidity::uniswap::UniswapLikeLiquidity, liquidity_collector::LiquidityCollector,
     metrics::NoopMetrics,
@@ -181,10 +184,13 @@ async fn eth_integration(web3: Web3) {
 
     let uniswap_liquidity = UniswapLikeLiquidity::new(
         IUniswapLikeRouter::at(&web3, uniswap_router.address()),
-        uniswap_pair_provider.clone(),
         gpv2.settlement.clone(),
         HashSet::new(),
         web3.clone(),
+        Arc::new(PoolFetcher {
+            pair_provider: uniswap_pair_provider,
+            web3: web3.clone(),
+        }),
     );
     let solver = solver::naive_solver::NaiveSolver {};
     let liquidity_collector = LiquidityCollector {

--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -7,7 +7,7 @@ use model::{
 };
 use secp256k1::SecretKey;
 use serde_json::json;
-use shared::{amm_pair_provider::UniswapPairProvider, Web3};
+use shared::{amm_pair_provider::UniswapPairProvider, pool_fetching::PoolFetcher, Web3};
 use solver::{
     liquidity::uniswap::UniswapLikeLiquidity, liquidity_collector::LiquidityCollector,
     metrics::NoopMetrics,
@@ -155,10 +155,13 @@ async fn onchain_settlement(web3: Web3) {
     // Drive solution
     let uniswap_liquidity = UniswapLikeLiquidity::new(
         IUniswapLikeRouter::at(&web3, uniswap_router.address()),
-        uniswap_pair_provider.clone(),
         gpv2.settlement.clone(),
         HashSet::new(),
         web3.clone(),
+        Arc::new(PoolFetcher {
+            pair_provider: uniswap_pair_provider,
+            web3: web3.clone(),
+        }),
     );
     let solver = solver::naive_solver::NaiveSolver {};
     let liquidity_collector = LiquidityCollector {

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -9,6 +9,7 @@ use secp256k1::SecretKey;
 use serde_json::json;
 use shared::{
     amm_pair_provider::UniswapPairProvider,
+    pool_fetching::PoolFetcher,
     token_list::{Token, TokenList},
     Web3,
 };
@@ -148,10 +149,13 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
     // Drive solution
     let uniswap_liquidity = UniswapLikeLiquidity::new(
         IUniswapLikeRouter::at(&web3, uniswap_router.address()),
-        uniswap_pair_provider.clone(),
         gpv2.settlement.clone(),
         HashSet::new(),
         web3.clone(),
+        Arc::new(PoolFetcher {
+            pair_provider: uniswap_pair_provider,
+            web3: web3.clone(),
+        }),
     );
     let solver = solver::naive_solver::NaiveSolver {};
     let liquidity_collector = LiquidityCollector {

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -1,5 +1,5 @@
 //! Contains command line arguments and related helpers that are shared between the binaries.
-use crate::{gas_price_estimation::GasEstimatorType, pool_aggregating::BaselineSources};
+use crate::{gas_price_estimation::GasEstimatorType, pool_aggregating::BaselineSource};
 use ethcontract::{H160, U256};
 use std::{
     num::{NonZeroU64, ParseFloatError},
@@ -59,11 +59,11 @@ pub struct Arguments {
         long,
         env = "BASELINE_SOURCES",
         default_value = "Uniswap,Sushiswap",
-        possible_values = &BaselineSources::variants(),
+        possible_values = &BaselineSource::variants(),
         case_insensitive = true,
         use_delimiter = true
     )]
-    pub baseline_sources: Vec<BaselineSources>,
+    pub baseline_sources: Vec<BaselineSource>,
 
     /// The number of blocks kept in the pool cache.
     #[structopt(long, env, default_value = "10")]

--- a/shared/src/pool_aggregating.rs
+++ b/shared/src/pool_aggregating.rs
@@ -1,4 +1,4 @@
-use crate::pool_fetching::{Pool, PoolFetcher, PoolFetching};
+use crate::pool_fetching::{Pool, PoolFetching};
 use crate::Web3;
 use crate::{
     amm_pair_provider::{AmmPairProvider, SushiswapPairProvider, UniswapPairProvider},
@@ -11,53 +11,35 @@ use std::sync::Arc;
 use structopt::clap::arg_enum;
 
 arg_enum! {
-    #[derive(Debug, Clone)]
-    pub enum BaselineSources {
+    #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
+    pub enum BaselineSource {
         Uniswap,
         Sushiswap,
     }
 }
 
-pub async fn pair_providers(
-    sources: &[BaselineSources],
+pub async fn pair_provider(
+    source: BaselineSource,
     chain_id: u64,
     web3: &Web3,
-) -> Vec<Arc<dyn AmmPairProvider>> {
-    let mut providers: Vec<Arc<dyn AmmPairProvider>> = Vec::new();
-    for source in sources {
-        providers.push(match source {
-            BaselineSources::Uniswap => Arc::new(UniswapPairProvider {
-                factory: contracts::UniswapV2Factory::deployed(web3)
-                    .await
-                    .expect("couldn't load deployed uniswap router"),
-                chain_id,
-            }),
-            BaselineSources::Sushiswap => Arc::new(SushiswapPairProvider {
-                factory: contracts::SushiswapV2Factory::deployed(web3)
-                    .await
-                    .expect("couldn't load deployed sushiswap router"),
-            }),
-        })
+) -> Arc<dyn AmmPairProvider> {
+    match source {
+        BaselineSource::Uniswap => Arc::new(UniswapPairProvider {
+            factory: contracts::UniswapV2Factory::deployed(web3)
+                .await
+                .expect("couldn't load deployed uniswap router"),
+            chain_id,
+        }),
+        BaselineSource::Sushiswap => Arc::new(SushiswapPairProvider {
+            factory: contracts::SushiswapV2Factory::deployed(web3)
+                .await
+                .expect("couldn't load deployed sushiswap router"),
+        }),
     }
-    providers
 }
 
 pub struct PoolAggregator {
-    pub pool_fetchers: Vec<PoolFetcher>,
-}
-
-impl PoolAggregator {
-    pub async fn from_providers(pair_providers: &[Arc<dyn AmmPairProvider>], web3: &Web3) -> Self {
-        let pool_fetchers = pair_providers
-            .iter()
-            .cloned()
-            .map(|pair_provider| PoolFetcher {
-                pair_provider,
-                web3: web3.clone(),
-            })
-            .collect();
-        Self { pool_fetchers }
-    }
+    pub pool_fetchers: Vec<Arc<dyn PoolFetching>>,
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
 For this we turn the cache of the aggregator of uniswap and sushiswapinto the aggregator of the cache of uniswap and the cache of sushiswap so that we have two caches instead of one.
I kept the order book as the single cache of the aggregator because we don't need this there.
This code is likely to change further when we integrate balance pools but I wanted to accomplish this first.

### Test Plan
Existing tests still work as this just moves code around without changing logic.
