### PR TITLE
Added balancer liquidity provider for solvers

### DIFF
--- a/shared/src/balancer/pool_cache.rs
+++ b/shared/src/balancer/pool_cache.rs
@@ -2,6 +2,7 @@ use crate::{
     balancer::{
         event_handler::BalancerPoolRegistry,
         pool_storage::{RegisteredWeightedPool, WeightedPool},
+        swap::fixed_point::Bfp,
     },
     pool_fetching::{handle_contract_error, MAX_BATCH_SIZE},
     recent_block_cache::{Block, CacheFetching, CacheKey, CacheMetrics, RecentBlockCache},
@@ -125,7 +126,7 @@ fn handle_results(results: Vec<FetchedWeightedPool>) -> Result<Vec<WeightedPool>
             acc.push(WeightedPool::new(
                 fetched_pool.registered_pool,
                 balances,
-                swap_fee_percentage,
+                Bfp::from_wei(swap_fee_percentage),
             ));
             Ok(acc)
         })

--- a/shared/src/balancer/pool_fetching.rs
+++ b/shared/src/balancer/pool_fetching.rs
@@ -19,6 +19,7 @@ use anyhow::Result;
 use model::TokenPair;
 use std::{collections::HashSet, sync::Arc};
 
+#[mockall::automock]
 #[async_trait::async_trait]
 pub trait WeightedPoolFetching: Send + Sync {
     async fn fetch(

--- a/shared/src/balancer/pool_storage.rs
+++ b/shared/src/balancer/pool_storage.rs
@@ -38,18 +38,18 @@ use ethcontract::{H160, H256, U256};
 use model::TokenPair;
 use std::collections::{HashMap, HashSet};
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PoolTokenState {
     pub balance: U256,
     pub weight: Bfp,
     pub scaling_exponent: u8,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct WeightedPool {
     pub pool_id: H256,
     pub pool_address: H160,
-    pub swap_fee_percentage: U256,
+    pub swap_fee_percentage: Bfp,
     pub reserves: HashMap<H160, PoolTokenState>,
 }
 
@@ -57,7 +57,7 @@ impl WeightedPool {
     pub fn new(
         pool_data: RegisteredWeightedPool,
         balances: Vec<U256>,
-        swap_fee_percentage: U256,
+        swap_fee_percentage: Bfp,
     ) -> Self {
         let mut reserves = HashMap::new();
         // We expect the weight and token indices are aligned with balances returned from EVM query.

--- a/shared/src/balancer/swap.rs
+++ b/shared/src/balancer/swap.rs
@@ -43,14 +43,14 @@ impl WeightedPool {
     fn add_swap_fee_amount(&self, amount: U256) -> Result<U256, Error> {
         // https://github.com/balancer-labs/balancer-v2-monorepo/blob/6c9e24e22d0c46cca6dd15861d3d33da61a60b98/pkg/core/contracts/pools/BasePool.sol#L454-L457
         Bfp::from_wei(amount)
-            .div_up(Bfp::from_wei(self.swap_fee_percentage).complement())
+            .div_up(self.swap_fee_percentage.complement())
             .map(|amount_with_fees| amount_with_fees.as_uint256())
     }
 
     fn subtract_swap_fee_amount(&self, amount: U256) -> Result<U256, Error> {
         // https://github.com/balancer-labs/balancer-v2-monorepo/blob/6c9e24e22d0c46cca6dd15861d3d33da61a60b98/pkg/core/contracts/pools/BasePool.sol#L462-L466
         let amount = Bfp::from_wei(amount);
-        let fee_amount = amount.mul_up(Bfp::from_wei(self.swap_fee_percentage))?;
+        let fee_amount = amount.mul_up(self.swap_fee_percentage)?;
         amount
             .sub(fee_amount)
             .map(|amount_without_fees| amount_without_fees.as_uint256())
@@ -163,7 +163,7 @@ mod tests {
             pool_id: Default::default(),
             pool_address: H160::zero(),
             reserves,
-            swap_fee_percentage,
+            swap_fee_percentage: Bfp::from_wei(swap_fee_percentage),
         }
     }
 

--- a/shared/src/baseline_solver.rs
+++ b/shared/src/baseline_solver.rs
@@ -5,6 +5,9 @@ use model::TokenPair;
 use num::BigRational;
 use std::collections::{HashMap, HashSet};
 
+/// The maximum number of hops to use when trading with AMMs along a path.
+pub const DEFAULT_MAX_HOPS: usize = 2;
+
 type PathCandidate = Vec<H160>;
 
 pub trait BaselineSolvable {
@@ -184,6 +187,17 @@ pub fn token_path_to_pair_path(token_list: &[H160]) -> Vec<TokenPair> {
             TokenPair::new(window[0], window[1]).expect("token list contains same token in a row")
         })
         .collect()
+}
+
+pub fn relevant_token_pairs(
+    sell_token: H160,
+    buy_token: H160,
+    base_tokens: &HashSet<H160>,
+    max_hops: usize,
+) -> impl Iterator<Item = TokenPair> {
+    path_candidates(sell_token, buy_token, base_tokens, max_hops)
+        .into_iter()
+        .flat_map(|path| token_path_to_pair_path(&path))
 }
 
 #[cfg(test)]

--- a/shared/src/price_estimate.rs
+++ b/shared/src/price_estimate.rs
@@ -2,7 +2,7 @@ use crate::{
     bad_token::BadTokenDetecting,
     baseline_solver::{
         estimate_buy_amount, estimate_sell_amount, estimate_spot_price, path_candidates,
-        token_path_to_pair_path,
+        token_path_to_pair_path, DEFAULT_MAX_HOPS,
     },
     conversions::U256Ext,
     pool_fetching::{Pool, PoolFetching},
@@ -20,8 +20,6 @@ use std::{
     sync::Arc,
 };
 use thiserror::Error;
-
-const MAX_HOPS: usize = 2;
 
 #[derive(Error, Debug)]
 pub enum PriceEstimationError {
@@ -315,7 +313,8 @@ impl BaselinePriceEstimator {
         CompareFn: Fn(U256, &[H160], &HashMap<TokenPair, Vec<Pool>>) -> O,
         O: Ord,
     {
-        let path_candidates = path_candidates(sell_token, buy_token, &self.base_tokens, MAX_HOPS);
+        let path_candidates =
+            path_candidates(sell_token, buy_token, &self.base_tokens, DEFAULT_MAX_HOPS);
         let all_pairs = path_candidates
             .iter()
             .flat_map(|candidate| token_path_to_pair_path(candidate).into_iter())

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -1,19 +1,19 @@
-use crate::settlement::SettlementEncoder;
-use anyhow::Result;
-use model::{order::OrderKind, TokenPair};
-use num::rational::Ratio;
-use primitive_types::{H160, U256};
-use std::sync::Arc;
-use strum_macros::{AsStaticStr, EnumVariantNames};
-
-#[cfg(test)]
-use model::order::Order;
-use shared::balancer::pool_storage::PoolTokenState;
-use std::collections::HashMap;
-
+pub mod balancer;
 pub mod offchain_orderbook;
 pub mod slippage;
 pub mod uniswap;
+
+use crate::settlement::SettlementEncoder;
+use anyhow::Result;
+#[cfg(test)]
+use model::order::Order;
+use model::{order::OrderKind, TokenPair};
+use num::{rational::Ratio, BigRational};
+use primitive_types::{H160, U256};
+use shared::balancer::pool_storage::PoolTokenState;
+use std::collections::HashMap;
+use std::sync::Arc;
+use strum_macros::{AsStaticStr, EnumVariantNames};
 
 /// Defines the different types of liquidity our solvers support
 #[derive(Clone, AsStaticStr, EnumVariantNames, Debug)]
@@ -127,7 +127,7 @@ impl std::fmt::Debug for ConstantProductOrder {
 #[derive(Clone)]
 pub struct WeightedProductOrder {
     pub reserves: HashMap<H160, PoolTokenState>,
-    pub fee: Ratio<u32>,
+    pub fee: BigRational,
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
 }
 
@@ -171,7 +171,7 @@ impl Default for ConstantProductOrder {
         ConstantProductOrder {
             tokens: Default::default(),
             reserves: Default::default(),
-            fee: Ratio::new(0, 1),
+            fee: num::Zero::zero(),
             settlement_handling: tests::CapturingSettlementHandler::arc(),
         }
     }
@@ -182,7 +182,7 @@ impl Default for WeightedProductOrder {
     fn default() -> Self {
         WeightedProductOrder {
             reserves: Default::default(),
-            fee: Ratio::new(0, 1),
+            fee: num::Zero::zero(),
             settlement_handling: tests::CapturingSettlementHandler::arc(),
         }
     }

--- a/solver/src/liquidity/balancer.rs
+++ b/solver/src/liquidity/balancer.rs
@@ -20,6 +20,11 @@ use shared::{
 };
 use std::{collections::HashSet, sync::Arc};
 
+struct Contracts {
+    settlement: GPv2Settlement,
+    vault: BalancerV2Vault,
+}
+
 /// A liquidity provider for Balancer V2 weighted pools.
 pub struct BalancerV2Liquidity {
     contracts: Arc<Contracts>,
@@ -75,11 +80,6 @@ impl BalancerV2Liquidity {
 
         Ok(liquidity)
     }
-}
-
-struct Contracts {
-    settlement: GPv2Settlement,
-    vault: BalancerV2Vault,
 }
 
 struct SettlementHandler {

--- a/solver/src/liquidity/balancer.rs
+++ b/solver/src/liquidity/balancer.rs
@@ -1,0 +1,338 @@
+//! Module for providing Balancer V2 pool liquidity to the solvers.
+
+use crate::{
+    interactions::{
+        allowances::{AllowanceManaging, Allowances},
+        BalancerSwapGivenOutInteraction,
+    },
+    liquidity::{
+        slippage, AmmOrderExecution, LimitOrder, SettlementHandling, WeightedProductOrder,
+    },
+    settlement::SettlementEncoder,
+};
+use anyhow::Result;
+use contracts::{BalancerV2Vault, GPv2Settlement};
+use ethcontract::{H160, H256};
+use shared::{
+    balancer::pool_fetching::WeightedPoolFetching,
+    baseline_solver::{relevant_token_pairs, DEFAULT_MAX_HOPS},
+    recent_block_cache::Block,
+};
+use std::{collections::HashSet, sync::Arc};
+
+/// A liquidity provider for Balancer V2 weighted pools.
+pub struct BalancerV2Liquidity {
+    contracts: Arc<Contracts>,
+    pool_fetcher: Arc<dyn WeightedPoolFetching>,
+    allowance_manager: Box<dyn AllowanceManaging>,
+    base_tokens: HashSet<H160>,
+}
+
+impl BalancerV2Liquidity {
+    /// Returns relevant Balancer V2 weighted pools given a list of off-chain
+    /// orders.
+    pub async fn get_liquidity(
+        &self,
+        orders: &[LimitOrder],
+        block: Block,
+    ) -> Result<Vec<WeightedProductOrder>> {
+        let pairs = orders
+            .iter()
+            .flat_map(|order| {
+                relevant_token_pairs(
+                    order.sell_token,
+                    order.buy_token,
+                    &self.base_tokens,
+                    DEFAULT_MAX_HOPS,
+                )
+            })
+            .collect();
+        let pools = self.pool_fetcher.fetch(pairs, block).await?;
+
+        let tokens = pools
+            .iter()
+            .flat_map(|pool| pool.reserves.keys())
+            .copied()
+            .collect();
+        let allowances = Arc::new(
+            self.allowance_manager
+                .get_allowances(tokens, self.contracts.vault.address())
+                .await?,
+        );
+
+        let liquidity = pools
+            .into_iter()
+            .map(|pool| WeightedProductOrder {
+                reserves: pool.reserves,
+                fee: pool.swap_fee_percentage.into(),
+                settlement_handling: Arc::new(SettlementHandler {
+                    pool_id: pool.pool_id,
+                    contracts: self.contracts.clone(),
+                    allowances: allowances.clone(),
+                }),
+            })
+            .collect();
+
+        Ok(liquidity)
+    }
+}
+
+struct Contracts {
+    settlement: GPv2Settlement,
+    vault: BalancerV2Vault,
+}
+
+struct SettlementHandler {
+    pool_id: H256,
+    contracts: Arc<Contracts>,
+    allowances: Arc<Allowances>,
+}
+
+impl SettlementHandling<WeightedProductOrder> for SettlementHandler {
+    fn encode(&self, execution: AmmOrderExecution, encoder: &mut SettlementEncoder) -> Result<()> {
+        let (asset_in, amount_in) = execution.input;
+        let (asset_out, amount_out) = execution.output;
+
+        encoder.append_to_execution_plan(self.allowances.approve_token(asset_in, amount_in)?);
+        encoder.append_to_execution_plan(BalancerSwapGivenOutInteraction {
+            settlement: self.contracts.settlement.clone(),
+            vault: self.contracts.vault.clone(),
+            pool_id: self.pool_id,
+            asset_in,
+            asset_out,
+            amount_out,
+            amount_in_max: slippage::amount_plus_max_slippage(amount_in),
+            // Balancer pools allow passing additonal user data in order to
+            // control pool behaviour for swaps. That being said, weighted pools
+            // do not seem to make use of this at the moment so leave it empty.
+            user_data: Default::default(),
+        });
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        interactions::allowances::{Approval, MockAllowanceManaging},
+        settlement::Interaction,
+    };
+    use maplit::{hashmap, hashset};
+    use mockall::predicate::*;
+    use model::TokenPair;
+    use num::BigRational;
+    use shared::{
+        balancer::{
+            pool_fetching::MockWeightedPoolFetching,
+            pool_storage::{PoolTokenState, WeightedPool},
+        },
+        dummy_contract,
+    };
+
+    fn dummy_contracts() -> Arc<Contracts> {
+        Arc::new(Contracts {
+            settlement: dummy_contract!(GPv2Settlement, H160([0xc0; 20])),
+            vault: dummy_contract!(BalancerV2Vault, H160([0xc1; 20])),
+        })
+    }
+
+    fn token_pair(seed0: u8, seed1: u8) -> TokenPair {
+        TokenPair::new(H160([seed0; 20]), H160([seed1; 20])).unwrap()
+    }
+
+    #[tokio::test]
+    async fn fetches_liquidity() {
+        let mut pool_fetcher = MockWeightedPoolFetching::new();
+        let mut allowance_manager = MockAllowanceManaging::new();
+
+        let pools = vec![
+            WeightedPool {
+                pool_id: H256([0x90; 32]),
+                pool_address: H160([0x90; 20]),
+                swap_fee_percentage: "0.002".parse().unwrap(),
+                reserves: hashmap! {
+                    H160([0x70; 20]) => PoolTokenState {
+                        balance: 100.into(),
+                        weight: "0.25".parse().unwrap(),
+                        scaling_exponent: 16,
+                    },
+                    H160([0x71; 20]) => PoolTokenState {
+                        balance: 1_000_000.into(),
+                        weight: "0.25".parse().unwrap(),
+                        scaling_exponent: 12,
+                    },
+                    H160([0xb0; 20]) => PoolTokenState {
+                        balance: 1_000_000_000_000_000_000u128.into(),
+                        weight: "0.5".parse().unwrap(),
+                        scaling_exponent: 0,
+                    },
+                },
+            },
+            WeightedPool {
+                pool_id: H256([0x91; 32]),
+                pool_address: H160([0x91; 20]),
+                swap_fee_percentage: "0.001".parse().unwrap(),
+                reserves: hashmap! {
+                    H160([0x73; 20]) => PoolTokenState {
+                        balance: 1_000_000_000_000_000_000u128.into(),
+                        weight: "0.5".parse().unwrap(),
+                        scaling_exponent: 0,
+                    },
+                    H160([0xb0; 20]) => PoolTokenState {
+                        balance: 1_000_000_000_000_000_000u128.into(),
+                        weight: "0.5".parse().unwrap(),
+                        scaling_exponent: 0,
+                    },
+                },
+            },
+        ];
+
+        // Fetches pools for all relevant tokens, in this example, there is no
+        // pool for token 0x72..72.
+        pool_fetcher
+            .expect_fetch()
+            .with(
+                eq(hashset![
+                    token_pair(0x70, 0x71),
+                    token_pair(0x70, 0xb0),
+                    token_pair(0xb0, 0x71),
+                    token_pair(0x70, 0x72),
+                    token_pair(0xb0, 0x72),
+                    token_pair(0xb0, 0x73),
+                ]),
+                always(),
+            )
+            .returning({
+                let pools = pools.clone();
+                move |_, _| Ok(pools.clone())
+            });
+
+        // Fetches allowances for all tokens in pools.
+        allowance_manager
+            .expect_get_allowances()
+            .with(
+                eq(hashset![
+                    H160([0x70; 20]),
+                    H160([0x71; 20]),
+                    H160([0x73; 20]),
+                    H160([0xb0; 20]),
+                ]),
+                always(),
+            )
+            .returning(|_, _| Ok(Allowances::empty(H160([0xc1; 20]))));
+
+        let liquidity_provider = BalancerV2Liquidity {
+            contracts: dummy_contracts(),
+            pool_fetcher: Arc::new(pool_fetcher),
+            allowance_manager: Box::new(allowance_manager),
+            base_tokens: hashset![H160([0xb0; 20])],
+        };
+        let liquidity = liquidity_provider
+            .get_liquidity(
+                &[
+                    LimitOrder {
+                        sell_token: H160([0x70; 20]),
+                        buy_token: H160([0x71; 20]),
+                        ..Default::default()
+                    },
+                    LimitOrder {
+                        sell_token: H160([0x70; 20]),
+                        buy_token: H160([0x72; 20]),
+                        ..Default::default()
+                    },
+                    LimitOrder {
+                        sell_token: H160([0xb0; 20]),
+                        buy_token: H160([0x73; 20]),
+                        ..Default::default()
+                    },
+                ],
+                Block::Recent,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(liquidity.len(), 2);
+        assert_eq!(
+            (&liquidity[0].reserves, &liquidity[0].fee),
+            (&pools[0].reserves, &BigRational::new(2.into(), 1000.into())),
+        );
+        assert_eq!(
+            (&liquidity[1].reserves, &liquidity[1].fee),
+            (&pools[1].reserves, &BigRational::new(1.into(), 1000.into())),
+        );
+    }
+
+    #[test]
+    fn encodes_swaps_in_settlement() {
+        let contracts = dummy_contracts();
+        let handler = SettlementHandler {
+            pool_id: H256([0x90; 32]),
+            contracts: contracts.clone(),
+            allowances: Arc::new(Allowances::new(
+                contracts.vault.address(),
+                hashmap! {
+                    H160([0x70; 20]) => 0.into(),
+                    H160([0x71; 20]) => 100.into(),
+                },
+            )),
+        };
+
+        let mut encoder = SettlementEncoder::new(Default::default());
+        handler
+            .encode(
+                AmmOrderExecution {
+                    input: (H160([0x70; 20]), 10.into()),
+                    output: (H160([0x71; 20]), 11.into()),
+                },
+                &mut encoder,
+            )
+            .unwrap();
+        handler
+            .encode(
+                AmmOrderExecution {
+                    input: (H160([0x71; 20]), 12.into()),
+                    output: (H160([0x72; 20]), 13.into()),
+                },
+                &mut encoder,
+            )
+            .unwrap();
+
+        let [_, interactions, _] = encoder.finish().interactions;
+        assert_eq!(
+            interactions,
+            [
+                Approval::Approve {
+                    token: H160([0x70; 20]),
+                    spender: contracts.vault.address(),
+                }
+                .encode(),
+                BalancerSwapGivenOutInteraction {
+                    settlement: contracts.settlement.clone(),
+                    vault: contracts.vault.clone(),
+                    pool_id: H256([0x90; 32]),
+                    asset_in: H160([0x70; 20]),
+                    asset_out: H160([0x71; 20]),
+                    amount_out: 11.into(),
+                    amount_in_max: slippage::amount_plus_max_slippage(10.into()),
+                    user_data: Default::default(),
+                }
+                .encode(),
+                Approval::AllowanceSufficient.encode(),
+                BalancerSwapGivenOutInteraction {
+                    settlement: contracts.settlement.clone(),
+                    vault: contracts.vault.clone(),
+                    pool_id: H256([0x90; 32]),
+                    asset_in: H160([0x71; 20]),
+                    asset_out: H160([0x72; 20]),
+                    amount_out: 13.into(),
+                    amount_in_max: slippage::amount_plus_max_slippage(12.into()),
+                    user_data: Default::default(),
+                }
+                .encode(),
+            ]
+            .concat(),
+        );
+    }
+}

--- a/solver/src/liquidity/uniswap.rs
+++ b/solver/src/liquidity/uniswap.rs
@@ -10,15 +10,13 @@ use anyhow::Result;
 use contracts::{GPv2Settlement, IUniswapLikeRouter};
 use primitive_types::{H160, U256};
 use shared::{
-    baseline_solver::{path_candidates, token_path_to_pair_path},
+    baseline_solver::{path_candidates, token_path_to_pair_path, DEFAULT_MAX_HOPS},
     pool_fetching::PoolFetching,
     recent_block_cache::Block,
     Web3,
 };
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
-
-pub const MAX_HOPS: usize = 2;
 
 pub struct UniswapLikeLiquidity {
     inner: Arc<Inner>,
@@ -71,7 +69,7 @@ impl UniswapLikeLiquidity {
                 order.sell_token,
                 order.buy_token,
                 &self.base_tokens,
-                MAX_HOPS,
+                DEFAULT_MAX_HOPS,
             );
             pools.extend(
                 path_candidates

--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -6,15 +6,14 @@ use num::BigRational;
 use shared::{
     baseline_solver::{
         estimate_buy_amount, estimate_sell_amount, path_candidates, BaselineSolvable,
+        DEFAULT_MAX_HOPS,
     },
     pool_fetching::Pool,
 };
 use std::collections::{HashMap, HashSet};
 
 use crate::{
-    liquidity::{
-        uniswap::MAX_HOPS, AmmOrderExecution, ConstantProductOrder, LimitOrder, Liquidity,
-    },
+    liquidity::{AmmOrderExecution, ConstantProductOrder, LimitOrder, Liquidity},
     settlement::Settlement,
     solver::Solver,
 };
@@ -106,7 +105,7 @@ impl BaselineSolver {
             order.sell_token,
             order.buy_token,
             &self.base_tokens,
-            MAX_HOPS,
+            DEFAULT_MAX_HOPS,
         );
 
         let (path, executed_sell_amount, executed_buy_amount) = match order.kind {


### PR DESCRIPTION
This PR adds a liquidity provider for Balancer V2 pools. Internally, it uses a `WeightedPoolFetching` implementation in order to get all weighted pools relevant for some collection of input order and uses those to create `Liquidity::WeightedProduct` orders that can be used by the solvers.

Additionally, a `SettlementHandling` implementation in order to turn a Balancer pool swap into an interaction is provided.

### Test Plan

Added a couple of unit tests to check happy path for the logic.
