### PR TITLE
[Trivial] info log winning solutions

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -430,7 +430,7 @@ impl Driver {
                 tracing::info!("settlement without onchain liquidity");
             }
 
-            tracing::debug!("winning settlement: {:?}", settlement);
+            tracing::info!("winning settlement: {:?}", settlement);
             self.submit_settlement(settlement.clone()).await;
             self.inflight_trades = settlement
                 .settlement


### PR DESCRIPTION
To make it easier to see which solver ended up winning the competition without having to enable all the debug logs.

### Test Plan
🤷 
