### PR TITLE
[Easy] Better Query logging Paraswap

### DIFF
--- a/solver/src/solver/paraswap_solver/api.rs
+++ b/solver/src/solver/paraswap_solver/api.rs
@@ -45,7 +45,10 @@ impl ParaswapApi for DefaultParaswapApi {
         &self,
         query: TransactionBuilderQuery,
     ) -> Result<TransactionBuilderResponse> {
-        tracing::debug!("Querying Paraswap API (transaction) with {:?}", query);
+        tracing::debug!(
+            "Querying Paraswap API (transaction) with {}",
+            serde_json::to_string(&query).unwrap()
+        );
         let text = query
             .into_request(&self.client)
             .send()
@@ -110,7 +113,7 @@ impl PriceQuery {
 }
 
 /// A Paraswap API price response.
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq, Default, Serialize)]
 pub struct PriceResponse {
     /// Opaque type, which the API expects to get echoed back in the exact form when requesting settlement transaction data
     pub price_route_raw: Value,
@@ -221,9 +224,8 @@ fn debug_bytes(bytes: &Bytes, formatter: &mut std::fmt::Formatter) -> Result<(),
 
 #[cfg(test)]
 mod tests {
-    use reqwest::StatusCode;
-
     use super::*;
+    use reqwest::StatusCode;
 
     #[tokio::test]
     #[ignore]
@@ -246,7 +248,10 @@ mod tests {
             .await
             .expect("Response is not json");
 
-        println!("Price Response: {:?}", &price_response,);
+        println!(
+            "Price Response: {}",
+            serde_json::to_string_pretty(&price_response).unwrap()
+        );
 
         let transaction_query = TransactionBuilderQuery {
             src_token: from,
@@ -260,6 +265,11 @@ mod tests {
             user_address: shared::addr!("E0B3700e0aadcb18ed8d4BFF648Bc99896a18ad1"),
             referrer: "GPv2".to_string(),
         };
+
+        println!(
+            "Transaction Query: {}",
+            serde_json::to_string_pretty(&transaction_query).unwrap()
+        );
 
         let client = Client::new();
         let transaction_response = transaction_query


### PR DESCRIPTION
Our alerts channel logs queries as Json Objects with a bunch of gross metadata like

<details><summary> Old Logs </summary>
{ src_token: 0xd533a949740bb3306d119cc777fa900ba034cd52, dest_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, src_amount: 20301759336292663296325, dest_amount: 16624989161216988003, from_decimals: 18, to_decimals: 18, price_route: Object({"adapterVersion": String("4.0.0"), "bestRoute": Array([Object({"data": Object({"factory": String("0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"), "gasUSD": String("6.577505"), "initCode": String("0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"), "path": Array([String("0xd533a949740bb3306d119cc777fa900ba034cd52"), String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")]), "router": String("0x86d3579b043585A97532514016dCF0C2d6C4b6a1"), "tokenFrom": String("0xd533a949740bb3306d119cc777fa900ba034cd52"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")}), "destAmount": String("2331628779908648017"), "destAmountFeeDeducted": String("2331628779908648017"), "exchange": String("UniswapV2"), "percent": String("14"), "srcAmount": String("2842246307080972861485")}), Object({"data": Object({"gasUSD": String("13.155010"), "tokenFrom": String("0xd533a949740bb3306d119cc777fa900ba034cd52"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"), "version": Number(2)}), "destAmount": String("14310002012100348982"), "destAmountFeeDeducted": String("14310002012100348982"), "exchange": String("ParaSwapPool4"), "percent": String("86"), "srcAmount": String("17459513029211690434839")})]), "bestRouteGas": String("351600"), "bestRouteGasCostUSD": String("28.908134"), "blockNumber": Number(12729702), "contractMethod": String("simpleSwap"), "destAmount": String("16641630792008997000"), "destAmountFeeDeducted": String("16641630792008997000"), "details": Object({"destAmount": String("16641630792008997000"), "srcAmount": String("20301759336292663296325"), "tokenFrom": String("0xd533a949740bb3306d119cc777fa900ba034cd52"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")}), "fromUSD": String("37152.2195854155"), "hmac": String("60b4199028c1775e68535bb34efb0a5bdf0d980d"), "maxImpactReached": Bool(false), "multiRoute": Array([]), "others": Array([Object({"data": Object({"gasUSD": String("8.221881"), "tokenFrom": String("0xd533a949740bb3306d119cc777fa900ba034cd52"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"), "version": Number(4)}), "exchange": String("ParaSwapPool"), "rate": String("16559095489656239120"), "rateFeeDeducted": String("16559095489656239120"), "unit": String("815648300000000"), "unitFeeDeducted": String("815648300000000")}), Object({"data": Object({"factory": String("0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"), "gasUSD": String("6.577505"), "initCode": String("0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"), "path": Array([String("0xd533a949740bb3306d119cc777fa900ba034cd52"), String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")]), "router": String("0x86d3579b043585A97532514016dCF0C2d6C4b6a1"), "tokenFrom": String("0xd533a949740bb3306d119cc777fa900ba034cd52"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")}), "exchange": String("UniswapV2"), "rate": String("16289684864304337596"), "rateFeeDeducted": String("16289684864304337596"), "unit": String("823347805298338"), "unitFeeDeducted": String("823347805298338")}), Object({"data": Object({"gasUSD": String("13.155010"), "tokenFrom": String("0xd533a949740bb3306d119cc777fa900ba034cd52"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"), "version": Number(2)}), "exchange": String("ParaSwapPool4"), "rate": String("16636054442388459903"), "rateFeeDeducted": String("16636054442388459903"), "unit": String("819844066526761"), "unitFeeDeducted": String("819844066526761")}), Object({"data": Object({"factory": String("0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac"), "gasUSD": String("7.399693"), "initCode": String("0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303"), "path": Array([String("0xd533a949740bb3306d119cc777fa900ba034cd52"), String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")]), "router": String("0xBc1315CD2671BC498fDAb42aE1214068003DC51e"), "tokenFrom": String("0xd533a949740bb3306d119cc777fa900ba034cd52"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")}), "exchange": String("SushiSwap"), "rate": String("16553573438235577835"), "rateFeeDeducted": String("16553573438235577835"), "unit": String("819363705039803"), "unitFeeDeducted": String("819363705039803")}), Object({"data": Object({"factory": String("0x9DEB29c9a4c7A88a3C0257393b7f3335338D9A9D"), "gasUSD": String("7.399693"), "initCode": String("0x69d637e77615df9f235f642acebbdad8963ef35c5523142078c9b8f9d0ceba7e"), "path": Array([String("0xd533a949740bb3306d119cc777fa900ba034cd52"), String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")]), "router": String("0xF806F9972F9A34FC05394cA6CF2cc606297Ca6D5"), "tokenFrom": String("0xd533a949740bb3306d119cc777fa900ba034cd52"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")}), "exchange": String("DefiSwap"), "rate": String("9166601535439045128"), "rateFeeDeducted": String("9166601535439045128"), "unit": String("828222484894308"), "unitFeeDeducted": String("828222484894308")}), Object({"data": Object({"factory": String("0x696708Db871B77355d6C2bE7290B27CF0Bb9B24b"), "gasUSD": String("7.399693"), "initCode": String("0x50955d9250740335afc702786778ebeae56a5225e4e18b7cb046e61437cde6b3"), "path": Array([String("0xd533a949740bb3306d119cc777fa900ba034cd52"), String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")]), "router": String("0xEC4c8110E5B5Bf0ad8aa89e3371d9C3b8CdCD778"), "tokenFrom": String("0xd533a949740bb3306d119cc777fa900ba034cd52"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")}), "exchange": String("LinkSwap"), "rate": String("338514589720352383"), "rateFeeDeducted": String("338514589720352383"), "unit": String("848492721156459"), "unitFeeDeducted": String("848492721156459")}), Object({"data": Object({"fee": Number(10000), "gasUSD": String("16.443762"), "tokenFrom": String("0xd533a949740bb3306d119cc777fa900ba034cd52"), "tokenTo": String("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")}), "exchange": String("UniswapV3"), "rate": String("16614542774547240130"), "rateFeeDeducted": String("16614542774547240130"), "unit": String("820500117660759"), "unitFeeDeducted": String("820500117660759")})]), "priceID": String("fdd4080b-ad5a-45fb-8548-a415bb3d5e13"), "priceWithSlippage": String("16475214484088907030"), "side": String("SELL"), "spender": String("0xb70Bc06D2c9Bf03b3373799606dc7d39346c06B3"), "srcAmount": String("20301759336292663296325"), "toUSD": String("37037.7799070031"), "toUSDFeeDeducted": String("37037.7799070031")}), user_address: 0xa6ddbd0de6b310819b49f680f65871bee85f517e, referrer: "GPv2" }
</details>

 Now we make it better:
 
 <details><summary> New Log </summary>
 Transaction Query: {"srcToken":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","destToken":"0x6810e776880c02933d47db1b9fc05908e5386b96","srcAmount":"135000000000000000000","destAmount":"1561900693092920640000","fromDecimals":18,"toDecimals":18,"priceRoute":{"adapterVersion":"4.0.0","bestRoute":[{"data":{"fee":10000,"gasUSD":"9.728862","tokenFrom":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","tokenTo":"0x6810e776880c02933d47db1b9fc05908e5386b96"},"destAmount":"1215090720183816617266","destAmountFeeDeducted":"1215090720183816617266","exchange":"UniswapV3","percent":"70","srcAmount":"94500000000000000000"},{"data":{"exchangeProxy":"0x6317c5e82a06e1d8bf200d21f4510ac2c038ac81","gasUSD":"5.837317","swaps":[{"maxPrice":"115792089237316195423570985008687907853269984665640564039457584007913129639935","pool":"0xe42237f32708bd5c04d69cc77e1e36c8f911a016","tokenInParam":"40500000000000000000","tokenOutParam":"0"}],"tokenFrom":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","tokenTo":"0x6810e776880c02933d47db1b9fc05908e5386b96"},"destAmount":"520354494363872982733","destAmountFeeDeducted":"520354494363872982733","exchange":"Balancer","percent":"30","srcAmount":"40500000000000000000"}],"bestRouteGas":"411600","bestRouteGasCostUSD":"20.021997","blockNumber":12736171,"contractMethod":"simpleSwap","destAmount":"1735445214547689600000","destAmountFeeDeducted":"1735445214547689600000","details":{"destAmount":"1735445214547689600000","srcAmount":"135000000000000000000","tokenFrom":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","tokenTo":"0x6810e776880c02933d47db1b9fc05908e5386b96"},"fromUSD":"285520.9500000000","hmac":"e84e9969f87acf10a3fc5d25941a3955054e2dc4","maxImpactReached":false,"multiRoute":[],"others":[{"data":{"factory":"0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f","gasUSD":"3.891544","initCode":"0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f","path":["0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","0x6810e776880c02933d47db1b9fc05908e5386b96"],"router":"0x86d3579b043585A97532514016dCF0C2d6C4b6a1","tokenFrom":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","tokenTo":"0x6810e776880c02933d47db1b9fc05908e5386b96"},"exchange":"UniswapV2","rate":"386882710477435275354","rateFeeDeducted":"386882710477435275354","unit":"12620477268426034025","unitFeeDeducted":"12620477268426034025"},{"data":{"exchangeProxy":"0x6317c5e82a06e1d8bf200d21f4510ac2c038ac81","gasUSD":"5.837317","pool":"0xe42237f32708bd5c04d69cc77e1e36c8f911a016","tokenFrom":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","tokenTo":"0x6810e776880c02933d47db1b9fc05908e5386b96"},"exchange":"Balancer","rate":"1688118870377789981171","rateFeeDeducted":"1688118870377789981171","unit":"12998742150689719549","unitFeeDeducted":"12998742150689719549"},{"data":{"factory":"0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac","gasUSD":"4.377987","initCode":"0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303","path":["0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","0x6810e776880c02933d47db1b9fc05908e5386b96"],"router":"0xBc1315CD2671BC498fDAb42aE1214068003DC51e","tokenFrom":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","tokenTo":"0x6810e776880c02933d47db1b9fc05908e5386b96"},"exchange":"SushiSwap","rate":"413572178859828441136","rateFeeDeducted":"413572178859828441136","unit":"12770238391613705780","unitFeeDeducted":"12770238391613705780"},{"data":{"gasUSD":"9.728862","path":["0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE","0xb1CD6e4153B2a390Cf00A6556b0fC1458C4A5533","0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C","0xd7eB9DB184DA9f099B84e2F86b1da1Fe6b305B3d","0x6810e776880C02933D47DB1b9fc05908e5386b96"],"tokenFrom":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","tokenTo":"0x6810e776880c02933d47db1b9fc05908e5386b96"},"exchange":"Bancor","rate":"739815658390870294528","rateFeeDeducted":"739815658390870294528","unit":"12927366098030856192","unitFeeDeducted":"12927366098030856192"},{"data":{"fee":10000,"gasUSD":"9.728862","tokenFrom":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","tokenTo":"0x6810e776880c02933d47db1b9fc05908e5386b96"},"exchange":"UniswapV3","rate":"1727669788265667972415","rateFeeDeducted":"1727669788265667972415","unit":"13000100914593206408","unitFeeDeducted":"13000100914593206408"}],"priceID":"273f9409-6c46-4359-9909-5647f2b34a78","priceWithSlippage":"1718090762402212704000","side":"SELL","spender":"0xb70Bc06D2c9Bf03b3373799606dc7d39346c06B3","srcAmount":"135000000000000000000","toUSD":"282651.9620933822","toUSDFeeDeducted":"282651.9620933822"},"userAddress":"0xe0b3700e0aadcb18ed8d4bff648bc99896a18ad1","referrer":"GPv2"}
 </details>
 
 We might also consider just logging the URL instead of the input JSON.... What do you think about that @fleupold ?

### Test Plan
Added a print statement of the query in the test as well. But maybe we should remove all print statements.... Doesn't matter - no new tests.
