### PR TITLE
[Balancer] Batch and fetch scaling factors for Weighted Pool Data

### DIFF
--- a/shared/src/balancer/event_handler.rs
+++ b/shared/src/balancer/event_handler.rs
@@ -371,7 +371,7 @@ mod tests {
                 pool_id: pool_ids[i],
                 tokens: vec![tokens[i], tokens[i + 1]],
                 weights: vec![weights[i], weights[i + 1]],
-                scaling_factors: vec![0, 0],
+                scaling_exponents: vec![0, 0],
             };
             dummy_data_fetcher
                 .expect_get_pool_data()
@@ -412,7 +412,7 @@ mod tests {
                     pool_address: pool_addresses[i],
                     tokens: vec![tokens[i], tokens[i + 1]],
                     normalized_weights: vec![weights[i], weights[i + 1]],
-                    scaling_factors: vec![0, 0],
+                    scaling_exponents: vec![0, 0],
                     block_created: i as u64 + 1
                 },
                 "failed assertion at index {}",
@@ -454,7 +454,7 @@ mod tests {
                 pool_id: pool_ids[i],
                 tokens: vec![tokens[i], tokens[i + 1]],
                 weights: vec![weights[i], weights[i + 1]],
-                scaling_factors: vec![0, 0],
+                scaling_exponents: vec![0, 0],
             };
             dummy_data_fetcher
                 .expect_get_pool_data()
@@ -479,7 +479,7 @@ mod tests {
                     pool_id: new_pool_id,
                     tokens: vec![new_token],
                     weights: vec![new_weight],
-                    scaling_factors: vec![0],
+                    scaling_exponents: vec![0],
                 })
             });
 
@@ -502,7 +502,7 @@ mod tests {
                     pool_address: pool_addresses[i],
                     tokens: vec![tokens[i], tokens[i + 1]],
                     normalized_weights: vec![weights[i], weights[i + 1]],
-                    scaling_factors: vec![0, 0],
+                    scaling_exponents: vec![0, 0],
                     block_created: i as u64
                 },
                 "assertion failed at index {}",
@@ -544,7 +544,7 @@ mod tests {
                 pool_address: new_pool_address,
                 tokens: vec![new_token],
                 normalized_weights: vec![new_weight],
-                scaling_factors: vec![0],
+                scaling_exponents: vec![0],
                 block_created: new_event_block
             }
         );
@@ -574,7 +574,7 @@ mod tests {
                 pool_id: pool_ids[i],
                 tokens: tokens[i..n].to_owned(),
                 weights: vec![],
-                scaling_factors: vec![],
+                scaling_exponents: vec![],
             };
             dummy_data_fetcher
                 .expect_get_pool_data()
@@ -606,7 +606,7 @@ mod tests {
                 pool_id: pool_ids[i],
                 tokens: tokens[i..n].to_owned(),
                 normalized_weights: vec![],
-                scaling_factors: vec![],
+                scaling_exponents: vec![],
                 block_created: 0,
                 pool_address: pool_addresses[i],
             });

--- a/shared/src/balancer/event_handler.rs
+++ b/shared/src/balancer/event_handler.rs
@@ -1,3 +1,5 @@
+use crate::pool_fetching::MAX_BATCH_SIZE;
+use crate::token_info::{TokenInfoFetcher, TokenInfoFetching};
 use crate::{
     current_block::BlockRetrieving,
     event_handling::{BlockNumber, EventHandler, EventIndex, EventStoring},
@@ -13,6 +15,7 @@ use contracts::{
     BalancerV2Vault, BalancerV2WeightedPool, BalancerV2WeightedPoolFactory,
 };
 use derivative::Derivative;
+use ethcontract::batch::CallBatch;
 use ethcontract::common::DeploymentInformation;
 use ethcontract::{
     dyns::DynWeb3, Bytes, Event as EthContractEvent, EventMetadata, H160, H256, U256,
@@ -38,6 +41,7 @@ pub struct RegisteredWeightedPool {
     pub pool_address: H160,
     pub tokens: Vec<H160>,
     pub normalized_weights: Vec<U256>,
+    pub scaling_factors: Vec<u8>,
     block_created: u64,
 }
 
@@ -55,6 +59,7 @@ impl RegisteredWeightedPool {
             pool_address,
             tokens: pool_data.tokens,
             normalized_weights: pool_data.weights,
+            scaling_factors: pool_data.scaling_factors,
             block_created,
         });
     }
@@ -65,6 +70,7 @@ pub struct WeightedPoolData {
     pool_id: H256,
     tokens: Vec<H160>,
     weights: Vec<U256>,
+    scaling_factors: Vec<u8>,
 }
 
 #[automock]
