### PR TITLE
Fetch initial weighted pool data on-chain

### DIFF
--- a/shared/src/sources/balancer/pool_init.rs
+++ b/shared/src/sources/balancer/pool_init.rs
@@ -5,6 +5,7 @@
 
 use crate::sources::balancer::{
     graph_api::{BalancerSubgraphClient, RegisteredWeightedPools},
+    info_fetching::PoolInfoFetching,
     pool_storage::RegisteredWeightedPool,
 };
 use anyhow::{anyhow, bail, Result};
@@ -15,6 +16,8 @@ use ethcontract::{
     common::{truffle::Network, DeploymentInformation},
     Artifact, H160,
 };
+use futures::stream::{self, StreamExt as _, TryStreamExt as _};
+use std::sync::Arc;
 
 #[derive(Debug, Default, PartialEq)]
 pub struct BalancerRegisteredPools {
@@ -48,11 +51,11 @@ impl PoolInitializing for EmptyPoolInitializer {
 /// The default Balancer pool initializer.
 pub enum DefaultPoolInitializer {
     Subgraph(SubgraphPoolInitializer),
-    Empty(EmptyPoolInitializer),
+    Fetched(FetchedPoolInitializer),
 }
 
 impl DefaultPoolInitializer {
-    pub fn new(chain_id: u64) -> Result<Self> {
+    pub fn new(chain_id: u64, pool_info: Arc<dyn PoolInfoFetching>) -> Result<Self> {
         const MAINNET_CHAIN_ID: u64 = 1;
 
         Ok(if chain_id == MAINNET_CHAIN_ID {
@@ -63,7 +66,7 @@ impl DefaultPoolInitializer {
             // `eth_call`s). This means we can only use the pure Subgraph
             // initializer on Mainnet - the only network with archive node
             // support at the moment.
-            DefaultPoolInitializer::Empty(EmptyPoolInitializer(chain_id))
+            DefaultPoolInitializer::Fetched(FetchedPoolInitializer::new(chain_id, pool_info)?)
         })
     }
 }
@@ -73,7 +76,7 @@ impl PoolInitializing for DefaultPoolInitializer {
     async fn initialize_pools(&self) -> Result<BalancerRegisteredPools> {
         let registered_pools = match self {
             DefaultPoolInitializer::Subgraph(inner) => inner.initialize_pools().await,
-            DefaultPoolInitializer::Empty(inner) => inner.initialize_pools().await,
+            DefaultPoolInitializer::Fetched(inner) => inner.initialize_pools().await,
         }?;
 
         tracing::debug!("initialized registered pools {:?}", registered_pools);
@@ -142,6 +145,105 @@ where
     }
 }
 
+/// A pool initializer that uses the Balancer subgraph to get all created pool
+/// addresses and then fetches pool data onchain.
+///
+/// This is used for networks such as Rinkeby where the subgraph does not
+/// correctly index pool data.
+pub struct FetchedPoolInitializer(FetchedPoolInitializerInner<BalancerSubgraphClient>);
+
+impl FetchedPoolInitializer {
+    pub fn new(chain_id: u64, pool_info: Arc<dyn PoolInfoFetching>) -> Result<Self> {
+        Ok(Self(FetchedPoolInitializerInner {
+            chain_id,
+            pool_info,
+            client: BalancerSubgraphClient::for_chain(chain_id)?,
+        }))
+    }
+}
+
+#[async_trait::async_trait]
+impl PoolInitializing for FetchedPoolInitializer {
+    async fn initialize_pools(&self) -> Result<BalancerRegisteredPools> {
+        self.0.initialize_pools_inner().await
+    }
+}
+
+/// Inner generic subgraph pool initializer implementation to allow for mocking
+/// and unit tests.
+struct FetchedPoolInitializerInner<S> {
+    chain_id: u64,
+    pool_info: Arc<dyn PoolInfoFetching>,
+    client: S,
+}
+
+impl<S> FetchedPoolInitializerInner<S>
+where
+    S: BalancerSubgraph,
+{
+    async fn initialize_pools_inner(&self) -> Result<BalancerRegisteredPools> {
+        let mut pools = self.client.weighted_pools().await?;
+
+        // For subgraphs on networks without an archive node (all the testnets)
+        // the results from the query will all have missing token data, so fetch
+        // them on-chain based on address.
+
+        #[allow(clippy::eval_order_dependence)]
+        let result = BalancerRegisteredPools {
+            weighted_pools: self
+                .fetch_pool_info(
+                    pools
+                        .pools_by_factory
+                        .remove(&deployment_address(
+                            BalancerV2WeightedPoolFactory::artifact(),
+                            self.chain_id,
+                        )?)
+                        .unwrap_or_default(),
+                    pools.fetched_block_number,
+                )
+                .await?,
+            weighted_2token_pools: self
+                .fetch_pool_info(
+                    pools
+                        .pools_by_factory
+                        .remove(&deployment_address(
+                            BalancerV2WeightedPool2TokensFactory::artifact(),
+                            self.chain_id,
+                        )?)
+                        .unwrap_or_default(),
+                    pools.fetched_block_number,
+                )
+                .await?,
+            fetched_block_number: pools.fetched_block_number,
+        };
+
+        // Log an error in order to trigger an alert. This will allow us to make
+        // sure we get notified if new pool factories are added that we don't
+        // index for.
+        for factory in pools.pools_by_factory.keys() {
+            tracing::error!("unsupported pool factory {:?}", factory);
+        }
+
+        Ok(result)
+    }
+
+    async fn fetch_pool_info(
+        &self,
+        pools: Vec<RegisteredWeightedPool>,
+        block_number: u64,
+    ) -> Result<Vec<RegisteredWeightedPool>> {
+        stream::iter(pools)
+            .then(|pool| {
+                let pool_info = self.pool_info.clone();
+                async move {
+                    RegisteredWeightedPool::new(block_number, pool.pool_address, &*pool_info).await
+                }
+            })
+            .try_collect()
+            .await
+    }
+}
+
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 trait BalancerSubgraph: Send + Sync {
@@ -196,10 +298,14 @@ async fn deployment_block(artifact: &Artifact, chain_id: u64) -> Result<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sources::balancer::swap::fixed_point::Bfp;
+    use crate::sources::balancer::{
+        info_fetching::{MockPoolInfoFetching, WeightedPoolInfo},
+        swap::fixed_point::Bfp,
+    };
     use anyhow::bail;
     use ethcontract::H256;
     use maplit::hashmap;
+    use mockall::{predicate::*, Sequence};
 
     #[tokio::test]
     async fn initializes_empty_pools() {
@@ -340,5 +446,120 @@ mod tests {
         };
 
         assert!(initializer.initialize_pools_inner().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn fetches_pool_info_on_chain() {
+        let chain_id = 1;
+
+        let weighted_factory =
+            deployment_address(BalancerV2WeightedPoolFactory::artifact(), chain_id).unwrap();
+        let weighted_2token_factory =
+            deployment_address(BalancerV2WeightedPool2TokensFactory::artifact(), chain_id).unwrap();
+
+        let mut subgraph = MockBalancerSubgraph::new();
+        subgraph.expect_weighted_pools().returning(move || {
+            Ok(RegisteredWeightedPools {
+                pools_by_factory: hashmap! {
+                    weighted_factory => vec![RegisteredWeightedPool {
+                        pool_id: H256([1; 32]),
+                        pool_address: H160([1; 20]),
+                        tokens: vec![],
+                        scaling_exponents: vec![],
+                        normalized_weights: vec![],
+                        block_created: 42,
+                    }],
+                    weighted_2token_factory => vec![RegisteredWeightedPool {
+                        pool_id: H256([2; 32]),
+                        pool_address: H160([2; 20]),
+                        tokens: vec![],
+                        scaling_exponents: vec![],
+                        normalized_weights: vec![],
+                        block_created: 42,
+                    }],
+                    addr!("0102030405060708091011121314151617181920") => vec![RegisteredWeightedPool {
+                        pool_id: H256([3; 32]),
+                        pool_address: H160([3; 20]),
+                        tokens: vec![],
+                        scaling_exponents: vec![],
+                        normalized_weights: vec![],
+                        block_created: 42,
+                    }],
+                },
+                fetched_block_number: 42,
+            })
+        });
+
+        let mut pool_info = MockPoolInfoFetching::new();
+        let mut seq = Sequence::new();
+        pool_info
+            .expect_get_pool_data()
+            .times(1)
+            .in_sequence(&mut seq)
+            .with(eq(H160([1; 20])))
+            .returning(|_| {
+                Ok(WeightedPoolInfo {
+                    pool_id: H256([1; 32]),
+                    tokens: vec![H160([0x11; 20]), H160([0x22; 20])],
+                    scaling_exponents: vec![0, 0],
+                    weights: vec![
+                        Bfp::from_wei(500_000_000_000_000_000u128.into()),
+                        Bfp::from_wei(500_000_000_000_000_000u128.into()),
+                    ],
+                })
+            });
+        pool_info
+            .expect_get_pool_data()
+            .times(1)
+            .in_sequence(&mut seq)
+            .with(eq(H160([2; 20])))
+            .returning(|_| {
+                Ok(WeightedPoolInfo {
+                    pool_id: H256([2; 32]),
+                    tokens: vec![H160([0x11; 20]), H160([0x33; 20]), H160([0x44; 20])],
+                    scaling_exponents: vec![0, 0, 0],
+                    weights: vec![
+                        Bfp::from_wei(500_000_000_000_000_000u128.into()),
+                        Bfp::from_wei(250_000_000_000_000_000u128.into()),
+                        Bfp::from_wei(250_000_000_000_000_000u128.into()),
+                    ],
+                })
+            });
+
+        let initializer = FetchedPoolInitializerInner {
+            chain_id,
+            pool_info: Arc::new(pool_info),
+            client: subgraph,
+        };
+
+        assert_eq!(
+            initializer.initialize_pools_inner().await.unwrap(),
+            BalancerRegisteredPools {
+                weighted_pools: vec![RegisteredWeightedPool {
+                    pool_id: H256([1; 32]),
+                    pool_address: H160([1; 20]),
+                    tokens: vec![H160([0x11; 20]), H160([0x22; 20])],
+                    scaling_exponents: vec![0, 0],
+                    normalized_weights: vec![
+                        Bfp::from_wei(500_000_000_000_000_000u128.into()),
+                        Bfp::from_wei(500_000_000_000_000_000u128.into()),
+                    ],
+                    block_created: 42,
+                }],
+                weighted_2token_pools: vec![RegisteredWeightedPool {
+                    pool_id: H256([2; 32]),
+                    pool_address: H160([2; 20]),
+                    tokens: vec![H160([0x11; 20]), H160([0x33; 20]), H160([0x44; 20])],
+                    scaling_exponents: vec![0, 0, 0],
+                    normalized_weights: vec![
+                        Bfp::from_wei(500_000_000_000_000_000u128.into()),
+                        Bfp::from_wei(250_000_000_000_000_000u128.into()),
+                        Bfp::from_wei(250_000_000_000_000_000u128.into()),
+                    ],
+                    block_created: 42,
+                }],
+                fetched_block_number: 42,
+            },
+        );
     }
 }


### PR DESCRIPTION
This PR adds an additional pool initializer based on on-chain token data, using only pool addresses, factory and type from the subgraph. This allows the pool initialization to be done without having to index historical events since the dawn of time for networks without archive node support (which causes Balancer pools to not have all the required token data).

This currently doesn't quite work and requires a change to the Balancer subgraph balancer-labs/balancer-subgraph-v2#91

### Test Plan

Added unit test for new pool initializer. Waiting to merge pending required subgraph change. We should then be able to trade with old pools on Rinkeby without event indexing.

Manual test: run the solver connected to a Rinkeby node and see that the pool initialization works :tada:
```
$ cargo run -p solver -- --baseline-sources BalancerV2 --solvers Baseline
...
2021-07-08T19:00:56.003Z DEBUG shared::sources::balancer::pool_init: initialized registered pools BalancerRegisteredPools ...
...
```

