### PR TITLE
Fix test enforcing specific output order

### DIFF
--- a/shared/src/balancer/event_handler.rs
+++ b/shared/src/balancer/event_handler.rs
@@ -34,7 +34,7 @@ pub struct PoolCreated {
     pub pool_address: H160,
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
 pub struct RegisteredWeightedPool {
     pub pool_id: H256,
     pub pool_address: H160,
@@ -728,8 +728,11 @@ mod tests {
             vec![weighted_pools[0].clone()]
         );
         assert_eq!(
-            registry.pools_containing_token_pair(token_pairs[1]),
-            vec![weighted_pools[0].clone(), weighted_pools[1].clone()]
+            registry
+                .pools_containing_token_pair(token_pairs[1])
+                .into_iter()
+                .collect::<HashSet<_>>(),
+            hashset![weighted_pools[0].clone(), weighted_pools[1].clone()]
         );
         assert_eq!(
             registry.pools_containing_token_pair(token_pairs[2]),


### PR DESCRIPTION
I've noticed that a test on current master may fail if the order of the output from a `HashSet` is not the expected one.
To me it looks like having a consistent output order is not important, so I just changed the test to use a `HashSet`.

See https://github.com/gnosis/gp-v2-services/runs/2838468484 for an example of this issue.

### Test Plan
Run unit tests multiple times.