### PR TITLE
[Easy] Cleanup Balancer Module

### DIFF
--- a/shared/src/balancer/event_handler.rs
+++ b/shared/src/balancer/event_handler.rs
@@ -153,6 +153,10 @@ impl EventStoring<WeightedPoolFactoryEvent> for PoolStorage {
         &mut self,
         events: Vec<EthContractEvent<WeightedPoolFactoryEvent>>,
     ) -> Result<()> {
+        tracing::info!(
+            "inserting {} Balancer Weighted Pools from events",
+            events.len()
+        );
         self.insert_events(convert_weighted_pool_created(events)?)
             .await
     }
@@ -180,6 +184,10 @@ impl EventStoring<WeightedPool2TokensFactoryEvent> for PoolStorage {
         &mut self,
         events: Vec<EthContractEvent<WeightedPool2TokensFactoryEvent>>,
     ) -> Result<()> {
+        tracing::info!(
+            "Inserting {} Balancer Weighted 2-Token Pools from events",
+            events.len()
+        );
         self.insert_events(convert_two_token_pool_created(events)?)
             .await
     }

--- a/shared/src/balancer/event_handler.rs
+++ b/shared/src/balancer/event_handler.rs
@@ -12,16 +12,16 @@
 //!
 //! *Note that* when loading pool from a cold start synchronization can take quite long, but is
 //! otherwise as quick as possible (i.e. taking advantage of as much cached information as possible).
-use crate::balancer::{
-    info_fetching::PoolInfoFetcher,
-    pool_storage::{PoolCreated, PoolStorage, RegisteredWeightedPool},
-};
-use crate::token_info::TokenInfoFetching;
 use crate::{
+    balancer::{
+        info_fetching::PoolInfoFetcher,
+        pool_storage::{PoolCreated, PoolStorage, RegisteredWeightedPool},
+    },
     current_block::BlockRetrieving,
     event_handling::{BlockNumber, EventHandler, EventIndex, EventStoring},
     impl_event_retrieving,
     maintenance::Maintaining,
+    token_info::TokenInfoFetching,
     Web3,
 };
 use anyhow::{anyhow, Context, Result};
@@ -32,8 +32,7 @@ use contracts::{
 };
 use ethcontract::{common::DeploymentInformation, Event as EthContractEvent, H256};
 use model::TokenPair;
-use std::sync::Arc;
-use std::{collections::HashSet, ops::RangeInclusive};
+use std::{collections::HashSet, ops::RangeInclusive, sync::Arc};
 use tokio::sync::Mutex;
 
 /// The Pool Registry maintains an event handler for each of the Balancer Pool Factory contracts

--- a/shared/src/balancer/info_fetching.rs
+++ b/shared/src/balancer/info_fetching.rs
@@ -1,13 +1,12 @@
 //! Responsible for conversion of a `pool_address` into `WeightedPoolInfo` which is used by the
 //! event handler to construct a `RegisteredWeightedPool`.
-use crate::balancer::swap::fixed_point::Bfp;
-use crate::pool_fetching::MAX_BATCH_SIZE;
-use crate::token_info::TokenInfoFetching;
-use crate::Web3;
+use crate::{
+    balancer::swap::fixed_point::Bfp, pool_fetching::MAX_BATCH_SIZE, token_info::TokenInfoFetching,
+    Web3,
+};
 use anyhow::{anyhow, Result};
 use contracts::{BalancerV2Vault, BalancerV2WeightedPool};
-use ethcontract::batch::CallBatch;
-use ethcontract::{Bytes, H160, H256};
+use ethcontract::{batch::CallBatch, Bytes, H160, H256};
 use mockall::*;
 use std::sync::Arc;
 

--- a/shared/src/balancer/pool_cache.rs
+++ b/shared/src/balancer/pool_cache.rs
@@ -1,9 +1,10 @@
 use crate::balancer::event_handler::BalancerPoolRegistry;
 use crate::balancer::pool_storage::RegisteredWeightedPool;
