### PR TITLE
Make Database a trait

### DIFF
--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -5,12 +5,8 @@ use ethcontract::{
 };
 use model::DomainSeparator;
 use orderbook::{
-    account_balances::Web3BalanceFetcher,
-    database::{Database, Postgres},
-    event_updater::EventUpdater,
-    fee::EthAwareMinFeeCalculator,
-    metrics::Metrics,
-    orderbook::Orderbook,
+    account_balances::Web3BalanceFetcher, database::Postgres, event_updater::EventUpdater,
+    fee::EthAwareMinFeeCalculator, metrics::Metrics, orderbook::Orderbook,
 };
 use prometheus::Registry;
 use shared::{
@@ -140,7 +136,11 @@ impl OrderbookServices {
             .as_u64();
         let db = Arc::new(Postgres::new("postgresql://").unwrap());
         db.clear().await.unwrap();
-        let event_updater = Arc::new(EventUpdater::new(gpv2.settlement.clone(), db.clone(), None));
+        let event_updater = Arc::new(EventUpdater::new(
+            gpv2.settlement.clone(),
+            db.as_ref().clone(),
+            None,
+        ));
         let pair_provider = Arc::new(UniswapPairProvider {
             factory: uniswap_factory.clone(),
             chain_id,

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -9,7 +9,7 @@ mod get_solvable_orders;
 mod get_trades;
 
 use crate::{
-    database::Database,
+    database::trades::TradeRetrieving,
     fee::EthAwareMinFeeCalculator,
     metrics::start_request,
     metrics::{end_request, LabelledReply, Metrics},
@@ -30,7 +30,7 @@ use warp::{
 };
 
 pub fn handle_all_routes(
-    database: Arc<dyn Database>,
+    database: Arc<dyn TradeRetrieving>,
     orderbook: Arc<Orderbook>,
     fee_calculator: Arc<EthAwareMinFeeCalculator>,
     price_estimator: Arc<dyn PriceEstimating>,

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -8,9 +8,13 @@ mod get_orders;
 mod get_solvable_orders;
 mod get_trades;
 
-use crate::metrics::{end_request, LabelledReply, Metrics};
-use crate::{database::Database, metrics::start_request};
-use crate::{fee::EthAwareMinFeeCalculator, orderbook::Orderbook};
+use crate::{
+    database::Database,
+    fee::EthAwareMinFeeCalculator,
+    metrics::start_request,
+    metrics::{end_request, LabelledReply, Metrics},
+    orderbook::Orderbook,
+};
 use anyhow::Error as anyhowError;
 use hex::{FromHex, FromHexError};
 use model::h160_hexadecimal;
@@ -26,7 +30,7 @@ use warp::{
 };
 
 pub fn handle_all_routes(
-    database: Database,
+    database: Arc<dyn Database>,
     orderbook: Arc<Orderbook>,
     fee_calculator: Arc<EthAwareMinFeeCalculator>,
     price_estimator: Arc<dyn PriceEstimating>,

--- a/orderbook/src/api/get_order_by_uid.rs
+++ b/orderbook/src/api/get_order_by_uid.rs
@@ -1,5 +1,5 @@
 use crate::api::convert_get_orders_error_to_reply;
-use crate::database::OrderFilter;
+use crate::database::orders::OrderFilter;
 use crate::orderbook::Orderbook;
 use anyhow::Result;
 use model::order::{Order, OrderUid};

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -1,6 +1,6 @@
 use super::H160Wrapper;
 use crate::api::convert_get_orders_error_to_reply;
-use crate::database::OrderFilter;
+use crate::database::orders::OrderFilter;
 use crate::orderbook::Orderbook;
 use anyhow::Result;
 use model::order::Order;

--- a/orderbook/src/api/get_trades.rs
+++ b/orderbook/src/api/get_trades.rs
@@ -7,6 +7,7 @@ use model::order::OrderUid;
 use model::trade::Trade;
 use serde::Deserialize;
 use std::convert::Infallible;
+use std::sync::Arc;
 use warp::reply::{Json, WithStatus};
 use warp::{hyper::StatusCode, Filter, Rejection, Reply};
 
@@ -56,7 +57,9 @@ fn get_trades_response(result: Result<Vec<Trade>>) -> WithStatus<Json> {
     }
 }
 
-pub fn get_trades(db: Database) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+pub fn get_trades(
+    db: Arc<dyn Database>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     get_trades_request().and_then(move |request_result| {
         let database = db.clone();
         async move {

--- a/orderbook/src/api/get_trades.rs
+++ b/orderbook/src/api/get_trades.rs
@@ -1,6 +1,7 @@
 use super::H160Wrapper;
 use crate::api::convert_get_trades_error_to_reply;
-use crate::database::{Database, TradeFilter};
+use crate::database::trades::TradeFilter;
+use crate::database::trades::TradeRetrieving;
 use anyhow::Result;
 use futures::TryStreamExt;
 use model::order::OrderUid;
@@ -58,7 +59,7 @@ fn get_trades_response(result: Result<Vec<Trade>>) -> WithStatus<Json> {
 }
 
 pub fn get_trades(
-    db: Arc<dyn Database>,
+    db: Arc<dyn TradeRetrieving>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     get_trades_request().and_then(move |request_result| {
         let database = db.clone();

--- a/orderbook/src/database.rs
+++ b/orderbook/src/database.rs
@@ -3,13 +3,68 @@ mod fees;
 mod orders;
 mod trades;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use contracts::gpv2_settlement::Event as ContractEvent;
+use ethcontract::Event as EthContractEvent;
+use futures::{stream::BoxStream, StreamExt};
+use model::{
+    order::{Order, OrderKind, OrderUid},
+    trade::Trade as ModelTrade,
+};
+use primitive_types::{H160, U256};
+use shared::{event_handling::EventIndex, maintenance::Maintaining};
 use sqlx::{Executor, PgPool, Row};
 use std::collections::HashMap;
 
 pub use events::*;
 pub use orders::OrderFilter;
 pub use trades::TradeFilter;
+
+use crate::fee::MinFeeStoring;
+
+#[async_trait::async_trait]
+pub trait Database: Send + Sync {
+    async fn clear(&self) -> Result<()>;
+    async fn count_rows_in_tables(&self) -> Result<HashMap<&'static str, i64>>;
+
+    async fn block_number_of_most_recent_event(&self) -> Result<u64>;
+    async fn insert_events(&self, events: Vec<(EventIndex, Event)>) -> Result<()>;
+    async fn replace_events(
+        &self,
+        delete_from_block_number: u64,
+        events: Vec<(EventIndex, Event)>,
+    ) -> Result<()>;
+    fn contract_to_db_events(
+        &self,
+        contract_events: Vec<EthContractEvent<ContractEvent>>,
+    ) -> Result<Vec<(EventIndex, Event)>>;
+
+    async fn insert_order(&self, order: &Order) -> Result<(), InsertionError>;
+    async fn cancel_order(&self, order_uid: &OrderUid, now: DateTime<Utc>) -> Result<()>;
+    fn orders<'a>(&'a self, filter: &'a OrderFilter) -> BoxStream<'a, Result<Order>>;
+
+    fn trades<'a>(&'a self, filter: &'a TradeFilter) -> BoxStream<'a, Result<ModelTrade>>;
+
+    async fn save_fee_measurement(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
+        expiry: DateTime<Utc>,
+        min_fee: U256,
+    ) -> Result<()>;
+    async fn get_min_fee(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
+        min_expiry: DateTime<Utc>,
+    ) -> Result<Option<U256>>;
+    async fn remove_expired_fee_measurements(&self, max_expiry: DateTime<Utc>) -> Result<()>;
+}
 
 // TODO: There is remaining optimization potential by implementing sqlx encoding and decoding for
 // U256 directly instead of going through BigDecimal. This is not very important as this is fast
@@ -26,7 +81,7 @@ const ALL_TABLES: [&str; 5] = [
 
 // The pool uses an Arc internally.
 #[derive(Clone)]
-pub struct Database {
+pub struct Postgres {
     pool: PgPool,
 }
 
@@ -44,7 +99,7 @@ impl From<sqlx::Error> for InsertionError {
 
 // The implementation is split up into several modules which contain more public methods.
 
-impl Database {
+impl Postgres {
     pub fn new(uri: &str) -> Result<Self> {
         Ok(Self {
             pool: PgPool::connect_lazy(uri)?,
@@ -52,7 +107,7 @@ impl Database {
     }
 
     /// Delete all data in the database. Only used by tests.
-    pub async fn clear(&self) -> Result<()> {
+    async fn clear_(&self) -> Result<()> {
         for table in ALL_TABLES.iter() {
             self.pool
                 .execute(format!("TRUNCATE {};", table).as_str())
@@ -67,12 +122,127 @@ impl Database {
         row.try_get(0).map_err(Into::into)
     }
 
-    pub async fn count_rows_in_tables(&self) -> Result<HashMap<&'static str, i64>> {
+    async fn count_rows_in_tables_(&self) -> Result<HashMap<&'static str, i64>> {
         let mut result = HashMap::new();
         for &table in ALL_TABLES.iter() {
             result.insert(table, self.count_rows_in_table(table).await?);
         }
         Ok(result)
+    }
+}
+
+#[async_trait::async_trait]
+impl Database for Postgres {
+    async fn clear(&self) -> Result<()> {
+        self.clear_().await
+    }
+
+    async fn count_rows_in_tables(&self) -> Result<HashMap<&'static str, i64>> {
+        self.count_rows_in_tables_().await
+    }
+
+    async fn block_number_of_most_recent_event(&self) -> Result<u64> {
+        self.block_number_of_most_recent_event_().await
+    }
+
+    async fn insert_events(&self, events: Vec<(EventIndex, Event)>) -> Result<()> {
+        self.insert_events_(events).await
+    }
+
+    async fn replace_events(
+        &self,
+        delete_from_block_number: u64,
+        events: Vec<(EventIndex, Event)>,
+    ) -> Result<()> {
+        self.replace_events_(delete_from_block_number, events).await
+    }
+
+    fn contract_to_db_events(
+        &self,
+        contract_events: Vec<EthContractEvent<ContractEvent>>,
+    ) -> Result<Vec<(EventIndex, Event)>> {
+        self.contract_to_db_events_(contract_events)
+    }
+
+    async fn insert_order(&self, order: &Order) -> Result<(), InsertionError> {
+        self.insert_order_(order).await
+    }
+
+    async fn cancel_order(&self, order_uid: &OrderUid, now: DateTime<Utc>) -> Result<()> {
+        self.cancel_order_(order_uid, now).await
+    }
+
+    fn orders<'a>(&'a self, filter: &'a OrderFilter) -> BoxStream<'a, Result<Order>> {
+        self.orders_(filter).boxed()
+    }
+
+    fn trades<'a>(&'a self, filter: &'a TradeFilter) -> BoxStream<'a, Result<ModelTrade>> {
+        self.trades_(filter).boxed()
+    }
+
+    async fn save_fee_measurement(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
+        expiry: DateTime<Utc>,
+        min_fee: U256,
+    ) -> Result<()> {
+        self.save_fee_measurement_(sell_token, buy_token, amount, kind, expiry, min_fee)
+            .await
+    }
+
+    async fn get_min_fee(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
+        min_expiry: DateTime<Utc>,
+    ) -> Result<Option<U256>> {
+        self.get_min_fee_(sell_token, buy_token, amount, kind, min_expiry)
+            .await
+    }
+
+    async fn remove_expired_fee_measurements(&self, max_expiry: DateTime<Utc>) -> Result<()> {
+        self.remove_expired_fee_measurements_(max_expiry).await
+    }
+}
+
+#[async_trait::async_trait]
+impl Maintaining for Postgres {
+    async fn run_maintenance(&self) -> Result<()> {
+        self.remove_expired_fee_measurements(Utc::now())
+            .await
+            .context("fee measurement maintenance error")
+    }
+}
+
+#[async_trait::async_trait]
+impl MinFeeStoring for Postgres {
+    async fn save_fee_measurement(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
+        expiry: DateTime<Utc>,
+        min_fee: U256,
+    ) -> Result<()> {
+        Database::save_fee_measurement(self, sell_token, buy_token, amount, kind, expiry, min_fee)
+            .await
+    }
+
+    async fn get_min_fee(
+        &self,
+        sell_token: H160,
+        buy_token: Option<H160>,
+        amount: Option<U256>,
+        kind: Option<OrderKind>,
+        min_expiry: DateTime<Utc>,
+    ) -> Result<Option<U256>> {
+        Database::get_min_fee(self, sell_token, buy_token, amount, kind, min_expiry).await
     }
 }
 
@@ -83,7 +253,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn postgres_count_rows_in_tables_works() {
-        let db = Database::new("postgresql://").unwrap();
+        let db = Postgres::new("postgresql://").unwrap();
         db.clear().await.unwrap();
 
         let counts = db.count_rows_in_tables().await.unwrap();

--- a/orderbook/src/database.rs
+++ b/orderbook/src/database.rs
@@ -1,70 +1,12 @@
-mod events;
-mod fees;
-mod orders;
-mod trades;
+pub mod events;
+pub mod fees;
+pub mod orders;
+pub mod trades;
 
-use anyhow::{Context, Result};
-use chrono::{DateTime, Utc};
-use contracts::gpv2_settlement::Event as ContractEvent;
-use ethcontract::Event as EthContractEvent;
-use futures::{stream::BoxStream, StreamExt};
-use model::{
-    order::{Order, OrderKind, OrderUid},
-    trade::Trade as ModelTrade,
-};
-use primitive_types::{H160, U256};
-use shared::{event_handling::EventIndex, maintenance::Maintaining};
+use anyhow::Result;
+use futures::stream::BoxStream;
 use sqlx::{Executor, PgPool, Row};
 use std::collections::HashMap;
-
-pub use events::*;
-pub use orders::OrderFilter;
-pub use trades::TradeFilter;
-
-use crate::fee::MinFeeStoring;
-
-#[async_trait::async_trait]
-pub trait Database: Send + Sync {
-    async fn clear(&self) -> Result<()>;
-    async fn count_rows_in_tables(&self) -> Result<HashMap<&'static str, i64>>;
-
-    async fn block_number_of_most_recent_event(&self) -> Result<u64>;
-    async fn insert_events(&self, events: Vec<(EventIndex, Event)>) -> Result<()>;
-    async fn replace_events(
-        &self,
-        delete_from_block_number: u64,
-        events: Vec<(EventIndex, Event)>,
-    ) -> Result<()>;
-    fn contract_to_db_events(
-        &self,
-        contract_events: Vec<EthContractEvent<ContractEvent>>,
-    ) -> Result<Vec<(EventIndex, Event)>>;
-
-    async fn insert_order(&self, order: &Order) -> Result<(), InsertionError>;
-    async fn cancel_order(&self, order_uid: &OrderUid, now: DateTime<Utc>) -> Result<()>;
-    fn orders<'a>(&'a self, filter: &'a OrderFilter) -> BoxStream<'a, Result<Order>>;
-
-    fn trades<'a>(&'a self, filter: &'a TradeFilter) -> BoxStream<'a, Result<ModelTrade>>;
-
-    async fn save_fee_measurement(
-        &self,
-        sell_token: H160,
-        buy_token: Option<H160>,
-        amount: Option<U256>,
-        kind: Option<OrderKind>,
-        expiry: DateTime<Utc>,
-        min_fee: U256,
-    ) -> Result<()>;
-    async fn get_min_fee(
-        &self,
-        sell_token: H160,
-        buy_token: Option<H160>,
-        amount: Option<U256>,
-        kind: Option<OrderKind>,
-        min_expiry: DateTime<Utc>,
-    ) -> Result<Option<U256>>;
-    async fn remove_expired_fee_measurements(&self, max_expiry: DateTime<Utc>) -> Result<()>;
-}
 
 // TODO: There is remaining optimization potential by implementing sqlx encoding and decoding for
 // U256 directly instead of going through BigDecimal. This is not very important as this is fast
@@ -85,18 +27,6 @@ pub struct Postgres {
     pool: PgPool,
 }
 
-#[derive(Debug)]
-pub enum InsertionError {
-    DuplicatedRecord,
-    DbError(sqlx::Error),
-}
-
-impl From<sqlx::Error> for InsertionError {
-    fn from(err: sqlx::Error) -> Self {
-        Self::DbError(err)
-    }
-}
-
 // The implementation is split up into several modules which contain more public methods.
 
 impl Postgres {
@@ -107,7 +37,7 @@ impl Postgres {
     }
 
     /// Delete all data in the database. Only used by tests.
-    async fn clear_(&self) -> Result<()> {
+    pub async fn clear(&self) -> Result<()> {
         for table in ALL_TABLES.iter() {
             self.pool
                 .execute(format!("TRUNCATE {};", table).as_str())
@@ -122,7 +52,7 @@ impl Postgres {
         row.try_get(0).map_err(Into::into)
     }
 
-    async fn count_rows_in_tables_(&self) -> Result<HashMap<&'static str, i64>> {
+    pub async fn count_rows_in_tables(&self) -> Result<HashMap<&'static str, i64>> {
         let mut result = HashMap::new();
         for &table in ALL_TABLES.iter() {
             result.insert(table, self.count_rows_in_table(table).await?);
@@ -131,124 +61,10 @@ impl Postgres {
     }
 }
 
-#[async_trait::async_trait]
-impl Database for Postgres {
-    async fn clear(&self) -> Result<()> {
-        self.clear_().await
-    }
-
-    async fn count_rows_in_tables(&self) -> Result<HashMap<&'static str, i64>> {
-        self.count_rows_in_tables_().await
-    }
-
-    async fn block_number_of_most_recent_event(&self) -> Result<u64> {
-        self.block_number_of_most_recent_event_().await
-    }
-
-    async fn insert_events(&self, events: Vec<(EventIndex, Event)>) -> Result<()> {
-        self.insert_events_(events).await
-    }
-
-    async fn replace_events(
-        &self,
-        delete_from_block_number: u64,
-        events: Vec<(EventIndex, Event)>,
-    ) -> Result<()> {
-        self.replace_events_(delete_from_block_number, events).await
-    }
-
-    fn contract_to_db_events(
-        &self,
-        contract_events: Vec<EthContractEvent<ContractEvent>>,
-    ) -> Result<Vec<(EventIndex, Event)>> {
-        self.contract_to_db_events_(contract_events)
-    }
-
-    async fn insert_order(&self, order: &Order) -> Result<(), InsertionError> {
-        self.insert_order_(order).await
-    }
-
-    async fn cancel_order(&self, order_uid: &OrderUid, now: DateTime<Utc>) -> Result<()> {
-        self.cancel_order_(order_uid, now).await
-    }
-
-    fn orders<'a>(&'a self, filter: &'a OrderFilter) -> BoxStream<'a, Result<Order>> {
-        self.orders_(filter).boxed()
-    }
-
-    fn trades<'a>(&'a self, filter: &'a TradeFilter) -> BoxStream<'a, Result<ModelTrade>> {
-        self.trades_(filter).boxed()
-    }
-
-    async fn save_fee_measurement(
-        &self,
-        sell_token: H160,
-        buy_token: Option<H160>,
-        amount: Option<U256>,
-        kind: Option<OrderKind>,
-        expiry: DateTime<Utc>,
-        min_fee: U256,
-    ) -> Result<()> {
-        self.save_fee_measurement_(sell_token, buy_token, amount, kind, expiry, min_fee)
-            .await
-    }
-
-    async fn get_min_fee(
-        &self,
-        sell_token: H160,
-        buy_token: Option<H160>,
-        amount: Option<U256>,
-        kind: Option<OrderKind>,
-        min_expiry: DateTime<Utc>,
-    ) -> Result<Option<U256>> {
-        self.get_min_fee_(sell_token, buy_token, amount, kind, min_expiry)
-            .await
-    }
-
-    async fn remove_expired_fee_measurements(&self, max_expiry: DateTime<Utc>) -> Result<()> {
-        self.remove_expired_fee_measurements_(max_expiry).await
-    }
-}
-
-#[async_trait::async_trait]
-impl Maintaining for Postgres {
-    async fn run_maintenance(&self) -> Result<()> {
-        self.remove_expired_fee_measurements(Utc::now())
-            .await
-            .context("fee measurement maintenance error")
-    }
-}
-
-#[async_trait::async_trait]
-impl MinFeeStoring for Postgres {
-    async fn save_fee_measurement(
-        &self,
-        sell_token: H160,
-        buy_token: Option<H160>,
-        amount: Option<U256>,
-        kind: Option<OrderKind>,
-        expiry: DateTime<Utc>,
-        min_fee: U256,
-    ) -> Result<()> {
-        Database::save_fee_measurement(self, sell_token, buy_token, amount, kind, expiry, min_fee)
-            .await
-    }
-
-    async fn get_min_fee(
-        &self,
-        sell_token: H160,
-        buy_token: Option<H160>,
-        amount: Option<U256>,
-        kind: Option<OrderKind>,
-        min_expiry: DateTime<Utc>,
-    ) -> Result<Option<U256>> {
-        Database::get_min_fee(self, sell_token, buy_token, amount, kind, min_expiry).await
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::database::orders::OrderStoring;
 
     #[tokio::test]
     #[ignore]

--- a/orderbook/src/database/trades.rs
+++ b/orderbook/src/database/trades.rs
@@ -1,5 +1,5 @@
 use crate::conversions::{big_decimal_to_big_uint, h160_from_vec, h256_from_vec};
-use crate::database::Database;
+use crate::database::Postgres;
 use anyhow::{anyhow, Context, Result};
 use bigdecimal::BigDecimal;
 use ethcontract::H160;
@@ -15,8 +15,11 @@ pub struct TradeFilter {
     pub order_uid: Option<OrderUid>,
 }
 
-impl Database {
-    pub fn trades<'a>(&'a self, filter: &'a TradeFilter) -> impl Stream<Item = Result<Trade>> + 'a {
+impl Postgres {
+    pub fn trades_<'a>(
+        &'a self,
+        filter: &'a TradeFilter,
+    ) -> impl Stream<Item = Result<Trade>> + 'a {
         const QUERY: &str = "\
             SELECT \
                 t.block_number, \
@@ -108,9 +111,8 @@ impl TradesQueryRow {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
-    use crate::database::{Event, Settlement as DbSettlement, Trade as DbTrade};
+    use crate::database::{Database, Event, Settlement as DbSettlement, Trade as DbTrade};
     use ethcontract::H256;
     use model::order::{Order, OrderCreation, OrderMetaData};
     use model::trade::Trade;
@@ -129,7 +131,7 @@ mod tests {
     }
 
     async fn add_trade(
-        db: &Database,
+        db: &Postgres,
         owner: H160,
         order_uid: OrderUid,
         event_index: EventIndex,
@@ -156,7 +158,7 @@ mod tests {
     }
 
     async fn add_order_and_trade(
-        db: &Database,
+        db: &Postgres,
         owner: H160,
         order_uid: OrderUid,
         event_index: EventIndex,
@@ -176,7 +178,7 @@ mod tests {
         add_trade(db, owner, order_uid, event_index, tx_hash).await
     }
 
-    async fn assert_trades(db: &Database, filter: &TradeFilter, expected: &[Trade]) {
+    async fn assert_trades(db: &Postgres, filter: &TradeFilter, expected: &[Trade]) {
         let filtered = db
             .trades(&filter)
             .try_collect::<HashSet<Trade>>()
@@ -190,7 +192,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn postgres_trades_without_filter() {
-        let db = Database::new("postgresql://").unwrap();
+        let db = Postgres::new("postgresql://").unwrap();
         db.clear().await.unwrap();
         let (owners, order_ids) = generate_owners_and_order_ids(2, 2).await;
         assert_trades(&db, &TradeFilter::default(), &[]).await;
@@ -212,7 +214,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn postgres_trades_with_owner_filter() {
-        let db = Database::new("postgresql://").unwrap();
+        let db = Postgres::new("postgresql://").unwrap();
         db.clear().await.unwrap();
         let (owners, order_ids) = generate_owners_and_order_ids(3, 2).await;
 
@@ -262,7 +264,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn postgres_trades_with_order_uid_filter() {
-        let db = Database::new("postgresql://").unwrap();
+        let db = Postgres::new("postgresql://").unwrap();
         db.clear().await.unwrap();
 
         let (owners, order_ids) = generate_owners_and_order_ids(2, 3).await;
@@ -313,7 +315,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn postgres_trade_without_matching_order() {
-        let db = Database::new("postgresql://").unwrap();
+        let db = Postgres::new("postgresql://").unwrap();
         db.clear().await.unwrap();
 
         let (owners, order_ids) = generate_owners_and_order_ids(1, 1).await;
@@ -347,7 +349,7 @@ mod tests {
 
     // Testing Trades with settlements
     async fn add_settlement(
-        db: &Database,
+        db: &Postgres,
         event_index: EventIndex,
         solver: H160,
         transaction_hash: H256,
@@ -370,7 +372,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn postgres_trades_having_same_settlement_with_and_without_orders() {
-        let db = Database::new("postgresql://").unwrap();
+        let db = Postgres::new("postgresql://").unwrap();
         db.clear().await.unwrap();
         let (owners, order_ids) = generate_owners_and_order_ids(2, 2).await;
         assert_trades(&db, &TradeFilter::default(), &[]).await;
@@ -416,7 +418,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn postgres_trades_with_same_settlement_no_orders() {
-        let db = Database::new("postgresql://").unwrap();
+        let db = Postgres::new("postgresql://").unwrap();
         db.clear().await.unwrap();
         let (owners, order_ids) = generate_owners_and_order_ids(2, 2).await;
         assert_trades(&db, &TradeFilter::default(), &[]).await;
@@ -462,7 +464,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn postgres_trades_with_two_settlements_in_same_block() {
-        let db = Database::new("postgresql://").unwrap();
+        let db = Postgres::new("postgresql://").unwrap();
         db.clear().await.unwrap();
         let (owners, order_ids) = generate_owners_and_order_ids(2, 2).await;
         assert_trades(&db, &TradeFilter::default(), &[]).await;

--- a/orderbook/src/event_updater.rs
+++ b/orderbook/src/event_updater.rs
@@ -1,76 +1,25 @@
-use crate::database::Database;
-use anyhow::{Context, Result};
+use crate::database::Postgres;
+use anyhow::Result;
 use contracts::{
-    gpv2_settlement::{self, Event as ContractEvent},
+    gpv2_settlement::{self},
     GPv2Settlement,
 };
-use ethcontract::{dyns::DynWeb3, Event};
-use shared::{
-    event_handling::{BlockNumber, EventHandler, EventStoring},
-    impl_event_retrieving,
-    maintenance::Maintaining,
-};
-use std::{ops::RangeInclusive, sync::Arc};
+use ethcontract::dyns::DynWeb3;
+use shared::{event_handling::EventHandler, impl_event_retrieving, maintenance::Maintaining};
 use tokio::sync::Mutex;
 
-pub struct DatabaseEventStoring(Arc<dyn Database>);
-
-pub struct EventUpdater(Mutex<EventHandler<DynWeb3, GPv2SettlementContract, DatabaseEventStoring>>);
-
-#[async_trait::async_trait]
-impl EventStoring<ContractEvent> for DatabaseEventStoring {
-    async fn replace_events(
-        &mut self,
-        events: Vec<Event<ContractEvent>>,
-        range: RangeInclusive<BlockNumber>,
-    ) -> Result<()> {
-        let db_events = self
-            .0
-            .contract_to_db_events(events)
-            .context("replace - failed to convert events")?;
-        tracing::debug!(
-            "replacing {} events from block number {}",
-            db_events.len(),
-            range.start().to_u64()
-        );
-        Database::replace_events(self.0.as_ref(), range.start().to_u64(), db_events)
-            .await
-            .context("failed to replace trades")?;
-        Ok(())
-    }
-
-    async fn append_events(&mut self, events: Vec<Event<ContractEvent>>) -> Result<()> {
-        let db_events = self
-            .0
-            .contract_to_db_events(events)
-            .context("append - failed to convert events")?;
-        tracing::debug!("inserting {} new events", db_events.len());
-        self.0
-            .insert_events(db_events)
-            .await
-            .context("failed to insert trades")?;
-        Ok(())
-    }
-
-    async fn last_event_block(&self) -> Result<u64> {
-        self.0.block_number_of_most_recent_event().await
-    }
-}
+pub struct EventUpdater(Mutex<EventHandler<DynWeb3, GPv2SettlementContract, Postgres>>);
 
 impl_event_retrieving! {
     pub GPv2SettlementContract for gpv2_settlement
 }
 
 impl EventUpdater {
-    pub fn new(
-        contract: GPv2Settlement,
-        db: Arc<dyn Database>,
-        start_sync_at_block: Option<u64>,
-    ) -> Self {
+    pub fn new(contract: GPv2Settlement, db: Postgres, start_sync_at_block: Option<u64>) -> Self {
         Self(Mutex::new(EventHandler::new(
             contract.raw_instance().web3(),
             GPv2SettlementContract(contract),
-            DatabaseEventStoring(db),
+            db,
             start_sync_at_block,
         )))
     }

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -1,15 +1,12 @@
-use std::collections::HashMap;
-
 use anyhow::Result;
 use chrono::{DateTime, Duration, Utc};
+use gas_estimation::GasPriceEstimating;
 use model::order::{OrderKind, BUY_ETH_ADDRESS};
 use primitive_types::{H160, U256};
+use shared::{bad_token::BadTokenDetecting, price_estimate::PriceEstimating};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
-
-use crate::database::Database;
-use gas_estimation::GasPriceEstimating;
-use shared::{bad_token::BadTokenDetecting, price_estimate::PriceEstimating};
 
 pub type Measurement = (U256, DateTime<Utc>);
 
@@ -24,7 +21,7 @@ pub struct MinFeeCalculator {
     price_estimator: Arc<dyn PriceEstimating>,
     gas_estimator: Arc<dyn GasPriceEstimating>,
     native_token: H160,
-    measurements: Box<dyn MinFeeStoring>,
+    measurements: Arc<dyn MinFeeStoring>,
     now: Box<dyn Fn() -> DateTime<Utc> + Send + Sync>,
     discount_factor: f64,
     bad_token_detector: Arc<dyn BadTokenDetecting>,
@@ -108,7 +105,7 @@ impl EthAwareMinFeeCalculator {
         price_estimator: Arc<dyn PriceEstimating>,
         gas_estimator: Arc<dyn GasPriceEstimating>,
         native_token: H160,
-        database: Database,
+        measurements: Arc<dyn MinFeeStoring>,
         discount_factor: f64,
         bad_token_detector: Arc<dyn BadTokenDetecting>,
     ) -> Self {
@@ -117,7 +114,7 @@ impl EthAwareMinFeeCalculator {
                 price_estimator,
                 gas_estimator,
                 native_token,
-                database,
+                measurements,
                 discount_factor,
                 bad_token_detector,
             ),
@@ -158,7 +155,7 @@ impl MinFeeCalculator {
         price_estimator: Arc<dyn PriceEstimating>,
         gas_estimator: Arc<dyn GasPriceEstimating>,
         native_token: H160,
-        database: Database,
+        measurements: Arc<dyn MinFeeStoring>,
         discount_factor: f64,
         bad_token_detector: Arc<dyn BadTokenDetecting>,
     ) -> Self {
@@ -166,7 +163,7 @@ impl MinFeeCalculator {
             price_estimator,
             gas_estimator,
             native_token,
-            measurements: Box::new(database),
+            measurements,
             now: Box::new(Utc::now),
             discount_factor,
             bad_token_detector,
@@ -437,7 +434,7 @@ mod tests {
                 gas_estimator,
                 price_estimator,
                 native_token: Default::default(),
-                measurements: Box::new(InMemoryFeeStore::default()),
+                measurements: Arc::new(InMemoryFeeStore::default()),
                 now,
                 discount_factor: 1.0,
                 bad_token_detector: Arc::new(ListBasedDetector::deny_list(Vec::new())),
@@ -517,7 +514,7 @@ mod tests {
             price_estimator,
             gas_estimator: gas_price_estimator,
             native_token: Default::default(),
-            measurements: Box::new(InMemoryFeeStore::default()),
+            measurements: Arc::new(InMemoryFeeStore::default()),
             now: Box::new(Utc::now),
             discount_factor: 1.0,
             bad_token_detector: Arc::new(ListBasedDetector::deny_list(vec![unsupported_token])),

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -7,10 +7,10 @@ pub mod fee;
 pub mod metrics;
 pub mod orderbook;
 
-use crate::database::Database;
 use crate::orderbook::Orderbook;
 use anyhow::{anyhow, Context as _, Result};
 use contracts::GPv2Settlement;
+use database::Database;
 use fee::EthAwareMinFeeCalculator;
 use metrics::Metrics;
 use model::DomainSeparator;
@@ -23,7 +23,7 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::{task, task::JoinHandle};
 
 pub fn serve_task(
-    database: Database,
+    database: Arc<dyn Database>,
     orderbook: Arc<Orderbook>,
     fee_calculator: Arc<EthAwareMinFeeCalculator>,
     price_estimator: Arc<dyn PriceEstimating>,

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -10,7 +10,7 @@ pub mod orderbook;
 use crate::orderbook::Orderbook;
 use anyhow::{anyhow, Context as _, Result};
 use contracts::GPv2Settlement;
-use database::Database;
+use database::trades::TradeRetrieving;
 use fee::EthAwareMinFeeCalculator;
 use metrics::Metrics;
 use model::DomainSeparator;
@@ -23,7 +23,7 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::{task, task::JoinHandle};
 
 pub fn serve_task(
-    database: Arc<dyn Database>,
+    database: Arc<dyn TradeRetrieving>,
     orderbook: Arc<Orderbook>,
     fee_calculator: Arc<EthAwareMinFeeCalculator>,
     price_estimator: Arc<dyn PriceEstimating>,

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -6,7 +6,7 @@ use model::{
 };
 use orderbook::{
     account_balances::Web3BalanceFetcher,
-    database::{Database, OrderFilter, Postgres},
+    database::{orders::OrderFilter, Postgres},
     event_updater::EventUpdater,
     fee::EthAwareMinFeeCalculator,
     metrics::Metrics,
@@ -98,7 +98,7 @@ struct Arguments {
     pub pool_cache_lru_size: usize,
 }
 
-pub async fn database_metrics(metrics: Arc<Metrics>, database: Arc<dyn Database>) -> ! {
+pub async fn database_metrics(metrics: Arc<Metrics>, database: Postgres) -> ! {
     loop {
         match database.count_rows_in_tables().await {
             Ok(counts) => {
@@ -160,8 +160,11 @@ async fn main() {
         None
     };
 
-    let event_updater =
-        EventUpdater::new(settlement_contract.clone(), database.clone(), sync_start);
+    let event_updater = EventUpdater::new(
+        settlement_contract.clone(),
+        database.as_ref().clone(),
+        sync_start,
+    );
     let balance_fetcher =
         Web3BalanceFetcher::new(web3.clone(), gp_allowance, settlement_contract.address());
 
@@ -289,7 +292,7 @@ async fn main() {
     );
     let maintenance_task =
         task::spawn(service_maintainer.run_maintenance_on_new_block(current_block_stream));
-    let db_metrics_task = task::spawn(database_metrics(metrics, database));
+    let db_metrics_task = task::spawn(database_metrics(metrics, database.as_ref().clone()));
 
     tokio::select! {
         result = serve_task => tracing::error!(?result, "serve task exited"),

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -6,7 +6,7 @@ use model::{
 };
 use orderbook::{
     account_balances::Web3BalanceFetcher,
-    database::{Database, OrderFilter},
+    database::{Database, OrderFilter, Postgres},
     event_updater::EventUpdater,
     fee::EthAwareMinFeeCalculator,
     metrics::Metrics,
@@ -98,7 +98,7 @@ struct Arguments {
     pub pool_cache_lru_size: usize,
 }
 
-pub async fn database_metrics(metrics: Arc<Metrics>, database: Database) -> ! {
+pub async fn database_metrics(metrics: Arc<Metrics>, database: Arc<dyn Database>) -> ! {
     loop {
         match database.count_rows_in_tables().await {
             Ok(counts) => {
@@ -147,7 +147,8 @@ async fn main() {
         .expect("Deployed contract constants don't match the ones in this binary");
     let domain_separator =
         DomainSeparator::get_domain_separator(chain_id, settlement_contract.address());
-    let database = Database::new(args.db_url.as_str()).expect("failed to create database");
+    let database =
+        Arc::new(Postgres::new(args.db_url.as_str()).expect("failed to create database"));
 
     let sync_start = if args.skip_event_sync {
         web3.eth()
@@ -270,7 +271,7 @@ async fn main() {
     let service_maintainer = ServiceMaintenance {
         maintainers: vec![
             orderbook.clone(),
-            Arc::new(database.clone()),
+            database.clone(),
             Arc::new(event_updater),
             pool_fetcher,
         ],

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -51,7 +51,7 @@ pub enum OrderCancellationResult {
 
 pub struct Orderbook {
     domain_separator: DomainSeparator,
-    database: Database,
+    database: Arc<dyn Database>,
     balance_fetcher: Box<dyn BalanceFetching>,
     fee_validator: Arc<EthAwareMinFeeCalculator>,
     min_order_validity_period: Duration,
@@ -62,7 +62,7 @@ pub struct Orderbook {
 impl Orderbook {
     pub fn new(
         domain_separator: DomainSeparator,
-        database: Database,
+        database: Arc<dyn Database>,
         balance_fetcher: Box<dyn BalanceFetching>,
         fee_validator: Arc<EthAwareMinFeeCalculator>,
         min_order_validity_period: Duration,

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -1,7 +1,6 @@
 use crate::{
     account_balances::BalanceFetching,
-    database::OrderFilter,
-    database::{Database, InsertionError},
+    database::orders::{InsertionError, OrderFilter, OrderStoring},
     fee::{EthAwareMinFeeCalculator, MinFeeCalculating},
 };
 use anyhow::Result;
@@ -51,7 +50,7 @@ pub enum OrderCancellationResult {
 
 pub struct Orderbook {
     domain_separator: DomainSeparator,
-    database: Arc<dyn Database>,
+    database: Arc<dyn OrderStoring>,
     balance_fetcher: Box<dyn BalanceFetching>,
     fee_validator: Arc<EthAwareMinFeeCalculator>,
     min_order_validity_period: Duration,
@@ -62,7 +61,7 @@ pub struct Orderbook {
 impl Orderbook {
     pub fn new(
         domain_separator: DomainSeparator,
-        database: Arc<dyn Database>,
+        database: Arc<dyn OrderStoring>,
         balance_fetcher: Box<dyn BalanceFetching>,
         fee_validator: Arc<EthAwareMinFeeCalculator>,
         min_order_validity_period: Duration,


### PR DESCRIPTION
For https://github.com/gnosis/gp-v2-services/pull/741 it has been suggested to make the database a trait so that we wrap it with with a version that collects the query metrics.
The trait also has the advantage that consumers of the Database can now mock it if they want to.
It has the disadvantage that we are using Arc<dyn Database> instead of just Database in these places. When we introduced the database struct I was against this but now I think it is a slight advantage again. I also don't like repeating a bunch of function signatures several times to implement Database, MinFeeStoring, etc.


### Test Plan
existing tests still work
