### PR TITLE
Adding matcha solver

### DIFF
--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -10,6 +10,7 @@ use baseline_solver::BaselineSolver;
 use contracts::GPv2Settlement;
 use ethcontract::{H160, U256};
 use http_solver::{HttpSolver, SolverConfig};
+use matcha_solver::MatchaSolver;
 use naive_solver::NaiveSolver;
 use oneinch_solver::OneInchSolver;
 use paraswap_solver::ParaswapSolver;
@@ -22,10 +23,12 @@ use structopt::clap::arg_enum;
 
 mod baseline_solver;
 mod http_solver;
+mod matcha_solver;
 mod naive_solver;
 mod oneinch_solver;
 mod paraswap_solver;
 mod single_order_solver;
+mod solver_utils;
 
 // For solvers that enforce a timeout internally we set their timeout to the global solver timeout
 // minus this duration to account for additional delay for example from the network.
@@ -56,6 +59,7 @@ arg_enum! {
         Mip,
         OneInch,
         Paraswap,
+        Matcha,
     }
 }
 
@@ -121,6 +125,11 @@ pub fn create(
                     native_token,
                     min_order_size_one_inch,
                 ))
+            }
+            SolverType::Matcha => {
+                let matcha_solver =
+                    MatchaSolver::new(settlement_contract.clone(), chain_id).unwrap();
+                boxed(SingleOrderSolver::from(matcha_solver))
             }
             SolverType::Paraswap => boxed(SingleOrderSolver::from(ParaswapSolver::new(
                 settlement_contract.clone(),

--- a/solver/src/solver/matcha_solver.rs
+++ b/solver/src/solver/matcha_solver.rs
@@ -84,10 +84,10 @@ impl<F: AllowanceFetching> SingleOrderSolving for MatchaSolver<F> {
                 let swap = self.client.get_swap(query).await?;
                 tracing::debug!("proposed Matcha swap is {:?}", swap);
 
-                ensure!(
-                    swap.buy_amount >= order.buy_amount,
-                    "order limit price not respected",
-                );
+                if swap.buy_amount < order.buy_amount {
+                    tracing::debug!("Order limit price not respected");
+                    return Ok(None);
+                }
                 let settlement = Settlement::new(hashmap! {
                     order.sell_token => swap.sell_amount,
                     order.buy_token => swap.buy_amount,
@@ -113,10 +113,10 @@ impl<F: AllowanceFetching> SingleOrderSolving for MatchaSolver<F> {
                 let swap = self.client.get_swap(query).await?;
                 tracing::debug!("proposed Matcha swap is {:?}", swap);
 
-                ensure!(
-                    swap.sell_amount <= order.sell_amount,
-                    "order limit price not respected",
-                );
+                if swap.sell_amount > order.sell_amount {
+                    tracing::debug!("Order limit price not respected");
+                    return Ok(None);
+                }
                 let settlement = Settlement::new(hashmap! {
                     order.sell_token => swap.sell_amount,
                     order.buy_token => swap.buy_amount,
@@ -174,7 +174,7 @@ mod tests {
     use mockall::Sequence;
     use model::order::{Order, OrderCreation, OrderKind};
     use shared::dummy_contract;
-    use shared::transport::{create_env_test_transport, create_test_transport};
+    use shared::transport::{create_env_test_transport, create_test_transport, dummy};
 
     #[tokio::test]
     #[ignore]
@@ -209,7 +209,7 @@ mod tests {
     }
 
     #[tokio::test]
-    // #[ignore]
+    #[ignore]
     async fn solve_buy_order_on_matcha() {
         let web3 = Web3::new(create_env_test_transport());
         let chain_id = web3.eth().chain_id().await.unwrap().as_u64();
@@ -238,6 +238,135 @@ mod tests {
             .unwrap();
 
         println!("{:#?}", settlement);
+    }
+
+    #[tokio::test]
+    async fn test_satisfies_limit_price_for_sell_order() {
+        let mut client = Box::new(MockMatchaApi::new());
+        let mut allowance_fetcher = MockAllowanceFetching::new();
+
+        let sell_token = H160::from_low_u64_be(1);
+        let buy_token = H160::from_low_u64_be(1);
+
+        client.expect_get_swap().returning(|_| {
+            Ok(SwapResponse {
+            sell_amount: U256::from_dec_str("100").unwrap(),
+             buy_amount: U256::from_dec_str("91").unwrap(),
+             allowance_target: shared::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
+            price: 0.91_f64,
+            to: shared::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
+            data: web3::types::Bytes(hex::decode(
+                "d9627aa40000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000016345785d8a00000000000000000000000000000000000000000000000000001206e6c0056936e100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000006810e776880c02933d47db1b9fc05908e5386b96869584cd0000000000000000000000001000000000000000000000000000000000000011000000000000000000000000000000000000000000000092415e982f60d431ba"
+            ).unwrap()),
+            value: U256::from_dec_str("0").unwrap(),
+        })});
+
+        allowance_fetcher
+            .expect_existing_allowance()
+            .returning(|_, _| Ok(U256::zero()));
+
+        let solver = MatchaSolver {
+            settlement_contract: GPv2Settlement::at(&dummy::web3(), H160::zero()),
+            client,
+            allowance_fetcher,
+        };
+
+        let order_passing_limit = LimitOrder {
+            sell_token,
+            buy_token,
+            sell_amount: 100.into(),
+            buy_amount: 90.into(),
+            kind: model::order::OrderKind::Sell,
+            ..Default::default()
+        };
+        let order_violating_limit = LimitOrder {
+            sell_token,
+            buy_token,
+            sell_amount: 100.into(),
+            buy_amount: 110.into(),
+            kind: model::order::OrderKind::Sell,
+            ..Default::default()
+        };
+
+        let result = solver
+            .settle_order(order_passing_limit)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            result.clearing_prices(),
+            &hashmap! {
+                sell_token => 99.into(),
+                buy_token => 91.into(),
+            }
+        );
+
+        let result = solver.settle_order(order_violating_limit).await.unwrap();
+        assert!(result.is_none());
+    }
+    #[tokio::test]
+    async fn test_satisfies_limit_price_for_buy_order() {
+        let mut client = Box::new(MockMatchaApi::new());
+        let mut allowance_fetcher = MockAllowanceFetching::new();
+
+        let sell_token = H160::from_low_u64_be(1);
+        let buy_token = H160::from_low_u64_be(1);
+
+        client.expect_get_swap().returning(|_| {
+            Ok(SwapResponse {
+            sell_amount: U256::from_dec_str("100").unwrap(),
+             buy_amount: U256::from_dec_str("91").unwrap(),
+             allowance_target: shared::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
+            price: 0.91_f64,
+            to: shared::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
+            data: web3::types::Bytes(hex::decode(
+                "d9627aa40000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000016345785d8a00000000000000000000000000000000000000000000000000001206e6c0056936e100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000006810e776880c02933d47db1b9fc05908e5386b96869584cd0000000000000000000000001000000000000000000000000000000000000011000000000000000000000000000000000000000000000092415e982f60d431ba"
+            ).unwrap()),
+            value: U256::from_dec_str("0").unwrap(),
+        })});
+
+        allowance_fetcher
+            .expect_existing_allowance()
+            .returning(|_, _| Ok(U256::zero()));
+
+        let solver = MatchaSolver {
+            settlement_contract: GPv2Settlement::at(&dummy::web3(), H160::zero()),
+            client,
+            allowance_fetcher,
+        };
+
+        let order_passing_limit = LimitOrder {
+            sell_token,
+            buy_token,
+            sell_amount: 101.into(),
+            buy_amount: 91.into(),
+            kind: model::order::OrderKind::Buy,
+            ..Default::default()
+        };
+        let order_violating_limit = LimitOrder {
+            sell_token,
+            buy_token,
+            sell_amount: 99.into(),
+            buy_amount: 91.into(),
+            kind: model::order::OrderKind::Buy,
+            ..Default::default()
+        };
+
+        let result = solver
+            .settle_order(order_passing_limit)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            result.clearing_prices(),
+            &hashmap! {
+                sell_token => 99.into(),
+                buy_token => 91.into(),
+            }
+        );
+
+        let result = solver.settle_order(order_violating_limit).await.unwrap();
+        assert!(result.is_none());
     }
 
     #[tokio::test]

--- a/solver/src/solver/matcha_solver.rs
+++ b/solver/src/solver/matcha_solver.rs
@@ -1,6 +1,6 @@
 //! Module containing implementation of the Matcha solver.
 //!
-//! This simple solver will simply use the Matcha API to get a quote for a
+//! This solver will simply use the Matcha API to get a quote for a
 //! single GPv2 order and produce a settlement directly against Matcha.
 
 pub mod api;
@@ -25,7 +25,7 @@ use model::order::OrderKind;
 use std::fmt::{self, Display, Formatter};
 
 /// Constant maximum slippage of 5 BPS (0.05%) to use for on-chain liquidity.
-/// This is halve the 1inch slippage
+/// This is half the 1inch slippage
 pub const STANDARD_MATCHA_SLIPPAGE_BPS: u16 = 5;
 
 /// A GPv2 solver that matches GP orders to direct Matcha swaps.
@@ -153,7 +153,7 @@ impl<F: AllowanceFetching> SingleOrderSolving for MatchaSolver<F> {
 
 impl Interaction for SwapResponse {
     fn encode(&self) -> Vec<EncodedInteraction> {
-        vec![(self.to, self.value, Bytes(self.data.clone()))]
+        vec![(self.to, self.value, Bytes(self.data.0.clone()))]
     }
 }
 
@@ -209,7 +209,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    // #[ignore]
     async fn solve_buy_order_on_matcha() {
         let web3 = Web3::new(create_env_test_transport());
         let chain_id = web3.eth().chain_id().await.unwrap().as_u64();
@@ -267,9 +267,9 @@ mod tests {
                  allowance_target: shared::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
                 price: 13.121_002_575_170_278_f64,
                 to: shared::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
-                data: hex::decode(
+                data: web3::types::Bytes(hex::decode(
                     "d9627aa40000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000016345785d8a00000000000000000000000000000000000000000000000000001206e6c0056936e100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000006810e776880c02933d47db1b9fc05908e5386b96869584cd0000000000000000000000001000000000000000000000000000000000000011000000000000000000000000000000000000000000000092415e982f60d431ba"
-                ).unwrap(),
+                ).unwrap()),
                 value: U256::from_dec_str("0").unwrap(),
             })
         });

--- a/solver/src/solver/matcha_solver.rs
+++ b/solver/src/solver/matcha_solver.rs
@@ -1,0 +1,312 @@
+//! Module containing implementation of the Matcha solver.
+//!
+//! This simple solver will simply use the Matcha API to get a quote for a
+//! single GPv2 order and produce a settlement directly against Matcha.
+
+pub mod api;
+
+use super::solver_utils::{AllowanceFetching, Slippage};
+use crate::solver::matcha_solver::api::MatchaApi;
+use anyhow::{ensure, Result};
+use contracts::{GPv2Settlement, ERC20};
+use ethcontract::{dyns::DynWeb3, Bytes, U256};
+use maplit::hashmap;
+
+use super::single_order_solver::SingleOrderSolving;
+
+use self::api::{DefaultMatchaApi, SwapQuery, SwapResponse};
+use crate::{
+    encoding::EncodedInteraction,
+    interactions::Erc20ApproveInteraction,
+    liquidity::LimitOrder,
+    settlement::{Interaction, Settlement},
+};
+use model::order::OrderKind;
+use std::fmt::{self, Display, Formatter};
+
+/// Constant maximum slippage of 5 BPS (0.05%) to use for on-chain liquidity.
+/// This is halve the 1inch slippage
+pub const STANDARD_MATCHA_SLIPPAGE_BPS: u16 = 5;
+
+/// A GPv2 solver that matches GP orders to direct Matcha swaps.
+pub struct MatchaSolver<F> {
+    settlement_contract: GPv2Settlement,
+    client: Box<dyn MatchaApi + Send + Sync>,
+    allowance_fetcher: F,
+}
+
+/// Chain ID for Mainnet.
+const MAINNET_CHAIN_ID: u64 = 1;
+
+impl MatchaSolver<GPv2Settlement> {
+    pub fn new(settlement_contract: GPv2Settlement, chain_id: u64) -> Result<Self> {
+        ensure!(
+            chain_id == MAINNET_CHAIN_ID,
+            "Matcha solver only supported on Mainnet",
+        );
+
+        let allowance_fetcher = settlement_contract.clone();
+        Ok(Self {
+            settlement_contract,
+            allowance_fetcher,
+            client: Box::new(DefaultMatchaApi::default()),
+        })
+    }
+}
+impl<F> MatchaSolver<F> {
+    fn web3(&self) -> DynWeb3 {
+        self.settlement_contract.raw_instance().web3()
+    }
+}
+
+impl<F> std::fmt::Debug for MatchaSolver<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("MatchaSolver")
+    }
+}
+
+#[async_trait::async_trait]
+impl<F: AllowanceFetching> SingleOrderSolving for MatchaSolver<F> {
+    async fn settle_order(&self, order: LimitOrder) -> Result<Option<Settlement>> {
+        let (swap, mut settlement) = match order.kind {
+            OrderKind::Sell => {
+                let query = SwapQuery {
+                    sell_token: order.sell_token,
+                    buy_token: order.buy_token,
+                    sell_amount: Some(order.sell_amount),
+                    buy_amount: None,
+                    slippage_percentage: Slippage::basis_points(STANDARD_MATCHA_SLIPPAGE_BPS)
+                        .unwrap(),
+                    skip_validation: Some(true),
+                };
+
+                tracing::debug!("querying Matcha swap api with {:?}", query);
+                let swap = self.client.get_swap(query).await?;
+                tracing::debug!("proposed Matcha swap is {:?}", swap);
+
+                ensure!(
+                    swap.buy_amount >= order.buy_amount,
+                    "order limit price not respected",
+                );
+                let settlement = Settlement::new(hashmap! {
+                    order.sell_token => swap.sell_amount,
+                    order.buy_token => swap.buy_amount,
+                });
+                (swap, settlement)
+            }
+            OrderKind::Buy => {
+                let query = SwapQuery {
+                    sell_token: order.sell_token,
+                    buy_token: order.buy_token,
+                    sell_amount: None,
+                    buy_amount: Some(order.buy_amount),
+                    slippage_percentage: Slippage::basis_points(STANDARD_MATCHA_SLIPPAGE_BPS)
+                        .unwrap(),
+                    // From the api documentation:
+                    // SlippagePercentage(Optional): The maximum acceptable slippage in % of the buyToken amount if sellAmount is provided, the maximum acceptable slippage in % of the sellAmount amount if buyAmount is provided. This parameter will change over time with market conditions.
+                    // => Hence, allegedly, we don't need to build in buffers ourselves. Though the sell amount is not adjusted, if slippage is changed for buy order requests.
+                    // Todo: Continue discussion with the 0x-team
+                    skip_validation: Some(true),
+                };
+
+                tracing::debug!("querying Matcha swap api with {:?}", query);
+                let swap = self.client.get_swap(query).await?;
+                tracing::debug!("proposed Matcha swap is {:?}", swap);
+
+                ensure!(
+                    swap.sell_amount <= order.sell_amount,
+                    "order limit price not respected",
+                );
+                let settlement = Settlement::new(hashmap! {
+                    order.sell_token => swap.sell_amount,
+                    order.buy_token => swap.buy_amount,
+                });
+                (swap, settlement)
+            }
+        };
+        let spender = swap.allowance_target;
+        let sell_token = ERC20::at(&self.web3(), order.sell_token);
+        let existing_allowance = self
+            .allowance_fetcher
+            .existing_allowance(order.sell_token, spender)
+            .await?;
+
+        settlement.with_liquidity(&order, swap.sell_amount)?;
+
+        if existing_allowance < swap.sell_amount {
+            settlement
+                .encoder
+                .append_to_execution_plan(Erc20ApproveInteraction {
+                    token: sell_token,
+                    spender,
+                    amount: U256::MAX,
+                });
+        }
+        settlement.encoder.append_to_execution_plan(swap);
+        Ok(Some(settlement))
+    }
+
+    fn name(&self) -> &'static str {
+        "Matcha"
+    }
+}
+
+impl Interaction for SwapResponse {
+    fn encode(&self) -> Vec<EncodedInteraction> {
+        vec![(self.to, self.value, Bytes(self.data.clone()))]
+    }
+}
+
+impl<F> Display for MatchaSolver<F> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "MatchaSolver")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::liquidity::LimitOrder;
+    use crate::solver::matcha_solver::api::MockMatchaApi;
+    use crate::solver::solver_utils::MockAllowanceFetching;
+    use contracts::{GPv2Settlement, WETH9};
+    use ethcontract::{Web3, H160};
+    use mockall::Sequence;
+    use model::order::{Order, OrderCreation, OrderKind};
+    use shared::dummy_contract;
+    use shared::transport::{create_env_test_transport, create_test_transport};
+
+    #[tokio::test]
+    #[ignore]
+    async fn solve_sell_order_on_matcha() {
+        let web3 = Web3::new(create_env_test_transport());
+        let chain_id = web3.eth().chain_id().await.unwrap().as_u64();
+        let settlement = GPv2Settlement::deployed(&web3).await.unwrap();
+
+        let weth = WETH9::deployed(&web3).await.unwrap();
+        let gno = shared::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+
+        let solver = MatchaSolver::new(settlement, chain_id).unwrap();
+        let settlement = solver
+            .settle_order(
+                Order {
+                    order_creation: OrderCreation {
+                        sell_token: weth.address(),
+                        buy_token: gno,
+                        sell_amount: 1_000_000_000_000_000_000u128.into(),
+                        buy_amount: 1u128.into(),
+                        kind: OrderKind::Sell,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }
+                .into(),
+            )
+            .await
+            .unwrap();
+
+        println!("{:#?}", settlement);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn solve_buy_order_on_matcha() {
+        let web3 = Web3::new(create_env_test_transport());
+        let chain_id = web3.eth().chain_id().await.unwrap().as_u64();
+        let settlement = GPv2Settlement::deployed(&web3).await.unwrap();
+
+        let weth = WETH9::deployed(&web3).await.unwrap();
+        let gno = shared::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+
+        let solver = MatchaSolver::new(settlement, chain_id).unwrap();
+        let settlement = solver
+            .settle_order(
+                Order {
+                    order_creation: OrderCreation {
+                        sell_token: weth.address(),
+                        buy_token: gno,
+                        sell_amount: 1_000_000_000_000_000_000u128.into(),
+                        buy_amount: 1_000_000_000_000_000_000u128.into(),
+                        kind: OrderKind::Buy,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }
+                .into(),
+            )
+            .await
+            .unwrap();
+
+        println!("{:#?}", settlement);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn returns_error_on_non_mainnet() {
+        let web3 = Web3::new(create_test_transport(
+            &std::env::var("NODE_URL_RINKEBY").unwrap(),
+        ));
+        let chain_id = web3.eth().chain_id().await.unwrap().as_u64();
+        let settlement = GPv2Settlement::deployed(&web3).await.unwrap();
+
+        assert!(MatchaSolver::new(settlement, chain_id).is_err())
+    }
+
+    #[tokio::test]
+    async fn test_sets_allowance_if_necessary() {
+        let mut client = Box::new(MockMatchaApi::new());
+        let mut allowance_fetcher = MockAllowanceFetching::new();
+
+        let sell_token = H160::from_low_u64_be(1);
+        let buy_token = H160::from_low_u64_be(1);
+
+        client.expect_get_swap().returning(|_| {
+            Ok(SwapResponse {
+                sell_amount: U256::from_dec_str("100").unwrap(),
+                 buy_amount: U256::from_dec_str("91").unwrap(),
+                 allowance_target: shared::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
+                price: 13.121_002_575_170_278_f64,
+                to: shared::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
+                data: hex::decode(
+                    "d9627aa40000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000016345785d8a00000000000000000000000000000000000000000000000000001206e6c0056936e100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000006810e776880c02933d47db1b9fc05908e5386b96869584cd0000000000000000000000001000000000000000000000000000000000000011000000000000000000000000000000000000000000000092415e982f60d431ba"
+                ).unwrap(),
+                value: U256::from_dec_str("0").unwrap(),
+            })
+        });
+
+        // On first invocation no prior allowance, then max allowance set.
+        let mut seq = Sequence::new();
+        allowance_fetcher
+            .expect_existing_allowance()
+            .times(1)
+            .returning(|_, _| Ok(U256::zero()))
+            .in_sequence(&mut seq);
+        allowance_fetcher
+            .expect_existing_allowance()
+            .times(1)
+            .returning(|_, _| Ok(U256::max_value()))
+            .in_sequence(&mut seq);
+
+        let solver = MatchaSolver {
+            client,
+            allowance_fetcher,
+            settlement_contract: dummy_contract!(GPv2Settlement, H160::zero()),
+        };
+
+        let order = LimitOrder {
+            sell_token,
+            buy_token,
+            sell_amount: 100.into(),
+            buy_amount: 90.into(),
+            ..Default::default()
+        };
+
+        // On first run we have two main interactions (approve + swap)
+        let result = solver.settle_order(order.clone()).await.unwrap().unwrap();
+        assert_eq!(result.encoder.finish().interactions[1].len(), 2);
+
+        // On second run we have only have one main interactions (swap)
+        let result = solver.settle_order(order).await.unwrap().unwrap();
+        assert_eq!(result.encoder.finish().interactions[1].len(), 1)
+    }
+}

--- a/solver/src/solver/matcha_solver.rs
+++ b/solver/src/solver/matcha_solver.rs
@@ -62,8 +62,10 @@ impl SingleOrderSolving for MatchaSolver {
                     buy_token: order.buy_token,
                     sell_amount: Some(order.sell_amount),
                     buy_amount: None,
-                    slippage_percentage: Slippage::basis_points(STANDARD_MATCHA_SLIPPAGE_BPS)
-                        .unwrap(),
+                    slippage_percentage: Slippage::number_from_basis_points(
+                        STANDARD_MATCHA_SLIPPAGE_BPS,
+                    )
+                    .unwrap(),
                     skip_validation: Some(true),
                 };
 
@@ -83,8 +85,10 @@ impl SingleOrderSolving for MatchaSolver {
                     buy_token: order.buy_token,
                     sell_amount: None,
                     buy_amount: Some(order.buy_amount),
-                    slippage_percentage: Slippage::basis_points(STANDARD_MATCHA_SLIPPAGE_BPS)
-                        .unwrap(),
+                    slippage_percentage: Slippage::number_from_basis_points(
+                        STANDARD_MATCHA_SLIPPAGE_BPS,
+                    )
+                    .unwrap(),
                     // From the api documentation:
                     // SlippagePercentage(Optional): The maximum acceptable slippage in % of the buyToken amount if sellAmount is provided, the maximum acceptable slippage in % of the sellAmount amount if buyAmount is provided. This parameter will change over time with market conditions.
                     // => Hence, allegedly, we don't need to build in buffers ourselves. Though the sell amount is not adjusted, if slippage is changed for buy order requests.

--- a/solver/src/solver/matcha_solver/api.rs
+++ b/solver/src/solver/matcha_solver/api.rs
@@ -4,9 +4,7 @@
 //! <https://0x.org/docs/api#request-1>
 //! <https://api.0x.org/>
 
-use crate::solver::solver_utils::{
-    debug_bytes, deserialize_decimal_f64, deserialize_decimal_u256, Slippage,
-};
+use crate::solver::solver_utils::{debug_bytes, deserialize_decimal_f64, Slippage};
 use anyhow::Result;
 use derivative::Derivative;
 use ethcontract::{H160, U256};
@@ -86,7 +84,7 @@ pub struct SwapResponse {
     pub to: H160,
     #[derivative(Debug(format_with = "debug_bytes"))]
     pub data: Bytes,
-    #[serde(deserialize_with = "deserialize_decimal_u256")]
+    #[serde(with = "u256_decimal")]
     pub value: U256,
 }
 

--- a/solver/src/solver/matcha_solver/api.rs
+++ b/solver/src/solver/matcha_solver/api.rs
@@ -41,7 +41,7 @@ impl SwapQuery {
         // the full address and instead uses ellipsis (e.g. "0xeeee…eeee"). This
         // helper just works around that.
         fn addr2str(addr: H160) -> String {
-            format!("{:?}", addr)
+            format!("{:#x}", addr)
         }
 
         let mut url = base_url

--- a/solver/src/solver/matcha_solver/api.rs
+++ b/solver/src/solver/matcha_solver/api.rs
@@ -1,0 +1,227 @@
+//! Matcha HTTP API client implementation.
+//!
+//! For more information on the HTTP API, consult:
+//! <https://0x.org/docs/api#request-1>
+//! <https://api.0x.org/>
+
+use crate::solver::solver_utils::{
+    deserialize_decimal_f64, deserialize_decimal_u256, deserialize_prefixed_hex, Slippage,
+};
+
+use anyhow::Result;
+use ethcontract::{H160, U256};
+use reqwest::{Client, IntoUrl, Url};
+use serde::Deserialize;
+use shared::http::default_http_client;
+
+/// A Matcha API quote query parameters.
+///
+/// These parameters are currently incomplete, and missing parameters can be
+/// added incrementally as needed.
+#[derive(Clone, Debug, Default)]
+pub struct SwapQuery {
+    /// Contract address of a token to sell.
+    pub sell_token: H160,
+    /// Contract address of a token to buy.
+    pub buy_token: H160,
+    /// Amount of a token to sell, set in atoms.
+    pub sell_amount: Option<U256>,
+    /// Amount of a token to sell, set in atoms.
+    pub buy_amount: Option<U256>,
+    /// Limit of price slippage you are willing to accept.
+    pub slippage_percentage: Slippage,
+    /// Flag to disable checks of the required quantities.
+    pub skip_validation: Option<bool>,
+}
+
+impl SwapQuery {
+    /// Encodes the swap query as
+    fn into_url(self, base_url: &Url) -> Url {
+        // The `Display` implementation for `H160` unfortunately does not print
+        // the full address and instead uses ellipsis (e.g. "0xeeee…eeee"). This
+        // helper just works around that.
+        fn addr2str(addr: H160) -> String {
+            format!("{:?}", addr)
+        }
+
+        let mut url = base_url
+            .join("/swap/v1/quote?")
+            .expect("unexpectedly invalid URL segment");
+        url.query_pairs_mut()
+            .append_pair("sellToken", &addr2str(self.sell_token))
+            .append_pair("buyToken", &addr2str(self.buy_token))
+            .append_pair("slippagePercentage", &self.slippage_percentage.to_string());
+        // I am not setting any affiliate address, in order to save gas
+        // .append_pair("affiliateAddress", "0xgp_address")
+        if let Some(amount) = self.sell_amount {
+            url.query_pairs_mut()
+                .append_pair("sellAmount", &amount.to_string());
+        }
+        if let Some(amount) = self.buy_amount {
+            url.query_pairs_mut()
+                .append_pair("buyAmount", &amount.to_string());
+        }
+        if let Some(skip_validation) = self.skip_validation {
+            url.query_pairs_mut()
+                .append_pair("skipValidation", &skip_validation.to_string());
+        }
+        url
+    }
+}
+
+/// A Matcha API swap response.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapResponse {
+    #[serde(deserialize_with = "deserialize_decimal_u256")]
+    pub sell_amount: U256,
+    #[serde(deserialize_with = "deserialize_decimal_u256")]
+    pub buy_amount: U256,
+    pub allowance_target: H160,
+    #[serde(deserialize_with = "deserialize_decimal_f64")]
+    pub price: f64,
+    pub to: H160,
+    #[serde(deserialize_with = "deserialize_prefixed_hex")]
+    pub data: Vec<u8>,
+    #[serde(deserialize_with = "deserialize_decimal_u256")]
+    pub value: U256,
+}
+
+/// Mockable implementation of the API for unit test
+#[cfg_attr(test, mockall::automock)]
+#[async_trait::async_trait]
+pub trait MatchaApi {
+    async fn get_swap(&self, query: SwapQuery) -> Result<SwapResponse>;
+}
+
+/// Matcha API Client implementation.
+#[derive(Debug)]
+pub struct DefaultMatchaApi {
+    client: Client,
+    base_url: Url,
+}
+
+impl DefaultMatchaApi {
+    /// Create a new 1Inch HTTP API client with the specified base URL.
+    pub fn new(base_url: impl IntoUrl) -> Result<Self> {
+        Ok(Self {
+            client: default_http_client()?,
+            base_url: base_url.into_url()?,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl MatchaApi for DefaultMatchaApi {
+    /// Retrieves a swap for the specified parameters from the 1Inch API.
+    async fn get_swap(&self, query: SwapQuery) -> Result<SwapResponse> {
+        Ok(self
+            .client
+            .get(query.into_url(&self.base_url))
+            .send()
+            .await?
+            .json()
+            .await?)
+    }
+}
+
+impl Default for DefaultMatchaApi {
+    fn default() -> Self {
+        Self::new("https://api.0x.org/").expect("unexpected error parsing URL")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    // #[ignore]
+    async fn test_api_e2e() {
+        let matcha_client = DefaultMatchaApi::default();
+        let sell_token = shared::addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE");
+        let buy_token = shared::addr!("1a5f9352af8af974bfc03399e3767df6370d82e4");
+        let swap_query = SwapQuery {
+            sell_token,
+            buy_token,
+            sell_amount: Some(1_000_000_000_000_000_000u128.into()),
+            buy_amount: None,
+            slippage_percentage: Slippage(0.1_f64),
+            skip_validation: Some(true),
+        };
+
+        let price_response: SwapResponse = matcha_client.get_swap(swap_query).await.unwrap();
+
+        println!("Price Response: {:?}", &price_response);
+    }
+
+    #[test]
+    fn swap_query_serialization_0x_sell_order() {
+        let base_url = Url::parse("https://api.0x.org/").unwrap();
+        let url = SwapQuery {
+            sell_token: shared::addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+            buy_token: shared::addr!("111111111117dc0aa78b770fa6a738034120c302"),
+            sell_amount: Some(1_000_000_000_000_000_000u128.into()),
+            buy_amount: None,
+            slippage_percentage: Slippage::basis_points(30).unwrap(),
+            skip_validation: None,
+        }
+        .into_url(&base_url);
+
+        assert_eq!(
+            url.as_str(),
+            "https://api.0x.org/swap/v1/quote\
+                    ?sellToken=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
+                    &buyToken=0x111111111117dc0aa78b770fa6a738034120c302\
+                    &slippagePercentage=0.3\
+                    &sellAmount=1000000000000000000",
+        );
+    }
+
+    #[test]
+    fn swap_query_serialization_optional_skip_parameter() {
+        let base_url = Url::parse("https://api.0x.org/").unwrap();
+        let url = SwapQuery {
+            sell_token: shared::addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+            buy_token: shared::addr!("111111111117dc0aa78b770fa6a738034120c302"),
+            buy_amount: Some(1_000_000_000_000_000_000u128.into()),
+            sell_amount: None,
+            slippage_percentage: Slippage::basis_points(30).unwrap(),
+            skip_validation: Some(true),
+        }
+        .into_url(&base_url);
+
+        assert_eq!(
+            url.as_str(),
+            "https://api.0x.org/swap/v1/quote\
+                    ?sellToken=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
+                    &buyToken=0x111111111117dc0aa78b770fa6a738034120c302\
+                    &slippagePercentage=0.3\
+                    &buyAmount=1000000000000000000\
+                    &skipValidation=true",
+        );
+    }
+
+    #[test]
+    fn deserialize_swap_response() {
+        let swap = serde_json::from_str::<SwapResponse>(
+                r#"{"price":"13.12100257517027783","guaranteedPrice":"12.98979254941857505","to":"0xdef1c0ded9bec7f1a1670819833240f027b25eff","data":"0xd9627aa40000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000016345785d8a00000000000000000000000000000000000000000000000000001206e6c0056936e100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000006810e776880c02933d47db1b9fc05908e5386b96869584cd0000000000000000000000001000000000000000000000000000000000000011000000000000000000000000000000000000000000000092415e982f60d431ba","value":"0","gas":"111000","estimatedGas":"111000","gasPrice":"10000000000","protocolFee":"0","minimumProtocolFee":"0","buyTokenAddress":"0x6810e776880c02933d47db1b9fc05908e5386b96","sellTokenAddress":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","buyAmount":"1312100257517027783","sellAmount":"100000000000000000","sources":[{"name":"0x","proportion":"0"},{"name":"Uniswap","proportion":"0"},{"name":"Uniswap_V2","proportion":"0"},{"name":"Eth2Dai","proportion":"0"},{"name":"Kyber","proportion":"0"},{"name":"Curve","proportion":"0"},{"name":"Balancer","proportion":"0"},{"name":"Balancer_V2","proportion":"0"},{"name":"Bancor","proportion":"0"},{"name":"mStable","proportion":"0"},{"name":"Mooniswap","proportion":"0"},{"name":"Swerve","proportion":"0"},{"name":"SnowSwap","proportion":"0"},{"name":"SushiSwap","proportion":"1"},{"name":"Shell","proportion":"0"},{"name":"MultiHop","proportion":"0"},{"name":"DODO","proportion":"0"},{"name":"DODO_V2","proportion":"0"},{"name":"CREAM","proportion":"0"},{"name":"LiquidityProvider","proportion":"0"},{"name":"CryptoCom","proportion":"0"},{"name":"Linkswap","proportion":"0"},{"name":"MakerPsm","proportion":"0"},{"name":"KyberDMM","proportion":"0"},{"name":"Smoothy","proportion":"0"},{"name":"Component","proportion":"0"},{"name":"Saddle","proportion":"0"},{"name":"xSigma","proportion":"0"},{"name":"Uniswap_V3","proportion":"0"},{"name":"Curve_V2","proportion":"0"}],"orders":[{"makerToken":"0x6810e776880c02933d47db1b9fc05908e5386b96","takerToken":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","makerAmount":"1312100257517027783","takerAmount":"100000000000000000","fillData":{"tokenAddressPath":["0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","0x6810e776880c02933d47db1b9fc05908e5386b96"],"router":"0xd9e1ce17f2641f24ae83637ab66a2cca9c378b9f"},"source":"SushiSwap","sourcePathId":"0xf070a63548deb1c57a1540d63c986e01c1718a7a091d20da7020aa422c01b3de","type":0}],"allowanceTarget":"0xdef1c0ded9bec7f1a1670819833240f027b25eff","sellTokenToEthRate":"1","buyTokenToEthRate":"13.05137210499988309"}"#,
+            )
+            .unwrap();
+
+        assert_eq!(
+                swap,
+                SwapResponse {
+                    sell_amount: U256::from_dec_str("100000000000000000").unwrap(),
+                     buy_amount: U256::from_dec_str("1312100257517027783").unwrap(),
+                     allowance_target: shared::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
+                    price: 13.121_002_575_170_278_f64,
+                    to: shared::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
+                    data: hex::decode(
+                        "d9627aa40000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000016345785d8a00000000000000000000000000000000000000000000000000001206e6c0056936e100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000006810e776880c02933d47db1b9fc05908e5386b96869584cd0000000000000000000000001000000000000000000000000000000000000011000000000000000000000000000000000000000000000092415e982f60d431ba"
+                    ).unwrap(),
+                    value: U256::from_dec_str("0").unwrap(),
+                }
+            );
+    }
+}

--- a/solver/src/solver/matcha_solver/api.rs
+++ b/solver/src/solver/matcha_solver/api.rs
@@ -164,7 +164,7 @@ mod tests {
             buy_token: shared::addr!("111111111117dc0aa78b770fa6a738034120c302"),
             sell_amount: Some(1_000_000_000_000_000_000u128.into()),
             buy_amount: None,
-            slippage_percentage: Slippage::basis_points(30).unwrap(),
+            slippage_percentage: Slippage::number_from_basis_points(30).unwrap(),
             skip_validation: None,
         }
         .into_url(&base_url);
@@ -174,20 +174,20 @@ mod tests {
             "https://api.0x.org/swap/v1/quote\
                     ?sellToken=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                     &buyToken=0x111111111117dc0aa78b770fa6a738034120c302\
-                    &slippagePercentage=0.3\
+                    &slippagePercentage=0.003\
                     &sellAmount=1000000000000000000",
         );
     }
 
     #[test]
-    fn swap_query_serialization_optional_skip_parameter() {
+    fn swap_query_serialization_0x_buy_order() {
         let base_url = Url::parse("https://api.0x.org/").unwrap();
         let url = SwapQuery {
             sell_token: shared::addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
             buy_token: shared::addr!("111111111117dc0aa78b770fa6a738034120c302"),
             buy_amount: Some(1_000_000_000_000_000_000u128.into()),
             sell_amount: None,
-            slippage_percentage: Slippage::basis_points(30).unwrap(),
+            slippage_percentage: Slippage::number_from_basis_points(30).unwrap(),
             skip_validation: Some(true),
         }
         .into_url(&base_url);
@@ -197,7 +197,7 @@ mod tests {
             "https://api.0x.org/swap/v1/quote\
                     ?sellToken=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                     &buyToken=0x111111111117dc0aa78b770fa6a738034120c302\
-                    &slippagePercentage=0.3\
+                    &slippagePercentage=0.003\
                     &buyAmount=1000000000000000000\
                     &skipValidation=true",
         );

--- a/solver/src/solver/oneinch_solver.rs
+++ b/solver/src/solver/oneinch_solver.rs
@@ -108,7 +108,7 @@ impl OneInchSolver {
             to_token_address: order.buy_token,
             amount: order.sell_amount,
             from_address: self.settlement_contract.address(),
-            slippage: Slippage::basis_points(MAX_SLIPPAGE_BPS).unwrap(),
+            slippage: Slippage::percentage_from_basis_points(MAX_SLIPPAGE_BPS).unwrap(),
             protocols,
             // Disable balance/allowance checks, as the settlement contract
             // does not hold balances to traded tokens.

--- a/solver/src/solver/oneinch_solver.rs
+++ b/solver/src/solver/oneinch_solver.rs
@@ -4,9 +4,10 @@
 //! single GPv2 order and produce a settlement directly against 1Inch.
 
 pub mod api;
+use super::solver_utils::{AllowanceFetching, Slippage};
 
-use self::api::{Amount, OneInchClient, Slippage, Swap, SwapQuery};
-use super::{paraswap_solver::AllowanceFetching, single_order_solver::SingleOrderSolving};
+use self::api::{Amount, OneInchClient, Swap, SwapQuery};
+use super::single_order_solver::SingleOrderSolving;
 use crate::{
     encoding::EncodedInteraction,
     interactions::Erc20ApproveInteraction,
@@ -196,7 +197,7 @@ mod tests {
     use crate::liquidity::LimitOrder;
     use crate::solver::oneinch_solver::api::Protocols;
     use crate::solver::oneinch_solver::api::Spender;
-    use crate::solver::paraswap_solver::MockAllowanceFetching;
+    use crate::solver::solver_utils::MockAllowanceFetching;
     use contracts::{GPv2Settlement, WETH9};
     use ethcontract::{Web3, H160};
     use maplit::hashset;

--- a/solver/src/solver/oneinch_solver/api.rs
+++ b/solver/src/solver/oneinch_solver/api.rs
@@ -269,7 +269,7 @@ mod tests {
     #[test]
     fn slippage_from_basis_points() {
         assert_eq!(
-            Slippage::basis_points(50).unwrap(),
+            Slippage::percentage_from_basis_points(50).unwrap(),
             Slippage::percentage(0.5).unwrap(),
         )
     }
@@ -296,7 +296,7 @@ mod tests {
             to_token_address: shared::addr!("111111111117dc0aa78b770fa6a738034120c302"),
             amount: 1_000_000_000_000_000_000u128.into(),
             from_address: shared::addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
-            slippage: Slippage::basis_points(50).unwrap(),
+            slippage: Slippage::percentage_from_basis_points(50).unwrap(),
             protocols: None,
             disable_estimate: None,
             complexity_level: None,
@@ -325,7 +325,7 @@ mod tests {
             to_token_address: shared::addr!("111111111117dc0aa78b770fa6a738034120c302"),
             amount: 1_000_000_000_000_000_000u128.into(),
             from_address: shared::addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
-            slippage: Slippage::basis_points(50).unwrap(),
+            slippage: Slippage::percentage_from_basis_points(50).unwrap(),
             protocols: Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
             disable_estimate: Some(true),
             complexity_level: Some(Amount::new(1).unwrap()),
@@ -480,7 +480,7 @@ mod tests {
                 to_token_address: shared::addr!("111111111117dc0aa78b770fa6a738034120c302"),
                 amount: 1_000_000_000_000_000_000u128.into(),
                 from_address: shared::addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
-                slippage: Slippage::basis_points(50).unwrap(),
+                slippage: Slippage::percentage_from_basis_points(50).unwrap(),
                 protocols: None,
                 disable_estimate: None,
                 complexity_level: None,
@@ -502,7 +502,7 @@ mod tests {
                 to_token_address: shared::addr!("a3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2"),
                 amount: 100_000_000_000_000_000_000u128.into(),
                 from_address: shared::addr!("4e608b7da83f8e9213f554bdaa77c72e125529d0"),
-                slippage: Slippage::basis_points(50).unwrap(),
+                slippage: Slippage::percentage_from_basis_points(50).unwrap(),
                 protocols: Some(vec!["WETH".to_string(), "UNISWAP_V2".to_string()]),
                 disable_estimate: Some(true),
                 complexity_level: Some(Amount::new(2).unwrap()),

--- a/solver/src/solver/oneinch_solver/api.rs
+++ b/solver/src/solver/oneinch_solver/api.rs
@@ -3,9 +3,10 @@
 //! For more information on the HTTP API, consult:
 //! <https://docs.1inch.io/api/quote-swap>
 //! <https://api.1inch.exchange/swagger/ethereum/>
-use crate::solver::solver_utils::{deserialize_decimal_u256, deserialize_prefixed_hex, Slippage};
+use crate::solver::solver_utils::{deserialize_prefixed_hex, Slippage};
 use anyhow::{ensure, Context, Result};
 use ethcontract::{H160, U256};
+use model::u256_decimal;
 use reqwest::{Client, IntoUrl, Url};
 use serde::Deserialize;
 use shared::http::default_http_client;
@@ -125,9 +126,9 @@ impl SwapQuery {
 pub struct Swap {
     pub from_token: Token,
     pub to_token: Token,
-    #[serde(deserialize_with = "deserialize_decimal_u256")]
+    #[serde(with = "u256_decimal")]
     pub from_token_amount: U256,
-    #[serde(deserialize_with = "deserialize_decimal_u256")]
+    #[serde(with = "u256_decimal")]
     pub to_token_amount: U256,
     pub protocols: Vec<Vec<Vec<Protocol>>>,
     pub tx: Transaction,
@@ -160,9 +161,9 @@ pub struct Transaction {
     pub to: H160,
     #[serde(deserialize_with = "deserialize_prefixed_hex")]
     pub data: Vec<u8>,
-    #[serde(deserialize_with = "deserialize_decimal_u256")]
+    #[serde(with = "u256_decimal")]
     pub value: U256,
-    #[serde(deserialize_with = "deserialize_decimal_u256")]
+    #[serde(with = "u256_decimal")]
     pub gas_price: U256,
     pub gas: u64,
 }

--- a/solver/src/solver/paraswap_solver.rs
+++ b/solver/src/solver/paraswap_solver.rs
@@ -1,8 +1,5 @@
-use contracts::GPv2Settlement;
-use ethcontract::{Bytes, H160};
-use maplit::hashmap;
-use std::sync::Arc;
 mod api;
+
 use self::api::{
     DefaultParaswapApi, ParaswapApi, PriceQuery, PriceResponse, Side, TransactionBuilderQuery,
     TransactionBuilderResponse,
@@ -15,8 +12,12 @@ use crate::{
     settlement::{Interaction, Settlement},
 };
 use anyhow::{anyhow, Result};
+use contracts::GPv2Settlement;
 use derivative::Derivative;
+use ethcontract::{Bytes, H160};
+use maplit::hashmap;
 use shared::{conversions::U256Ext, token_info::TokenInfoFetching, Web3};
+use std::sync::Arc;
 
 const REFERRER: &str = "GPv2";
 const APPROVAL_RECEIVER: H160 = shared::addr!("b70bc06d2c9bf03b3373799606dc7d39346c06b3");

--- a/solver/src/solver/paraswap_solver/api.rs
+++ b/solver/src/solver/paraswap_solver/api.rs
@@ -1,11 +1,11 @@
+use crate::solver::solver_utils::debug_bytes;
 use anyhow::{Context, Result};
 use derivative::Derivative;
 use ethcontract::{H160, U256};
+use model::u256_decimal;
 use reqwest::{Client, RequestBuilder, Url};
 use serde::{de::Error, Deserialize, Deserializer, Serialize};
 use serde_json::Value;
-
-use model::u256_decimal;
 use web3::types::Bytes;
 
 const BASE_URL: &str = "https://apiv4.paraswap.io";
@@ -213,10 +213,6 @@ pub struct TransactionBuilderResponse {
     /// the suggested gas price
     #[serde(with = "u256_decimal")]
     pub gas_price: U256,
-}
-
-fn debug_bytes(bytes: &Bytes, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-    formatter.write_fmt(format_args!("0x{}", hex::encode(&bytes.0)))
 }
 
 #[cfg(test)]

--- a/solver/src/solver/paraswap_solver/api.rs
+++ b/solver/src/solver/paraswap_solver/api.rs
@@ -2,10 +2,11 @@ use crate::solver::solver_utils::debug_bytes;
 use anyhow::{Context, Result};
 use derivative::Derivative;
 use ethcontract::{H160, U256};
-use model::u256_decimal;
 use reqwest::{Client, RequestBuilder, Url};
 use serde::{de::Error, Deserialize, Deserializer, Serialize};
 use serde_json::Value;
+
+use model::u256_decimal;
 use web3::types::Bytes;
 
 const BASE_URL: &str = "https://apiv4.paraswap.io";

--- a/solver/src/solver/solver_utils.rs
+++ b/solver/src/solver/solver_utils.rs
@@ -6,6 +6,7 @@ use serde::{
     de::{Deserializer, Error as _},
     Deserialize,
 };
+use web3::types::Bytes;
 
 use std::{
     borrow::Cow,
@@ -83,4 +84,11 @@ where
         .strip_prefix("0x")
         .ok_or_else(|| D::Error::custom("hex missing '0x' prefix"))?;
     hex::decode(hex_str).map_err(D::Error::custom)
+}
+
+pub fn debug_bytes(
+    bytes: &Bytes,
+    formatter: &mut std::fmt::Formatter,
+) -> Result<(), std::fmt::Error> {
+    formatter.write_fmt(format_args!("0x{}", hex::encode(&bytes.0)))
 }

--- a/solver/src/solver/solver_utils.rs
+++ b/solver/src/solver/solver_utils.rs
@@ -1,0 +1,86 @@
+use anyhow::{ensure, Result};
+use contracts::{GPv2Settlement, ERC20};
+use ethcontract::H160;
+use ethcontract::U256;
+use serde::{
+    de::{Deserializer, Error as _},
+    Deserialize,
+};
+
+use std::{
+    borrow::Cow,
+    fmt::{self, Display, Formatter},
+};
+
+// Helper trait to mock the smart contract interaction
+#[cfg_attr(test, mockall::automock)]
+#[async_trait::async_trait]
+pub trait AllowanceFetching: Send + Sync {
+    async fn existing_allowance(&self, token: H160, spender: H160) -> Result<U256>;
+}
+
+#[async_trait::async_trait]
+impl AllowanceFetching for GPv2Settlement {
+    async fn existing_allowance(&self, token: H160, spender: H160) -> Result<U256> {
+        let token_contract = ERC20::at(&self.raw_instance().web3(), token);
+        Ok(token_contract
+            .allowance(self.address(), spender)
+            .call()
+            .await?)
+    }
+}
+
+/// A slippage amount.
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Default)]
+pub struct Slippage(pub f64);
+
+impl Slippage {
+    /// Creates a slippage amount from the specified percentage.
+    pub fn percentage(amount: f64) -> Result<Self> {
+        // 1Inch API only accepts a slippage from 0 to 50.
+        ensure!(
+            (0. ..=50.).contains(&amount),
+            "slippage outside of [0%, 50%] range"
+        );
+        Ok(Slippage(amount))
+    }
+
+    /// Creates a slippage amount from the specified basis points.
+    pub fn basis_points(bps: u16) -> Result<Self> {
+        let percent = (bps as f64) / 100.;
+        Slippage::percentage(percent)
+    }
+}
+
+impl Display for Slippage {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+pub fn deserialize_decimal_f64<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let decimal_str = Cow::<str>::deserialize(deserializer)?;
+    decimal_str.parse::<f64>().map_err(D::Error::custom)
+}
+
+pub fn deserialize_decimal_u256<'de, D>(deserializer: D) -> Result<U256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let decimal_str = Cow::<str>::deserialize(deserializer)?;
+    U256::from_dec_str(&*decimal_str).map_err(D::Error::custom)
+}
+
+pub fn deserialize_prefixed_hex<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let prefixed_hex_str = Cow::<str>::deserialize(deserializer)?;
+    let hex_str = prefixed_hex_str
+        .strip_prefix("0x")
+        .ok_or_else(|| D::Error::custom("hex missing '0x' prefix"))?;
+    hex::decode(hex_str).map_err(D::Error::custom)
+}

--- a/solver/src/solver/solver_utils.rs
+++ b/solver/src/solver/solver_utils.rs
@@ -1,5 +1,4 @@
 use anyhow::{ensure, Result};
-use ethcontract::U256;
 use serde::{
     de::{Deserializer, Error as _},
     Deserialize,
@@ -45,14 +44,6 @@ where
 {
     let decimal_str = Cow::<str>::deserialize(deserializer)?;
     decimal_str.parse::<f64>().map_err(D::Error::custom)
-}
-
-pub fn deserialize_decimal_u256<'de, D>(deserializer: D) -> Result<U256, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let decimal_str = Cow::<str>::deserialize(deserializer)?;
-    U256::from_dec_str(&*decimal_str).map_err(D::Error::custom)
 }
 
 pub fn deserialize_prefixed_hex<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>

--- a/solver/src/solver/solver_utils.rs
+++ b/solver/src/solver/solver_utils.rs
@@ -26,9 +26,15 @@ impl Slippage {
     }
 
     /// Creates a slippage amount from the specified basis points.
-    pub fn basis_points(bps: u16) -> Result<Self> {
-        let percent = (bps as f64) / 100.;
+    pub fn percentage_from_basis_points(basis_points: u16) -> Result<Self> {
+        let percent = (basis_points as f64) / 100.;
         Slippage::percentage(percent)
+    }
+
+    /// Creates a slippage amount from the specified basis points as number.
+    pub fn number_from_basis_points(basis_points: u16) -> Result<Self> {
+        let number_representation = (basis_points as f64) / 10000.;
+        Ok(Slippage(number_representation))
     }
 }
 


### PR DESCRIPTION
This code adds the matcha solver, similar to paraswap. Also, it refactors used components into solver_utils.rs.

Though, I have some questions and comments:
1. Why was for oneinch the pmm disabled? Do I need to do something similar for matcha?
2. The matcha API for buy orders is still a riddle to me. If we change the slippage percentage, they don't increase the sell_amounts, hence I think they are allowing the slippage on the buy order side, which makes more sense to me anyways. Though the API docs state it differently. I am in contact with the team.
In the current paraswap API, we will always sell "too many sell token" and hence continuously overpay paraswap, which is far from optimal. Having the slippage on the buy_amount seems best to me.
3. How did you guys test the solvers before? I just run it with an unregisted solver private key, and got:
```
0: method 'settle(address[],uint256[],(uint256,uint256,address,uint256,uint256,uint32,bytes32,uint256,uint256,uint256,bytes)[],(address,uint256,bytes)[][3])' failure: contract call reverted with message: Some("GPv2: not a solver")
    1: contract call reverted with message: Some("GPv2: not a solver")
2021-06-24T16:31:38.753Z  WARN solver::driver: settlement failure for: 
SettlementWithSolver {
    name: "Matcha",
    settlement: Settlement {
        encoder: SettlementEncoder {
            tokens: [
                0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2,
                0xdac17f958d2ee523a2206206994597c13d831ec7,
                0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee,
            ],
            clearing_prices: {
                0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee: 200000000000000,
                0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2: 200000000000000,
                0xdac17f958d2ee523a2206206994597c13d831ec7: 397918,
            },
            trades: [
                Trade {
                    order: Order {
                        order_meta_data: OrderMetaData {
                            creation_date: 2021-06-24T16:30:58.325347Z,
                            owner: 0x070330e027a3e4327ba69f0c8a1885df4b545837,
                            uid: 0xdac08f2f83c9bf8100b918aedfc336a7461cd8252cec7fcac20c48e92cdcdc36070330e027a3e4327ba69f0c8a1885df4b54583760d4b7f1,
                            available_balance: Some(
                                5978826,
                            ),
```
hence I am quite confident that it works nicely, though not 100%. Any better test suggestions are welcomed :) 

### Test Plan
Unit tests
