### PR TITLE
Make paraswap slippage configurable

### DIFF
--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -148,6 +148,14 @@ struct Arguments {
         parse(try_from_str = shared::arguments::wei_from_gwei)
     )]
     gas_price_cap: f64,
+
+    /// The maximum gas price the solver is willing to pay in a settlement
+    #[structopt(
+        long,
+        env,
+        default_value = "0",
+    )]
+    paraswap_slippage_bps: usize,
 }
 
 #[tokio::main]
@@ -277,6 +285,7 @@ async fn main() {
         args.min_order_size_one_inch,
         args.disabled_one_inch_protocols,
         account.address(),
+        args.paraswap_slippage_bps,
     )
     .expect("failure creating solvers");
     let liquidity_collector = LiquidityCollector {

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -150,11 +150,7 @@ struct Arguments {
     gas_price_cap: f64,
 
     /// The maximum gas price the solver is willing to pay in a settlement
-    #[structopt(
-        long,
-        env,
-        default_value = "0",
-    )]
+    #[structopt(long, env, default_value = "0")]
     paraswap_slippage_bps: usize,
 }
 

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -149,8 +149,8 @@ struct Arguments {
     )]
     gas_price_cap: f64,
 
-    /// The maximum gas price the solver is willing to pay in a settlement
-    #[structopt(long, env, default_value = "0")]
+    /// The slippage tolerance we apply to the price quoted by Paraswap
+    #[structopt(long, env, default_value = "10")]
     paraswap_slippage_bps: usize,
 }
 

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -75,6 +75,7 @@ pub fn create(
     min_order_size_one_inch: U256,
     disabled_one_inch_protocols: Vec<String>,
     solver_address: H160,
+    paraswap_slippage_bps: usize,
 ) -> Result<Vec<Box<dyn Solver>>> {
     // Tiny helper function to help out with type inference. Otherwise, all
     // `Box::new(...)` expressions would have to be cast `as Box<dyn Solver>`.
@@ -126,6 +127,7 @@ pub fn create(
                 settlement_contract.clone(),
                 solver_address,
                 token_info_fetcher.clone(),
+                paraswap_slippage_bps,
             ))),
         })
         .collect()

--- a/solver/src/solver/paraswap_solver.rs
+++ b/solver/src/solver/paraswap_solver.rs
@@ -436,7 +436,7 @@ mod test {
             solver_address: Default::default(),
             token_info: Arc::new(token_info),
             allowance_fetcher,
-            settlement_contract: GPv2Settlement::at(&testutil::dummy_web3(), H160::zero()),
+            settlement_contract: dummy_contract!(GPv2Settlement, H160::zero()),
             slippage_bps: 1000, // 10%
         };
 


### PR DESCRIPTION
May fix an alert we have seen somewhat frequently in prod:

> ERROR (pod: dfusion-v2-solver-mainnet-75875777c5-gzjq5):
2021-06-23T12:18:13.603Z ERROR solver::solver::single_order_solver: Inner solver error: TransactionBuilderQuery result parsing failed: {"error":"Destination Amount Mismatch"}
Caused by:
   missing field from at line 1 column 39


My assumption is that slippage is changing the destination amount too much, so that the order is no longer fillable. However, the [docs for the transaction builder query](https://developers.paraswap.network/api/build-parameters-for-transaction-builder-only) specifically state that the `destAmount` can be adjusted with slippage. My strategy would be to try setting slippage to 0 and if we see too many failed settlement we can increase it back to a value that we feel comfortable with.

In that case we might want to start treating the error above as "benign" and not alert on it.

### Test Plan
Added a unittest to verify slippage computation logic.