### PR TITLE
Add combined fee and price route

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -296,6 +296,84 @@ paths:
           description: Token non-existent or no valid price found
         500:
           description: Unexpected internal error while processing the request
+  /api/v1/feeAndQuote/sell:
+    get:
+      description: |
+        For a total available amount of sell_token returns the fee in the sell token and the
+        resulting buy amount after the fee has been deducted.
+        sellAmountBeforeFee is the total amount that is available for the order. From it the fee
+        is deducted and the buy amount is calculated.
+      parameters:
+        - name: sellToken
+          in: query
+          schema:
+            $ref: "#/components/schemas/Address"
+          required: true
+        - name: buyToken
+          in: query
+          schema:
+            $ref: "#/components/schemas/Address"
+          required: true
+        - name: sellAmountBeforeFee
+          in: query
+          schema:
+            $ref: "#/components/schemas/TokenAmount"
+          required: true
+      responses:
+        200:
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeeAndQuoteSellResponse"
+        400:
+          description: Error with the input data.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeeAndQuoteError"
+        404:
+          description: Token non-existent or not connected to native token
+        500:
+          description: Unexpected internal error while processing the request
+  /api/v1/feeAndQuote/buy:
+    get:
+      description: |
+        For a target buy amount returns the total sell_amount that is needed and how much of it is
+        the fee.
+      parameters:
+        - name: sellToken
+          in: query
+          schema:
+            $ref: "#/components/schemas/Address"
+          required: true
+        - name: buyToken
+          in: query
+          schema:
+            $ref: "#/components/schemas/Address"
+          required: true
+        - name: buyAmountAfterFee
+          in: query
+          schema:
+            $ref: "#/components/schemas/TokenAmount"
+          required: true
+      responses:
+        200:
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeeAndQuoteBuyResponse"
+        400:
+          description: Error with the input data.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeeAndQuoteError"
+        404:
+          description: Token non-existent or not connected to native token
+        500:
+          description: Unexpected internal error while processing the request
 components:
   schemas:
     TransactionHash:
@@ -589,6 +667,33 @@ components:
         errorType:
           type: string
           enum: [InvalidSignature, WrongOwner, OrderNotFound, AlreadyCancelled, OrderFullyExecuted, OrderExpired]
+        description:
+          type: string
+      required:
+        - errorType
+        - description
+    FeeAndQuoteSellResponse:
+      type: object
+      properties:
+        fee:
+          $ref: "#/components/schemas/FeeInformation"
+        buyAmountAfterFee:
+          description: The buy amount after deducting the fee.
+          $ref: "#/components/schemas/TokenAmount"
+    FeeAndQuoteBuyResponse:
+      type: object
+      properties:
+        fee:
+          $ref: "#/components/schemas/FeeInformation"
+        sellAmountBeforeFee:
+          description: The sell amount including the fee.
+          $ref: "#/components/schemas/TokenAmount"
+    FeeAndQuoteError:
+      type: object
+      properties:
+        errorType:
+          type: string
+          enum: ["NoLiquidity", "UnsupportedToken", "AmountIsZero", "SellAmountDoesNotCoverFee"]
         description:
           type: string
       required:

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -1,5 +1,6 @@
 mod cancel_order;
 mod create_order;
+mod get_fee_and_quote;
 mod get_fee_info;
 mod get_markets;
 mod get_order_by_uid;
