### PR TITLE
Using Paraswap Solver

### DIFF
--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -12,7 +12,7 @@ pub struct Arguments {
     #[structopt(
         long,
         env = "LOG_FILTER",
-        default_value = "warn,orderbook=debug,solver=debug,shared=debug,shared::transport=info"
+        default_value = "warn,orderbook=debug,solver=debug,shared=debug,shared::http_transport=info"
     )]
     pub log_filter: String,
 

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -18,8 +18,8 @@ anyhow = "1.0"
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 contracts = { path = "../contracts" }
-ethcontract = { version = "0.12.2", default-features = false }
 derivative = "2.2"
+ethcontract = { version = "0.12.2", default-features = false }
 futures = "0.3"
 gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.2.0", features = ["web3_"] }
 hex = "0.4"

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -176,7 +176,7 @@ async fn main() {
         .expect("failed to get network id");
     let network_name = network_name(&network_id, chain_id);
     let account = Account::Offline(args.private_key, Some(chain_id));
-    let settlement_contract = solver::get_settlement_contract(&web3, account)
+    let settlement_contract = solver::get_settlement_contract(&web3, account.clone())
         .await
         .expect("couldn't load deployed settlement");
     let native_token_contract = WETH9::deployed(&web3)
@@ -276,6 +276,7 @@ async fn main() {
         args.solver_time_limit,
         args.min_order_size_one_inch,
         args.disabled_one_inch_protocols,
+        account.address(),
     )
     .expect("failure creating solvers");
     let liquidity_collector = LiquidityCollector {

--- a/solver/src/paraswap_solver.rs
+++ b/solver/src/paraswap_solver.rs
@@ -31,13 +31,13 @@ pub struct ParaswapSolver<F> {
     client: Box<dyn ParaswapApi + Send + Sync>,
 }
 
-impl ParaswapSolver<H160> {
+impl ParaswapSolver<GPv2Settlement> {
     pub fn new(
         settlement_contract: GPv2Settlement,
         solver_address: H160,
         token_info: Arc<dyn TokenInfoFetching>,
     ) -> Self {
-        let allowance_fetcher = settlement_contract.address();
+        let allowance_fetcher = settlement_contract.clone();
         Self {
             settlement_contract,
             solver_address,
@@ -57,7 +57,7 @@ impl<F> std::fmt::Debug for ParaswapSolver<F> {
 /// Helper trait to mock the smart contract interaction
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
-trait AllowanceFetching: Send + Sync {
+pub trait AllowanceFetching: Send + Sync {
     async fn existing_allowance(&self, token: H160, spender: H160) -> Result<U256>;
 }
 

--- a/solver/src/paraswap_solver.rs
+++ b/solver/src/paraswap_solver.rs
@@ -20,24 +20,27 @@ use self::api::{DefaultParaswapApi, ParaswapApi, PriceResponse, TransactionBuild
 mod api;
 
 const REFERRER: &str = "GPv2";
+const APPROVAL_RECEIVER: H160 = shared::addr!("b70bc06d2c9bf03b3373799606dc7d39346c06b3");
 
 /// A GPv2 solver that matches GP orders to direct ParaSwap swaps.
-struct ParaswapSolver<F> {
+pub struct ParaswapSolver<F> {
     settlement_contract: GPv2Settlement,
+    solver_address: H160,
     token_info: Arc<dyn TokenInfoFetching>,
     allowance_fetcher: F,
     client: Box<dyn ParaswapApi + Send + Sync>,
 }
 
 impl ParaswapSolver<H160> {
-    #![allow(dead_code)]
     pub fn new(
         settlement_contract: GPv2Settlement,
+        solver_address: H160,
         token_info: Arc<dyn TokenInfoFetching>,
     ) -> Self {
         let allowance_fetcher = settlement_contract.address();
         Self {
             settlement_contract,
+            solver_address,
             token_info,
             allowance_fetcher,
             client: Box::new(DefaultParaswapApi::default()),
@@ -77,7 +80,7 @@ where
     async fn settle_order(&self, order: LimitOrder) -> Result<Settlement> {
         let (amount, side) = match order.kind {
             model::order::OrderKind::Buy => (order.buy_amount, Side::Buy),
-            model::order::OrderKind::Sell => (order.buy_amount, Side::Sell),
+            model::order::OrderKind::Sell => (order.sell_amount, Side::Sell),
         };
         let token_infos = self
             .token_info
@@ -105,35 +108,35 @@ where
         );
 
         // 0.1% slippage
-        let src_amount_with_slippage = price_response
-            .src_amount
-            .checked_mul(1001.into())
+        let dest_amount_with_slippage = price_response
+            .dest_amount
+            .checked_mul(999.into())
             .ok_or_else(|| anyhow!("Overflow during slippage computation"))?
             / 1000;
         let transaction_query = TransactionBuilderQuery {
             src_token: order.sell_token,
             dest_token: order.buy_token,
-            src_amount: src_amount_with_slippage,
-            dest_amount: price_response.dest_amount,
+            src_amount: price_response.src_amount,
+            dest_amount: dest_amount_with_slippage,
             from_decimals: decimals(&order.sell_token)?,
             to_decimals: decimals(&order.buy_token)?,
             price_route: price_response.price_route_raw,
-            user_address: self.settlement_contract.address(),
+            user_address: self.solver_address,
             referrer: REFERRER.to_string(),
         };
         let transaction = self.client.transaction(transaction_query).await?;
 
         let mut settlement = Settlement::new(hashmap! {
             order.sell_token => price_response.dest_amount,
-            order.buy_token => src_amount_with_slippage,
+            order.buy_token => price_response.src_amount,
         });
         settlement.with_liquidity(&order, amount)?;
 
         if self
             .allowance_fetcher
-            .existing_allowance(order.sell_token, transaction.to)
+            .existing_allowance(order.sell_token, APPROVAL_RECEIVER)
             .await?
-            < src_amount_with_slippage
+            < price_response.src_amount
         {
             let sell_token_contract = ERC20::at(
                 &self.settlement_contract.raw_instance().web3(),
@@ -143,7 +146,7 @@ where
                 .encoder
                 .append_to_execution_plan(Erc20ApproveInteraction {
                     token: sell_token_contract,
-                    spender: transaction.to,
+                    spender: APPROVAL_RECEIVER,
                     amount: U256::MAX,
                 });
         }
@@ -241,6 +244,7 @@ mod test {
 
         let solver = ParaswapSolver {
             client,
+            solver_address: Default::default(),
             token_info: Arc::new(token_info),
             allowance_fetcher,
             settlement_contract: GPv2Settlement::at(&testutil::dummy_web3(), H160::zero()),
@@ -286,6 +290,7 @@ mod test {
 
         let solver = ParaswapSolver {
             client,
+            solver_address: Default::default(),
             token_info: Arc::new(token_info),
             allowance_fetcher,
             settlement_contract: GPv2Settlement::at(&testutil::dummy_web3(), H160::zero()),
@@ -363,6 +368,7 @@ mod test {
 
         let solver = ParaswapSolver {
             client,
+            solver_address: Default::default(),
             token_info: Arc::new(token_info),
             allowance_fetcher,
             settlement_contract: GPv2Settlement::at(&testutil::dummy_web3(), H160::zero()),

--- a/solver/src/single_order_solver.rs
+++ b/solver/src/single_order_solver.rs
@@ -65,7 +65,7 @@ impl<I: SingleOrderSolving + Send + Sync> Solver for SingleOrderSolver<I> {
                     // It could be that the inner solver can't match an order and would
                     // return an error for whatever reason. In that case, we want
                     // to continue trying to solve for other orders.
-                    tracing::warn!("Inner solver error: {}", err);
+                    tracing::warn!("Inner solver error: {:?}", err);
                     None
                 }
             })

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -10,6 +10,7 @@ use crate::{
     liquidity::Liquidity,
     naive_solver::NaiveSolver,
     oneinch_solver::OneInchSolver,
+    paraswap_solver::ParaswapSolver,
     settlement::Settlement,
     single_order_solver::SingleOrderSolver,
 };
@@ -50,6 +51,7 @@ arg_enum! {
         Baseline,
         Mip,
         OneInch,
+        Paraswap,
     }
 }
 
@@ -68,6 +70,7 @@ pub fn create(
     solver_timeout: Duration,
     min_order_size_one_inch: U256,
     disabled_one_inch_protocols: Vec<String>,
+    solver_address: H160,
 ) -> Result<Vec<Box<dyn Solver>>> {
     // Tiny helper function to help out with type inference. Otherwise, all
     // `Box::new(...)` expressions would have to be cast `as Box<dyn Solver>`.
@@ -115,6 +118,11 @@ pub fn create(
                     min_order_size_one_inch,
                 ))
             }
+            SolverType::Paraswap => boxed(SingleOrderSolver::from(ParaswapSolver::new(
+                settlement_contract.clone(),
+                solver_address,
+                token_info_fetcher.clone(),
+            ))),
         })
         .collect()
 }


### PR DESCRIPTION
This PR starts using the new Paraswap Solver (if configured).

It turns out we need to approve a different contract (not the router we invoke the tx on) and the user_address needs to be the tx.origin (not the settlement contract).

### Test Plan
Tested a few pairs (GNO/WETH, WETH/DAI, BAL/ETH) and made sure settlement simulations would pass.
