### PR TITLE
694/cancel order on invalid status

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -588,7 +588,7 @@ components:
       properties:
         errorType:
           type: string
-          enum: [InvalidSignature, WrongOwner, OrderNotFound]
+          enum: [InvalidSignature, WrongOwner, OrderNotFound, OrderAlreadyCancelled, OrderFullyExecuted, OrderExpired]
         description:
           type: string
       required:

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -588,7 +588,7 @@ components:
       properties:
         errorType:
           type: string
-          enum: [InvalidSignature, WrongOwner, OrderNotFound, OrderAlreadyCancelled, OrderFullyExecuted, OrderExpired]
+          enum: [InvalidSignature, WrongOwner, OrderNotFound, AlreadyCancelled, OrderFullyExecuted, OrderExpired]
         description:
           type: string
       required:

--- a/orderbook/src/api/cancel_order.rs
+++ b/orderbook/src/api/cancel_order.rs
@@ -144,6 +144,18 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
         let response =
+            cancel_order_response(Ok(OrderCancellationResult::OrderFullyExecuted)).into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let response = cancel_order_response(Ok(OrderCancellationResult::OrderAlreadyCancelled))
+            .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let response =
+            cancel_order_response(Ok(OrderCancellationResult::OrderExpired)).into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let response =
             cancel_order_response(Ok(OrderCancellationResult::WrongOwner)).into_response();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 

--- a/orderbook/src/api/cancel_order.rs
+++ b/orderbook/src/api/cancel_order.rs
@@ -36,6 +36,18 @@ pub fn cancel_order_response(result: Result<OrderCancellationResult>) -> impl Re
             super::error("InvalidSignature", "Likely malformed signature"),
             StatusCode::BAD_REQUEST,
         ),
+        Ok(OrderCancellationResult::OrderAlreadyCancelled) => (
+            super::error("OrderAlreadyCancelled", "Order is already cancelled"),
+            StatusCode::BAD_REQUEST,
+        ),
+        Ok(OrderCancellationResult::OrderFullyExecuted) => (
+            super::error("OrderFullyExecuted", "Order is fully executed"),
+            StatusCode::BAD_REQUEST,
+        ),
+        Ok(OrderCancellationResult::OrderExpired) => (
+            super::error("OrderExpired", "Order is expired"),
+            StatusCode::BAD_REQUEST,
+        ),
         Ok(OrderCancellationResult::OrderNotFound) => (
             super::error("OrderNotFound", "order not located in database"),
             StatusCode::NOT_FOUND,

--- a/orderbook/src/api/cancel_order.rs
+++ b/orderbook/src/api/cancel_order.rs
@@ -36,8 +36,8 @@ pub fn cancel_order_response(result: Result<OrderCancellationResult>) -> impl Re
             super::error("InvalidSignature", "Likely malformed signature"),
             StatusCode::BAD_REQUEST,
         ),
-        Ok(OrderCancellationResult::OrderAlreadyCancelled) => (
-            super::error("OrderAlreadyCancelled", "Order is already cancelled"),
+        Ok(OrderCancellationResult::AlreadyCancelled) => (
+            super::error("AlreadyCancelled", "Order is already cancelled"),
             StatusCode::BAD_REQUEST,
         ),
         Ok(OrderCancellationResult::OrderFullyExecuted) => (
@@ -147,8 +147,8 @@ mod tests {
             cancel_order_response(Ok(OrderCancellationResult::OrderFullyExecuted)).into_response();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
-        let response = cancel_order_response(Ok(OrderCancellationResult::OrderAlreadyCancelled))
-            .into_response();
+        let response =
+            cancel_order_response(Ok(OrderCancellationResult::AlreadyCancelled)).into_response();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
         let response =

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -9,7 +9,7 @@ use chrono::Utc;
 use futures::TryStreamExt;
 use model::order::{OrderCancellation, OrderCreationPayload};
 use model::{
-    order::{Order, OrderUid, BUY_ETH_ADDRESS},
+    order::{Order, OrderStatus, OrderUid, BUY_ETH_ADDRESS},
     DomainSeparator,
 };
 use primitive_types::{H160, U256};
@@ -165,14 +165,21 @@ impl Orderbook {
 
         match cancellation.validate(&self.domain_separator) {
             Some(signer) => {
-                if signer == order.order_meta_data.owner {
-                    // order is already known to exist in DB at this point!
-                    self.database
-                        .cancel_order(&order.order_meta_data.uid, Utc::now())
-                        .await?;
-                    Ok(OrderCancellationResult::Cancelled)
-                } else {
-                    Ok(OrderCancellationResult::WrongOwner)
+                match order.order_meta_data.status {
+                    OrderStatus::Fulfilled => Ok(OrderCancellationResult::OrderFullyExecuted),
+                    OrderStatus::Cancelled => Ok(OrderCancellationResult::OrderAlreadyCancelled),
+                    OrderStatus::Expired => Ok(OrderCancellationResult::OrderExpired),
+                    OrderStatus::Open => {
+                        if signer == order.order_meta_data.owner {
+                            // order is already known to exist in DB at this point!
+                            self.database
+                                .cancel_order(&order.order_meta_data.uid, Utc::now())
+                                .await?;
+                            Ok(OrderCancellationResult::Cancelled)
+                        } else {
+                            Ok(OrderCancellationResult::WrongOwner)
+                        }
+                    }
                 }
             }
             None => Ok(OrderCancellationResult::InvalidSignature),

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -44,7 +44,7 @@ pub enum OrderCancellationResult {
     InvalidSignature,
     WrongOwner,
     OrderNotFound,
-    OrderAlreadyCancelled,
+    AlreadyCancelled,
     OrderFullyExecuted,
     OrderExpired,
 }
@@ -167,7 +167,7 @@ impl Orderbook {
             Some(signer) => {
                 match order.order_meta_data.status {
                     OrderStatus::Fulfilled => Ok(OrderCancellationResult::OrderFullyExecuted),
-                    OrderStatus::Cancelled => Ok(OrderCancellationResult::OrderAlreadyCancelled),
+                    OrderStatus::Cancelled => Ok(OrderCancellationResult::AlreadyCancelled),
                     OrderStatus::Expired => Ok(OrderCancellationResult::OrderExpired),
                     OrderStatus::Open => {
                         if signer == order.order_meta_data.owner {

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -44,6 +44,9 @@ pub enum OrderCancellationResult {
     InvalidSignature,
     WrongOwner,
     OrderNotFound,
+    OrderAlreadyCancelled,
+    OrderFullyExecuted,
+    OrderExpired,
 }
 
 pub struct Orderbook {


### PR DESCRIPTION
# Summary

Fixes #694 

Depends on #715 

Adds 3 new error types for order cancellation based on order status.

### Test Plan
Unit tests
