### PR TITLE
Use node url from env variable for tests

### DIFF
--- a/orderbook/src/account_balances.rs
+++ b/orderbook/src/account_balances.rs
@@ -191,12 +191,12 @@ mod tests {
     use contracts::ERC20Mintable;
     use ethcontract::prelude::Account;
     use hex_literal::hex;
-    use shared::transport::create_test_transport;
+    use shared::transport::create_env_test_transport;
 
     #[tokio::test]
     #[ignore]
     async fn mainnet_can_transfer() {
-        let http = create_test_transport("http://127.0.0.1:8545");
+        let http = create_env_test_transport();
         let web3 = Web3::new(http);
         let settlement = contracts::GPv2Settlement::deployed(&web3).await.unwrap();
         let allowance = settlement.allowance_manager().call().await.unwrap();
@@ -214,7 +214,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn mainnet_cannot_transfer() {
-        let http = create_test_transport("http://127.0.0.1:8545");
+        let http = create_env_test_transport();
         let web3 = Web3::new(http);
         let settlement = contracts::GPv2Settlement::deployed(&web3).await.unwrap();
         let allowance = settlement.allowance_manager().call().await.unwrap();
@@ -234,7 +234,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn watch_testnet_balance() {
-        let http = create_test_transport("http://127.0.0.1:8545");
+        let http = create_env_test_transport();
         let web3 = Web3::new(http);
 
         let accounts: Vec<H160> = web3.eth().accounts().await.expect("get accounts failed");

--- a/shared/src/bad_token/trace_call.rs
+++ b/shared/src/bad_token/trace_call.rs
@@ -270,7 +270,7 @@ mod tests {
     use super::*;
     use crate::{
         amm_pair_provider::{SushiswapPairProvider, UniswapPairProvider},
-        transport::create_test_transport,
+        transport::create_env_test_transport,
     };
     use hex_literal::hex;
     use web3::types::{
@@ -386,7 +386,7 @@ mod tests {
     #[ignore]
     async fn mainnet_tokens() {
         // shared::tracing::initialize("orderbook::bad_token=debug,shared::transport=debug");
-        let http = create_test_transport("https://dev-openethereum.mainnet.gnosisdev.com/");
+        let http = create_env_test_transport();
         let web3 = Web3::new(http);
 
         let base_tokens = &[

--- a/shared/src/current_block.rs
+++ b/shared/src/current_block.rs
@@ -131,8 +131,8 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn mainnet() {
-        let node = "https://dev-openethereum.mainnet.gnosisdev.com";
-        let transport = create_test_transport(node);
+        let node = std::env::var("NODE_URL").unwrap();
+        let transport = create_test_transport(&node);
         let web3 = Web3::new(transport);
         let receiver = current_block_stream(web3, Duration::from_secs(1))
             .await

--- a/shared/src/transport.rs
+++ b/shared/src/transport.rs
@@ -30,6 +30,15 @@ where
     MetricTransport::new(transport, Arc::new(NoopTransportMetrics))
 }
 
+/// Like above but takes url from the environment NODE_URL.
+pub fn create_env_test_transport() -> MetricTransport<HttpTransport>
+where
+{
+    let env = std::env::var("NODE_URL").unwrap();
+    let transport = HttpTransport::new(env.parse().unwrap());
+    MetricTransport::new(transport, Arc::new(NoopTransportMetrics))
+}
+
 pub trait TransportMetrics: Send + Sync {
     fn report_query(&self, label: &str, elapsed: Duration);
 }

--- a/solver/src/oneinch_solver.rs
+++ b/solver/src/oneinch_solver.rs
@@ -183,8 +183,9 @@ mod tests {
     use super::*;
     use crate::{liquidity::LimitOrder, testutil};
     use contracts::{GPv2Settlement, WETH9};
-    use ethcontract::H160;
+    use ethcontract::{Web3, H160};
     use model::order::{Order, OrderCreation, OrderKind};
+    use shared::transport::{create_env_test_transport, create_test_transport};
 
     fn dummy_solver() -> OneInchSolver {
         let web3 = testutil::dummy_web3();
@@ -229,7 +230,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn solve_order_on_oneinch() {
-        let web3 = testutil::infura("mainnet");
+        let web3 = Web3::new(create_env_test_transport());
         let chain_id = web3.eth().chain_id().await.unwrap().as_u64();
         let settlement = GPv2Settlement::deployed(&web3).await.unwrap();
 
@@ -264,7 +265,9 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn returns_error_on_non_mainnet() {
-        let web3 = testutil::infura("rinkeby");
+        let web3 = Web3::new(create_test_transport(
+            &std::env::var("NODE_URL_RINKEBY").unwrap(),
+        ));
         let chain_id = web3.eth().chain_id().await.unwrap().as_u64();
         let settlement = GPv2Settlement::deployed(&web3).await.unwrap();
 

--- a/solver/src/pending_transactions.rs
+++ b/solver/src/pending_transactions.rs
@@ -30,8 +30,9 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn mainnet() {
-        let node = "https://staging-openethereum.mainnet.gnosisdev.com";
-        let transport = DynTransport::new(web3::transports::Http::new(node).unwrap());
+        let transport = DynTransport::new(
+            web3::transports::Http::new(&std::env::var("NODE_URL").unwrap()).unwrap(),
+        );
         let transactions = pending_transactions(&transport).await.unwrap();
         dbg!(transactions.as_slice());
         assert!(!transactions.is_empty());

--- a/solver/src/settlement_simulation.rs
+++ b/solver/src/settlement_simulation.rs
@@ -77,15 +77,14 @@ pub fn tenderly_link(
 mod tests {
     use super::*;
     use ethcontract::{Account, PrivateKey};
-    use shared::transport::create_test_transport;
+    use shared::transport::create_env_test_transport;
 
     // cargo test -p solver settlement_simulation::tests::mainnet -- --ignored --nocapture
     #[tokio::test]
     #[ignore]
     async fn mainnet() {
         // Create some bogus settlements to see that the simulation returns an error.
-        let node = "https://dev-openethereum.mainnet.gnosisdev.com";
-        let transport = create_test_transport(node);
+        let transport = create_env_test_transport();
         let web3 = Web3::new(transport);
         let block = web3.eth().block_number().await.unwrap().as_u64();
         let network_id = web3.net().version().await.unwrap();

--- a/solver/src/testutil.rs
+++ b/solver/src/testutil.rs
@@ -1,7 +1,6 @@
 use contracts::WETH9;
 use jsonrpc_core::Call as RpcCall;
 use serde_json::Value;
-use shared::transport::create_test_transport;
 use web3::{api::Web3, types::H160, Transport};
 
 // To create an ethcontract instance we need to provide a web3 even though we never use it. This
@@ -24,16 +23,4 @@ pub fn dummy_web3() -> Web3<DummyTransport> {
 
 pub fn dummy_weth(addr: impl Into<H160>) -> WETH9 {
     WETH9::at(&dummy_web3(), addr.into())
-}
-
-pub fn infura(network: impl AsRef<str>) -> shared::Web3 {
-    let infura_project_id =
-        std::env::var("INFURA_PROJECT_ID").expect("Missing INFURA_PROJECT_ID env variable");
-    let node_url = format!(
-        "https://{}.infura.io/v3/{}",
-        network.as_ref(),
-        infura_project_id
-    );
-
-    Web3::new(create_test_transport(&node_url))
 }


### PR DESCRIPTION
We have a bunch of #ignore tests that are supposed to be run against a
real node. Instead of hardcoding the node url it is nicer to take it
from an env variable so that we don't have gnosis specific urls in the
code and so that it is easier to use a custom node.

### Test Plan
tested that env var works