+use crate::pool_cache::PoolCacheMetrics;
 use crate::pool_fetching::{handle_contract_error, MAX_BATCH_SIZE};
 use crate::{
     balancer::pool_storage::WeightedPool,
-    recent_block_cache::{Block, CacheFetching, CacheKey, CacheMetrics, RecentBlockCache},
+    recent_block_cache::{Block, CacheFetching, CacheKey, RecentBlockCache},
     Web3,
 };
 use anyhow::Result;
@@ -12,10 +13,6 @@ use ethcontract::batch::CallBatch;
 use ethcontract::errors::MethodError;
 use ethcontract::{BlockId, Bytes, H160, H256, U256};
 use std::{collections::HashSet, sync::Arc};
-
-pub trait PoolCacheMetrics: Send + Sync {
-    fn pools_fetched(&self, cache_hits: usize, cache_misses: usize);
-}
 
 pub struct PoolReserveFetcher {
     pool_registry: Arc<BalancerPoolRegistry>,
@@ -92,12 +89,6 @@ impl CacheFetching<H256, WeightedPool> for PoolReserveFetcher {
             results.push(future.await);
         }
         handle_results(results)
-    }
-}
-
-impl CacheMetrics for Arc<dyn PoolCacheMetrics> {
-    fn entries_fetched(&self, cache_hits: usize, cache_misses: usize) {
-        self.pools_fetched(cache_hits, cache_misses)
     }
 }
 

--- a/shared/src/balancer/pool_cache.rs
+++ b/shared/src/balancer/pool_cache.rs
@@ -1,18 +1,16 @@
-use crate::balancer::event_handler::BalancerPoolRegistry;
-use crate::balancer::pool_storage::RegisteredWeightedPool;
-use crate::pool_fetching::{handle_contract_error, MAX_BATCH_SIZE};
 use crate::{
-    balancer::pool_storage::WeightedPool,
-    recent_block_cache::{Block, CacheFetching, CacheKey, RecentBlockCache},
+    balancer::{
+        event_handler::BalancerPoolRegistry,
+        pool_storage::{RegisteredWeightedPool, WeightedPool},
+    },
+    pool_fetching::{handle_contract_error, MAX_BATCH_SIZE},
+    recent_block_cache::{Block, CacheFetching, CacheKey, CacheMetrics, RecentBlockCache},
     Web3,
 };
 use anyhow::Result;
 use contracts::{BalancerV2Vault, BalancerV2WeightedPool};
-use ethcontract::batch::CallBatch;
-use ethcontract::errors::MethodError;
-use ethcontract::{BlockId, Bytes, H160, H256, U256};
+use ethcontract::{batch::CallBatch, errors::MethodError, BlockId, Bytes, H160, H256, U256};
 use std::{collections::HashSet, sync::Arc};
