### PR TITLE
Consider pool limits in BaselineSolvable computation

### DIFF
--- a/shared/src/baseline_solver.rs
+++ b/shared/src/baseline_solver.rs
@@ -304,8 +304,8 @@ mod tests {
 
         let path = vec![sell_token, intermediate, buy_token];
         let pools = [
-            Pool::uniswap(TokenPair::new(path[0], path[1]).unwrap(), (10_000, 10_000)),
-            Pool::uniswap(TokenPair::new(path[1], path[2]).unwrap(), (20_000, 5_000)),
+            Pool::uniswap(TokenPair::new(path[0], path[1]).unwrap(), (100, 100)),
+            Pool::uniswap(TokenPair::new(path[1], path[2]).unwrap(), (200, 50)),
         ];
         let pools = hashmap! {
             pools[0].tokens => vec![pools[0]],
@@ -321,7 +321,7 @@ mod tests {
             estimate_sell_amount(10.into(), &path, &pools)
                 .unwrap()
                 .value,
-            42.into()
+            105.into()
         );
     }
 

--- a/shared/src/baseline_solver.rs
+++ b/shared/src/baseline_solver.rs
@@ -304,8 +304,8 @@ mod tests {
 
         let path = vec![sell_token, intermediate, buy_token];
         let pools = [
-            Pool::uniswap(TokenPair::new(path[0], path[1]).unwrap(), (100, 100)),
-            Pool::uniswap(TokenPair::new(path[1], path[2]).unwrap(), (200, 50)),
+            Pool::uniswap(TokenPair::new(path[0], path[1]).unwrap(), (10_000, 10_000)),
+            Pool::uniswap(TokenPair::new(path[1], path[2]).unwrap(), (20_000, 5_000)),
         ];
         let pools = hashmap! {
             pools[0].tokens => vec![pools[0]],
@@ -321,7 +321,7 @@ mod tests {
             estimate_sell_amount(10.into(), &path, &pools)
                 .unwrap()
                 .value,
-            105.into()
+            42.into()
         );
     }
 

--- a/shared/src/price_estimate.rs
+++ b/shared/src/price_estimate.rs
@@ -731,15 +731,9 @@ mod tests {
 
         // Direct trade is better when selling token_b
         let pools = vec![
-            Pool::uniswap(TokenPair::new(token_a, token_b).unwrap(), (10_000, 10_000)),
-            Pool::uniswap(
-                TokenPair::new(token_a, intermediate).unwrap(),
-                (9_000, 10_000),
-            ),
-            Pool::uniswap(
-                TokenPair::new(intermediate, token_b).unwrap(),
-                (9_000, 10_000),
-            ),
+            Pool::uniswap(TokenPair::new(token_a, token_b).unwrap(), (1000, 1000)),
+            Pool::uniswap(TokenPair::new(token_a, intermediate).unwrap(), (900, 1000)),
+            Pool::uniswap(TokenPair::new(intermediate, token_b).unwrap(), (900, 1000)),
         ];
 
         let pool_fetcher = Arc::new(FakePoolFetcher(pools));
@@ -836,23 +830,17 @@ mod tests {
             // gas price.
             Pool::uniswap(
                 TokenPair::new(native, sell).unwrap(),
-                (100_000_000_000_000, 2_000_000),
+                (100_000_000_000, 2_000),
             ),
             Pool::uniswap(
                 TokenPair::new(native, buy).unwrap(),
-                (100_000_000_000_000, 1_000_000),
+                (100_000_000_000, 1_000),
             ),
             // Direct connection 1 to 3.
-            Pool::uniswap(TokenPair::new(sell, buy).unwrap(), (1_000_000, 800_000)),
+            Pool::uniswap(TokenPair::new(sell, buy).unwrap(), (1000, 800)),
             // Intermediate from 1 to 2 to 2, cheaper than direct.
-            Pool::uniswap(
-                TokenPair::new(sell, intermediate).unwrap(),
-                (1_000_000, 1_000_000),
-            ),
-            Pool::uniswap(
-                TokenPair::new(intermediate, buy).unwrap(),
-                (1_000_000, 1_000_000),
-            ),
+            Pool::uniswap(TokenPair::new(sell, intermediate).unwrap(), (1000, 1000)),
+            Pool::uniswap(TokenPair::new(intermediate, buy).unwrap(), (1000, 1000)),
         ];
 
         let pool_fetcher = Arc::new(FakePoolFetcher(pools.clone()));

--- a/shared/src/price_estimate.rs
+++ b/shared/src/price_estimate.rs
@@ -432,7 +432,7 @@ mod tests {
         let token_b = H160::from_low_u64_be(2);
         let pool = Pool::uniswap(
             TokenPair::new(token_a, token_b).unwrap(),
-            (10u128.pow(30), 10u128.pow(29)),
+            (10u128.pow(28), 10u128.pow(27)),
         );
 
         let pool_fetcher = Arc::new(FakePoolFetcher(vec![pool]));
@@ -499,7 +499,7 @@ mod tests {
         let token_b = H160::from_low_u64_be(2);
         let pool = Pool::uniswap(
             TokenPair::new(token_a, token_b).unwrap(),
-            (10u128.pow(30), 10u128.pow(29)),
+            (10u128.pow(28), 10u128.pow(27)),
         );
 
         let pool_fetcher = Arc::new(FakePoolFetcher(vec![pool]));
@@ -529,11 +529,11 @@ mod tests {
         let token_c = H160::from_low_u64_be(3);
         let pool_ab = Pool::uniswap(
             TokenPair::new(token_a, token_b).unwrap(),
-            (10u128.pow(30), 10u128.pow(29)),
+            (10u128.pow(28), 10u128.pow(27)),
         );
         let pool_bc = Pool::uniswap(
             TokenPair::new(token_b, token_c).unwrap(),
-            (10u128.pow(30), 10u128.pow(29)),
+            (10u128.pow(28), 10u128.pow(27)),
         );
 
         let pool_fetcher = Arc::new(FakePoolFetcher(vec![pool_ab, pool_bc]));
@@ -583,7 +583,7 @@ mod tests {
         let token_b = H160::from_low_u64_be(2);
         let pool_ab = Pool::uniswap(
             TokenPair::new(token_a, token_b).unwrap(),
-            (10u128.pow(30), 10u128.pow(29)),
+            (10u128.pow(28), 10u128.pow(27)),
         );
         let pool_fetcher = Arc::new(FakePoolFetcher(vec![pool_ab]));
         let bad_token = Arc::new(ListBasedDetector::deny_list(vec![token_a]));
@@ -646,7 +646,7 @@ mod tests {
 
         let pool = Pool::uniswap(
             TokenPair::new(token_a, token_b).unwrap(),
-            (10u128.pow(30), 10u128.pow(29)),
+            (10u128.pow(28), 10u128.pow(27)),
         );
 
         let pool_fetcher = Arc::new(FakePoolFetcher(vec![pool]));
@@ -731,9 +731,15 @@ mod tests {
 
         // Direct trade is better when selling token_b
         let pools = vec![
-            Pool::uniswap(TokenPair::new(token_a, token_b).unwrap(), (1000, 1000)),
-            Pool::uniswap(TokenPair::new(token_a, intermediate).unwrap(), (900, 1000)),
-            Pool::uniswap(TokenPair::new(intermediate, token_b).unwrap(), (900, 1000)),
+            Pool::uniswap(TokenPair::new(token_a, token_b).unwrap(), (10_000, 10_000)),
+            Pool::uniswap(
+                TokenPair::new(token_a, intermediate).unwrap(),
+                (9_000, 10_000),
+            ),
+            Pool::uniswap(
+                TokenPair::new(intermediate, token_b).unwrap(),
+                (9_000, 10_000),
+            ),
         ];
 
         let pool_fetcher = Arc::new(FakePoolFetcher(pools));
@@ -830,17 +836,23 @@ mod tests {
             // gas price.
             Pool::uniswap(
                 TokenPair::new(native, sell).unwrap(),
-                (100_000_000_000, 2_000),
+                (100_000_000_000_000, 2_000_000),
             ),
             Pool::uniswap(
                 TokenPair::new(native, buy).unwrap(),
-                (100_000_000_000, 1_000),
+                (100_000_000_000_000, 1_000_000),
             ),
             // Direct connection 1 to 3.
-            Pool::uniswap(TokenPair::new(sell, buy).unwrap(), (1000, 800)),
+            Pool::uniswap(TokenPair::new(sell, buy).unwrap(), (1_000_000, 800_000)),
             // Intermediate from 1 to 2 to 2, cheaper than direct.
-            Pool::uniswap(TokenPair::new(sell, intermediate).unwrap(), (1000, 1000)),
-            Pool::uniswap(TokenPair::new(intermediate, buy).unwrap(), (1000, 1000)),
+            Pool::uniswap(
+                TokenPair::new(sell, intermediate).unwrap(),
+                (1_000_000, 1_000_000),
+            ),
+            Pool::uniswap(
+                TokenPair::new(intermediate, buy).unwrap(),
+                (1_000_000, 1_000_000),
+            ),
         ];
 
         let pool_fetcher = Arc::new(FakePoolFetcher(pools.clone()));

--- a/shared/src/sources/uniswap/pool_fetching.rs
+++ b/shared/src/sources/uniswap/pool_fetching.rs
@@ -422,6 +422,8 @@ mod tests {
 
     #[test]
     fn check_final_reserve_limits() {
+        // final out reserve too low
+        assert!(check_final_reserves(0.into(), 1.into(), 1_000_000.into(), 0.into()).is_none());
         // final in reserve too high
         assert!(
             check_final_reserves(1.into(), 0.into(), *POOL_MAX_RESERVES, 1_000_000.into())


### PR DESCRIPTION
This PR modifies the Uniswap pool `BaselineSolvable` implementation to consider pool reserve limits when computing input and output amounts.


### Test Plan

Added new tests for new checking method, modified existing tests to be in valid pool range.
