### PR TITLE
Add support for disabling specific ParaSwap DEXs

### DIFF
--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -168,6 +168,12 @@ struct Arguments {
     /// The slippage tolerance we apply to the price quoted by Paraswap
     #[structopt(long, env, default_value = "10")]
     paraswap_slippage_bps: usize,
+
+    /// The list of disabled ParaSwap DEXs. By default, the `ParaSwapPool4`
+    /// DEX (representing a private market maker) is disabled as it increases
+    /// price by 1% if built transactions don't actually get executed.
+    #[structopt(long, env, default_value = "ParaSwapPool4", use_delimiter = true)]
+    disabled_paraswap_dexs: Vec<String>,
 }
 
 #[tokio::main]
@@ -327,6 +333,7 @@ async fn main() {
         args.min_order_size_one_inch,
         args.disabled_one_inch_protocols,
         args.paraswap_slippage_bps,
+        args.disabled_paraswap_dexs,
     )
     .expect("failure creating solvers");
     let liquidity_collector = LiquidityCollector {

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -85,6 +85,7 @@ pub fn create(
     min_order_size_one_inch: U256,
     disabled_one_inch_protocols: Vec<String>,
     paraswap_slippage_bps: usize,
+    disabled_paraswap_dexs: Vec<String>,
 ) -> Result<Vec<Box<dyn Solver>>> {
     // Tiny helper function to help out with type inference. Otherwise, all
     // `Box::new(...)` expressions would have to be cast `as Box<dyn Solver>`.
@@ -163,6 +164,7 @@ pub fn create(
                 account.address(),
                 token_info_fetcher.clone(),
                 paraswap_slippage_bps,
+                disabled_paraswap_dexs.clone(),
             ))),
         })
         .collect()


### PR DESCRIPTION
This PR adds support for disabling specific ParaSwap DEXs when querying for a price and building a transaction with the ParaSwap solver.

This was added in order to temporarily disable `ParaSwapPool4` private market maker as we are running into issues with settling solutions when they are part of the ParaSwap route. The reason for this is that when we build the ParaSwap transaction, we ask the private market maker for a binding quote. When we end up not using that quote (because the ParaSwap route loses in the price competition) then the solver address that is making the request to build the transaction gets flagged by the PMM, who eventually charges an additional 1% on the binding quote because of the repeatedly unused requests. This additional 1% causes the settlement to fail because the price does not match the settlement price.

This is an imperfect solution, but its a temporary band-aid to alleviate the problem until we can implement a better, but much more involved, solution. The issue we have now is that we require the calldata before deciding the winning solution. This means that we have to request a binding quote from the PMM before we can determine whether or not we want to use it. A long term fix for this, would be to move the solution competition to before the the calldata is built, and then call the transaction builder ParaSwap API only if it is the winning settlement, thus preventing these kinds of issues in the future. Created #828.

Tagging @anxolin as this might affect front end price estimation, as the quoted price from ParaSwap may not actually be usable by the solver since we do not have access to some PMM liquidity in the services.

### Test Plan

Adjust the unit tests, and ran manual tests with `cargo test -p solver -- paraswap_solver --ignored`.
