### PR TITLE
Sell order filled status calculation fix

### DIFF
--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -311,7 +311,7 @@ fn is_sell_order_filled(
     if executed_amount.is_zero() {
         return false;
     }
-    let total_amount = executed_amount + executed_fee;
+    let total_amount = executed_amount - executed_fee;
     total_amount == *amount
 }
 
@@ -374,7 +374,7 @@ mod tests {
         let order_row = OrdersQueryRow {
             kind: DbOrderKind::Sell,
             sell_amount: BigDecimal::from(2),
-            sum_sell: BigDecimal::from(1),
+            sum_sell: BigDecimal::from(3),
             sum_fee: BigDecimal::from(1),
             ..order_row
         };


### PR DESCRIPTION
# Summary

Sell amounts are stored on db with the fee
When checking whether a sell order is filled, we should SUBTRACT
the fee, NOT ADD it (like I did in the first place...)

Example of an order where the issue can be seen: https://protocol-rinkeby.gnosis.io/api/v1/orders/0x5654e2c80637b3764975f74563deb15fceb791f2ca7e3b9dd46dda1495e578d7ca011d01a4b75a36afb5e2b69e0ba8f01c6b500e60e4691e

The order was fully executed, but status is `cancelled`.

### Test Plan
Unit tests
