### PR TITLE
[Paraswap] Get src/dest amount from priceRoute instead of bestRoute

### DIFF
--- a/solver/src/solver/paraswap_solver/api.rs
+++ b/solver/src/solver/paraswap_solver/api.rs
@@ -128,12 +128,6 @@ impl<'de> Deserialize<'de> for PriceResponse {
         #[derive(Deserialize)]
         #[serde(rename_all = "camelCase")]
         struct PriceRoute {
-            best_route: Vec<BestRoute>,
-        }
-
-        #[derive(Deserialize, Clone)]
-        #[serde(rename_all = "camelCase")]
-        struct BestRoute {
             #[serde(with = "u256_decimal")]
             src_amount: U256,
             #[serde(with = "u256_decimal")]
@@ -141,16 +135,11 @@ impl<'de> Deserialize<'de> for PriceResponse {
         }
 
         let parsed = ParsedRaw::deserialize(deserializer)?;
-        let price_route = serde_json::from_value::<PriceRoute>(parsed.price_route.clone())
-            .map_err(D::Error::custom)?;
-        let BestRoute {
+        let PriceRoute {
             src_amount,
             dest_amount,
-        } = price_route
-            .best_route
-            .first()
-            .cloned()
-            .ok_or_else(|| D::Error::custom("No best route"))?;
+        } = serde_json::from_value::<PriceRoute>(parsed.price_route.clone())
+            .map_err(D::Error::custom)?;
         Ok(PriceResponse {
             price_route_raw: parsed.price_route,
             src_amount,
@@ -232,14 +221,14 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn test_api_e2e() {
-        let from = shared::addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE");
-        let to = shared::addr!("1a5f9352af8af974bfc03399e3767df6370d82e4");
+        let from = shared::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+        let to = shared::addr!("960b236a07cf122663c4303350609a66a7b288c0");
         let price_query = PriceQuery {
             from,
             to,
             from_decimals: 18,
             to_decimals: 18,
-            amount: 1_000_000_000_000_000_000u128.into(),
+            amount: 1_499_200_000_000_000_000u128.into(),
             side: Side::Sell,
         };
 

--- a/solver/src/solver/paraswap_solver/api.rs
+++ b/solver/src/solver/paraswap_solver/api.rs
@@ -221,14 +221,14 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn test_api_e2e() {
-        let from = shared::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
-        let to = shared::addr!("960b236a07cf122663c4303350609a66a7b288c0");
+        let from = shared::addr!("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+        let to = shared::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
         let price_query = PriceQuery {
             from,
             to,
             from_decimals: 18,
             to_decimals: 18,
-            amount: 1_499_200_000_000_000_000u128.into(),
+            amount: 135_000_000_000_000_000_000u128.into(),
             side: Side::Sell,
         };
 


### PR DESCRIPTION
For more complex execution plans best Route may contain multiple elements each of which containing a fraction of the total src/dest Amount. In the current API parsing code I used the first item of bestRoute which only works for "simple" execution plans.

Instead we need to use the src/dest amount from the more top level priceRoute field.

This addresses some of the alerts we saw in prod yesterday (`TransactionBuilderQuery result parsing failed: {"error":"Destination Amount Mismatch"}`) and was also the reason why the Paraswap solver wasn't used for our internal buyback program: https://gnosisinc.slack.com/archives/CC3C5SMB5/p1624316904013100

### Test Plan
Adjusting e2e to trade a really large amount (test not passing on current main)
