### PR TITLE
Pass target transaction confirmation time as Instant instead of Duration

### DIFF
--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -11,7 +11,7 @@ use futures::stream::StreamExt;
 use gas_estimation::GasPriceEstimating;
 use gas_price_stream::gas_price_stream;
 use primitive_types::{H160, U256};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use transaction_retry::RetryResult;
 
 const GAS_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
@@ -80,7 +80,7 @@ pub async fn submit(
         transaction_retry::gas_price_increase::minimum_increase(gas_price.to_f64_lossy())
     });
     let stream = gas_price_stream(
-        target_confirm_time,
+        Instant::now() + target_confirm_time,
         gas_price_cap,
         gas_limit,
         gas,


### PR DESCRIPTION
The current code is always picking the gas price for target_confirm_time
which is by default 30 seconds. Even if we have already for example
waited 1 minute.
With this commit we have a target confirmation point in time and the
remaining time is calculated appropriately.

Iirc we were doing it like in this commit in gpv1 so I probably made this mistake when initially creating the gas price stream here.

I have not added a test because the stream is annoying to test as it uses tokio sleep and the current time and the logic is simple. However I think I found good way to make it more testable which I will do in another PR.

### Test Plan
still compiles
