### PR TITLE
[Cleanup] Balancer Split Files and Document

### DIFF
--- a/shared/src/balancer.rs
+++ b/shared/src/balancer.rs
@@ -1,2 +1,3 @@
 pub mod event_handler;
+mod info_fetching;
 pub mod pool_fetching;

--- a/shared/src/balancer.rs
+++ b/shared/src/balancer.rs
@@ -1,4 +1,4 @@
 pub mod event_handler;
 mod info_fetching;
 pub mod pool_fetching;
-mod pool_models;
+mod pool_storage;

--- a/shared/src/balancer.rs
+++ b/shared/src/balancer.rs
@@ -1,3 +1,4 @@
 pub mod event_handler;
 mod info_fetching;
 pub mod pool_fetching;
+mod pool_models;

--- a/shared/src/balancer.rs
+++ b/shared/src/balancer.rs
@@ -1,21 +1,22 @@
-//! This module contains event handling for maintaining in-memory storage of a balancer pool registry
-//! along with public facing tools for retrieving known pools from this registry on demand.
+//! Contains event handling for maintaining in-memory storage of a
+//! [`BalancerPoolRegistry`](crate::balancer::event_handler::BalancerPoolRegistry) along with tools for retrieving
+//! known pools from this registry on demand.
 //!
-//! While the static information of the pools (Id, Address, Tokens) can be kept in memory as part
-//! of the registry, their dynamic information (such as current reserves) is block-dependent and
-//! must be queried from the EVM upon request. For this we provide `BalancerPoolFetcher`
-//! which is responsible for retrieving requested pools from the registry and attaching the most
-//! recent reserves to the result.
+//! While the static information of the pools (such as `pool_id`, `address`, `tokens`) can be
+//! kept in memory as part of the registry, their dynamic information (such as current reserves)
+//! is block-dependent and must be queried from the EVM upon request.
+//! For this we provide [`BalancerPoolFetcher`](crate::balancer::pool_fetching::BalancerPoolFetcher) which is responsible for
+//! retrieving requested pools from the registry and attaching the most recent reserves to the result.
 //!
 //! The module is designed return the most recent pool info on demand.
 //! The only public facing components necessary to achieve this are
 //!
-//! 1. `BalancerPoolRegistry` which contains an event handler for each distinct Balancer Pool
+//! 1. [`BalancerPoolRegistry`](crate::balancer::event_handler::BalancerPoolRegistry) which contains an event handler for each distinct Balancer Pool
 //! Factory contract and maintains its own in-memory storage of each pool and its static information.
 //!
-//! 2. `BalancerPoolFetcher` which holds an instance of `BalancerPoolRegistry`, implements
-//! `BalancerPoolFetching` and thus exposes a `fetch` method which returns a collection of
-//! "relevant" `WeightedPools` for a given collection of `TokenPair`.
+//! 2. [`BalancerPoolFetcher`](crate::balancer::pool_fetching::BalancerPoolFetcher) which holds an instance of `BalancerPoolRegistry`,
+//! implements [`WeightedPoolFetching`](crate::balancer::pool_fetching::WeightedPoolFetching) and thus exposes a `fetch` method
+//! which returns a collection of relevant `WeightedPools` for a given collection of `TokenPair`.
 //!
 //! For this reason, only the `event_handler` and `pool_fetching` are declare as public,
 //! while `pool_storage` and `info_fetching` merely contains internal logic regarding how

--- a/shared/src/balancer.rs
+++ b/shared/src/balancer.rs
@@ -1,3 +1,29 @@
+//! This module contains event handling for maintaining in-memory storage of a balancer pool registry
+//! along with public facing tools for retrieving known pools from this registry on demand.
+//!
+//! While the static information of the pools (Id, Address, Tokens) can be kept in memory as part
+//! of the registry, their dynamic information (such as current reserves) is block-dependent and
+//! must be queried from the EVM upon request. For this we provide `BalancerPoolFetcher`
+//! which is responsible for retrieving requested pools from the registry and attaching the most
+//! recent reserves to the result.
+//!
+//! The module is designed return the most recent pool info on demand.
+//! The only public facing components necessary to achieve this are
+//!
+//! 1. `BalancerPoolRegistry` which contains an event handler for each distinct Balancer Pool
+//! Factory contract and maintains its own in-memory storage of each pool and its static information.
+//!
+//! 2. `BalancerPoolFetcher` which holds an instance of `BalancerPoolRegistry`, implements
+//! `BalancerPoolFetching` and thus exposes a `fetch` method which returns a collection of
+//! "relevant" `WeightedPools` for a given collection of `TokenPair`.
+//!
+//! For this reason, only the `event_handler` and `pool_fetching` are declare as public,
+//! while `pool_storage` and `info_fetching` merely contains internal logic regarding how
+//! information is collected and stored.
+//!
+//! Once should think of `PoolStorage` as a type of Database for which one is not concerned
+//! with how it maintains itself.
+
 pub mod event_handler;
 mod info_fetching;
 pub mod pool_fetching;

--- a/shared/src/balancer.rs
+++ b/shared/src/balancer.rs
@@ -19,7 +19,7 @@
 //! which returns a collection of relevant `WeightedPools` for a given collection of `TokenPair`.
 //!
 //! For this reason, only the `event_handler` and `pool_fetching` are declared as public,
-//! while `pool_storage` and `info_fetching` merely contains internal logic regarding how
+//! while `pool_storage` and `info_fetching` merely contain internal logic regarding how
 //! information is collected and stored.
 //!
 //! Once should think of `PoolStorage` as a type of Database for which one is not concerned

--- a/shared/src/balancer.rs
+++ b/shared/src/balancer.rs
@@ -1,21 +1,21 @@
 //! Contains event handling for maintaining in-memory storage of a
-//! [`BalancerPoolRegistry`](crate::balancer::event_handler::BalancerPoolRegistry) along with tools for retrieving
+//! `BalancerPoolRegistry` along with tools for retrieving
 //! known pools from this registry on demand.
 //!
 //! While the static information of the pools (such as `pool_id`, `address`, `tokens`) can be
 //! kept in memory as part of the registry, their dynamic information (such as current reserves)
 //! is block-dependent and must be queried from the EVM upon request.
-//! For this we provide [`BalancerPoolFetcher`](crate::balancer::pool_fetching::BalancerPoolFetcher) which is responsible for
+//! For this we provide `BalancerPoolFetcher` which is responsible for
 //! retrieving requested pools from the registry and attaching the most recent reserves to the result.
 //!
 //! The module is designed return the most recent pool info on demand.
 //! The only public facing components necessary to achieve this are
 //!
-//! 1. [`BalancerPoolRegistry`](crate::balancer::event_handler::BalancerPoolRegistry) which contains an event handler for each distinct Balancer Pool
+//! 1. `BalancerPoolRegistry` which contains an event handler for each distinct Balancer Pool
 //! Factory contract and maintains its own in-memory storage of each pool and its static information.
 //!
-//! 2. [`BalancerPoolFetcher`](crate::balancer::pool_fetching::BalancerPoolFetcher) which holds an instance of `BalancerPoolRegistry`,
-//! implements [`WeightedPoolFetching`](crate::balancer::pool_fetching::WeightedPoolFetching) and thus exposes a `fetch` method
+//! 2. `BalancerPoolFetcher` which holds an instance of `BalancerPoolRegistry`,
+//! implements `WeightedPoolFetching` and thus exposes a `fetch` method
 //! which returns a collection of relevant `WeightedPools` for a given collection of `TokenPair`.
 //!
 //! For this reason, only the `event_handler` and `pool_fetching` are declare as public,

--- a/shared/src/balancer.rs
+++ b/shared/src/balancer.rs
@@ -18,7 +18,7 @@
 //! implements `WeightedPoolFetching` and thus exposes a `fetch` method
 //! which returns a collection of relevant `WeightedPools` for a given collection of `TokenPair`.
 //!
-//! For this reason, only the `event_handler` and `pool_fetching` are declare as public,
+//! For this reason, only the `event_handler` and `pool_fetching` are declared as public,
 //! while `pool_storage` and `info_fetching` merely contains internal logic regarding how
 //! information is collected and stored.
 //!

--- a/shared/src/balancer.rs
+++ b/shared/src/balancer.rs
@@ -8,7 +8,7 @@
 //! For this we provide `BalancerPoolFetcher` which is responsible for
 //! retrieving requested pools from the registry and attaching the most recent reserves to the result.
 //!
-//! The module is designed return the most recent pool info on demand.
+//! The module is designed to return the most recent pool info on demand.
 //! The only public facing components necessary to achieve this are
 //!
 //! 1. `BalancerPoolRegistry` which contains an event handler for each distinct Balancer Pool

