### PR TITLE
[Thought Experiment] Implement a simple service component registry

### DIFF
--- a/shared/src/gas_price_estimation.rs
+++ b/shared/src/gas_price_estimation.rs
@@ -72,7 +72,9 @@ fn is_mainnet(network_id: &str) -> bool {
     network_id == "1"
 }
 
+#[derive(Default)]
 pub struct FakeGasPriceEstimator(pub Arc<Mutex<f64>>);
+
 #[async_trait::async_trait]
 impl GasPriceEstimating for FakeGasPriceEstimator {
     async fn estimate_with_limits(&self, _: f64, _: std::time::Duration) -> Result<f64> {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -15,6 +15,7 @@ pub mod metrics;
 pub mod network;
 pub mod price_estimate;
 pub mod recent_block_cache;
+pub mod service_registry;
 pub mod sources;
 pub mod subgraph;
 pub mod time;

--- a/shared/src/service_registry.rs
+++ b/shared/src/service_registry.rs
@@ -1,0 +1,136 @@
+//! A general purpose registry for a service's components.
+//!
+//! The registry allows adding new components as well as linking them so that
+//! they can be accessed as a trait object.
+
+use std::{
+    any::{Any, TypeId},
+    collections::HashMap,
+    sync::Arc,
+};
+
+#[derive(Default)]
+pub struct ServiceRegistry {
+    instances: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
+}
+
+impl ServiceRegistry {
+    pub fn register_as<T, U>(&mut self) -> &mut Self
+    where
+        T: ServiceInitializable + ServiceLinkable<U> + Send + Sync + 'static,
+        U: Send + Sync + ?Sized + 'static,
+    {
+        self.register::<T>().link::<T, U>()
+    }
+
+    pub fn register<T>(&mut self) -> &mut Self
+    where
+        T: ServiceInitializable + Send + Sync + 'static,
+    {
+        let instance = T::init(&self);
+        self.add(instance)
+    }
+
+    pub fn add<T>(&mut self, instance: T) -> &mut Self
+    where
+        T: Send + Sync + 'static,
+    {
+        // This is counter intuitive, but we don't store the `Arc` directly in
+        // our instance map because we require double boxing. This is because a
+        // single `Arc<T>` can be shared with multiple `Arc<dyn X>` trait
+        // objects, and we need to keep a separate entry in the map for each of
+        // them for them to hold different v-tables.
+        self.instances
+            .insert(TypeId::of::<Arc<T>>(), Box::new(Arc::new(instance)));
+        self
+    }
+
+    pub fn link<T, U>(&mut self) -> &mut Self
+    where
+        T: ServiceLinkable<U> + Send + Sync + 'static,
+        U: Send + Sync + ?Sized + 'static,
+    {
+        self.instances
+            .insert(TypeId::of::<Arc<U>>(), Box::new(self.get::<T>().as_link()));
+        self
+    }
+
+    pub fn get<T>(&self) -> Arc<T>
+    where
+        T: Send + Sync + ?Sized + 'static,
+    {
+        self.try_get().expect("missing service")
+    }
+
+    pub fn try_get<T>(&self) -> Option<Arc<T>>
+    where
+        T: Send + Sync + ?Sized + 'static,
+    {
+        Some(
+            self.instances
+                .get(&TypeId::of::<Arc<T>>())?
+                .downcast_ref::<Arc<T>>()
+                .expect("incorrectly registered service")
+                .clone(),
+        )
+    }
+}
+
+pub trait ServiceInitializable: Sized {
+    fn init(registry: &ServiceRegistry) -> Self;
+}
+
+pub trait ServiceLinkable<T: ?Sized> {
+    fn as_link(self: Arc<Self>) -> Arc<T>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    trait Fooable: Send + Sync {
+        fn foo(&self) -> i32;
+    }
+
+    struct Foo;
+    impl Fooable for Foo {
+        fn foo(&self) -> i32 {
+            42
+        }
+    }
+    impl ServiceInitializable for Foo {
+        fn init(_: &ServiceRegistry) -> Self {
+            Foo
+        }
+    }
+    impl ServiceLinkable<dyn Fooable> for Foo {
+        fn as_link(self: Arc<Self>) -> Arc<dyn Fooable> {
+            self
+        }
+    }
+
+    struct Bar(Arc<dyn Fooable>);
+    impl Bar {
+        fn magic(&self) -> i32 {
+            (self.0.foo() * 191) / 6
+        }
+    }
+    impl ServiceInitializable for Bar {
+        fn init(registry: &ServiceRegistry) -> Self {
+            Bar(registry.get())
+        }
+    }
+
+    #[test]
+    fn can_register_and_get() {
+        let mut registry = ServiceRegistry::default();
+        registry
+            // Register a `Foo` implementation for a `Fooable` component.
+            .register_as::<Foo, dyn Fooable>()
+            // Register a concrete `Bar` component.
+            .register::<Bar>();
+
+        assert_eq!(registry.get::<dyn Fooable>().foo(), 42);
+        assert_eq!(registry.get::<Bar>().magic(), 1337);
+    }
+}

--- a/shared/src/sources/uniswap/pool_fetching.rs
+++ b/shared/src/sources/uniswap/pool_fetching.rs
@@ -17,6 +17,7 @@ const POOL_SWAP_GAS_COST: usize = 60_000;
 /// `reserve_a` refers to the reserve of the excluded token.
 type RelativeReserves = (U256, U256, H160);
 
+#[mockall::automock]
 #[async_trait::async_trait]
 pub trait PoolFetching: Send + Sync {
     async fn fetch(&self, token_pairs: HashSet<TokenPair>, at_block: Block) -> Result<Vec<Pool>>;


### PR DESCRIPTION
This PR implements adds an implementation for a simple component registry. This is a very simple way to do dependency injection all the while keeping all components in a single registry.

The main motivation here is:
- Passing down components to nested components requires piping parameters all the way down to where components are registered.
- Some top level component creation functions take a huge amount of parameters, for example [`solver::create` takes 16](https://github.com/gnosis/gp-v2-services/blob/e6d9e1e336266b8c86d8de40b2c21097ee0fc7f8/solver/src/solver.rs#L66-L83)
- Reduces friction of re-using shared components across different parts of code as they are easily accessible (`registry::get<dyn MyComponentTrait>()`). Especially if service components are created with something like `MyComponentImplementation::new(&registry)`, then adding a new field `Arc<dyn SomeSharedComponentTrait>` can be done entirely locally to the component implementation.
- Is actually fairly small amount of code without the need for `unsafe`.

There are still some TODOs:
- `async` and `Result` intiailzation
- Better ergonomics with mocks (maybe even have a way to create a lazy "Mock" service registry), although I don't entirely see it to be that useful for mocking and testing.

Let me know what y'all think. It might be complete overkill for our project :stuck_out_tongue:. This is partially inspired from the ASP.NET Core dependency injection system which I have used in the past and found to be extremely useful when building large services instead of doing manual dependency injection.

### Test Plan

Added a test demonstrating why it may useful. Also added a sample for the `BaselinePriceEstimator` for how it would be able to construct itself from a service registry.
