### PR TITLE
Paraswap buy order slippage

### DIFF
--- a/solver/src/solver/paraswap_solver/api.rs
+++ b/solver/src/solver/paraswap_solver/api.rs
@@ -223,7 +223,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn test_api_e2e() {
+    async fn test_api_e2e_sell() {
         let from = shared::addr!("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
         let to = shared::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
         let price_query = PriceQuery {
@@ -250,6 +250,57 @@ mod tests {
             src_amount: price_response.src_amount,
             // 10% slippage
             dest_amount: price_response.dest_amount * 90 / 100,
+            from_decimals: 18,
+            to_decimals: 18,
+            price_route: price_response.price_route_raw,
+            user_address: shared::addr!("E0B3700e0aadcb18ed8d4BFF648Bc99896a18ad1"),
+            referrer: "GPv2".to_string(),
+        };
+
+        let client = Client::new();
+        let transaction_response = transaction_query
+            .into_request(&client)
+            .send()
+            .await
+            .unwrap();
+
+        let response_status = transaction_response.status();
+        let response_text = transaction_response.text().await.unwrap();
+        println!("Transaction Response: {}", &response_text);
+
+        assert_eq!(response_status, StatusCode::OK);
+        assert!(serde_json::from_str::<TransactionBuilderResponse>(&response_text).is_ok());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_api_e2e_buy() {
+        let from = shared::addr!("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+        let to = shared::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+        let price_query = PriceQuery {
+            from,
+            to,
+            from_decimals: 18,
+            to_decimals: 18,
+            amount: 1_800_000_000_000_000_000_000u128.into(),
+            side: Side::Buy,
+        };
+
+        let price_response: PriceResponse = reqwest::get(price_query.into_url())
+            .await
+            .expect("price query failed")
+            .json()
+            .await
+            .expect("Response is not json");
+
+        println!("Price Response: {:?}", &price_response,);
+
+        let transaction_query = TransactionBuilderQuery {
+            src_token: from,
+            dest_token: to,
+            // 10% slippage
+            src_amount: price_response.src_amount * 110 / 100,
+            dest_amount: price_response.dest_amount,
             from_decimals: 18,
             to_decimals: 18,
             price_route: price_response.price_route_raw,


### PR DESCRIPTION
Fixes #788

Great catch by @josojo and the real reason for the `destAmount` mismatch error we have been seing. I think it's still worthwhile to keep slippage configurable (based on #778)  but let me know if you feel otherwise.

### Test Plan
Added an e2e test which confirms that this was actually the issue (if slippage is added on other side we get exactly the error we see).

Also added unit test to the solver that makes sure slippage is computed correctly.
