### PR TITLE
[Trivial] Log limit orders on runloop

### DIFF
--- a/solver/src/liquidity_collector.rs
+++ b/solver/src/liquidity_collector.rs
@@ -22,7 +22,7 @@ impl LiquidityCollector {
             .get_liquidity(inflight_trades)
             .await
             .context("failed to get orderbook")?;
-        tracing::debug!("got {} orders", limit_orders.len());
+        tracing::info!("got {} orders: {:?}", limit_orders.len(), limit_orders);
 
         let mut amms = vec![];
         for liquidity in self.uniswap_like_liquidity.iter() {


### PR DESCRIPTION
I was trying to debug why 

https://gnosis-protocol.io/orders/e79c851ee4c66e8da4c0d322f4a96f9cdb80039086e6156db214ae9522603c370aa7c71ea5944dd0b46a031092936b31a678bc7660dd64aa

and 

https://gnosis-protocol.io/orders/e55b4bbc0fc2816d97b091d2106e370eea13ba622f8e505be20067a78b0ba2c20aa7c71ea5944dd0b46a031092936b31a678bc7660dd6528

took so long to get settled (I assume it's due to a conflicting order on the same token pair)

To make debugging easier it would be help to log the list of orders we are trying to match in each runloop (including UID) so that we can look them up in the explorer.

### Test Plan
Run and see the following print statement:

> 2021-07-01T14:37:59.568Z  INFO solver::liquidity_collector: got 1 orders: [Limit Order 0xbbaa09c9c9285df9f1cd96e2bf9f8e71e5187c73f306b39db5fb1e41ba9f0548e0b3700e0aadcb18ed8d4bff648bc99896a18ad160ddd7f1]

> 