### PR TITLE
Paraswap query input logging

### DIFF
--- a/solver/src/solver/paraswap_solver.rs
+++ b/solver/src/solver/paraswap_solver.rs
@@ -102,9 +102,7 @@ where
             side,
         };
 
-        tracing::debug!("querying Paraswap API with {:?}", price_query);
         let price_response = self.client.price(price_query).await?;
-        tracing::debug!("got response {:?}", price_response);
 
         if !satisfies_limit_price(&order, &price_response) {
             tracing::debug!("Order limit price not respected");

--- a/solver/src/solver/paraswap_solver/api.rs
+++ b/solver/src/solver/paraswap_solver/api.rs
@@ -29,9 +29,8 @@ pub struct DefaultParaswapApi {
 #[async_trait::async_trait]
 impl ParaswapApi for DefaultParaswapApi {
     async fn price(&self, query: PriceQuery) -> Result<PriceResponse> {
-        tracing::debug!("Querying Paraswap API (price) with {:?}", query);
         let url = query.into_url();
-        tracing::debug!("Paraswap API (price) query url: {}", url);
+        tracing::debug!("Querying Paraswap API (price) for url {}", url);
         let text = reqwest::get(url)
             .await
             .context("PriceQuery failed")?

--- a/solver/src/solver/paraswap_solver/api.rs
+++ b/solver/src/solver/paraswap_solver/api.rs
@@ -29,7 +29,10 @@ pub struct DefaultParaswapApi {
 #[async_trait::async_trait]
 impl ParaswapApi for DefaultParaswapApi {
     async fn price(&self, query: PriceQuery) -> Result<PriceResponse> {
-        let text = reqwest::get(query.into_url())
+        tracing::debug!("Querying Paraswap API (price) with {:?}", query);
+        let url = query.into_url();
+        tracing::debug!("Paraswap API (price) query url: {}", url);
+        let text = reqwest::get(url)
             .await
             .context("PriceQuery failed")?
             .text()
@@ -43,6 +46,7 @@ impl ParaswapApi for DefaultParaswapApi {
         &self,
         query: TransactionBuilderQuery,
     ) -> Result<TransactionBuilderResponse> {
+        tracing::debug!("Querying Paraswap API (transaction) with {:?}", query);
         let text = query
             .into_request(&self.client)
             .send()
@@ -185,6 +189,7 @@ impl TransactionBuilderQuery {
             .expect("unexpectedly invalid URL segment");
         url.query_pairs_mut().append_pair("skipChecks", "true");
 
+        tracing::debug!("Paraswap API (transaction) query url: {}", url);
         client.post(url).json(&self)
     }
 }


### PR DESCRIPTION
This PR adds extra logging for Paraswap to return some missing information. In particular, before this the input of the transaction query was not logged.

### Test Plan

Try the solver locally.
<details><summary>sample output</summary>

```
2021-06-24T10:53:24.034Z DEBUG solver::solver::paraswap_solver::api: Querying Paraswap API (price) with PriceQue
ry { from: 0xc944e90c64b2c07662a292be6244bdf05cda44a7, to: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, from_deci
mals: 18, to_decimals: 18, amount: 4716074047149098790753, side: Sell }
2021-06-24T10:53:10.065Z DEBUG solver::solver::paraswap_solver::api: Paraswap API (price) query url: https://api
v4.paraswap.io/v2/prices?from=0xc944e90c64b2c07662a292be6244bdf05cda44a7&to=0xc02aaa39b223fe8d0a0e5c4f27ead9083c
756cc2&fromDecimals=18&toDecimals=18&amount=4716074047149098790753&side=SELL&network=1
2021-06-24T10:53:26.854Z DEBUG solver::solver::paraswap_solver::api: Querying Paraswap API (transaction) with Tr
ansactionBuilderQuery { src_token: 0xc944e90c64b2c07662a292be6244bdf05cda44a7, dest_token: 0xc02aaa39b223fe8d0a0
e5c4f27ead9083c756cc2, src_amount: 4716074047149098790753, dest_amount: 1456783386954220896, from_decimals: 18, 
to_decimals: 18, price_route: Object({"adapterVersion": String("4.0.0"), "bestRoute": Array([Object({"data": Obj
ect({"factory": String("0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"), "gasUSD": String("1.707780"), "initCode": 
String("0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"), "path": Array([String("0xc944e90c6
4b2c07662a292be6244bdf05cda44a7"), String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")]), "router": String("0x8
6d3579b043585A97532514016dCF0C2d6C4b6a1"), "tokenFrom": String("0xc944e90c64b2c07662a292be6244bdf05cda44a7"), "t
okenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")}), "destAmount": String("1458241628582803700"), "d
estAmountFeeDeducted": String("1458241628582803700"), "exchange": String("UniswapV2"), "percent": String("100"),
 "srcAmount": String("4716074047149098790753")})]), "bestRouteGas": String("99435"), "bestRouteGasCostUSD": Stri
ng("2.122664"), "blockNumber": Number(12696415), "contractMethod": String("swapOnUniswap"), "destAmount": String
("1458241628582803700"), "destAmountFeeDeducted": String("1458241628582803700"), "details": Object({"destAmount"
: String("1458241628582803700"), "srcAmount": String("4716074047149098790753"), "tokenFrom": String("0xc944e90c6
4b2c07662a292be6244bdf05cda44a7"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")}), "fromUSD":
 String("2845.3536709405"), "hmac": String("0d027e79ae57cff68241ea2295df1ccb65dee94c"), "maxImpactReached": Bool
(false), "multiRoute": Array([]), "others": Array([Object({"data": Object({"gasUSD": String("2.134726"), "tokenF
rom": String("0xc944e90c64b2c07662a292be6244bdf05cda44a7"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead90
83c756cc2"), "version": Number(4)}), "exchange": String("ParaSwapPool"), "rate": String("1457580027885802226"), 
"rateFeeDeducted": String("1457580027885802226"), "unit": String("309066400000000"), "unitFeeDeducted": String("
309066400000000")}), Object({"data": Object({"factory": String("0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"), "g
asUSD": String("1.707780"), "initCode": String("0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da34884
5f"), "path": Array([String("0xc944e90c64b2c07662a292be6244bdf05cda44a7"), String("0xc02aaa39b223fe8d0a0e5c4f27e
ad9083c756cc2")]), "router": String("0x86d3579b043585A97532514016dCF0C2d6C4b6a1"), "tokenFrom": String("0xc944e9
0c64b2c07662a292be6244bdf05cda44a7"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")}), "exchan
ge": String("UniswapV2"), "rate": String("1458241628582803731"), "rateFeeDeducted": String("1458241628582803731"
), "unit": String("310457537697242"), "unitFeeDeducted": String("310457537697242")}), Object({"data": Object({"e
xchangeProxy": String("0x6317c5e82a06e1d8bf200d21f4510ac2c038ac81"), "gasUSD": String("2.561671"), "pool": Strin
g("0xa73d442fc0783e91a5b0c1b557aeea344e0146b6"), "tokenFrom": String("0xc944e90c64b2c07662a292be6244bdf05cda44a7
"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")}), "exchange": String("Balancer"), "rate": S
tring("928121065829185968"), "rateFeeDeducted": String("928121065829185968"), "unit": String("312637916438342"),
 "unitFeeDeducted": String("312637916438342")}), Object({"data": Object({"factory": String("0xC0AEe478e3658e2610
c5F7A4A2E1777cE9e4f2Ac"), "gasUSD": String("1.921253"), "initCode": String("0xe18a34eb0e04b04f7a0ac29a6e80748dca
96319b42c54d679cb821dca90c6303"), "path": Array([String("0xc944e90c64b2c07662a292be6244bdf05cda44a7"), String("0
xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")]), "router": String("0xBc1315CD2671BC498fDAb42aE1214068003DC51e"), "
tokenFrom": String("0xc944e90c64b2c07662a292be6244bdf05cda44a7"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f2
7ead9083c756cc2")}), "exchange": String("SushiSwap"), "rate": String("1454642017441359450"), "rateFeeDeducted": 
String("1454642017441359450"), "unit": String("309067726647841"), "unitFeeDeducted": String("309067726647841")})
, Object({"data": Object({"fee": Number(3000), "gasUSD": String("4.269452"), "tokenFrom": String("0xc944e90c64b2
c07662a292be6244bdf05cda44a7"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")}), "exchange": S
tring("UniswapV3"), "rate": String("1456268381779320312"), "rateFeeDeducted": String("1456268381779320312"), "un
it": String("309315677223825"), "unitFeeDeducted": String("309315677223825")})]), "priceID": String("37006d01-83
2e-466e-971a-2795a27bbac3"), "priceWithSlippage": String("1443659212296975663"), "side": String("SELL"), "spende
r": String("0xb70Bc06D2c9Bf03b3373799606dc7d39346c06B3"), "srcAmount": String("4716074047149098790753"), "toUSD"
: String("2836.2362203446"), "toUSDFeeDeducted": String("2836.2362203446")}), user_address: 0xcb1ff0c484a2267e39
e19a82a8c313e633c106c6, referrer: "GPv2" }
2021-06-24T10:53:26.854Z DEBUG solver::solver::paraswap_solver::api: Paraswap API (transaction) query url: https
://apiv4.paraswap.io/v2/transactions/1?skipChecks=true

```
</details>
