### PR TITLE
Balancer weighted pool Graph query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,6 +2515,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_with",
  "structopt",
  "thiserror",
  "tokio",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -29,6 +29,7 @@ prometheus = "0.12"
 reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0"
 serde_json = "1.0"
+serde_with = { version = "1.9", default-features = false }
 structopt = { version = "0.3", default-features = false }
 thiserror = "1.0"
 tokio = { version = "1.6", features = ["macros", "time"] }

--- a/shared/src/balancer.rs
+++ b/shared/src/balancer.rs
@@ -26,6 +26,7 @@
 //! with how it maintains itself.
 
 pub mod event_handler;
+pub mod graph_api;
 mod info_fetching;
 mod pool_cache;
 pub mod pool_fetching;

--- a/shared/src/balancer/graph_api.rs
+++ b/shared/src/balancer/graph_api.rs
@@ -1,0 +1,413 @@
+//! Module containing The Graph API client used for retrieving Balancer weighted
+//! pools from the Balancer V2 subgraph.
+//!
+//! The pools retrieved from this client are used to prime the graph event store
+//! to reduce start-up time. We do not use this in general for retrieving pools
+//! as to:
+//! - not rely on external services
+//! - ensure that we are using the latest up-to-date pool data by using events
+//!   from the node
+
+use super::pool_storage::RegisteredWeightedPool;
+use crate::subgraph::SubgraphClient;
+use anyhow::{bail, Result};
+use serde_json::json;
+
+/// The threshold of number of blocks after which its considered safe that there
+/// will not be futher re-orgs
+const REORG_THRESHOLD: u64 = 10;
+
+/// The page size when querying pools.
+#[cfg(not(test))]
+const QUERY_PAGE_SIZE: usize = 1000;
+#[cfg(test)]
+const QUERY_PAGE_SIZE: usize = 10;
+
+/// A client to the Balancer V2 subgraph.
+///
+/// This client is not implemented to allow general GraphQL queries, but instead
+/// implements high-level methods that perform GraphQL queries under the hood.
+pub struct BalancerSubgraphClient(SubgraphClient);
+
+impl BalancerSubgraphClient {
+    /// Creates a new Balancer subgraph client for the specified chain ID.
+    pub fn for_chain(chain_id: u64) -> Result<Self> {
+        let subgraph_name = match chain_id {
+            1 => "balancer-v2",
+            4 => "balancer-rinkeby-v2",
+            _ => bail!("unsupported chain {}", chain_id),
+        };
+        Ok(Self(SubgraphClient::new("balancer-labs", subgraph_name)?))
+    }
+
+    /// Retrieves the list of registered pools from the subgraph.
+    pub async fn get_weighted_pools(&self) -> Result<(u64, Vec<RegisteredWeightedPool>)> {
+        use pools_query::*;
+
+        let block_number = self.get_safe_block().await?;
+        let mut results = Vec::<RegisteredWeightedPool>::new();
+        while {
+            // We do paging by last ID instead of using `skip`. This is the
+            // suggested approach to paging best performance:
+            // <https://thegraph.com/docs/graphql-api#pagination>
+            let last_id = results
+                .last()
+                .map(|pool| json!(pool.pool_id))
+                .unwrap_or_else(|| json!(""));
+
+            let page = self
+                .0
+                .query::<Data>(
+                    QUERY,
+                    Some(json_map! {
+                        "block" => block_number,
+                        "pageSize" => QUERY_PAGE_SIZE,
+                        "lastId" => last_id,
+                    }),
+                )
+                .await?
+                .pools;
+            let has_next_page = page.len() == QUERY_PAGE_SIZE;
+
+            results.reserve(page.len());
+            for pool in page {
+                results.push(pool.into_registered(block_number)?);
+            }
+
+            has_next_page
+        } {}
+
+        Ok((block_number, results))
+    }
+
+    /// Retrieves a recent block number for which it is safe to assume no
+    /// reorgs will happen.
+    async fn get_safe_block(&self) -> Result<u64> {
+        use block_number_query::*;
+
+        // Ideally we would want to use block hash here so that we can check
+        // that there indeed is no reorg. However, it does not seem possible to
+        // retrieve historic block hashes just from the subgraph (it always
+        // returns `null`).
+        Ok(self
+            .0
+            .query::<Data>(QUERY, None)
+            .await?
+            .meta
+            .block
+            .number
+            .saturating_sub(REORG_THRESHOLD))
+    }
+}
+
+mod pools_query {
+    use crate::balancer::{pool_storage::RegisteredWeightedPool, swap::fixed_point::Bfp};
+    use anyhow::{anyhow, ensure, Result};
+    use ethcontract::{H160, H256};
+    use serde::Deserialize;
+
+    pub const QUERY: &str = r#"
+        query Pools($block: Int, $pageSize: Int, $lastId: ID) {
+            pools(
+                block: { number: $block }
+                first: $pageSize
+                where: {
+                    id_gt: $lastId
+                    poolType: Weighted
+                }
+            ) {
+                id
+                address
+                tokens {
+                    address
+                    decimals
+                    weight
+                }
+                historicalValues(
+                    first: 1
+                    orderBy: block
+                ) {
+                    block
+                }
+            }
+        }
+    "#;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    pub struct Data {
+        pub pools: Vec<Pool>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Pool {
+        pub id: H256,
+        pub address: H160,
+        pub tokens: Vec<Token>,
+        pub historical_values: Vec<HistoricalValue>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    pub struct Token {
+        pub address: H160,
+        pub decimals: u8,
+        #[serde(with = "serde_with::rust::display_fromstr")]
+        pub weight: Bfp,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    pub struct HistoricalValue {
+        #[serde(with = "serde_with::rust::display_fromstr")]
+        pub block: u64,
+    }
+
+    impl Pool {
+        pub fn into_registered(self, block_fetched: u64) -> Result<RegisteredWeightedPool> {
+            // The Balancer subgraph does not contain information for the block
+            // in which a pool was created. Instead, we assume it is the block
+            // that the data was fetched or the oldest historical liquidity
+            // values, depending on whether the latter is available.
+            let block_created_guesstimate = self
+                .historical_values
+                .get(0)
+                .map(|value| value.block)
+                .unwrap_or(block_fetched);
+            ensure!(
+                block_created_guesstimate <= block_fetched,
+                "historical data more recent than fetched block",
+            );
+
+            let token_count = self.tokens.len();
+            self.tokens.iter().try_fold(
+                RegisteredWeightedPool {
+                    pool_id: self.id,
+                    pool_address: self.address,
+                    tokens: Vec::with_capacity(token_count),
+                    normalized_weights: Vec::with_capacity(token_count),
+                    scaling_exponents: Vec::with_capacity(token_count),
+                    block_created: block_created_guesstimate,
+                },
+                |mut registered_pool, token| {
+                    registered_pool.tokens.push(token.address);
+                    registered_pool
+                        .normalized_weights
+                        .push(token.weight.as_uint256());
+                    registered_pool.scaling_exponents.push(
+                        18u8.checked_sub(token.decimals).ok_or_else(|| {
+                            anyhow!("unsupported token with more than 18 decimals")
+                        })?,
+                    );
+                    Ok(registered_pool)
+                },
+            )
+        }
+    }
+}
+
+mod block_number_query {
+    use serde::Deserialize;
+
+    pub const QUERY: &str = r#"{
+        _meta {
+            block { number }
+        }
+    }"#;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    pub struct Data {
+        #[serde(rename = "_meta")]
+        pub meta: Meta,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    pub struct Meta {
+        pub block: Block,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    pub struct Block {
+        pub number: u64,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::balancer::swap::fixed_point::Bfp;
+    use ethcontract::{H160, H256};
+
+    #[test]
+    fn decode_pools_data() {
+        use pools_query::*;
+
+        assert_eq!(
+            serde_json::from_value::<Data>(json!({
+                "pools": [
+                    {
+                        "address": "0x2222222222222222222222222222222222222222",
+                        "historicalValues": [{ "block": "42" }],
+                        "id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+                        "tokens": [
+                            {
+                                "address": "0x3333333333333333333333333333333333333333",
+                                "decimals": 3,
+                                "weight": "0.5"
+                            },
+                            {
+                                "address": "0x4444444444444444444444444444444444444444",
+                                "decimals": 4,
+                                "weight": "0.5"
+                            },
+                        ],
+                    },
+                ],
+            }))
+            .unwrap(),
+            Data {
+                pools: vec![Pool {
+                    id: H256([0x11; 32]),
+                    address: H160([0x22; 20]),
+                    tokens: vec![
+                        Token {
+                            address: H160([0x33; 20]),
+                            decimals: 3,
+                            weight: Bfp::from_wei(500_000_000_000_000_000u128.into()),
+                        },
+                        Token {
+                            address: H160([0x44; 20]),
+                            decimals: 4,
+                            weight: Bfp::from_wei(500_000_000_000_000_000u128.into()),
+                        },
+                    ],
+                    historical_values: vec![HistoricalValue { block: 42 }],
+                }],
+            }
+        );
+    }
+
+    #[test]
+    fn decode_block_number_data() {
+        use block_number_query::*;
+
+        assert_eq!(
+            serde_json::from_value::<Data>(json!({
+                "_meta": {
+                    "block": {
+                        "number": 42,
+                    },
+                },
+            }))
+            .unwrap(),
+            Data {
+                meta: Meta {
+                    block: Block { number: 42 }
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn convert_pool_to_registered_pool() {
+        use pools_query::*;
+
+        let pool = Pool {
+            id: H256([2; 32]),
+            address: H160([1; 20]),
+            tokens: vec![
+                Token {
+                    address: H160([2; 20]),
+                    decimals: 1,
+                    weight: "1.337".parse().unwrap(),
+                },
+                Token {
+                    address: H160([3; 20]),
+                    decimals: 2,
+                    weight: "4.2".parse().unwrap(),
+                },
+            ],
+            historical_values: vec![HistoricalValue { block: 1 }],
+        };
+
+        assert_eq!(
+            pool.into_registered(2).unwrap(),
+            RegisteredWeightedPool {
+                pool_id: H256([2; 32]),
+                pool_address: H160([1; 20]),
+                tokens: vec![H160([2; 20]), H160([3; 20])],
+                scaling_exponents: vec![17, 16],
+                normalized_weights: vec![
+                    1_337_000_000_000_000_000u128.into(),
+                    4_200_000_000_000_000_000u128.into(),
+                ],
+                block_created: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn pool_conversion_with_missing_historical_data() {
+        use pools_query::*;
+
+        let pool = Pool {
+            id: H256([2; 32]),
+            address: H160([1; 20]),
+            tokens: vec![],
+            historical_values: vec![],
+        };
+
+        assert_eq!(
+            pool.into_registered(2).unwrap(),
+            RegisteredWeightedPool {
+                pool_id: H256([2; 32]),
+                pool_address: H160([1; 20]),
+                tokens: vec![],
+                scaling_exponents: vec![],
+                normalized_weights: vec![],
+                block_created: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn pool_conversion_inconsistent_block_data() {
+        use pools_query::*;
+
+        let pool = Pool {
+            id: H256([2; 32]),
+            address: H160([1; 20]),
+            tokens: vec![],
+            historical_values: vec![HistoricalValue { block: 3 }],
+        };
+        assert!(pool.into_registered(2).is_err());
+    }
+
+    #[test]
+    fn pool_conversion_invalid_decimals() {
+        use pools_query::*;
+
+        let pool = Pool {
+            id: H256([2; 32]),
+            address: H160([1; 20]),
+            tokens: vec![Token {
+                address: H160([2; 20]),
+                decimals: 19,
+                weight: "1.337".parse().unwrap(),
+            }],
+            historical_values: vec![],
+        };
+        assert!(pool.into_registered(2).is_err());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn balancer_subgraph_query() {
+        let client = BalancerSubgraphClient::for_chain(1).unwrap();
+        let (block_number, pools) = client.get_weighted_pools().await.unwrap();
+        println!("{:#?}", pools);
+        println!(
+            "Retrieved {} total pools at block {}",
+            pools.len(),
+            block_number,
+        );
+    }
+}

--- a/shared/src/balancer/swap.rs
+++ b/shared/src/balancer/swap.rs
@@ -1,3 +1,3 @@
 mod error;
-mod fixed_point;
+pub mod fixed_point;
 mod weighted_math;

--- a/shared/src/conversions.rs
+++ b/shared/src/conversions.rs
@@ -1,7 +1,5 @@
 use anyhow::{ensure, Result};
-use num::{bigint::Sign, Zero};
-use num::{rational::Ratio, BigInt};
-use num::{BigRational, ToPrimitive as _};
+use num::{bigint::Sign, rational::Ratio, BigInt, BigRational, ToPrimitive as _, Zero as _};
 use primitive_types::U256;
 
 pub fn big_rational_to_float(ratio: &BigRational) -> Option<f64> {
@@ -28,6 +26,9 @@ pub fn u256_to_big_rational(input: &U256) -> BigRational {
 }
 
 pub fn big_int_to_u256(input: &BigInt) -> Result<U256> {
+    if input.is_zero() {
+        return Ok(0.into());
+    }
     let (sign, bytes) = input.to_bytes_be();
     ensure!(sign == Sign::Plus, "Negative BigInt to U256 conversion");
     ensure!(bytes.len() <= 32, "BigInt too big for U256 conversion");
@@ -61,5 +62,20 @@ impl U256Ext for U256 {
     }
     fn to_big_rational(&self) -> BigRational {
         u256_to_big_rational(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn big_integer_to_u256() {
+        for val in &[0i32, 42, 1337] {
+            assert_eq!(
+                big_int_to_u256(&BigInt::from(*val)).unwrap(),
+                U256::from(*val),
+            );
+        }
     }
 }

--- a/shared/src/event_handling.rs
+++ b/shared/src/event_handling.rs
@@ -10,7 +10,7 @@ use std::ops::RangeInclusive;
 use tokio::sync::Mutex;
 
 // We expect that there is never a reorg that changes more than the last n blocks.
-const MAX_REORG_BLOCK_COUNT: u64 = 25;
+pub const MAX_REORG_BLOCK_COUNT: u64 = 25;
 // Saving events, we process at most this many at a time.
 const INSERT_EVENT_BATCH_SIZE: usize = 10_000;
 

--- a/shared/src/macros.rs
+++ b/shared/src/macros.rs
@@ -4,3 +4,15 @@ macro_rules! addr {
         ::ethcontract::H160(::hex_literal::hex!($val))
     };
 }
+
+#[macro_export]
+macro_rules! json_map {
+    ($($key:expr => $value:expr),* $(,)?) => {{
+        #[allow(unused_mut)]
+        let mut map = ::serde_json::Map::<String, ::serde_json::Value>::new();
+        $(
+            map.insert(($key).into(), ($value).into());
+        )*
+        map
+    }}
+}


### PR DESCRIPTION
This PR adds a Balancer subgraph client capable of fetching weighted pools. It currently fetches them as "registered pools" (i.e. without dynamic pool data like reserves and fees). Ultimately, we hope to add these pools to the pool registry on start up so that it can have a quick cold start (instead of taking a long time to do the initial indexing of pools).

One code smell from this PR is that Balancer subgraph does not specify the creation block for the pool. To work around this we provide a "best-guess" estimate based on the block used for fetching and the earliest historic liquidity value (which I assume gets indexed whenever the pool gets funded).

Additionally, last time I checked the subgraph does not index weighted 2-token pools, which is a significant number of the created Balancer V2 pools. I plan on following up with the Balancer team ASAP.

### Test Plan

Added a some unit tests. 

<details><summary>Also, you can check the queried pools:</summary>

```
$ cargo test -p shared -- --ignored --nocapture balancer_subgraph_query
...
    RegisteredWeightedPool {
        pool_id: 0x01abc00e86c7e258823b9a055fd62ca6cf61a16300010000000000000000003b,
        pool_address: 0x01abc00e86c7e258823b9a055fd62ca6cf61a163,
        tokens: [
            0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e,
            0x1f9840a85d5af5bf1d1762f925bdaddc4201f984,
            0x6b3595068778dd592e39a122f4f5a5cf09c90fe2,
            0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9,
            0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2,
            0xba100000625a3754423978a60c9317c58a424e3d,
            0xc00e94cb662c3520282e6f5717214004a7f26888,
            0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2,
        ],
        normalized_weights: [
            125000000000000000,
            125000000000000000,
            125000000000000000,
            125000000000000000,
            125000000000000000,
            125000000000000000,
            125000000000000000,
            125000000000000000,
        ],
        scaling_exponents: [
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
        ],
        block_created: 12602403,
    }
...
Retrieved 74 total pools at block 12653195
test balancer::graph_api::tests::balancer_subgraph_query ... ok
```

And you can verify that this indeed is the total number of pools:
```
$ curl -s https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2 --data-raw '{"query":"{ pools(first: 1000, where: {poolType: Weighted}) {id} }"}' | jq '.data.pools | length'
74
```

And check one of the pools (for example the first one):
```
$ curl -s https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2 --data-raw '{"query":"{ pools(first: 1, where: {poolType: Weighted}) {id address tokens {address weight decimals}} }"}' | jq '.data.pools[0]'
{
  "address": "0x01abc00e86c7e258823b9a055fd62ca6cf61a163",
  "id": "0x01abc00e86c7e258823b9a055fd62ca6cf61a16300010000000000000000003b",
  "tokens": [
    {
      "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
      "decimals": 18,
      "weight": "0.125"
    },
    {
      "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
      "decimals": 18,
      "weight": "0.125"
    },
    {
      "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
      "decimals": 18,
      "weight": "0.125"
    },
    {
      "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
      "decimals": 18,
      "weight": "0.125"
    },
    {
      "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
      "decimals": 18,
      "weight": "0.125"
    },
    {
      "address": "0xba100000625a3754423978a60c9317c58a424e3d",
      "decimals": 18,
      "weight": "0.125"
    },
    {
      "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
      "decimals": 18,
      "weight": "0.125"
    },
    {
      "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
      "decimals": 18,
      "weight": "0.125"
    }
  ]
}
```

</details>