@@ -77,24 +83,43 @@ trait PoolDataFetching: Send + Sync {
 impl PoolDataFetching for Web3 {
     /// Could result in ethcontract::{NodeError, MethodError or ContractError}
     async fn get_pool_data(&self, pool_address: H160) -> Result<WeightedPoolData> {
+        let mut batch = CallBatch::new(self.transport());
         let pool_contract = BalancerV2WeightedPool::at(self, pool_address);
         // Need vault and pool_id before we can fetch tokens.
         let vault = BalancerV2Vault::deployed(&self).await?;
         let pool_id = H256::from(pool_contract.methods().get_pool_id().call().await?.0);
-        let tokens = vault
+
+        // token_data and weight calls can be batched
+        let token_data = vault
             .methods()
             .get_pool_tokens(Bytes(pool_id.0))
-            .call()
-            .await?
-            .0;
+            .batch_call(&mut batch);
+        let normalized_weights = pool_contract
+            .methods()
+            .get_normalized_weights()
+            .batch_call(&mut batch);
+        batch.execute_all(MAX_BATCH_SIZE).await;
+
+        let tokens = token_data.await?.0;
+        // This is already a batch call for a list of token decimals.
+        let token_decimals = TokenInfoFetcher { web3: self.clone() }
+            .get_token_infos(&tokens)
+            .await;
+        let scaling_factors = token_decimals
+            .iter()
+            .map(|(_, info)| {
+                // Note that balancer does not support tokens with more than 18 decimals
+                // https://github.com/balancer-labs/balancer-v2-monorepo/blob/ce70f7663e0ac94b25ed60cb86faaa8199fd9e13/pkg/pool-utils/contracts/BasePool.sol#L497-L508
+                18 - info
+                    .decimals
+                    .expect("all token decimals must be available build pool data")
+            })
+            .collect();
         Ok(WeightedPoolData {
             pool_id,
             tokens,
-            weights: pool_contract
-                .methods()
-                .get_normalized_weights()
-                .call()
-                .await?,
+            weights: normalized_weights.await?,
+            scaling_factors,
         })
     }
 }
@@ -338,6 +363,7 @@ mod tests {
                 pool_id: pool_ids[i],
                 tokens: vec![tokens[i], tokens[i + 1]],
                 weights: vec![weights[i], weights[i + 1]],
+                scaling_factors: vec![0, 0],
             };
             dummy_data_fetcher
                 .expect_get_pool_data()
@@ -378,6 +404,7 @@ mod tests {
                     pool_address: pool_addresses[i],
                     tokens: vec![tokens[i], tokens[i + 1]],
                     normalized_weights: vec![weights[i], weights[i + 1]],
+                    scaling_factors: vec![0, 0],
                     block_created: i as u64 + 1
                 },
                 "failed assertion at index {}",
@@ -419,6 +446,7 @@ mod tests {
                 pool_id: pool_ids[i],
                 tokens: vec![tokens[i], tokens[i + 1]],
                 weights: vec![weights[i], weights[i + 1]],
+                scaling_factors: vec![0, 0],
             };
             dummy_data_fetcher
                 .expect_get_pool_data()
@@ -443,6 +471,7 @@ mod tests {
                     pool_id: new_pool_id,
                     tokens: vec![new_token],
                     weights: vec![new_weight],
+                    scaling_factors: vec![0],
                 })
             });
 
@@ -465,6 +494,7 @@ mod tests {
                     pool_address: pool_addresses[i],
                     tokens: vec![tokens[i], tokens[i + 1]],
                     normalized_weights: vec![weights[i], weights[i + 1]],
+                    scaling_factors: vec![0, 0],
                     block_created: i as u64
                 },
                 "assertion failed at index {}",
@@ -506,6 +536,7 @@ mod tests {
                 pool_address: new_pool_address,
                 tokens: vec![new_token],
                 normalized_weights: vec![new_weight],
+                scaling_factors: vec![0],
                 block_created: new_event_block
             }
         );
@@ -535,6 +566,7 @@ mod tests {
                 pool_id: pool_ids[i],
                 tokens: tokens[i..n].to_owned(),
                 weights: vec![],
+                scaling_factors: vec![],
             };
             dummy_data_fetcher
                 .expect_get_pool_data()
@@ -566,6 +598,7 @@ mod tests {
                 pool_id: pool_ids[i],
                 tokens: tokens[i..n].to_owned(),
                 normalized_weights: vec![],
+                scaling_factors: vec![],
                 block_created: 0,
                 pool_address: pool_addresses[i],
             });

--- a/shared/src/balancer/pool_fetching.rs
+++ b/shared/src/balancer/pool_fetching.rs
@@ -14,6 +14,7 @@ use ethcontract::{BlockId, Bytes, H160, H256, U256};
 pub struct PoolTokenState {
     pub balance: U256,
     pub weight: U256,
+    pub scaling_factor: u8,
 }
 
 pub struct WeightedPool {
@@ -34,6 +35,7 @@ impl WeightedPool {
                 PoolTokenState {
                     balance,
                     weight: pool_data.normalized_weights[i],
+                    scaling_factor: pool_data.scaling_factors[i],
                 },
             );
         }

--- a/shared/src/balancer/pool_fetching.rs
+++ b/shared/src/balancer/pool_fetching.rs
@@ -14,7 +14,7 @@ use ethcontract::{BlockId, Bytes, H160, H256, U256};
 pub struct PoolTokenState {
     pub balance: U256,
     pub weight: U256,
-    pub scaling_factor: u8,
+    pub scaling_exponent: u8,
 }
 
 pub struct WeightedPool {
@@ -35,7 +35,7 @@ impl WeightedPool {
                 PoolTokenState {
                     balance,
                     weight: pool_data.normalized_weights[i],
-                    scaling_factor: pool_data.scaling_factors[i],
+                    scaling_exponent: pool_data.scaling_exponents[i],
                 },
             );
         }


### PR DESCRIPTION
Part of #603 - which is near completion.

For pool arithmetic, pool scaling factors must be included in the pool data. We now optimize our EVM queries by spliiting into three batched calls

1. Pool ID must be fetched before we can query the tokens.
2. Tokens and normalized weights (these are independent queries now batched as a single call). 
3. token_decimals - makes use of pre-existing `TokenInfoFetcher` which already batches together queries for retrieving decimals for a list of token addresses.

This is the final missing piece that @fedgiac will need to incorporate his pool math work.

### Test Plan
No logical changes, existing CI.
