### PR TITLE
[Trivial] Debug log paraswap price estimate response

### DIFF
--- a/solver/src/solver/paraswap_solver.rs
+++ b/solver/src/solver/paraswap_solver.rs
@@ -104,6 +104,8 @@ where
 
         tracing::debug!("querying Paraswap API with {:?}", price_query);
         let price_response = self.client.price(price_query).await?;
+        tracing::debug!("got response {:?}", price_response);
+
         if !satisfies_limit_price(&order, &price_response) {
             tracing::debug!("Order limit price not respected");
             return Ok(None);


### PR DESCRIPTION
@alfetopito ran into an issue that the Paraswap solver wasn't used for his GNO<>ANT trade.

I debugged this and it looks like his limit price wasn't satisfied (which is weird as the Baseline Solver found a solution)

>Jun 18, 2021 @ 16:25:26.320	2021-06-18T14:25:26.312Z DEBUG solver::solver::paraswap_solver: querying Paraswap API with PriceQuery { from: 0x6810e776880c02933d47db1b9fc05908e5386b96, to: 0x960b236a07cf122663c4303350609a66a7b288c0, from_decimals: 18, to_decimals: 18, amount: 1429205184221781883, side: Sell }
2021-06-18T14:25:28.285Z DEBUG solver::solver::paraswap_solver: Order limit price not respected

Adding a debug log of the response so we can see if it happens again how far off the price estimate is (it will also log the full price_route object).

### Test Plan
CI
