### PR TITLE
Rework Balancer contract error enum

### DIFF
--- a/shared/src/balancer.rs
+++ b/shared/src/balancer.rs
@@ -27,6 +27,6 @@
 
 pub mod event_handler;
 mod info_fetching;
-mod logexpmath;
 pub mod pool_fetching;
 mod pool_storage;
+mod swap;

--- a/shared/src/balancer/swap.rs
+++ b/shared/src/balancer/swap.rs
@@ -1,0 +1,2 @@
+mod error;
+mod fixed_point;

--- a/shared/src/balancer/swap/error.rs
+++ b/shared/src/balancer/swap/error.rs
@@ -1,0 +1,55 @@
+//! Module listing all the errors from the Balancer contracts that are needed
+//! for this project. An exhaustive list can be found here:
+//! https://github.com/balancer-labs/balancer-v2-monorepo/blob/6c9e24e22d0c46cca6dd15861d3d33da61a60b98/pkg/solidity-utils/contracts/helpers/BalancerErrors.sol
+
+use std::fmt;
+
+macro_rules! errors_from_codes {
+    ( $( ( $variant:ident, $code:literal ) ),+ $(,)? ) => {
+        #[derive(thiserror::Error, Debug, PartialEq, Eq)]
+        pub enum Error {
+            $(
+                $variant,
+            )*
+        }
+
+        impl fmt::Display for Error {
+            fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+                match self {
+                    $(
+                        Self::$variant => write!(f, "{}", format!("BAL#{:0>3}: {}", $code, stringify!($variant))),
+                    )*
+                }
+            }
+        }
+
+        #[cfg(test)]
+        impl From<&str> for Error {
+            fn from(errno: &str) -> Self {
+                match errno.parse::<u16>().unwrap() {
+                    $(
+                        $code => Self::$variant,
+                    )*
+                    _ => panic!("Invalid error code"),
+                }
+            }
+        }
+    }
+}
+
+errors_from_codes!(
+    (XOutOfBounds, 6),
+    (YOutOfBounds, 7),
+    (ProductOutOfBounds, 8),
+    (InvalidExponent, 9),
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expected_error_formatting() {
+        assert_eq!(format!("{}", Error::XOutOfBounds), "BAL#006: XOutOfBounds");
+    }
+}

--- a/shared/src/balancer/swap/fixed_point.rs
+++ b/shared/src/balancer/swap/fixed_point.rs
@@ -1,0 +1,3 @@
+#![allow(dead_code)]
+
+mod logexpmath;


### PR DESCRIPTION
This PR reworks how the Balancer error enum is created and makes it derive `thiserror::Error` following the discussion in #726.
This enum will be further extended with new error codes in the future.

I also set up the folder structure in preparation for future additions.

### Test Plan
Old unit tests working, new unit test for the error message format.