@@ -34,12 +35,14 @@ pub fn handle_all_routes(
     let create_order = create_order::create_order(orderbook.clone());
     let get_orders = get_orders::get_orders(orderbook.clone());
     let legacy_fee_info = get_fee_info::legacy_get_fee_info(fee_calculator.clone());
-    let fee_info = get_fee_info::get_fee_info(fee_calculator);
+    let fee_info = get_fee_info::get_fee_info(fee_calculator.clone());
     let get_order = get_order_by_uid::get_order_by_uid(orderbook.clone());
     let get_solvable_orders = get_solvable_orders::get_solvable_orders(orderbook.clone());
     let get_trades = get_trades::get_trades(database);
     let cancel_order = cancel_order::cancel_order(orderbook);
     let get_amount_estimate = get_markets::get_amount_estimate(price_estimator.clone());
+    let get_fee_and_quote =
+        get_fee_and_quote::get_fee_and_quote(fee_calculator, price_estimator.clone());
     let cors = warp::cors()
         .allow_any_origin()
         .allow_methods(vec!["GET", "POST", "DELETE", "OPTIONS", "PUT", "PATCH"])
@@ -61,6 +64,8 @@ pub fn handle_all_routes(
             .or(cancel_order.map(|reply| LabelledReply::new(reply, "cancel_order")))
             .unify()
             .or(get_amount_estimate.map(|reply| LabelledReply::new(reply, "get_amount_estimate")))
+            .unify()
+            .or(get_fee_and_quote.map(|reply| LabelledReply::new(reply, "get_fee_and_price")))
             .unify(),
     );
     routes_with_labels

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -41,8 +41,10 @@ pub fn handle_all_routes(
     let get_trades = get_trades::get_trades(database);
     let cancel_order = cancel_order::cancel_order(orderbook);
     let get_amount_estimate = get_markets::get_amount_estimate(price_estimator.clone());
-    let get_fee_and_quote =
-        get_fee_and_quote::get_fee_and_quote(fee_calculator, price_estimator.clone());
+    let get_fee_and_quote_sell =
+        get_fee_and_quote::get_fee_and_quote_sell(fee_calculator.clone(), price_estimator.clone());
+    let get_fee_and_quote_buy =
+        get_fee_and_quote::get_fee_and_quote_buy(fee_calculator, price_estimator.clone());
     let cors = warp::cors()
         .allow_any_origin()
         .allow_methods(vec!["GET", "POST", "DELETE", "OPTIONS", "PUT", "PATCH"])
@@ -65,7 +67,11 @@ pub fn handle_all_routes(
             .unify()
             .or(get_amount_estimate.map(|reply| LabelledReply::new(reply, "get_amount_estimate")))
             .unify()
-            .or(get_fee_and_quote.map(|reply| LabelledReply::new(reply, "get_fee_and_price")))
+            .or(get_fee_and_quote_sell
+                .map(|reply| LabelledReply::new(reply, "get_fee_and_quote_sell")))
+            .unify()
+            .or(get_fee_and_quote_buy
+                .map(|reply| LabelledReply::new(reply, "get_fee_and_quote_buy")))
             .unify(),
     );
     routes_with_labels

--- a/orderbook/src/api/get_fee_and_quote.rs
+++ b/orderbook/src/api/get_fee_and_quote.rs
@@ -1,0 +1,238 @@
+use crate::fee::{MinFeeCalculating, MinFeeCalculationError};
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use ethcontract::{H160, U256};
+use model::h160_hexadecimal;
+use model::{order::OrderKind, u256_decimal};
+use serde::{Deserialize, Serialize};
+use shared::{
+    conversions::{big_int_to_u256, U256Ext},
+    price_estimate::{PriceEstimating, PriceEstimationError},
+};
+use std::convert::Infallible;
+use std::sync::Arc;
+use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
+
+#[derive(Deserialize)]
+struct Query {
+    #[serde(with = "h160_hexadecimal")]
+    sell_token: H160,
+    #[serde(with = "h160_hexadecimal")]
+    buy_token: H160,
+    // For sell orders in sell token, for buy orders in the buy token.
+    #[serde(with = "u256_decimal")]
+    in_amount_before_fees: U256,
+    kind: OrderKind,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Response {
+    expiration_date: DateTime<Utc>,
+    #[serde(with = "u256_decimal")]
+    min_fee: U256,
+    // For sell orders in buy token, for buy orders in the sell token.
+    #[serde(with = "u256_decimal")]
+    out_amount_before_fees: U256,
+    // For buy orders this is the same as out_amount_before_fees. For sell orders this is less
+    // than out_amount_before_fees because the fee is first deducted from the sell amount before
+    // applying the price.
+    #[serde(with = "u256_decimal")]
+    out_amount_after_fees: U256,
+}
+
+#[derive(Debug)]
+enum Error {
+    NotFound,
+    UnsupportedToken(H160),
+    AmountIsZero,
+    SellAmountDoesNotCoverFee,
+    Other(anyhow::Error),
+}
+
+impl From<MinFeeCalculationError> for Error {
+    fn from(other: MinFeeCalculationError) -> Self {
+        match other {
+            MinFeeCalculationError::NotFound => Error::NotFound,
+            MinFeeCalculationError::UnsupportedToken(token) => Error::UnsupportedToken(token),
+            MinFeeCalculationError::Other(error) => Error::Other(error),
+        }
+    }
+}
+
+impl From<PriceEstimationError> for Error {
+    fn from(other: PriceEstimationError) -> Self {
+        match other {
+            PriceEstimationError::UnsupportedToken(token) => Error::UnsupportedToken(token),
+            PriceEstimationError::Other(error) => Error::Other(error),
+        }
+    }
+}
+
+fn request() -> impl Filter<Extract = (Query,), Error = Rejection> + Clone {
+    warp::path!("fee_and_quote")
+        .and(warp::get())
+        .and(warp::query::<Query>())
+}
+
+fn response(result: Result<Response, Error>) -> impl Reply {
+    match result {
+        Ok(response) => reply::with_status(reply::json(&response), StatusCode::OK),
+        Err(Error::NotFound) => reply::with_status(
+            super::error("NotFound", "Token was not found"),
+            StatusCode::NOT_FOUND,
+        ),
+        Err(Error::UnsupportedToken(token)) => reply::with_status(
+            super::error("UnsupportedToken", format!("Token address {:?}", token)),
+            StatusCode::BAD_REQUEST,
+        ),
+        Err(Error::AmountIsZero) => reply::with_status(
+            super::error(
+                "AmountIsZero",
+                "The input amount must be greater than zero.".to_string(),
+            ),
+            StatusCode::BAD_REQUEST,
+        ),
+        Err(Error::SellAmountDoesNotCoverFee) => reply::with_status(
+            super::error(
+                "SellAmountDoesNotCoverFee",
+                "The sell amount for the sell order is lower than the fee.".to_string(),
+            ),
+            StatusCode::BAD_REQUEST,
+        ),
+        Err(Error::Other(err)) => {
+            tracing::error!(?err, "get_fee_and_price error");
+            reply::with_status(super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}
+
+async fn calculate(
+    fee_calculator: Arc<dyn MinFeeCalculating>,
+    price_estimator: Arc<dyn PriceEstimating>,
+    query: Query,
+) -> Result<Response, Error> {
+    if query.in_amount_before_fees.is_zero() {
+        return Err(Error::AmountIsZero);
+    }
+
+    let (min_fee, expiration_date) = fee_calculator
+        .min_fee(query.sell_token, None, None, None)
+        .await?;
+    let in_amount_after_fee = match query.kind {
+        OrderKind::Buy => query.in_amount_before_fees,
+        OrderKind::Sell => query
+            .in_amount_before_fees
+            .checked_sub(min_fee)
+            .ok_or(Error::SellAmountDoesNotCoverFee)?,
+    };
+
+    let price = price_estimator
+        .estimate_price(
+            query.sell_token,
+            query.buy_token,
+            in_amount_after_fee,
+            query.kind,
+        )
+        .await?;
+    let out_amount_before_fees = big_int_to_u256(
+        &match query.kind {
+            OrderKind::Buy => query.in_amount_before_fees.to_big_rational() * &price,
+            OrderKind::Sell => query.in_amount_before_fees.to_big_rational() / &price,
+        }
+        .to_integer(),
+    )
+    .map_err(Error::Other)?;
+    let out_amount_after_fees = big_int_to_u256(
+        &match query.kind {
+            OrderKind::Buy => in_amount_after_fee.to_big_rational() * &price,
+            OrderKind::Sell => in_amount_after_fee.to_big_rational() / &price,
+        }
+        .to_integer(),
+    )
+    .map_err(Error::Other)?;
+
+    Ok(Response {
+        expiration_date,
+        min_fee,
+        out_amount_before_fees,
+        out_amount_after_fees,
+    })
+}
+
+pub fn get_fee_and_quote(
+    fee_calculator: Arc<dyn MinFeeCalculating>,
+    price_estimator: Arc<dyn PriceEstimating>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    request().and_then(move |query| {
+        let fee_calculator = fee_calculator.clone();
+        let price_estimator = price_estimator.clone();
+        async move {
+            Result::<_, Infallible>::Ok(response(
+                calculate(fee_calculator, price_estimator, query).await,
+            ))
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fee::MockMinFeeCalculating;
+    use futures::FutureExt;
+    use num::BigRational;
+    use shared::price_estimate::mocks::FakePriceEstimator;
+
+    #[test]
+    fn calculate_sell() {
+        let mut fee_calculator = MockMinFeeCalculating::new();
+        fee_calculator
+            .expect_min_fee()
+            .returning(|_, _, _, _| Ok((U256::from(3), Utc::now())));
+        let price_estimator = FakePriceEstimator(BigRational::from_float(0.5).unwrap());
+        let result = calculate(
+            Arc::new(fee_calculator),
+            Arc::new(price_estimator),
+            Query {
+                sell_token: H160::from_low_u64_ne(0),
+                buy_token: H160::from_low_u64_ne(1),
+                in_amount_before_fees: 10.into(),
+                kind: OrderKind::Sell,
+            },
+        )
+        .now_or_never()
+        .unwrap()
+        .unwrap();
+        assert_eq!(result.min_fee, 3.into());
+        assert_eq!(result.out_amount_before_fees, 20.into());
+        // After the deducting the fee 10 - 3 = 7 units of sell token are being sold.
+        assert_eq!(result.out_amount_after_fees, 14.into());
+    }
+
+    #[test]
+    fn calculate_buy() {
+        let mut fee_calculator = MockMinFeeCalculating::new();
+        fee_calculator
+            .expect_min_fee()
+            .returning(|_, _, _, _| Ok((U256::from(3), Utc::now())));
+        let price_estimator = FakePriceEstimator(BigRational::from_float(2.0).unwrap());
+        let result = calculate(
+            Arc::new(fee_calculator),
+            Arc::new(price_estimator),
+            Query {
+                sell_token: H160::from_low_u64_ne(0),
+                buy_token: H160::from_low_u64_ne(1),
+                in_amount_before_fees: 10.into(),
+                kind: OrderKind::Buy,
+            },
+        )
+        .now_or_never()
+        .unwrap()
+        .unwrap();
+        // To buy 10 units of buy_token the fee in sell_token must be at least 3 and at least 20
+        // units of sell_token must be sold.
+        assert_eq!(result.min_fee, 3.into());
+        assert_eq!(result.out_amount_before_fees, 20.into());
+        assert_eq!(result.out_amount_after_fees, 20.into());
+    }
+}

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -11,7 +11,7 @@ use crate::database::Database;
 use gas_estimation::GasPriceEstimating;
 use shared::{bad_token::BadTokenDetecting, price_estimate::PriceEstimating};
 
-type Measurement = (U256, DateTime<Utc>);
+pub type Measurement = (U256, DateTime<Utc>);
 
 pub type EthAwareMinFeeCalculator = EthAdapter<MinFeeCalculator>;
 
@@ -32,7 +32,7 @@ pub struct MinFeeCalculator {
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
-pub trait MinFeeCalculating {
+pub trait MinFeeCalculating: Send + Sync {
     // Returns the minimum amount of fee required to accept an order selling the specified order
     // and an expiry date for the estimate.
     // Returns an error if there is some estimation error and Ok(None) if no information about the given


### PR DESCRIPTION
Part of https://github.com/gnosis/gp-v2-services/issues/679 . See that issue for motivation.

In this PR I add a naive implementation of the combined route. This is what afaik the front end does at the moment just done by the backend. After this PR we can improve the implementation to take the amounts into account like with Felix' more accurate fee route.

I would like to discuss how the route should look like before I add the openapi documentation. I have chosen the structure of the fee route which passes all the parameters through the query. This is different from the markets route which passes them in the path. I prefer the query version.

I haven't added the price impact that is mentioned in the issue because I wasn't sure how to correctly calculate it.

I chose a new route instead of a v2 of an existing route because I the new name is clearer but I don't mind changing this.

### Test Plan
new unit tests and manual test (TODO)
