### PR TITLE
[Easy-Refactor] Rename AmmOrder to ConstantProductOrder

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -512,7 +512,7 @@ fn liquidity_with_price(
                 Liquidity::Limit(limit_order) => [limit_order.sell_token, limit_order.buy_token]
                     .iter()
                     .all(|token| prices.contains_key(token)),
-                Liquidity::Amm(_) => true,
+                Liquidity::ConstantProduct(_) => true,
             });
     if !removed_orders.is_empty() {
         tracing::debug!(
@@ -536,7 +536,7 @@ fn is_only_selling_trusted_tokens(settlement: &Settlement, token_list: &TokenLis
 mod tests {
     use super::*;
     use crate::{
-        liquidity::{tests::CapturingSettlementHandler, AmmOrder, LimitOrder},
+        liquidity::{tests::CapturingSettlementHandler, ConstantProductOrder, LimitOrder},
         settlement::Trade,
     };
     use maplit::hashmap;
@@ -570,7 +570,7 @@ mod tests {
                 settlement_handling: CapturingSettlementHandler::arc(),
                 id: "0".into(),
             }),
-            Liquidity::Amm(AmmOrder {
+            Liquidity::ConstantProduct(ConstantProductOrder {
                 tokens: TokenPair::new(buy_token, native_token).unwrap(),
                 reserves: (1_000_000, 1_000_000),
                 fee: Ratio::new(3, 1000),

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -17,7 +17,7 @@ pub mod uniswap;
 #[derive(Clone, AsStaticStr, EnumVariantNames, Debug)]
 pub enum Liquidity {
     Limit(LimitOrder),
-    Amm(AmmOrder),
+    ConstantProduct(ConstantProductOrder),
 }
 
 /// A trait associating some liquidity model to how it is executed and encoded
@@ -106,14 +106,14 @@ impl Default for LimitOrder {
 
 /// 2 sided constant product automated market maker with equal reserve value and a trading fee (e.g. Uniswap, Sushiswap)
 #[derive(Clone)]
-pub struct AmmOrder {
+pub struct ConstantProductOrder {
     pub tokens: TokenPair,
     pub reserves: (u128, u128),
     pub fee: Ratio<u32>,
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
 }
 
-impl std::fmt::Debug for AmmOrder {
+impl std::fmt::Debug for ConstantProductOrder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "AMM {:?}", self.tokens)
     }
@@ -125,13 +125,13 @@ pub struct AmmOrderExecution {
     pub output: (H160, U256),
 }
 
-impl AmmOrder {
+impl ConstantProductOrder {
     pub fn constant_product(&self) -> U256 {
         U256::from(self.reserves.0) * U256::from(self.reserves.1)
     }
 }
 
-impl Settleable for AmmOrder {
+impl Settleable for ConstantProductOrder {
     type Execution = AmmOrderExecution;
 
     fn settlement_handling(&self) -> &dyn SettlementHandling<Self> {
@@ -140,9 +140,9 @@ impl Settleable for AmmOrder {
 }
 
 #[cfg(test)]
-impl Default for AmmOrder {
+impl Default for ConstantProductOrder {
     fn default() -> Self {
-        AmmOrder {
+        ConstantProductOrder {
             tokens: Default::default(),
             reserves: Default::default(),
             fee: Ratio::new(0, 1),

--- a/solver/src/liquidity/uniswap.rs
+++ b/solver/src/liquidity/uniswap.rs
@@ -17,7 +17,7 @@ pub const MAX_HOPS: usize = 2;
 use super::slippage;
 use crate::{interactions::UniswapInteraction, settlement::SettlementEncoder};
 
-use super::{AmmOrder, AmmOrderExecution, LimitOrder, SettlementHandling};
+use super::{AmmOrderExecution, ConstantProductOrder, LimitOrder, SettlementHandling};
 
 pub struct UniswapLikeLiquidity {
     inner: Arc<Inner>,
@@ -58,7 +58,7 @@ impl UniswapLikeLiquidity {
         &self,
         offchain_orders: impl Iterator<Item = &LimitOrder> + Send + Sync,
         at_block: Block,
-    ) -> Result<Vec<AmmOrder>> {
+    ) -> Result<Vec<ConstantProductOrder>> {
         let mut pools = HashSet::new();
 
         for order in offchain_orders {
@@ -81,7 +81,7 @@ impl UniswapLikeLiquidity {
             tokens.insert(pool.tokens.get().0);
             tokens.insert(pool.tokens.get().1);
 
-            result.push(AmmOrder {
+            result.push(ConstantProductOrder {
                 tokens: pool.tokens,
                 reserves: pool.reserves,
                 fee: pool.fee,
@@ -151,7 +151,7 @@ impl Inner {
     }
 }
 
-impl SettlementHandling<AmmOrder> for Inner {
+impl SettlementHandling<ConstantProductOrder> for Inner {
     // Creates the required interaction to convert the given input into output. Applies 0.1% slippage tolerance to the output.
     fn encode(&self, execution: AmmOrderExecution, encoder: &mut SettlementEncoder) -> Result<()> {
         encoder.append_to_execution_plan(self._settle(execution.input, execution.output));

--- a/solver/src/liquidity_collector.rs
+++ b/solver/src/liquidity_collector.rs
@@ -38,7 +38,7 @@ impl LiquidityCollector {
         Ok(limit_orders
             .into_iter()
             .map(Liquidity::Limit)
-            .chain(amms.into_iter().map(Liquidity::Amm))
+            .chain(amms.into_iter().map(Liquidity::ConstantProduct))
             .collect())
     }
 }

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -245,7 +245,7 @@ mod tests {
         let sell_token = H160::from_low_u64_be(1);
         let liquidity = vec![
             // Only filter limit orders
-            Liquidity::Amm(Default::default()),
+            Liquidity::ConstantProduct(Default::default()),
             // Orders with high enough amount
             Liquidity::Limit(LimitOrder {
                 sell_amount: 100_000.into(),

--- a/solver/src/solver/naive_solver/multi_order_solver.rs
+++ b/solver/src/solver/naive_solver/multi_order_solver.rs
@@ -1,6 +1,6 @@
 use crate::{liquidity, settlement::Settlement};
 use anyhow::Result;
-use liquidity::{AmmOrder, AmmOrderExecution, LimitOrder};
+use liquidity::{AmmOrderExecution, ConstantProductOrder, LimitOrder};
 use model::order::OrderKind;
 use num::{rational::Ratio, BigInt, BigRational};
 use primitive_types::U256;
@@ -36,7 +36,7 @@ impl TokenContext {
 
 pub fn solve(
     orders: impl Iterator<Item = LimitOrder> + Clone,
-    pool: &AmmOrder,
+    pool: &ConstantProductOrder,
 ) -> Option<Settlement> {
     let mut orders: Vec<LimitOrder> = orders.collect();
     while !orders.is_empty() {
@@ -78,7 +78,7 @@ pub fn solve(
 ///
 fn solve_orders(
     orders: impl Iterator<Item = LimitOrder> + Clone,
-    pool: &AmmOrder,
+    pool: &ConstantProductOrder,
     context_a: &TokenContext,
     context_b: &TokenContext,
 ) -> Option<Settlement> {
@@ -116,7 +116,7 @@ fn solve_without_uniswap(
 ///
 fn solve_with_uniswap(
     orders: impl Iterator<Item = LimitOrder> + Clone,
-    pool: &AmmOrder,
+    pool: &ConstantProductOrder,
     shortage: &TokenContext,
     excess: &TokenContext,
 ) -> Option<Settlement> {
@@ -149,7 +149,7 @@ fn solve_with_uniswap(
     Some(settlement)
 }
 
-impl AmmOrder {
+impl ConstantProductOrder {
     fn get_reserve(&self, token: &Address) -> Option<U256> {
         if &self.tokens.get().0 == token {
             Some(self.reserves.0.into())
@@ -163,7 +163,7 @@ impl AmmOrder {
 
 fn split_into_contexts(
     orders: impl Iterator<Item = LimitOrder>,
-    pool: &AmmOrder,
+    pool: &ConstantProductOrder,
 ) -> (TokenContext, TokenContext) {
     let mut contexts = HashMap::new();
     for order in orders {
@@ -312,7 +312,7 @@ mod tests {
         ];
 
         let amm_handler = CapturingSettlementHandler::arc();
-        let pool = AmmOrder {
+        let pool = ConstantProductOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
             fee: Ratio::new(3, 1000),
@@ -372,7 +372,7 @@ mod tests {
         ];
 
         let amm_handler = CapturingSettlementHandler::arc();
-        let pool = AmmOrder {
+        let pool = ConstantProductOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_000).as_u128(), to_wei(1_000_000).as_u128()),
             fee: Ratio::new(3, 1000),
@@ -428,7 +428,7 @@ mod tests {
         ];
 
         let amm_handler = CapturingSettlementHandler::arc();
-        let pool = AmmOrder {
+        let pool = ConstantProductOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
             fee: Ratio::new(3, 1000),
@@ -488,7 +488,7 @@ mod tests {
         ];
 
         let amm_handler = CapturingSettlementHandler::arc();
-        let pool = AmmOrder {
+        let pool = ConstantProductOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
             fee: Ratio::new(3, 1000),
@@ -552,7 +552,7 @@ mod tests {
         ];
 
         let amm_handler = CapturingSettlementHandler::arc();
-        let pool = AmmOrder {
+        let pool = ConstantProductOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_001).as_u128(), to_wei(1_000_000).as_u128()),
             fee: Ratio::new(3, 1000),
@@ -633,7 +633,7 @@ mod tests {
         ];
 
         let amm_handler = CapturingSettlementHandler::arc();
-        let pool = AmmOrder {
+        let pool = ConstantProductOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_000).as_u128(), to_wei(1_000_000).as_u128()),
             fee: Ratio::new(3, 1000),
@@ -679,7 +679,7 @@ mod tests {
         ];
 
         let amm_handler = CapturingSettlementHandler::arc();
-        let pool = AmmOrder {
+        let pool = ConstantProductOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_001).as_u128(), to_wei(1_000_000).as_u128()),
             fee: Ratio::new(3, 1000),
@@ -805,7 +805,7 @@ mod tests {
         ];
 
         let amm_handler = CapturingSettlementHandler::arc();
-        let pool = AmmOrder {
+        let pool = ConstantProductOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (u128::MAX, u128::MAX),
             fee: Ratio::new(3, 1000),
@@ -848,7 +848,7 @@ mod tests {
             .into(),
         ];
         // Reserves are much smaller than buy amount
-        let pool = AmmOrder {
+        let pool = ConstantProductOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (25000075, 2500007500),
             fee: Ratio::new(3, 1000),


### PR DESCRIPTION
Partial fulfillment of #769.

This PR simply renames all occurrences of `AmmOrder` to `ConstantProductOrder`. In essence, making way for `WeightedProductOrder`.

### Test Plan
Existing UI
