### PR TITLE
Filter orders that have same buy and sell token

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -655,6 +655,7 @@ components:
               TransferEthToContract,
               UnsupportedToken,
               WrongOwner,
+              SameBuyAndSellToken,
             ]
         description:
           type: string

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -74,6 +74,13 @@ pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
             ),
             StatusCode::BAD_REQUEST,
         ),
+        Ok(AddOrderResult::SameBuyAndSellToken) => (
+            super::error(
+                "SameBuyAndSellToken",
+                "Buy token is the same as the sell token.",
+            ),
+            StatusCode::BAD_REQUEST,
+        ),
         Err(_) => (super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR),
     };
     warp::reply::with_status(body, status_code)

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -35,6 +35,7 @@ pub enum AddOrderResult {
     InsufficientFee,
     UnsupportedToken(H160),
     TransferEthToContract,
+    SameBuyAndSellToken,
 }
 
 #[derive(Debug)]
@@ -81,6 +82,9 @@ impl Orderbook {
 
     pub async fn add_order(&self, payload: OrderCreationPayload) -> Result<AddOrderResult> {
         let order = payload.order_creation;
+        if order.sell_token == order.buy_token {
+            return Ok(AddOrderResult::SameBuyAndSellToken);
+        }
         if order.valid_to
             < shared::time::now_in_epoch_seconds() + self.min_order_validity_period.as_secs() as u32
         {


### PR DESCRIPTION
This doesn't make sense and caused a panic because we have a code path
that is unwrapping `order_creation.token_pair()` which fails if the
tokens are the same.
It is reasonable to have this as an invariant so we filter it out on
order creation.

### Test Plan
didn't add test because the check is obvious enough