-use crate::recent_block_cache::CacheMetrics;
 
 pub struct PoolReserveFetcher {
     pool_registry: Arc<BalancerPoolRegistry>,

--- a/shared/src/balancer/pool_fetching.rs
+++ b/shared/src/balancer/pool_fetching.rs
@@ -6,11 +6,10 @@ use anyhow::Result;
 use model::TokenPair;
 use std::collections::HashSet;
 
-use crate::balancer::pool_cache::{BalancerPoolReserveCache, PoolReserveFetcher};
+use crate::balancer::pool_cache::{BalancerPoolReserveCache, PoolReserveFetcher, WeightedPoolCacheMetrics};
 use crate::balancer::{event_handler::BalancerPoolRegistry, pool_storage::WeightedPool};
 use crate::current_block::CurrentBlockStream;
 use crate::maintenance::Maintaining;
-use crate::pool_cache::PoolCacheMetrics;
 use crate::recent_block_cache::{Block, CacheConfig, RecentBlockCache};
 use crate::token_info::TokenInfoFetching;
 use crate::Web3;
@@ -36,7 +35,7 @@ impl BalancerPoolFetcher {
         token_info_fetcher: Arc<dyn TokenInfoFetching>,
         config: CacheConfig,
         block_stream: CurrentBlockStream,
-        metrics: Arc<dyn PoolCacheMetrics>,
+        metrics: Arc<dyn WeightedPoolCacheMetrics>,
     ) -> Result<Self> {
         let pool_registry =
             Arc::new(BalancerPoolRegistry::new(web3.clone(), token_info_fetcher).await?);

--- a/shared/src/balancer/pool_fetching.rs
+++ b/shared/src/balancer/pool_fetching.rs
@@ -2,18 +2,21 @@
 //! when given a collection of `TokenPair`. Each of these pools are then queried for
 //! their `token_balances` and the `PoolFetcher` returns all up-to-date `WeightedPools`
 //! to be consumed by external users (e.g. Price Estimators and Solvers).
+use crate::{
+    balancer::{
+        event_handler::BalancerPoolRegistry,
+        pool_cache::{BalancerPoolReserveCache, PoolReserveFetcher, WeightedPoolCacheMetrics},
+        pool_storage::WeightedPool,
+    },
+    current_block::CurrentBlockStream,
+    maintenance::Maintaining,
+    recent_block_cache::{Block, CacheConfig, RecentBlockCache},
+    token_info::TokenInfoFetching,
+    Web3,
+};
 use anyhow::Result;
 use model::TokenPair;
-use std::collections::HashSet;
-
-use crate::balancer::pool_cache::{BalancerPoolReserveCache, PoolReserveFetcher, WeightedPoolCacheMetrics};
-use crate::balancer::{event_handler::BalancerPoolRegistry, pool_storage::WeightedPool};
-use crate::current_block::CurrentBlockStream;
-use crate::maintenance::Maintaining;
-use crate::recent_block_cache::{Block, CacheConfig, RecentBlockCache};
-use crate::token_info::TokenInfoFetching;
-use crate::Web3;
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 #[async_trait::async_trait]
 pub trait WeightedPoolFetching: Send + Sync {

--- a/shared/src/balancer/pool_fetching.rs
+++ b/shared/src/balancer/pool_fetching.rs
@@ -6,10 +6,11 @@ use anyhow::Result;
 use model::TokenPair;
 use std::collections::HashSet;
 
-use crate::balancer::pool_cache::{BalancerPoolReserveCache, PoolCacheMetrics, PoolReserveFetcher};
+use crate::balancer::pool_cache::{BalancerPoolReserveCache, PoolReserveFetcher};
 use crate::balancer::{event_handler::BalancerPoolRegistry, pool_storage::WeightedPool};
 use crate::current_block::CurrentBlockStream;
 use crate::maintenance::Maintaining;
+use crate::pool_cache::PoolCacheMetrics;
 use crate::recent_block_cache::{Block, CacheConfig, RecentBlockCache};
 use crate::token_info::TokenInfoFetching;
 use crate::Web3;

--- a/shared/src/balancer/pool_storage.rs
+++ b/shared/src/balancer/pool_storage.rs
@@ -136,32 +136,6 @@ impl PoolStorage {
         }
     }
 
-    // Builds Balancer Pool Storage from The Graph Client.
-    pub async fn _new_with_data(data_fetcher: Box<dyn PoolInfoFetching>) -> Result<(Self, u64)> {
-        let client = graph_api::BalancerSubgraphClient::for_chain(1)?;
-        // TODO - implement get_two_token_weighted_pools as well.
-        let (block_number, registered_pools) = client.get_weighted_pools().await?;
-        let mut pools_by_token: HashMap<_, HashSet<H256>> = HashMap::new();
-        let mut pools = HashMap::new();
-        for pool in registered_pools {
-            for token in &pool.tokens {
-                pools_by_token
-                    .entry(*token)
-                    .or_default()
-                    .insert(pool.pool_id);
-            }
-            pools.insert(pool.pool_id, pool);
-        }
-        Ok((
-            PoolStorage {
-                pools_by_token,
-                pools,
-                data_fetcher,
-            },
-            block_number,
-        ))
-    }
-
     /// Returns all pools containing both tokens from `TokenPair`
     pub fn ids_for_pools_containing_token_pair(&self, token_pair: TokenPair) -> HashSet<H256> {
         let empty_set = HashSet::new();

--- a/shared/src/balancer/pool_storage.rs
+++ b/shared/src/balancer/pool_storage.rs
@@ -28,8 +28,10 @@
 //!     current balances of each of the pool's tokens (aka the pool's "reserves").
 //!
 //! Tests included here are those pertaining to the expected functionality of `PoolStorage`
-use crate::balancer::{info_fetching::PoolInfoFetching, swap::fixed_point::Bfp};
-use crate::event_handling::EventIndex;
+use crate::{
+    balancer::{info_fetching::PoolInfoFetching, swap::fixed_point::Bfp},
+    event_handling::EventIndex,
+};
 use anyhow::Result;
 use derivative::Derivative;
 use ethcontract::{H160, H256, U256};

--- a/shared/src/balancer/pool_storage.rs
+++ b/shared/src/balancer/pool_storage.rs
@@ -202,7 +202,6 @@ impl PoolStorage {
     }
 
     pub async fn insert_events(&mut self, events: Vec<(EventIndex, PoolCreated)>) -> Result<()> {
-        let num_events = events.len();
         for (index, creation) in events {
             let weighted_pool = RegisteredWeightedPool::from_event(
                 index.block_number,
@@ -219,11 +218,6 @@ impl PoolStorage {
                     .insert(pool_id);
             }
         }
-        tracing::info!(
-            "inserted {} balancer pool creation events. Synced to block {}",
-            num_events,
-            self.last_event_block()
-        );
         Ok(())
     }
 

--- a/shared/src/balancer/pool_storage.rs
+++ b/shared/src/balancer/pool_storage.rs
@@ -28,7 +28,7 @@
 //!     current balances of each of the pool's tokens (aka the pool's "reserves").
 //!
 //! Tests included here are those pertaining to the expected functionality of `PoolStorage`
-use crate::balancer::{graph_api, info_fetching::PoolInfoFetching, swap::fixed_point::Bfp};
+use crate::balancer::{info_fetching::PoolInfoFetching, swap::fixed_point::Bfp};
 use crate::event_handling::EventIndex;
 use anyhow::Result;
 use derivative::Derivative;

--- a/shared/src/balancer/swap.rs
+++ b/shared/src/balancer/swap.rs
@@ -1,6 +1,8 @@
-use crate::balancer::pool_storage::{PoolTokenState, WeightedPool};
-use crate::baseline_solver::BaselineSolvable;
-use crate::conversions::u256_to_big_int;
+use crate::{
+    balancer::pool_storage::{PoolTokenState, WeightedPool},
+    baseline_solver::BaselineSolvable,
+    conversions::u256_to_big_int,
+};
 use error::Error;
 use ethcontract::{H160, U256};
 use fixed_point::Bfp;

--- a/shared/src/balancer/swap/weighted_math.rs
+++ b/shared/src/balancer/swap/weighted_math.rs
@@ -2,8 +2,7 @@
 //! smart contract. The original contract code can be found at:
 //! https://github.com/balancer-labs/balancer-v2-monorepo/blob/6c9e24e22d0c46cca6dd15861d3d33da61a60b98/pkg/core/contracts/pools/weighted/WeightedMath.sol
 
-use super::error::Error;
-use super::fixed_point::Bfp;
+use super::{error::Error, fixed_point::Bfp};
 use ethcontract::U256;
 use lazy_static::lazy_static;
 


### PR DESCRIPTION
- Rename `PoolCacheMetrics` to `WeightedPoolCacheMetrics` to avoid possibility of confusing invalid imports 
- A few useful log statements in event handler

Note that the last item may be removed upon suggestion (since its not yet used and needs some rework).


### Test Plan
no logic changes.
