### PR TITLE
*PoolModel - use H160 token addresses instead of String

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,7 @@ dependencies = [
  "num-bigint 0.3.2",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,6 +2567,7 @@ dependencies = [
  "hex-literal",
  "itertools 0.10.1",
  "jsonrpc-core",
+ "lazy_static",
  "maplit",
  "mockall",
  "model",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2555,6 +2555,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bigdecimal",
  "chrono",
  "contracts",
  "derivative",

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-bigdecimal = "0.2"
+bigdecimal = { version = "0.2", features = ["serde"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 contracts = { path = "../contracts" }
 derivative = "2.2"

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+bigdecimal = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 contracts = { path = "../contracts" }
 derivative = "2.2"

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -27,6 +27,7 @@ hex = "0.4"
 hex-literal = "0.3"
 itertools = "0.10"
 jsonrpc-core = "17.0"
+lazy_static = "1.4.0"
 maplit = "1.0"
 model = { path = "../model" }
 num = "0.4"

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -424,13 +424,16 @@ mod tests {
         let url = std::env::var("GP_V2_OPTIMIZER_URL")
             .unwrap_or_else(|_| "http://localhost:8000".to_string());
 
+        let buy_token = H160::from_low_u64_be(1337);
+        let sell_token = H160::from_low_u64_be(43110);
+
         let mut mock_token_info_fetcher = MockTokenInfoFetching::new();
         mock_token_info_fetcher
             .expect_get_token_infos()
             .return_once(move |_| {
                 hashmap! {
-                    H160::zero() => TokenInfo { decimals: Some(18)},
-                    H160::from_low_u64_be(1) => TokenInfo { decimals: Some(18)},
+                    buy_token => TokenInfo { decimals: Some(18)},
+                    sell_token => TokenInfo { decimals: Some(18)},
                 }
             });
         let mock_token_info_fetcher: Arc<dyn TokenInfoFetching> = Arc::new(mock_token_info_fetcher);
@@ -457,8 +460,8 @@ mod tests {
         let base = |x: u128| x * 10u128.pow(18);
         let orders = vec![
             Liquidity::Limit(LimitOrder {
-                buy_token: H160::zero(),
-                sell_token: H160::from_low_u64_be(1),
+                buy_token,
+                sell_token,
                 buy_amount: base(1).into(),
                 sell_amount: base(2).into(),
                 kind: OrderKind::Sell,
@@ -468,7 +471,7 @@ mod tests {
                 id: "0".to_string(),
             }),
             Liquidity::Amm(AmmOrder {
-                tokens: TokenPair::new(H160::zero(), H160::from_low_u64_be(1)).unwrap(),
+                tokens: TokenPair::new(buy_token, sell_token).unwrap(),
                 reserves: (base(100), base(100)),
                 fee: Ratio::new(0, 1),
                 settlement_handling: CapturingSettlementHandler::arc(),

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -135,21 +135,21 @@ impl HttpSolver {
             .collect()
     }
 
-    fn map_orders_for_solver(&self, orders: Vec<LimitOrder>) -> HashMap<String, LimitOrder> {
+    fn map_orders_for_solver(&self, orders: Vec<LimitOrder>) -> HashMap<usize, LimitOrder> {
         orders
             .into_iter()
             .enumerate()
-            .map(|(index, order)| (index.to_string(), order))
+            .map(|(index, order)| (index, order))
             .collect()
     }
 
     async fn order_models(
         &self,
-        orders: &HashMap<String, LimitOrder>,
+        orders: &HashMap<usize, LimitOrder>,
         gas_price: f64,
-    ) -> Result<HashMap<String, OrderModel>> {
+    ) -> Result<HashMap<usize, OrderModel>> {
         let order_cost = self.order_cost(gas_price).await;
-        let mut result: HashMap<String, OrderModel> = HashMap::new();
+        let mut result: HashMap<usize, OrderModel> = HashMap::new();
         for (index, order) in orders {
             let order_fee = self.order_fee(&order)?;
             let order = OrderModel {
@@ -168,24 +168,24 @@ impl HttpSolver {
                     token: self.native_token,
                 },
             };
-            result.insert(index.clone(), order);
+            result.insert(*index, order);
         }
         Ok(result)
     }
 
-    fn map_amms_for_solver(&self, orders: Vec<AmmOrder>) -> HashMap<String, AmmOrder> {
+    fn map_amms_for_solver(&self, orders: Vec<AmmOrder>) -> HashMap<usize, AmmOrder> {
         orders
             .into_iter()
             .enumerate()
-            .map(|(index, amm)| (index.to_string(), amm))
+            .map(|(index, amm)| (index, amm))
             .collect()
     }
 
     async fn amm_models(
         &self,
-        amms: &HashMap<String, AmmOrder>,
+        amms: &HashMap<usize, AmmOrder>,
         gas_price: f64,
-    ) -> HashMap<String, PoolModel> {
+    ) -> HashMap<usize, PoolModel> {
         let uniswap_cost = self.uniswap_cost(gas_price).await;
         amms.iter()
             .map(|(index, amm)| {
@@ -215,7 +215,7 @@ impl HttpSolver {
                     mandatory: false,
                     reserves,
                 };
-                (index.clone(), uniswap)
+                (*index, uniswap)
             })
             .collect()
     }

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -19,7 +19,6 @@ use shared::{
     price_estimate::{PriceEstimating, PriceEstimationError},
     token_info::{TokenInfo, TokenInfoFetching},
 };
-use std::ops::Div;
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -207,7 +206,7 @@ impl HttpSolver {
 
                 let uniswap = PoolModel {
                     pool_type: PoolType::UniswapV2,
-                    fee: BigDecimal::from(*amm.fee.numer()).div(BigDecimal::from(*amm.fee.denom())),
+                    fee: BigDecimal::from(*amm.fee.numer()) / BigDecimal::from(*amm.fee.denom()),
                     cost: CostModel {
                         amount: uniswap_cost,
                         token: self.native_token,

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use ::model::order::OrderKind;
 use anyhow::{ensure, Context, Result};
+use bigdecimal::BigDecimal;
 use ethcontract::U256;
 use futures::join;
 use num::{BigRational, ToPrimitive};
@@ -18,6 +19,7 @@ use shared::{
     price_estimate::{PriceEstimating, PriceEstimationError},
     token_info::{TokenInfo, TokenInfoFetching},
 };
+use std::ops::Div;
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -202,9 +204,10 @@ impl HttpSolver {
                         weight: U256::from(500_000_000_000_000_000u128),
                     },
                 );
+
                 let uniswap = PoolModel {
                     pool_type: PoolType::UniswapV2,
-                    fee: *amm.fee.numer() as f64 / *amm.fee.denom() as f64,
+                    fee: BigDecimal::from(*amm.fee.numer()).div(BigDecimal::from(*amm.fee.denom())),
                     cost: CostModel {
                         amount: uniswap_cost,
                         token: self.native_token,

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -44,7 +44,6 @@ pub enum PoolType {
 pub struct PoolModel {
     pub pool_type: PoolType,
     pub reserves: HashMap<H160, PoolTokenData>,
-    #[serde(with = "serde_with::rust::display_fromstr")]
     pub fee: BigDecimal,
     pub cost: CostModel,
     pub mandatory: bool,

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -58,20 +58,20 @@ pub struct TokenInfoModel {
 #[derive(Debug, Serialize)]
 pub struct CostModel {
     pub amount: u128,
-    pub token: String,
+    pub token: H160,
 }
 
 #[derive(Debug, Serialize)]
 pub struct FeeModel {
     pub amount: u128,
-    pub token: String,
+    pub token: H160,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct SettledBatchAuctionModel {
     pub orders: HashMap<String, ExecutedOrderModel>,
     pub uniswaps: HashMap<String, UpdatedUniswapModel>,
-    pub ref_token: String,
+    pub ref_token: H160,
     pub prices: HashMap<String, Price>,
 }
 

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -51,15 +51,15 @@ pub struct PoolModel {
 
 #[derive(Debug, Serialize)]
 pub struct TokenInfoModel {
-    pub decimals: Option<u32>,
+    pub decimals: Option<u8>,
     pub external_price: Option<f64>,
     pub normalize_priority: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct CostModel {
-    #[serde(with = "serde_with::rust::display_fromstr")]
-    pub amount: u128,
+    #[serde(with = "u256_decimal")]
+    pub amount: U256,
     pub token: H160,
 }
 

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -65,8 +65,8 @@ pub struct CostModel {
 
 #[derive(Debug, Serialize)]
 pub struct FeeModel {
-    #[serde(with = "serde_with::rust::display_fromstr")]
-    pub amount: u128,
+    #[serde(with = "u256_decimal")]
+    pub amount: U256,
     pub token: H160,
 }
 

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -1,3 +1,4 @@
+use bigdecimal::BigDecimal;
 use ethcontract::H160;
 use model::u256_decimal;
 use primitive_types::U256;
@@ -43,7 +44,8 @@ pub enum PoolType {
 pub struct PoolModel {
     pub pool_type: PoolType,
     pub reserves: HashMap<H160, PoolTokenData>,
-    pub fee: f64,
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub fee: BigDecimal,
     pub cost: CostModel,
     pub mandatory: bool,
 }
@@ -57,12 +59,14 @@ pub struct TokenInfoModel {
 
 #[derive(Debug, Serialize)]
 pub struct CostModel {
+    #[serde(with = "serde_with::rust::display_fromstr")]
     pub amount: u128,
     pub token: H160,
 }
 
 #[derive(Debug, Serialize)]
 pub struct FeeModel {
+    #[serde(with = "serde_with::rust::display_fromstr")]
     pub amount: u128,
     pub token: H160,
 }

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -8,8 +8,8 @@ use std::collections::HashMap;
 #[derive(Debug, Default, Serialize)]
 pub struct BatchAuctionModel {
     pub tokens: HashMap<H160, TokenInfoModel>,
-    pub orders: HashMap<String, OrderModel>,
-    pub amms: HashMap<String, PoolModel>,
+    pub orders: HashMap<usize, OrderModel>,
+    pub amms: HashMap<usize, PoolModel>,
     pub metadata: Option<MetadataModel>,
 }
 

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -72,10 +72,10 @@ pub struct FeeModel {
 
 #[derive(Debug, Deserialize)]
 pub struct SettledBatchAuctionModel {
-    pub orders: HashMap<String, ExecutedOrderModel>,
-    pub uniswaps: HashMap<String, UpdatedUniswapModel>,
+    pub orders: HashMap<usize, ExecutedOrderModel>,
+    pub uniswaps: HashMap<usize, UpdatedUniswapModel>,
     pub ref_token: H160,
-    pub prices: HashMap<String, Price>,
+    pub prices: HashMap<H160, Price>,
 }
 
 impl SettledBatchAuctionModel {

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -1,3 +1,4 @@
+use ethcontract::H160;
 use model::u256_decimal;
 use primitive_types::U256;
 use serde::{Deserialize, Serialize};
@@ -5,7 +6,7 @@ use std::collections::HashMap;
 
 #[derive(Debug, Default, Serialize)]
 pub struct BatchAuctionModel {
-    pub tokens: HashMap<String, TokenInfoModel>,
+    pub tokens: HashMap<H160, TokenInfoModel>,
     pub orders: HashMap<String, OrderModel>,
     pub uniswaps: HashMap<String, PoolModel>,
     pub metadata: Option<MetadataModel>,
@@ -13,8 +14,8 @@ pub struct BatchAuctionModel {
 
 #[derive(Debug, Serialize)]
 pub struct OrderModel {
-    pub sell_token: String,
-    pub buy_token: String,
+    pub sell_token: H160,
+    pub buy_token: H160,
     #[serde(with = "u256_decimal")]
     pub sell_amount: U256,
     #[serde(with = "u256_decimal")]
@@ -41,7 +42,7 @@ pub enum PoolType {
 #[derive(Debug, Serialize)]
 pub struct PoolModel {
     pub pool_type: PoolType,
-    pub reserves: HashMap<String, PoolTokenData>,
+    pub reserves: HashMap<H160, PoolTokenData>,
     pub fee: f64,
     pub cost: CostModel,
     pub mandatory: bool,

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -203,6 +203,7 @@ mod tests {
     use crate::liquidity::tests::CapturingSettlementHandler;
     use maplit::hashmap;
     use model::TokenPair;
+    use std::str::FromStr;
 
     #[test]
     fn convert_settlement_() {


### PR DESCRIPTION
Partial fulfillment of #769 

Addressing the comment brought up [here](https://github.com/gnosis/gp-v2-services/pull/761#discussion_r655303506) that we shouldn't be using String for token identifiers.

There is a lot more code to change here though since the entire solver infrastructure relies on a `HashMap<String, H160>`
