### PR TITLE
[Easy]  (de)serialization for BigRational as Decimal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,7 @@ dependencies = [
  "hex-literal",
  "lazy_static",
  "maplit",
+ "num",
  "num-bigint 0.3.2",
  "primitive-types",
  "secp256k1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,6 +1529,7 @@ dependencies = [
 name = "model"
 version = "0.1.0"
 dependencies = [
+ "bigdecimal",
  "chrono",
  "enum-utils",
  "ethabi",

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -13,6 +13,7 @@ hex = { version = "0.4", default-features = false }
 hex-literal = "0.3"
 lazy_static = "1.4"
 maplit = "1.0"
+num = "0.4"
 num-bigint = "0.3"
 primitive-types = { version = "0.9" }
 secp256k1 = "0.20"

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+bigdecimal = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 ethabi = "14.0"
 enum-utils = "0.1"

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod appdata_hexadecimal;
 pub mod h160_hexadecimal;
 pub mod order;
+pub mod ratio_as_decimal;
 pub mod trade;
 pub mod u256_decimal;
 

--- a/model/src/ratio_as_decimal.rs
+++ b/model/src/ratio_as_decimal.rs
@@ -82,7 +82,7 @@ fn sign_04_to_03(sign_04: Sign04) -> Sign03 {
 #[cfg(test)]
 mod tests {
     use crate::ratio_as_decimal::{deserialize, serialize};
-    use num::{BigInt, BigRational};
+    use num::{BigInt, BigRational, Zero};
     use serde_json::value::Serializer;
     use serde_json::Value;
 
@@ -100,6 +100,10 @@ mod tests {
             .unwrap(),
             Value::String("0.3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333".to_string())
         );
+        assert_eq!(
+            serialize(&BigRational::zero(), Serializer).unwrap(),
+            Value::String("0".to_string())
+        );
     }
 
     #[test]
@@ -113,6 +117,11 @@ mod tests {
         assert_eq!(
             deserialize(Value::String("1/2".to_string())).unwrap(),
             BigRational::from_float(0.5).unwrap()
+        );
+
+        assert_eq!(
+            deserialize(Value::String("0/1".to_string())).unwrap(),
+            BigRational::zero()
         );
     }
 }

--- a/model/src/ratio_as_decimal.rs
+++ b/model/src/ratio_as_decimal.rs
@@ -104,6 +104,14 @@ mod tests {
             serialize(&BigRational::zero(), Serializer).unwrap(),
             Value::String("0".to_string())
         );
+        assert_eq!(
+            serialize(
+                &BigRational::new(BigInt::from(-1), BigInt::from(1)),
+                Serializer
+            )
+            .unwrap(),
+            Value::String("-1ca".to_string())
+        );
     }
 
     #[test]
@@ -122,6 +130,10 @@ mod tests {
         assert_eq!(
             deserialize(Value::String("0/1".to_string())).unwrap(),
             BigRational::zero()
+        );
+        assert_eq!(
+            deserialize(Value::String("-1/1".to_string())).unwrap(),
+            BigRational::new(BigInt::from(-1), BigInt::from(1))
         );
     }
 }

--- a/model/src/ratio_as_decimal.rs
+++ b/model/src/ratio_as_decimal.rs
@@ -1,9 +1,7 @@
 use bigdecimal::{BigDecimal, One};
-use num::bigint::Sign as Sign04;
-use num::BigRational;
+use num::{bigint::Sign as Sign04, BigRational};
 use num_bigint::{BigInt, Sign as Sign03};
-use serde::Deserialize;
-use serde::{de, Deserializer, Serializer};
+use serde::{de, Deserialize, Deserializer, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
 use std::borrow::Cow;
 use std::str::FromStr;

--- a/model/src/ratio_as_decimal.rs
+++ b/model/src/ratio_as_decimal.rs
@@ -57,7 +57,7 @@ where
                 sign_03_to_04(numerator_bytes.0),
                 &numerator_bytes.1,
             );
-            let ten = BigRational::new(num::bigint::BigInt::from(10), num::bigint::BigInt::from(1));
+            let ten = BigRational::new(10.into(), 1.into());
             let numerator = BigRational::new(base, num::bigint::BigInt::one());
             Ok(numerator / ten.pow(exp as i32))
         }

