### PR TITLE
Make WeightedProductOrder implement BaselineSolvable

### DIFF
--- a/shared/src/sources/balancer/swap.rs
+++ b/shared/src/sources/balancer/swap.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::{
     baseline_solver::BaselineSolvable,
     conversions::u256_to_big_int,
@@ -9,6 +7,7 @@ use error::Error;
 use ethcontract::{H160, U256};
 use fixed_point::Bfp;
 use num::{BigRational, CheckedDiv};
+use std::collections::HashMap;
 use weighted_math::{calc_in_given_out, calc_out_given_in};
 
 mod error;

--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -11,12 +11,14 @@ use maplit::hashmap;
 use model::TokenPair;
 use num::BigRational;
 use shared::{
-    balancer::swap::{fixed_point::Bfp, WeightedPoolRef},
     baseline_solver::{
         estimate_buy_amount, estimate_sell_amount, path_candidates, BaselineSolvable,
         DEFAULT_MAX_HOPS,
     },
-    sources::uniswap::pool_fetching::Pool,
+    sources::{
+        balancer::swap::{fixed_point::Bfp, WeightedPoolRef},
+        uniswap::pool_fetching::Pool,
+    },
 };
 use std::{
     collections::{HashMap, HashSet},


### PR DESCRIPTION
This PR implements `BaselineSolvable` for the new `WeightedProductOrder` so that the `Liquidity` type can be used directly by the baseline solver.

### Test Plan

Added some unit tests for the new BigRational <-> Bfp conversion logic. Otherwise, the rest was just "wiring" up implementations together and doesn't really need to be tested beyond compilation.