--- a/shared/src/balancer/event_handler.rs
+++ b/shared/src/balancer/event_handler.rs
@@ -126,8 +126,7 @@ impl EventStoring<WeightedPoolFactoryEvent> for PoolStorage {
         events: Vec<EthContractEvent<WeightedPoolFactoryEvent>>,
         range: RangeInclusive<BlockNumber>,
     ) -> Result<()> {
-        PoolStorage::replace_events_inner(
-            self,
+        self.replace_events_inner(
             range.start().to_u64(),
             convert_weighted_pool_created(events)?,
         )
@@ -154,8 +153,7 @@ impl EventStoring<WeightedPool2TokensFactoryEvent> for PoolStorage {
         events: Vec<EthContractEvent<WeightedPool2TokensFactoryEvent>>,
         range: RangeInclusive<BlockNumber>,
     ) -> Result<()> {
-        PoolStorage::replace_events_inner(
-            self,
+        self.replace_events_inner(
             range.start().to_u64(),
             convert_two_token_pool_created(events)?,
         )

--- a/shared/src/balancer/event_handler.rs
+++ b/shared/src/balancer/event_handler.rs
@@ -1,6 +1,6 @@
 use crate::balancer::{
     info_fetching::PoolInfoFetcher,
-    pool_models::{PoolCreated, PoolStorage, RegisteredWeightedPool},
+    pool_storage::{PoolCreated, PoolStorage, RegisteredWeightedPool},
 };
 use crate::token_info::TokenInfoFetching;
 use crate::{
@@ -16,8 +16,7 @@ use contracts::{
     balancer_v2_weighted_pool_factory::{self, Event as WeightedPoolFactoryEvent},
     BalancerV2WeightedPool2TokensFactory, BalancerV2WeightedPoolFactory,
 };
-use ethcontract::common::DeploymentInformation;
-use ethcontract::Event as EthContractEvent;
+use ethcontract::{common::DeploymentInformation, Event as EthContractEvent};
 use model::TokenPair;
 use std::sync::Arc;
 use std::{collections::HashSet, ops::RangeInclusive};

--- a/shared/src/balancer/event_handler.rs
+++ b/shared/src/balancer/event_handler.rs
@@ -1,17 +1,17 @@
-/// This event handler contains mostly boiler plate code for the implementation of `EventReceiving`
-/// and `EventStoring` for Balancer Pool Factory contracts and `PoolStorage` respectively.
-/// Because there are multiple factory contracts for which we rely on event data, the
-/// `BalancerPoolRegistry` is responsible for multiple EventHandlers.
-///
-/// Apart from the event handling boiler plate, there are a few helper methods used as adapters
-/// for converting received contract event data into appropriate internal structs to be passed
-/// along to the `PoolStorage` (database) for update
-///
-/// Due to limitations of `EventReceiving` we must put each event handler behind its own Mutex.
-/// - These mutexes are locked during synchronization and pool fetching.
-///
-/// *Note that* when loading pool from a cold start synchronization can take quite long, but is
-/// otherwise as quick as possible (i.e. taking advantage of as much cached information as possible).
+//! This event handler contains mostly boiler plate code for the implementation of [`EventRetrieving`](crate::event_handling::EventRetrieving)
+//! and [`EventStoring`](crate::event_handling::EventStoring) for Balancer Pool Factory contracts and `PoolStorage` respectively.
+//! Because there are multiple factory contracts for which we rely on event data, the
+//! [`BalancerPoolRegistry`](BalancerPoolRegistry) is responsible for multiple EventHandlers.
+//!
+//! Apart from the event handling boiler plate, there are a few helper methods used as adapters
+//! for converting received contract event data into appropriate internal structs to be passed
+//! along to the `PoolStorage` (database) for update
+//!
+//! Due to limitations of [`EventRetrieving`](crate::event_handling::EventRetrieving) we must put each event handler behind its own Mutex.
+//! - These mutexes are locked during synchronization and pool fetching.
+//!
+//! *Note that* when loading pool from a cold start synchronization can take quite long, but is
+//! otherwise as quick as possible (i.e. taking advantage of as much cached information as possible).
 use crate::balancer::{
     info_fetching::PoolInfoFetcher,
     pool_storage::{PoolCreated, PoolStorage, RegisteredWeightedPool},

--- a/shared/src/balancer/event_handler.rs
+++ b/shared/src/balancer/event_handler.rs
@@ -1,4 +1,7 @@
-use crate::balancer::info_fetching::{PoolInfoFetcher, PoolInfoFetching};
+use crate::balancer::{
+    info_fetching::PoolInfoFetcher,
+    pool_models::{PoolCreated, PoolStorage, RegisteredWeightedPool},
+};
 use crate::token_info::TokenInfoFetching;
 use crate::{
     current_block::BlockRetrieving,
@@ -13,201 +16,18 @@ use contracts::{
     balancer_v2_weighted_pool_factory::{self, Event as WeightedPoolFactoryEvent},
     BalancerV2WeightedPool2TokensFactory, BalancerV2WeightedPoolFactory,
 };
-use derivative::Derivative;
 use ethcontract::common::DeploymentInformation;
-use ethcontract::{Event as EthContractEvent, H160, H256, U256};
-use itertools::Itertools;
+use ethcontract::Event as EthContractEvent;
 use model::TokenPair;
 use std::sync::Arc;
-use std::{
-    collections::{HashMap, HashSet},
-    fmt::Debug,
-    ops::RangeInclusive,
-};
+use std::{collections::HashSet, ops::RangeInclusive};
 use tokio::sync::Mutex;
-
-#[derive(Copy, Debug, Default, Clone, Eq, PartialEq)]
-pub struct PoolCreated {
-    pub pool_address: H160,
-}
-
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct RegisteredWeightedPool {
-    pub pool_id: H256,
-    pub pool_address: H160,
-    pub tokens: Vec<H160>,
-    pub normalized_weights: Vec<U256>,
-    pub scaling_exponents: Vec<u8>,
-    block_created: u64,
-}
-
-impl RegisteredWeightedPool {
-    /// Errors expected here are propagated from `get_pool_data`.
-    async fn from_event(
-        block_created: u64,
-        creation: PoolCreated,
-        data_fetcher: &dyn PoolInfoFetching,
-    ) -> Result<RegisteredWeightedPool> {
-        let pool_address = creation.pool_address;
-        let pool_data = data_fetcher.get_pool_data(pool_address).await?;
-        return Ok(RegisteredWeightedPool {
-            pool_id: pool_data.pool_id,
-            pool_address,
-            tokens: pool_data.tokens,
-            normalized_weights: pool_data.weights,
-            scaling_exponents: pool_data.scaling_exponents,
-            block_created,
-        });
-    }
-}
-
-/// The BalancerPool struct represents in-memory storage of all deployed Balancer Pools
-#[derive(Derivative)]
-#[derivative(Debug)]
-pub struct PoolStorage {
-    /// Used for O(1) access to all pool_ids for a given token
-    pools_by_token: HashMap<H160, HashSet<H256>>,
-    /// WeightedPool data for a given PoolId
-    pools: HashMap<H256, RegisteredWeightedPool>,
-    #[derivative(Debug = "ignore")]
-    data_fetcher: Box<dyn PoolInfoFetching>,
-}
-
-impl PoolStorage {
-    // Since all the fields are private, we expose helper methods to fetch relevant information
-    /// Returns all pools containing both tokens from TokenPair
-    pub fn pools_containing_token_pair(
-        &self,
-        token_pair: TokenPair,
-    ) -> Vec<RegisteredWeightedPool> {
-        let empty_set = HashSet::new();
-        let pools_0 = self
-            .pools_by_token
-            .get(&token_pair.get().0)
-            .unwrap_or(&empty_set);
-        let pools_1 = self
-            .pools_by_token
-            .get(&token_pair.get().1)
-            .unwrap_or(&empty_set);
-        pools_0
-            .intersection(pools_1)
-            .into_iter()
-            .map(|pool_id| {
-                self.pools
-                    .get(pool_id)
-                    .expect("failed iterating over known pools")
-                    .clone()
-            })
-            .collect::<Vec<RegisteredWeightedPool>>()
-    }
-
-    /// Given a collection of TokenPair, returns all pools containing at least one of the pairs.
-    pub fn pools_containing_token_pairs(
-        &self,
-        token_pairs: HashSet<TokenPair>,
-    ) -> Vec<RegisteredWeightedPool> {
-        token_pairs
-            .into_iter()
-            .flat_map(|pair| self.pools_containing_token_pair(pair))
-            .unique_by(|pool| pool.pool_id)
-            .collect()
-    }
-
-    pub fn new(data_fetcher: Box<dyn PoolInfoFetching>) -> Self {
-        PoolStorage {
-            pools_by_token: Default::default(),
-            pools: Default::default(),
-            data_fetcher,
-        }
-    }
-
-    async fn insert_events(&mut self, events: Vec<(EventIndex, PoolCreated)>) -> Result<()> {
-        for (index, creation) in events {
-            let weighted_pool = RegisteredWeightedPool::from_event(
-                index.block_number,
-                creation,
-                &*self.data_fetcher,
-            )
-            .await?;
-            let pool_id = weighted_pool.pool_id;
-            self.pools.insert(pool_id, weighted_pool.clone());
-            for token in weighted_pool.tokens {
-                self.pools_by_token
-                    .entry(token)
-                    .or_default()
-                    .insert(pool_id);
-            }
-        }
-        Ok(())
-    }
-
-    async fn replace_events_inner(
-        &mut self,
-        delete_from_block_number: u64,
-        events: Vec<(EventIndex, PoolCreated)>,
-    ) -> Result<()> {
-        tracing::debug!(
-            "replacing {} events from block number {}",
-            events.len(),
-            delete_from_block_number,
-        );
-        self.delete_pools(delete_from_block_number)?;
-        self.insert_events(events).await?;
-        Ok(())
-    }
-
-    fn delete_pools(&mut self, delete_from_block_number: u64) -> Result<()> {
-        self.pools
-            .retain(|_, pool| pool.block_created < delete_from_block_number);
-        // Note that this could result in an empty set for some tokens.
-        let retained_pool_ids: HashSet<H256> = self.pools.keys().copied().collect();
-        for (_, pool_set) in self.pools_by_token.iter_mut() {
-            *pool_set = pool_set
-                .intersection(&retained_pool_ids)
-                .cloned()
-                .collect::<HashSet<H256>>();
-        }
-        Ok(())
-    }
-
-    fn last_event_block(&self) -> u64 {
-        // Technically we could keep this updated more effectively in a field on balancer pools,
-        // but the maintenance seems like more overhead that needs to be tested.
-        self.pools
-            .iter()
-            .map(|(_, pool)| pool.block_created)
-            .max()
-            .unwrap_or(0)
-    }
-}
 
 pub struct BalancerPoolRegistry {
     weighted_pool_updater:
         Mutex<EventHandler<Web3, BalancerV2WeightedPoolFactoryContract, PoolStorage>>,
     two_token_pool_updater:
         Mutex<EventHandler<Web3, BalancerV2WeightedPool2TokensFactoryContract, PoolStorage>>,
-}
-
-impl BalancerPoolRegistry {
-    pub async fn get_pools_containing_token_pairs(
-        &self,
-        token_pairs: HashSet<TokenPair>,
-    ) -> Vec<RegisteredWeightedPool> {
-        let mut pool_set_1 = self
-            .weighted_pool_updater
-            .lock()
-            .await
-            .store
-            .pools_containing_token_pairs(token_pairs.clone());
-        let pool_set_2 = self
-            .two_token_pool_updater
-            .lock()
-            .await
-            .store
-            .pools_containing_token_pairs(token_pairs);
-        pool_set_1.extend(pool_set_2);
-        pool_set_1
-    }
 }
 
 impl BalancerPoolRegistry {
@@ -241,6 +61,26 @@ impl BalancerPoolRegistry {
             two_token_pool_updater,
         })
     }
+
+    pub async fn get_pools_containing_token_pairs(
+        &self,
+        token_pairs: HashSet<TokenPair>,
+    ) -> Vec<RegisteredWeightedPool> {
+        let mut pool_set_1 = self
+            .weighted_pool_updater
+            .lock()
+            .await
+            .store
+            .pools_containing_token_pairs(token_pairs.clone());
+        let pool_set_2 = self
+            .two_token_pool_updater
+            .lock()
+            .await
+            .store
+            .pools_containing_token_pairs(token_pairs);
+        pool_set_1.extend(pool_set_2);
+        pool_set_1
+    }
 }
 
 async fn get_deployment_block(
@@ -263,17 +103,20 @@ impl EventStoring<WeightedPoolFactoryEvent> for PoolStorage {
         events: Vec<EthContractEvent<WeightedPoolFactoryEvent>>,
         range: RangeInclusive<BlockNumber>,
     ) -> Result<()> {
-        let balancer_events = convert_weighted_pool_created(events)?;
-        PoolStorage::replace_events_inner(self, range.start().to_u64(), balancer_events).await?;
-        Ok(())
+        PoolStorage::replace_events_inner(
+            self,
+            range.start().to_u64(),
+            convert_weighted_pool_created(events)?,
+        )
+        .await
     }
 
     async fn append_events(
         &mut self,
         events: Vec<EthContractEvent<WeightedPoolFactoryEvent>>,
     ) -> Result<()> {
-        let balancer_events = convert_weighted_pool_created(events)?;
-        self.insert_events(balancer_events).await
+        self.insert_events(convert_weighted_pool_created(events)?)
+            .await
     }
 
     async fn last_event_block(&self) -> Result<u64> {
@@ -288,17 +131,20 @@ impl EventStoring<WeightedPool2TokensFactoryEvent> for PoolStorage {
         events: Vec<EthContractEvent<WeightedPool2TokensFactoryEvent>>,
         range: RangeInclusive<BlockNumber>,
     ) -> Result<()> {
-        let balancer_events = convert_two_token_pool_created(events)?;
-        PoolStorage::replace_events_inner(self, range.start().to_u64(), balancer_events).await?;
-        Ok(())
+        PoolStorage::replace_events_inner(
+            self,
+            range.start().to_u64(),
+            convert_two_token_pool_created(events)?,
+        )
+        .await
     }
 
     async fn append_events(
         &mut self,
         events: Vec<EthContractEvent<WeightedPool2TokensFactoryEvent>>,
     ) -> Result<()> {
-        let balancer_events = convert_two_token_pool_created(events)?;
-        self.insert_events(balancer_events).await
+        self.insert_events(convert_two_token_pool_created(events)?)
+            .await
     }
 
     async fn last_event_block(&self) -> Result<u64> {
@@ -357,317 +203,4 @@ fn convert_two_token_pool_created(
             pool_address: creation.pool,
         },
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::balancer::info_fetching::{MockPoolInfoFetching, WeightedPoolInfo};
-    use maplit::hashset;
-    use mockall::predicate::eq;
-
-    #[tokio::test]
-    async fn balancer_insert_events() {
-        let n = 3usize;
-        let pool_ids: Vec<H256> = (0..n).map(|i| H256::from_low_u64_be(i as u64)).collect();
-        let pool_addresses: Vec<H160> = (0..n).map(|i| H160::from_low_u64_be(i as u64)).collect();
-        let tokens: Vec<H160> = (0..n + 1)
-            .map(|i| H160::from_low_u64_be(i as u64))
-            .collect();
-        let weights: Vec<U256> = (0..n + 1).map(|i| U256::from(i as u64)).collect();
-        let creation_events: Vec<PoolCreated> = (0..n)
-            .map(|i| PoolCreated {
-                pool_address: pool_addresses[i],
-            })
-            .collect();
-
-        let events: Vec<(EventIndex, PoolCreated)> = vec![
-            (EventIndex::new(1, 0), creation_events[0]),
-            (EventIndex::new(2, 0), creation_events[1]),
-            (EventIndex::new(3, 0), creation_events[2]),
-        ];
-
-        let mut dummy_data_fetcher = MockPoolInfoFetching::new();
-        for i in 0..n {
-            let expected_pool_data = WeightedPoolInfo {
-                pool_id: pool_ids[i],
-                tokens: vec![tokens[i], tokens[i + 1]],
-                weights: vec![weights[i], weights[i + 1]],
-                scaling_exponents: vec![0, 0],
-            };
-            dummy_data_fetcher
-                .expect_get_pool_data()
-                .with(eq(pool_addresses[i]))
-                .returning(move |_| Ok(expected_pool_data.clone()));
-        }
-
-        let mut pool_store = PoolStorage {
-            pools_by_token: Default::default(),
-            pools: Default::default(),
-            data_fetcher: Box::new(dummy_data_fetcher),
-        };
-        pool_store.insert_events(events).await.unwrap();
-        // Note that it is never expected that blocks for events will differ,
-        // but in this test block_created for the pool is the first block it receives.
-        assert_eq!(pool_store.last_event_block(), 3);
-        assert_eq!(
-            pool_store.pools_by_token.get(&tokens[0]).unwrap(),
-            &hashset! { pool_ids[0] }
-        );
-        assert_eq!(
-            pool_store.pools_by_token.get(&tokens[1]).unwrap(),
-            &hashset! { pool_ids[0], pool_ids[1] }
-        );
-        assert_eq!(
-            pool_store.pools_by_token.get(&tokens[2]).unwrap(),
-            &hashset! { pool_ids[1], pool_ids[2] }
-        );
-        assert_eq!(
-            pool_store.pools_by_token.get(&tokens[3]).unwrap(),
-            &hashset! { pool_ids[2] }
-        );
-        for i in 0..n {
-            assert_eq!(
-                pool_store.pools.get(&pool_ids[i]).unwrap(),
-                &RegisteredWeightedPool {
-                    pool_id: pool_ids[i],
-                    pool_address: pool_addresses[i],
-                    tokens: vec![tokens[i], tokens[i + 1]],
-                    normalized_weights: vec![weights[i], weights[i + 1]],
-                    scaling_exponents: vec![0, 0],
-                    block_created: i as u64 + 1
-                },
-                "failed assertion at index {}",
-                i
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn balancer_replace_events() {
-        let start_block = 0;
-        let end_block = 5;
-        // Setup all the variables to initialize Balancer Pool State
-        let pool_ids: Vec<H256> = (start_block..end_block + 1)
-            .map(|i| H256::from_low_u64_be(i as u64))
-            .collect();
-        let pool_addresses: Vec<H160> = (start_block..end_block + 1)
-            .map(|i| H160::from_low_u64_be(i as u64))
-            .collect();
-        let tokens: Vec<H160> = (start_block..end_block + 2)
-            .map(|i| H160::from_low_u64_be(i as u64))
-            .collect();
-        let weights: Vec<U256> = (start_block..end_block + 2)
-            .map(|i| U256::from(i as u64))
-            .collect();
-        let creation_events: Vec<PoolCreated> = (start_block..end_block + 1)
-            .map(|i| PoolCreated {
-                pool_address: pool_addresses[i],
-            })
-            .collect();
-
-        let converted_events: Vec<(EventIndex, PoolCreated)> = (start_block..end_block + 1)
-            .map(|i| (EventIndex::new(i as u64, 0), creation_events[i]))
-            .collect();
-
-        let mut dummy_data_fetcher = MockPoolInfoFetching::new();
-        for i in start_block..end_block + 1 {
-            let expected_pool_data = WeightedPoolInfo {
-                pool_id: pool_ids[i],
-                tokens: vec![tokens[i], tokens[i + 1]],
-                weights: vec![weights[i], weights[i + 1]],
-                scaling_exponents: vec![0, 0],
-            };
-            dummy_data_fetcher
-                .expect_get_pool_data()
-                .with(eq(pool_addresses[i]))
-                .returning(move |_| Ok(expected_pool_data.clone()));
-        }
-
-        // Have to prepare return data for new stuff before we pass on the data fetcher
-        let new_pool_id = H256::from_low_u64_be(43110);
-        let new_pool_address = H160::from_low_u64_be(42);
-        let new_token = H160::from_low_u64_be(808);
-        let new_weight = U256::from(1337);
-        let new_creation = PoolCreated {
-            pool_address: new_pool_address,
-        };
-        let new_event = (EventIndex::new(3, 0), new_creation);
-        dummy_data_fetcher
-            .expect_get_pool_data()
-            .with(eq(new_pool_address))
-            .returning(move |_| {
-                Ok(WeightedPoolInfo {
-                    pool_id: new_pool_id,
-                    tokens: vec![new_token],
-                    weights: vec![new_weight],
-                    scaling_exponents: vec![0],
-                })
-            });
-
-        let mut pool_store = PoolStorage {
-            pools_by_token: Default::default(),
-            pools: Default::default(),
-            data_fetcher: Box::new(dummy_data_fetcher),
-        };
-        pool_store.insert_events(converted_events).await.unwrap();
-        // Let the tests begin!
-        assert_eq!(pool_store.last_event_block(), end_block as u64);
-        pool_store
-            .replace_events_inner(3, vec![new_event])
-            .await
-            .unwrap();
-        // Everything until block 3 is unchanged.
-        for i in 0..3 {
-            assert_eq!(
-                pool_store.pools.get(&pool_ids[i]).unwrap(),
-                &RegisteredWeightedPool {
-                    pool_id: pool_ids[i],
-                    pool_address: pool_addresses[i],
-                    tokens: vec![tokens[i], tokens[i + 1]],
-                    normalized_weights: vec![weights[i], weights[i + 1]],
-                    scaling_exponents: vec![0, 0],
-                    block_created: i as u64
-                },
-                "assertion failed at index {}",
-                i
-            );
-        }
-        assert_eq!(
-            pool_store.pools_by_token.get(&tokens[0]).unwrap(),
-            &hashset! { pool_ids[0] }
-        );
-        assert_eq!(
-            pool_store.pools_by_token.get(&tokens[1]).unwrap(),
-            &hashset! { pool_ids[0], pool_ids[1] }
-        );
-        assert_eq!(
-            pool_store.pools_by_token.get(&tokens[2]).unwrap(),
-            &hashset! { pool_ids[1], pool_ids[2] }
-        );
-        assert_eq!(
-            pool_store.pools_by_token.get(&tokens[3]).unwrap(),
-            &hashset! { pool_ids[2] }
-        );
-
-        // Everything old from block 3 on is gone.
-        for pool_id in pool_ids.iter().take(6).skip(3) {
-            assert!(pool_store.pools.get(pool_id).is_none());
-        }
-        for token in tokens.iter().take(7).skip(4) {
-            assert!(pool_store.pools_by_token.get(token).unwrap().is_empty());
-        }
-
-        let new_event_block = new_event.0.block_number;
-
-        // All new data is included.
-        assert_eq!(
-            pool_store.pools.get(&new_pool_id).unwrap(),
-            &RegisteredWeightedPool {
-                pool_id: new_pool_id,
-                pool_address: new_pool_address,
-                tokens: vec![new_token],
-                normalized_weights: vec![new_weight],
-                scaling_exponents: vec![0],
-                block_created: new_event_block
-            }
-        );
-
-        assert!(pool_store.pools_by_token.get(&new_token).is_some());
-        assert_eq!(pool_store.last_event_block(), new_event_block);
-    }
-
-    #[test]
-    fn pools_containing_pair_test() {
-        let n = 3;
-        let pool_ids: Vec<H256> = (0..n).map(|i| H256::from_low_u64_be(i as u64)).collect();
-        let pool_addresses: Vec<H160> = (0..n)
-            .map(|i| H160::from_low_u64_be(2 * i as u64))
-            .collect();
-        let tokens: Vec<H160> = (0..n)
-            .map(|i| H160::from_low_u64_be(2 * i as u64 + 1))
-            .collect();
-        let token_pairs: Vec<TokenPair> = (0..n)
-            .map(|i| TokenPair::new(tokens[i], tokens[(i + 1) % n]).unwrap())
-            .collect();
-
-        // Test the empty registry.
-        let mut dummy_data_fetcher = MockPoolInfoFetching::new();
-        // Have to load all expected data into fetcher before it is passed on.
-        for i in 0..n {
-            let expected_pool_data = WeightedPoolInfo {
-                pool_id: pool_ids[i],
-                tokens: tokens[i..n].to_owned(),
-                weights: vec![],
-                scaling_exponents: vec![],
-            };
-            dummy_data_fetcher
-                .expect_get_pool_data()
-                .with(eq(pool_addresses[i]))
-                .returning(move |_| Ok(expected_pool_data.clone()));
-        }
-        let mut registry = PoolStorage {
-            pools_by_token: Default::default(),
-            pools: Default::default(),
-            data_fetcher: Box::new(dummy_data_fetcher),
-        };
-        for token_pair in token_pairs.iter().take(n) {
-            assert!(registry.pools_containing_token_pair(*token_pair).is_empty());
-        }
-
-        // Now test non-empty pool with standard form.
-        let mut weighted_pools = vec![];
-        for i in 0..n {
-            for pool_id in pool_ids.iter().take(i + 1) {
-                // This is tokens[i] => { pool_id[0], pool_id[1], ..., pool_id[i] }
-                let entry = registry.pools_by_token.entry(tokens[i]).or_default();
-                entry.insert(*pool_id);
-            }
-            // This is weighted_pools[i] has tokens [tokens[i], tokens[i+1], ... , tokens[n]]
-            weighted_pools.push(RegisteredWeightedPool {
-                pool_id: pool_ids[i],
-                tokens: tokens[i..n].to_owned(),
-                normalized_weights: vec![],
-                scaling_exponents: vec![],
-                block_created: 0,
-                pool_address: pool_addresses[i],
-            });
-            registry
-                .pools
-                .insert(pool_ids[i], weighted_pools[i].clone());
-        }
-        // When n = 3, this above generates
-        // pool_store.pools_by_token = hashmap! {
-        //     tokens[0] => hashset! { pool_ids[0] },
-        //     tokens[1] => hashset! { pool_ids[0], pool_ids[1]},
-        //     tokens[2] => hashset! { pool_ids[0], pool_ids[1], pool_ids[2] },
-        // };
-        // pool_store.pools = hashmap! {
-        //     pool_ids[0] => WeightedPool {
-        //         tokens: vec![tokens[0], tokens[1], tokens[2]],
-        //         ..other fields
-        //     },
-        //     pool_ids[1] => WeightedPool {
-        //         tokens: vec![tokens[1], tokens[2]],
-        //         ..other fields
-        //     }
-        //     pool_ids[2] => WeightedPool {
-        //         tokens: vec![tokens[2]],
-        //         ..other fields
-        //     }
-        // };
-
-        assert_eq!(
-            registry.pools_containing_token_pair(token_pairs[0]),
-            vec![weighted_pools[0].clone()]
-        );
-        assert_eq!(
-            registry.pools_containing_token_pair(token_pairs[1]),
-            vec![weighted_pools[0].clone(), weighted_pools[1].clone()]
-        );
-        assert_eq!(
-            registry.pools_containing_token_pair(token_pairs[2]),
-            vec![weighted_pools[0].clone()]
-        );
-    }
 }

--- a/shared/src/balancer/event_handler.rs
+++ b/shared/src/balancer/event_handler.rs
@@ -1,13 +1,13 @@
-//! This event handler contains mostly boiler plate code for the implementation of [`EventRetrieving`](crate::event_handling::EventRetrieving)
-//! and [`EventStoring`](crate::event_handling::EventStoring) for Balancer Pool Factory contracts and `PoolStorage` respectively.
+//! This event handler contains mostly boiler plate code for the implementation of `EventRetrieving`
+//! and `EventStoring` for Balancer Pool Factory contracts and `PoolStorage` respectively.
 //! Because there are multiple factory contracts for which we rely on event data, the
-//! [`BalancerPoolRegistry`](BalancerPoolRegistry) is responsible for multiple EventHandlers.
+//! `BalancerPoolRegistry` is responsible for multiple EventHandlers.
 //!
 //! Apart from the event handling boiler plate, there are a few helper methods used as adapters
 //! for converting received contract event data into appropriate internal structs to be passed
 //! along to the `PoolStorage` (database) for update
 //!
-//! Due to limitations of [`EventRetrieving`](crate::event_handling::EventRetrieving) we must put each event handler behind its own Mutex.
+//! Due to limitations of `EventRetrieving` we must put each event handler behind its own Mutex.
 //! - These mutexes are locked during synchronization and pool fetching.
 //!
 //! *Note that* when loading pool from a cold start synchronization can take quite long, but is

--- a/shared/src/balancer/info_fetching.rs
+++ b/shared/src/balancer/info_fetching.rs
@@ -1,0 +1,73 @@
+use crate::pool_fetching::MAX_BATCH_SIZE;
+use crate::token_info::TokenInfoFetching;
+use crate::Web3;
+use anyhow::{anyhow, Result};
+use contracts::{BalancerV2Vault, BalancerV2WeightedPool};
+use ethcontract::batch::CallBatch;
+use ethcontract::{Bytes, H160, H256, U256};
+use mockall::*;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct WeightedPoolInfo {
+    pub pool_id: H256,
+    pub tokens: Vec<H160>,
+    pub weights: Vec<U256>,
+    pub scaling_exponents: Vec<u8>,
+}
+
+pub struct PoolInfoFetcher {
+    pub web3: Web3,
+    pub token_info_fetcher: Arc<dyn TokenInfoFetching>,
+}
+
+#[automock]
+#[async_trait::async_trait]
+pub trait PoolInfoFetching: Send + Sync {
+    async fn get_pool_data(&self, pool_address: H160) -> Result<WeightedPoolInfo>;
+}
+
+#[async_trait::async_trait]
+impl PoolInfoFetching for PoolInfoFetcher {
+    /// Could result in ethcontract::{NodeError, MethodError or ContractError}
+    async fn get_pool_data(&self, pool_address: H160) -> Result<WeightedPoolInfo> {
+        let mut batch = CallBatch::new(self.web3.transport());
+        let pool_contract = BalancerV2WeightedPool::at(&self.web3, pool_address);
+        // Need vault and pool_id before we can fetch tokens.
+        let vault = BalancerV2Vault::deployed(&self.web3).await?;
+        let pool_id = H256::from(pool_contract.methods().get_pool_id().call().await?.0);
+
+        // token_data and weight calls can be batched
+        let token_data = vault
+            .methods()
+            .get_pool_tokens(Bytes(pool_id.0))
+            .batch_call(&mut batch);
+        let normalized_weights = pool_contract
+            .methods()
+            .get_normalized_weights()
+            .batch_call(&mut batch);
+        batch.execute_all(MAX_BATCH_SIZE).await;
+
+        let tokens = token_data.await?.0;
+
+        let token_decimals = self.token_info_fetcher.get_token_infos(&tokens).await;
+        let ordered_decimals = tokens
+            .iter()
+            .map(|token| token_decimals.get(token).and_then(|t| t.decimals))
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| anyhow!("all token decimals required to build scaling factors"))?;
+        // Note that balancer does not support tokens with more than 18 decimals
+        // https://github.com/balancer-labs/balancer-v2-monorepo/blob/ce70f7663e0ac94b25ed60cb86faaa8199fd9e13/pkg/pool-utils/contracts/BasePool.sol#L497-L508
+        let scaling_exponents = ordered_decimals
+            .iter()
+            .map(|decimals| 18u8.checked_sub(*decimals))
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| anyhow!("token with more than 18 decimals"))?;
+        Ok(WeightedPoolInfo {
+            pool_id,
+            tokens,
+            weights: normalized_weights.await?,
+            scaling_exponents,
+        })
+    }
+}

--- a/shared/src/balancer/info_fetching.rs
+++ b/shared/src/balancer/info_fetching.rs
@@ -1,5 +1,5 @@
-/// Responsible for conversion of a `pool_address` into `WeightedPoolInfo` which is used by the
-/// event handler to construct a `RegisteredWeightedPool`.
+//! Responsible for conversion of a `pool_address` into `WeightedPoolInfo` which is used by the
+//! event handler to construct a `RegisteredWeightedPool`.
 use crate::pool_fetching::MAX_BATCH_SIZE;
 use crate::token_info::TokenInfoFetching;
 use crate::Web3;

--- a/shared/src/balancer/info_fetching.rs
+++ b/shared/src/balancer/info_fetching.rs
@@ -1,6 +1,5 @@
 /// Responsible for conversion of a `pool_address` into `WeightedPoolInfo` which is used by the
 /// event handler to construct a `RegisteredWeightedPool`.
-
 use crate::pool_fetching::MAX_BATCH_SIZE;
 use crate::token_info::TokenInfoFetching;
 use crate::Web3;

--- a/shared/src/balancer/info_fetching.rs
+++ b/shared/src/balancer/info_fetching.rs
@@ -26,7 +26,7 @@ pub struct WeightedPoolInfo {
 ///     Technically, `normalized_weights` could be queried along with `pool_id` in step 1,
 ///     but batching here or there doesn't make a difference.
 /// 3. Finally, the `scaling_exponents` are derived as 18 - decimals (for each the token in the pool)
-///     `TokenInfoFetching` is used for this which implements this query as a BatchCall internally.
+///     `TokenInfoFetching` is used here since it is optimized for recovering ERC20 info internally.
 ///
 /// Note that all token decimals are required to be returned from `TokenInfoFetching` in order
 /// to accurately construct `WeightedPoolInfo`.

--- a/shared/src/balancer/pool_fetching.rs
+++ b/shared/src/balancer/pool_fetching.rs
@@ -1,51 +1,18 @@
 use anyhow::Result;
 use model::TokenPair;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
-use crate::balancer::event_handler::{BalancerPoolRegistry, RegisteredWeightedPool};
+use crate::balancer::{
+    event_handler::BalancerPoolRegistry,
+    pool_models::{RegisteredWeightedPool, WeightedPool},
+};
 use crate::pool_fetching::{handle_contract_error, MAX_BATCH_SIZE};
 use crate::recent_block_cache::Block;
 use crate::Web3;
 use contracts::BalancerV2Vault;
 use ethcontract::batch::CallBatch;
 use ethcontract::errors::MethodError;
-use ethcontract::{BlockId, Bytes, H160, H256, U256};
-
-pub struct PoolTokenState {
-    pub balance: U256,
-    pub weight: U256,
-    pub scaling_exponent: u8,
-}
-
-pub struct WeightedPool {
-    pub pool_id: H256,
-    pub pool_address: H160,
-    pub reserves: HashMap<H160, PoolTokenState>,
-}
-
-impl WeightedPool {
-    fn new(pool_data: RegisteredWeightedPool, balances: Vec<U256>) -> Self {
-        let mut reserves = HashMap::new();
-        // We expect the weight and token indices are aligned with balances returned from EVM query.
-        // If necessary we would also pass the tokens along with the query result,
-        // use them and fetch the weights from the registry by token address.
-        for (i, balance) in balances.into_iter().enumerate() {
-            reserves.insert(
-                pool_data.tokens[i],
-                PoolTokenState {
-                    balance,
-                    weight: pool_data.normalized_weights[i],
-                    scaling_exponent: pool_data.scaling_exponents[i],
-                },
-            );
-        }
-        WeightedPool {
-            pool_id: pool_data.pool_id,
-            pool_address: pool_data.pool_address,
-            reserves,
-        }
-    }
-}
+use ethcontract::{BlockId, Bytes, H160, U256};
 
 #[async_trait::async_trait]
 pub trait WeightedPoolFetching: Send + Sync {

--- a/shared/src/balancer/pool_fetching.rs
+++ b/shared/src/balancer/pool_fetching.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 
 use crate::balancer::{
     event_handler::BalancerPoolRegistry,
-    pool_models::{RegisteredWeightedPool, WeightedPool},
+    pool_storage::{RegisteredWeightedPool, WeightedPool},
 };
 use crate::pool_fetching::{handle_contract_error, MAX_BATCH_SIZE};
 use crate::recent_block_cache::Block;

--- a/shared/src/balancer/pool_fetching.rs
+++ b/shared/src/balancer/pool_fetching.rs
@@ -1,5 +1,5 @@
-//! Pool Fetching is primarily concerned with retrieving relevant pools from the [`BalancerPoolRegistry`](BalancerPoolRegistry)
-//! when given a collection of [`TokenPair`](TokenPair). Each of these pools are then queried for
+//! Pool Fetching is primarily concerned with retrieving relevant pools from the `BalancerPoolRegistry`
+//! when given a collection of `TokenPair`. Each of these pools are then queried for
 //! their `token_balances` and the `PoolFetcher` returns all up-to-date `WeightedPools`
 //! to be consumed by external users (e.g. Price Estimators and Solvers).
 use anyhow::Result;

--- a/shared/src/balancer/pool_fetching.rs
+++ b/shared/src/balancer/pool_fetching.rs
@@ -1,7 +1,7 @@
-/// Pool Fetching is primarily concerned with retrieving relevant pools from the `BalancerPoolRegistry`
-/// when given a collection of `TokenPair`. Each of these pools are then queried for
-/// their `token_balances` and the `PoolFetcher` returns all up-to-date `WeightedPools`
-/// to be consumed by external users (e.g. Price Estimators and Solvers).
+//! Pool Fetching is primarily concerned with retrieving relevant pools from the [`BalancerPoolRegistry`](BalancerPoolRegistry)
+//! when given a collection of [`TokenPair`](TokenPair). Each of these pools are then queried for
+//! their `token_balances` and the `PoolFetcher` returns all up-to-date `WeightedPools`
+//! to be consumed by external users (e.g. Price Estimators and Solvers).
 use anyhow::Result;
 use model::TokenPair;
 use std::collections::HashSet;

--- a/shared/src/balancer/pool_fetching.rs
+++ b/shared/src/balancer/pool_fetching.rs
@@ -1,3 +1,7 @@
+/// Pool Fetching is primarily concerned with retrieving relevant pools from the `BalancerPoolRegistry`
+/// when given a collection of `TokenPair`. Each of these pools are then queried for
+/// their `token_balances` and the `PoolFetcher` returns all up-to-date `WeightedPools`
+/// to be consumed by external users (e.g. Price Estimators and Solvers).
 use anyhow::Result;
 use model::TokenPair;
 use std::collections::HashSet;

--- a/shared/src/balancer/pool_models.rs
+++ b/shared/src/balancer/pool_models.rs
@@ -1,0 +1,506 @@
+use crate::balancer::info_fetching::PoolInfoFetching;
+use crate::event_handling::EventIndex;
+use anyhow::Result;
+use derivative::Derivative;
+use ethcontract::{H160, H256, U256};
+use itertools::Itertools;
+use model::TokenPair;
+use std::collections::{HashMap, HashSet};
+
+pub struct PoolTokenState {
+    pub balance: U256,
+    pub weight: U256,
+    pub scaling_exponent: u8,
+}
+
+pub struct WeightedPool {
+    pub pool_id: H256,
+    pub pool_address: H160,
+    pub reserves: HashMap<H160, PoolTokenState>,
+}
+
+impl WeightedPool {
+    pub fn new(pool_data: RegisteredWeightedPool, balances: Vec<U256>) -> Self {
+        let mut reserves = HashMap::new();
+        // We expect the weight and token indices are aligned with balances returned from EVM query.
+        // If necessary we would also pass the tokens along with the query result,
+        // use them and fetch the weights from the registry by token address.
+        for (i, balance) in balances.into_iter().enumerate() {
+            reserves.insert(
+                pool_data.tokens[i],
+                PoolTokenState {
+                    balance,
+                    weight: pool_data.normalized_weights[i],
+                    scaling_exponent: pool_data.scaling_exponents[i],
+                },
+            );
+        }
+        WeightedPool {
+            pool_id: pool_data.pool_id,
+            pool_address: pool_data.pool_address,
+            reserves,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RegisteredWeightedPool {
+    pub pool_id: H256,
+    pub pool_address: H160,
+    pub tokens: Vec<H160>,
+    pub normalized_weights: Vec<U256>,
+    pub scaling_exponents: Vec<u8>,
+    pub block_created: u64,
+}
+
+#[derive(Copy, Debug, Default, Clone, Eq, PartialEq)]
+pub struct PoolCreated {
+    pub pool_address: H160,
+}
+
+impl RegisteredWeightedPool {
+    /// Errors expected here are propagated from `get_pool_data`.
+    pub async fn from_event(
+        block_created: u64,
+        creation: PoolCreated,
+        data_fetcher: &dyn PoolInfoFetching,
+    ) -> Result<RegisteredWeightedPool> {
+        let pool_address = creation.pool_address;
+        let pool_data = data_fetcher.get_pool_data(pool_address).await?;
+        return Ok(RegisteredWeightedPool {
+            pool_id: pool_data.pool_id,
+            pool_address,
+            tokens: pool_data.tokens,
+            normalized_weights: pool_data.weights,
+            scaling_exponents: pool_data.scaling_exponents,
+            block_created,
+        });
+    }
+}
+
+/// PoolStorage represents in-memory storage of all deployed Balancer Pools
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct PoolStorage {
+    /// Used for O(1) access to all pool_ids for a given token
+    pools_by_token: HashMap<H160, HashSet<H256>>,
+    /// WeightedPool data for a given PoolId
+    pools: HashMap<H256, RegisteredWeightedPool>,
+    #[derivative(Debug = "ignore")]
+    data_fetcher: Box<dyn PoolInfoFetching>,
+}
+
+impl PoolStorage {
+    /// Returns all pools containing both tokens from TokenPair
+    pub fn pools_containing_token_pair(
+        &self,
+        token_pair: TokenPair,
+    ) -> Vec<RegisteredWeightedPool> {
+        let empty_set = HashSet::new();
+        let pools_0 = self
+            .pools_by_token
+            .get(&token_pair.get().0)
+            .unwrap_or(&empty_set);
+        let pools_1 = self
+            .pools_by_token
+            .get(&token_pair.get().1)
+            .unwrap_or(&empty_set);
+        pools_0
+            .intersection(pools_1)
+            .into_iter()
+            .map(|pool_id| {
+                self.pools
+                    .get(pool_id)
+                    .expect("failed iterating over known pools")
+                    .clone()
+            })
+            .collect::<Vec<RegisteredWeightedPool>>()
+    }
+
+    /// Given a collection of TokenPair, returns all pools containing at least one of the pairs.
+    pub fn pools_containing_token_pairs(
+        &self,
+        token_pairs: HashSet<TokenPair>,
+    ) -> Vec<RegisteredWeightedPool> {
+        token_pairs
+            .into_iter()
+            .flat_map(|pair| self.pools_containing_token_pair(pair))
+            .unique_by(|pool| pool.pool_id)
+            .collect()
+    }
+
+    pub fn new(data_fetcher: Box<dyn PoolInfoFetching>) -> Self {
+        PoolStorage {
+            pools_by_token: Default::default(),
+            pools: Default::default(),
+            data_fetcher,
+        }
+    }
+
+    pub async fn insert_events(&mut self, events: Vec<(EventIndex, PoolCreated)>) -> Result<()> {
+        for (index, creation) in events {
+            let weighted_pool = RegisteredWeightedPool::from_event(
+                index.block_number,
+                creation,
+                &*self.data_fetcher,
+            )
+            .await?;
+            let pool_id = weighted_pool.pool_id;
+            self.pools.insert(pool_id, weighted_pool.clone());
+            for token in weighted_pool.tokens {
+                self.pools_by_token
+                    .entry(token)
+                    .or_default()
+                    .insert(pool_id);
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn replace_events_inner(
+        &mut self,
+        delete_from_block_number: u64,
+        events: Vec<(EventIndex, PoolCreated)>,
+    ) -> Result<()> {
+        tracing::debug!(
+            "replacing {} events from block number {}",
+            events.len(),
+            delete_from_block_number,
+        );
+        self.delete_pools(delete_from_block_number)?;
+        self.insert_events(events).await?;
+        Ok(())
+    }
+
+    fn delete_pools(&mut self, delete_from_block_number: u64) -> Result<()> {
+        self.pools
+            .retain(|_, pool| pool.block_created < delete_from_block_number);
+        // Note that this could result in an empty set for some tokens.
+        let retained_pool_ids: HashSet<H256> = self.pools.keys().copied().collect();
+        for (_, pool_set) in self.pools_by_token.iter_mut() {
+            *pool_set = pool_set
+                .intersection(&retained_pool_ids)
+                .cloned()
+                .collect::<HashSet<H256>>();
+        }
+        Ok(())
+    }
+
+    pub fn last_event_block(&self) -> u64 {
+        // Technically we could keep this updated more effectively in a field on balancer pools,
+        // but the maintenance seems like more overhead that needs to be tested.
+        self.pools
+            .iter()
+            .map(|(_, pool)| pool.block_created)
+            .max()
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::balancer::info_fetching::{MockPoolInfoFetching, WeightedPoolInfo};
+    use ethcontract::U256;
+    use maplit::hashset;
+    use mockall::predicate::eq;
+
+    #[tokio::test]
+    async fn balancer_insert_events() {
+        let n = 3usize;
+        let pool_ids: Vec<H256> = (0..n).map(|i| H256::from_low_u64_be(i as u64)).collect();
+        let pool_addresses: Vec<H160> = (0..n).map(|i| H160::from_low_u64_be(i as u64)).collect();
+        let tokens: Vec<H160> = (0..n + 1)
+            .map(|i| H160::from_low_u64_be(i as u64))
+            .collect();
+        let weights: Vec<U256> = (0..n + 1).map(|i| U256::from(i as u64)).collect();
+        let creation_events: Vec<PoolCreated> = (0..n)
+            .map(|i| PoolCreated {
+                pool_address: pool_addresses[i],
+            })
+            .collect();
+
+        let events: Vec<(EventIndex, PoolCreated)> = vec![
+            (EventIndex::new(1, 0), creation_events[0]),
+            (EventIndex::new(2, 0), creation_events[1]),
+            (EventIndex::new(3, 0), creation_events[2]),
+        ];
+
+        let mut dummy_data_fetcher = MockPoolInfoFetching::new();
+        for i in 0..n {
+            let expected_pool_data = WeightedPoolInfo {
+                pool_id: pool_ids[i],
+                tokens: vec![tokens[i], tokens[i + 1]],
+                weights: vec![weights[i], weights[i + 1]],
+                scaling_exponents: vec![0, 0],
+            };
+            dummy_data_fetcher
+                .expect_get_pool_data()
+                .with(eq(pool_addresses[i]))
+                .returning(move |_| Ok(expected_pool_data.clone()));
+        }
+
+        let mut pool_store = PoolStorage::new(Box::new(dummy_data_fetcher));
+        pool_store.insert_events(events).await.unwrap();
+        // Note that it is never expected that blocks for events will differ,
+        // but in this test block_created for the pool is the first block it receives.
+        assert_eq!(pool_store.last_event_block(), 3);
+        assert_eq!(
+            pool_store.pools_by_token.get(&tokens[0]).unwrap(),
+            &hashset! { pool_ids[0] }
+        );
+        assert_eq!(
+            pool_store.pools_by_token.get(&tokens[1]).unwrap(),
+            &hashset! { pool_ids[0], pool_ids[1] }
+        );
+        assert_eq!(
+            pool_store.pools_by_token.get(&tokens[2]).unwrap(),
+            &hashset! { pool_ids[1], pool_ids[2] }
+        );
+        assert_eq!(
+            pool_store.pools_by_token.get(&tokens[3]).unwrap(),
+            &hashset! { pool_ids[2] }
+        );
+        for i in 0..n {
+            assert_eq!(
+                pool_store.pools.get(&pool_ids[i]).unwrap(),
+                &RegisteredWeightedPool {
+                    pool_id: pool_ids[i],
+                    pool_address: pool_addresses[i],
+                    tokens: vec![tokens[i], tokens[i + 1]],
+                    normalized_weights: vec![weights[i], weights[i + 1]],
+                    scaling_exponents: vec![0, 0],
+                    block_created: i as u64 + 1
+                },
+                "failed assertion at index {}",
+                i
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn balancer_replace_events() {
+        let start_block = 0;
+        let end_block = 5;
+        // Setup all the variables to initialize Balancer Pool State
+        let pool_ids: Vec<H256> = (start_block..end_block + 1)
+            .map(|i| H256::from_low_u64_be(i as u64))
+            .collect();
+        let pool_addresses: Vec<H160> = (start_block..end_block + 1)
+            .map(|i| H160::from_low_u64_be(i as u64))
+            .collect();
+        let tokens: Vec<H160> = (start_block..end_block + 2)
+            .map(|i| H160::from_low_u64_be(i as u64))
+            .collect();
+        let weights: Vec<U256> = (start_block..end_block + 2)
+            .map(|i| U256::from(i as u64))
+            .collect();
+        let creation_events: Vec<PoolCreated> = (start_block..end_block + 1)
+            .map(|i| PoolCreated {
+                pool_address: pool_addresses[i],
+            })
+            .collect();
+
+        let converted_events: Vec<(EventIndex, PoolCreated)> = (start_block..end_block + 1)
+            .map(|i| (EventIndex::new(i as u64, 0), creation_events[i]))
+            .collect();
+
+        let mut dummy_data_fetcher = MockPoolInfoFetching::new();
+        for i in start_block..end_block + 1 {
+            let expected_pool_data = WeightedPoolInfo {
+                pool_id: pool_ids[i],
+                tokens: vec![tokens[i], tokens[i + 1]],
+                weights: vec![weights[i], weights[i + 1]],
+                scaling_exponents: vec![0, 0],
+            };
+            dummy_data_fetcher
+                .expect_get_pool_data()
+                .with(eq(pool_addresses[i]))
+                .returning(move |_| Ok(expected_pool_data.clone()));
+        }
+
+        // Have to prepare return data for new stuff before we pass on the data fetcher
+        let new_pool_id = H256::from_low_u64_be(43110);
+        let new_pool_address = H160::from_low_u64_be(42);
+        let new_token = H160::from_low_u64_be(808);
+        let new_weight = U256::from(1337);
+        let new_creation = PoolCreated {
+            pool_address: new_pool_address,
+        };
+        let new_event = (EventIndex::new(3, 0), new_creation);
+        dummy_data_fetcher
+            .expect_get_pool_data()
+            .with(eq(new_pool_address))
+            .returning(move |_| {
+                Ok(WeightedPoolInfo {
+                    pool_id: new_pool_id,
+                    tokens: vec![new_token],
+                    weights: vec![new_weight],
+                    scaling_exponents: vec![0],
+                })
+            });
+
+        let mut pool_store = PoolStorage {
+            pools_by_token: Default::default(),
+            pools: Default::default(),
+            data_fetcher: Box::new(dummy_data_fetcher),
+        };
+        pool_store.insert_events(converted_events).await.unwrap();
+        // Let the tests begin!
+        assert_eq!(pool_store.last_event_block(), end_block as u64);
+        pool_store
+            .replace_events_inner(3, vec![new_event])
+            .await
+            .unwrap();
+        // Everything until block 3 is unchanged.
+        for i in 0..3 {
+            assert_eq!(
+                pool_store.pools.get(&pool_ids[i]).unwrap(),
+                &RegisteredWeightedPool {
+                    pool_id: pool_ids[i],
+                    pool_address: pool_addresses[i],
+                    tokens: vec![tokens[i], tokens[i + 1]],
+                    normalized_weights: vec![weights[i], weights[i + 1]],
+                    scaling_exponents: vec![0, 0],
+                    block_created: i as u64
+                },
+                "assertion failed at index {}",
+                i
+            );
+        }
+        assert_eq!(
+            pool_store.pools_by_token.get(&tokens[0]).unwrap(),
+            &hashset! { pool_ids[0] }
+        );
+        assert_eq!(
+            pool_store.pools_by_token.get(&tokens[1]).unwrap(),
+            &hashset! { pool_ids[0], pool_ids[1] }
+        );
+        assert_eq!(
+            pool_store.pools_by_token.get(&tokens[2]).unwrap(),
+            &hashset! { pool_ids[1], pool_ids[2] }
+        );
+        assert_eq!(
+            pool_store.pools_by_token.get(&tokens[3]).unwrap(),
+            &hashset! { pool_ids[2] }
+        );
+
+        // Everything old from block 3 on is gone.
+        for pool_id in pool_ids.iter().take(6).skip(3) {
+            assert!(pool_store.pools.get(pool_id).is_none());
+        }
+        for token in tokens.iter().take(7).skip(4) {
+            assert!(pool_store.pools_by_token.get(token).unwrap().is_empty());
+        }
+
+        let new_event_block = new_event.0.block_number;
+
+        // All new data is included.
+        assert_eq!(
+            pool_store.pools.get(&new_pool_id).unwrap(),
+            &RegisteredWeightedPool {
+                pool_id: new_pool_id,
+                pool_address: new_pool_address,
+                tokens: vec![new_token],
+                normalized_weights: vec![new_weight],
+                scaling_exponents: vec![0],
+                block_created: new_event_block
+            }
+        );
+
+        assert!(pool_store.pools_by_token.get(&new_token).is_some());
+        assert_eq!(pool_store.last_event_block(), new_event_block);
+    }
+
+    #[test]
+    fn pools_containing_pair_test() {
+        let n = 3;
+        let pool_ids: Vec<H256> = (0..n).map(|i| H256::from_low_u64_be(i as u64)).collect();
+        let pool_addresses: Vec<H160> = (0..n)
+            .map(|i| H160::from_low_u64_be(2 * i as u64))
+            .collect();
+        let tokens: Vec<H160> = (0..n)
+            .map(|i| H160::from_low_u64_be(2 * i as u64 + 1))
+            .collect();
+        let token_pairs: Vec<TokenPair> = (0..n)
+            .map(|i| TokenPair::new(tokens[i], tokens[(i + 1) % n]).unwrap())
+            .collect();
+
+        // Test the empty registry.
+        let mut dummy_data_fetcher = MockPoolInfoFetching::new();
+        // Have to load all expected data into fetcher before it is passed on.
+        for i in 0..n {
+            let expected_pool_data = WeightedPoolInfo {
+                pool_id: pool_ids[i],
+                tokens: tokens[i..n].to_owned(),
+                weights: vec![],
+                scaling_exponents: vec![],
+            };
+            dummy_data_fetcher
+                .expect_get_pool_data()
+                .with(eq(pool_addresses[i]))
+                .returning(move |_| Ok(expected_pool_data.clone()));
+        }
+        let mut registry = PoolStorage::new(Box::new(dummy_data_fetcher));
+        for token_pair in token_pairs.iter().take(n) {
+            assert!(registry.pools_containing_token_pair(*token_pair).is_empty());
+        }
+
+        // Now test non-empty pool with standard form.
+        let mut weighted_pools = vec![];
+        for i in 0..n {
+            for pool_id in pool_ids.iter().take(i + 1) {
+                // This is tokens[i] => { pool_id[0], pool_id[1], ..., pool_id[i] }
+                let entry = registry.pools_by_token.entry(tokens[i]).or_default();
+                entry.insert(*pool_id);
+            }
+            // This is weighted_pools[i] has tokens [tokens[i], tokens[i+1], ... , tokens[n]]
+            weighted_pools.push(RegisteredWeightedPool {
+                pool_id: pool_ids[i],
+                tokens: tokens[i..n].to_owned(),
+                normalized_weights: vec![],
+                scaling_exponents: vec![],
+                block_created: 0,
+                pool_address: pool_addresses[i],
+            });
+            registry
+                .pools
+                .insert(pool_ids[i], weighted_pools[i].clone());
+        }
+        // When n = 3, this above generates
+        // pool_store.pools_by_token = hashmap! {
+        //     tokens[0] => hashset! { pool_ids[0] },
+        //     tokens[1] => hashset! { pool_ids[0], pool_ids[1]},
+        //     tokens[2] => hashset! { pool_ids[0], pool_ids[1], pool_ids[2] },
+        // };
+        // pool_store.pools = hashmap! {
+        //     pool_ids[0] => WeightedPool {
+        //         tokens: vec![tokens[0], tokens[1], tokens[2]],
+        //         ..other fields
+        //     },
+        //     pool_ids[1] => WeightedPool {
+        //         tokens: vec![tokens[1], tokens[2]],
+        //         ..other fields
+        //     }
+        //     pool_ids[2] => WeightedPool {
+        //         tokens: vec![tokens[2]],
+        //         ..other fields
+        //     }
+        // };
+
+        assert_eq!(
+            registry.pools_containing_token_pair(token_pairs[0]),
+            vec![weighted_pools[0].clone()]
+        );
+        // This test is non-deterministic by direct comparison because vectors could be returned unordered.
+        let res_pair_1 = registry.pools_containing_token_pair(token_pairs[1]);
+        assert_eq!(res_pair_1.len(), 2);
+        assert!(res_pair_1.contains(&weighted_pools[0]));
+        assert!(res_pair_1.contains(&weighted_pools[1]));
+
+        assert_eq!(
+            registry.pools_containing_token_pair(token_pairs[2]),
+            vec![weighted_pools[0].clone()]
+        );
+    }
+}

--- a/shared/src/balancer/pool_storage.rs
+++ b/shared/src/balancer/pool_storage.rs
@@ -1,33 +1,33 @@
-/// Pool Storage contains all the essential models required by the balancer module for operating
-/// between different knowledge-levels of pool information.
-///
-/// To briefly list and describe each of the models.
-///
-/// 1. `PoolCreated`:
-///     contains only the `pool_address` as this is the only information known about the pool
-///     at the time of event emission from the pool's factory contract.
-///
-/// 2. `RegisteredWeightedPool`:
-///     contains all constant/static information about the pool (that which is not block-sensitive).
-///     That is, `pool_id`, `address`, `tokens`, `normalized_weights`, `scaling_exponents` and `block_created`.
-///     When the `PoolCreated` event is received by the event handler, an instance of this type is
-///     constructed by fetching all additional information about the pool via `PoolInfoFetching`.
-///
-///     It is these pools which are stored, in memory, as part of the `BalancerPoolRegistry`.
-///
-/// 3. `PoolStorage`:
-///     This should be thought of as the Pool Registry's database which stores all static pool
-///     information in data structures that provide efficient lookup for the `PoolFetcher`.
-///
-///     Pool Storage implements all the CRUD methods expected of such a database.
-///
-/// 4. `WeightedPool`:
-///     This is the public facing pool structure returned by the `PoolFetcher` consisting of all
-///     the pool's most recent information (both static and dynamic).
-///     Essentially, this is all the relevant data from `RegisteredWeightedPool` along with the
-///     current balances of each of the pool's tokens (aka the pool's "reserves").
-///
-/// Tests included here are those pertaining to the expected functionality of `PoolStorage`
+//! Pool Storage contains all the essential models required by the balancer module for operating
+//! between different knowledge-levels of pool information.
+//!
+//! To briefly list and describe each of the models.
+//!
+//! 1. `PoolCreated`:
+//!     contains only the `pool_address` as this is the only information known about the pool
+//!     at the time of event emission from the pool's factory contract.
+//!
+//! 2. `RegisteredWeightedPool`:
+//!     contains all constant/static information about the pool (that which is not block-sensitive).
+//!     That is, `pool_id`, `address`, `tokens`, `normalized_weights`, `scaling_exponents` and `block_created`.
+//!     When the `PoolCreated` event is received by the event handler, an instance of this type is
+//!     constructed by fetching all additional information about the pool via `PoolInfoFetching`.
+//!
+//!     It is these pools which are stored, in memory, as part of the `BalancerPoolRegistry`.
+//!
+//! 3. `PoolStorage`:
+//!     This should be thought of as the Pool Registry's database which stores all static pool
+//!     information in data structures that provide efficient lookup for the `PoolFetcher`.
+//!
+//!     Pool Storage implements all the CRUD methods expected of such a database.
+//!
+//! 4. `WeightedPool`:
+//!     This is the public facing pool structure returned by the `PoolFetcher` consisting of all
+//!     the pool's most recent information (both static and dynamic).
+//!     Essentially, this is all the relevant data from `RegisteredWeightedPool` along with the
+//!     current balances of each of the pool's tokens (aka the pool's "reserves").
+//!
+//! Tests included here are those pertaining to the expected functionality of `PoolStorage`
 use crate::balancer::info_fetching::PoolInfoFetching;
 use crate::event_handling::EventIndex;
 use anyhow::Result;

--- a/shared/src/balancer/pool_storage.rs
+++ b/shared/src/balancer/pool_storage.rs
@@ -1,3 +1,34 @@
+/// Pool Storage contains all the essential Models the balancer module requires for
+/// operating between different knowledge-levels of pool information.
+///
+/// To briefly list and describe each of the models.
+///
+/// 1. `PoolCreated`:
+///     contains only the `pool_address` as this is all the information known about the pool
+///     at the time of event emission from the pool's factory contract.
+///
+/// 2. `RegisteredWeightedPool`:
+///     contains all constant/static information about the pool (i.e. that which is not block-sensitive)
+///     That is, `pool_id`, `address`, `tokens`, `normalized_weights`, `scaling_exponents` and `block_created`
+///     When the `PoolCreated` event is received by the event handler, an instance of this type is
+///     constructed by fetching all additional information about the pool via `PoolInfoFetching`.
+///
+///     It is these pools which are stored in-memory as part of the `BalancerPoolRegistry`.
+///
+/// 3. `PoolStorage`:
+///     This should be thought of as the PoolRegistry's database which stores all static pool
+///     information in data structures which natively provide efficient lookup for the `PoolFetcher`.
+///
+///     Pool Storage also implements all the CRUD methods expected of such a database.
+///
+/// 4. `WeightedPool`:
+///     This is the public facing Pool structure returned by the `PoolFetcher` consisting of all
+///     the pool's most recent information (both static and dynamic).
+///     Essentially, this is all the relevant data from `RegisteredWeightedPool` along with the
+///     current balances of each of the pools tokens (aka the pool's "reserves").
+///
+/// Tests included here are those pertaining to the expected functionality of `PoolStorage`
+
 use crate::balancer::info_fetching::PoolInfoFetching;
 use crate::event_handling::EventIndex;
 use anyhow::Result;
@@ -91,7 +122,7 @@ pub struct PoolStorage {
 }
 
 impl PoolStorage {
-    /// Returns all pools containing both tokens from TokenPair
+    /// Returns all pools containing both tokens from `TokenPair`
     pub fn pools_containing_token_pair(
         &self,
         token_pair: TokenPair,
@@ -117,7 +148,7 @@ impl PoolStorage {
             .collect::<Vec<RegisteredWeightedPool>>()
     }
 
-    /// Given a collection of TokenPair, returns all pools containing at least one of the pairs.
+    /// Given a collection of `TokenPair`, returns all pools containing at least one of the pairs.
     pub fn pools_containing_token_pairs(
         &self,
         token_pairs: HashSet<TokenPair>,

--- a/shared/src/balancer/pool_storage.rs
+++ b/shared/src/balancer/pool_storage.rs
@@ -28,7 +28,6 @@
 ///     current balances of each of the pool's tokens (aka the pool's "reserves").
 ///
 /// Tests included here are those pertaining to the expected functionality of `PoolStorage`
-
 use crate::balancer::info_fetching::PoolInfoFetching;
 use crate::event_handling::EventIndex;
 use anyhow::Result;

--- a/shared/src/balancer/pool_storage.rs
+++ b/shared/src/balancer/pool_storage.rs
@@ -1,31 +1,31 @@
-/// Pool Storage contains all the essential Models the balancer module requires for
-/// operating between different knowledge-levels of pool information.
+/// Pool Storage contains all the essential models required by the balancer module for operating
+/// between different knowledge-levels of pool information.
 ///
 /// To briefly list and describe each of the models.
 ///
 /// 1. `PoolCreated`:
-///     contains only the `pool_address` as this is all the information known about the pool
+///     contains only the `pool_address` as this is the only information known about the pool
 ///     at the time of event emission from the pool's factory contract.
 ///
 /// 2. `RegisteredWeightedPool`:
-///     contains all constant/static information about the pool (i.e. that which is not block-sensitive)
-///     That is, `pool_id`, `address`, `tokens`, `normalized_weights`, `scaling_exponents` and `block_created`
+///     contains all constant/static information about the pool (that which is not block-sensitive).
+///     That is, `pool_id`, `address`, `tokens`, `normalized_weights`, `scaling_exponents` and `block_created`.
 ///     When the `PoolCreated` event is received by the event handler, an instance of this type is
 ///     constructed by fetching all additional information about the pool via `PoolInfoFetching`.
 ///
-///     It is these pools which are stored in-memory as part of the `BalancerPoolRegistry`.
+///     It is these pools which are stored, in memory, as part of the `BalancerPoolRegistry`.
 ///
 /// 3. `PoolStorage`:
-///     This should be thought of as the PoolRegistry's database which stores all static pool
-///     information in data structures which natively provide efficient lookup for the `PoolFetcher`.
+///     This should be thought of as the Pool Registry's database which stores all static pool
+///     information in data structures that provide efficient lookup for the `PoolFetcher`.
 ///
-///     Pool Storage also implements all the CRUD methods expected of such a database.
+///     Pool Storage implements all the CRUD methods expected of such a database.
 ///
 /// 4. `WeightedPool`:
-///     This is the public facing Pool structure returned by the `PoolFetcher` consisting of all
+///     This is the public facing pool structure returned by the `PoolFetcher` consisting of all
 ///     the pool's most recent information (both static and dynamic).
 ///     Essentially, this is all the relevant data from `RegisteredWeightedPool` along with the
-///     current balances of each of the pools tokens (aka the pool's "reserves").
+///     current balances of each of the pool's tokens (aka the pool's "reserves").
 ///
 /// Tests included here are those pertaining to the expected functionality of `PoolStorage`
 

--- a/shared/src/balancer/pool_storage.rs
+++ b/shared/src/balancer/pool_storage.rs
@@ -206,7 +206,7 @@ mod tests {
     use mockall::predicate::eq;
 
     #[tokio::test]
-    async fn balancer_insert_events() {
+    async fn insert_events() {
         let n = 3usize;
         let pool_ids: Vec<H256> = (0..n).map(|i| H256::from_low_u64_be(i as u64)).collect();
         let pool_addresses: Vec<H160> = (0..n).map(|i| H160::from_low_u64_be(i as u64)).collect();
@@ -279,7 +279,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn balancer_replace_events() {
+    async fn replace_events() {
         let start_block = 0;
         let end_block = 5;
         // Setup all the variables to initialize Balancer Pool State
@@ -413,7 +413,7 @@ mod tests {
     }
 
     #[test]
-    fn pools_containing_pair_test() {
+    fn pools_containing_token_pairs() {
         let n = 3;
         let pool_ids: Vec<H256> = (0..n).map(|i| H256::from_low_u64_be(i as u64)).collect();
         let pool_addresses: Vec<H160> = (0..n)


### PR DESCRIPTION
event handler file had become quite large with a logical separation into 4

1. event handler: itself (responsible for definition and implementation of `BalancerPoolRegistry`)
2. pool_storage: all structs/models for the module including PoolStorage (this is analogous to the database file for GPv2Settlement event listening). 
3. pool_info_fetching: this include a trait and one implementation of the trait.
4. pool_fetching: unchanged.

No logic changes, but please check that all things which were made public are indeed correct.

Note that I have also documented the module and each file here as well.

### Test Plan
existing CI.