--- a/model/src/ratio_as_decimal.rs
+++ b/model/src/ratio_as_decimal.rs
@@ -110,7 +110,7 @@ mod tests {
                 Serializer
             )
             .unwrap(),
-            Value::String("-1ca".to_string())
+            Value::String("-1".to_string())
         );
     }
 

--- a/model/src/ratio_as_decimal.rs
+++ b/model/src/ratio_as_decimal.rs
@@ -4,6 +4,7 @@ use num_bigint::{BigInt, Sign as Sign03};
 use serde::{de, Deserialize, Deserializer, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
 use std::borrow::Cow;
+use std::convert::TryInto;
 use std::str::FromStr;
 
 pub struct DecimalBigRational;
@@ -53,7 +54,11 @@ where
         num::bigint::BigInt::from_bytes_le(sign_03_to_04(numerator_bytes.0), &numerator_bytes.1);
     let ten = BigRational::new(10.into(), 1.into());
     let numerator = BigRational::new(base, 1.into());
-    Ok(numerator / ten.pow(exp as i32))
+    Ok(numerator
+        / ten.pow(
+            exp.try_into()
+                .map_err(|err| de::Error::custom(format!("decimal exponent overflow: {}", err)))?,
+        ))
 }
 
 /// Simple one-to-one conversion of the Sign enum from num-bigint crates v0.3 and v0.4

--- a/model/src/ratio_as_decimal.rs
+++ b/model/src/ratio_as_decimal.rs
@@ -1,0 +1,102 @@
+use num::{BigRational, ToPrimitive};
+use serde::{de, Deserializer, Serializer};
+use serde_with::{DeserializeAs, SerializeAs};
+use std::fmt;
+use std::str::FromStr;
+
+pub struct DecimalBigRational;
+
+impl<'de> DeserializeAs<'de, BigRational> for DecimalBigRational {
+    fn deserialize_as<D>(deserializer: D) -> Result<BigRational, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize(deserializer)
+    }
+}
+
+impl<'de> SerializeAs<BigRational> for DecimalBigRational {
+    fn serialize_as<S>(source: &BigRational, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize(source, serializer)
+    }
+}
+
+pub fn serialize<S>(value: &BigRational, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let float_rep = value.numer().to_f64().unwrap() / value.denom().to_f64().unwrap();
+    serializer.serialize_str(&float_rep.to_string())
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<BigRational, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Visitor {}
+    impl<'de> de::Visitor<'de> for Visitor {
+        type Value = BigRational;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(
+                formatter,
+                "a BigRational encoded as a decimal encoded string"
+            )
+        }
+
+        fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            BigRational::from_str(&s).map_err(|err| {
+                de::Error::custom(format!(
+                    "failed to decode {:?} as decimal BigRational: {}",
+                    s, err
+                ))
+            })
+        }
+    }
+
+    deserializer.deserialize_str(Visitor {})
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ratio_as_decimal::{deserialize, serialize};
+    use num::{BigInt, BigRational};
+    use serde_json::value::Serializer;
+    use serde_json::Value;
+
+    #[test]
+    fn serializer() {
+        assert_eq!(
+            serialize(&BigRational::from_float(1.2).unwrap(), Serializer).unwrap(),
+            Value::String("1.2".to_string())
+        );
+        assert_eq!(
+            serialize(
+                &BigRational::new(BigInt::from(1), BigInt::from(3)),
+                Serializer
+            )
+            .unwrap(),
+            Value::String("0.3333333333333333".to_string())
+        );
+    }
+
+    #[test]
+    fn deserialize_err() {
+        let value = Value::String("hello".to_string());
+        assert!(deserialize(value).is_err());
+    }
+
+    #[test]
+    fn deserialize_ok() {
+        assert_eq!(
+            deserialize(Value::String("1/2".to_string())).unwrap(),
+            BigRational::from_float(0.5).unwrap()
+        );
+    }
+}


### PR DESCRIPTION
In response to the suggestion made [here](https://github.com/gnosis/gp-v2-services/pull/781#discussion_r663542657)

we now implement a `ratio_as_decimal` serialization for converting `BigRational` losslessly to String for export to the HTTP solver.

Should merge before #781 


### Test Plan
New tests for serialization and deserialization (please let me know if there are some other cases I may have missed)
