### PR TITLE
Fix BaselineSolvable parameters for weighted pool

### DIFF
--- a/shared/src/baseline_solver.rs
+++ b/shared/src/baseline_solver.rs
@@ -12,10 +12,10 @@ type PathCandidate = Vec<H160>;
 
 pub trait BaselineSolvable {
     // Given the desired output token, the amount and token input, return the expected amount of output token.
-    fn get_amount_out(&self, out_token: H160, in_amount: U256, in_token: H160) -> Option<U256>;
+    fn get_amount_out(&self, out_token: H160, input: (U256, H160)) -> Option<U256>;
 
     // Given the input token, the amount and token we want output, return the required amount of input token that needs to be provided.
-    fn get_amount_in(&self, in_token: H160, out_amount: U256, out_token: H160) -> Option<U256>;
+    fn get_amount_in(&self, in_token: H160, out: (U256, H160)) -> Option<U256>;
 
     // Returns the current price as defined in https://www.investopedia.com/terms/c/currencypair.asp#mntl-sc-block_1-0-18.
     // E.g. for the EUR/USD pool with balances 100 (base, EUR) & 125 (quote, USD), the spot price is 125/100.
@@ -63,7 +63,7 @@ pub fn estimate_buy_amount<'a, L: BaselineSolvable>(
                     .map(|liquidity| {
                         (
                             liquidity,
-                            liquidity.get_amount_out(*current, amount, previous),
+                            liquidity.get_amount_out(*current, (amount, previous)),
                         )
                     })
                     .max_by(|(_, amount_a), (_, amount_b)| amount_a.cmp(&amount_b))?;
@@ -99,7 +99,7 @@ pub fn estimate_sell_amount<'a, L: BaselineSolvable>(
                     .map(|liquidity| {
                         (
                             liquidity,
-                            liquidity.get_amount_in(*current, amount, previous),
+                            liquidity.get_amount_in(*current, (amount, previous)),
                         )
                     })
                     .min_by(|(_, amount_a), (_, amount_b)| {

--- a/shared/src/price_estimate.rs
+++ b/shared/src/price_estimate.rs
@@ -678,7 +678,7 @@ mod tests {
         let amount_in = amount_in.into();
         BigRational::new(
             amount_in.to_big_int(),
-            pool.get_amount_out(token_out, amount_in, token_in)
+            pool.get_amount_out(token_out, (amount_in, token_in))
                 .unwrap()
                 .as_u128()
                 .into(),

--- a/shared/src/sources/balancer/swap.rs
+++ b/shared/src/sources/balancer/swap.rs
@@ -87,7 +87,7 @@ impl BaselineSolvable for WeightedPoolRef<'_> {
         .flatten()
     }
 
-    fn get_amount_in(&self, out_token: H160, out_amount: U256, in_token: H160) -> Option<U256> {
+    fn get_amount_in(&self, in_token: H160, out_amount: U256, out_token: H160) -> Option<U256> {
         // Note that the output of this function does not depend on the pool
         // specialization. All contract branches compute this amount with:
         // https://github.com/balancer-labs/balancer-v2-monorepo/blob/6c9e24e22d0c46cca6dd15861d3d33da61a60b98/pkg/core/contracts/pools/BaseMinimalSwapInfoPool.sol#L75-L88
@@ -243,7 +243,7 @@ mod tests {
         );
 
         assert_eq!(
-            b.get_amount_in(tusd, 5_000_000_i128.into(), weth).unwrap(),
+            b.get_amount_in(weth, 5_000_000_i128.into(), tusd).unwrap(),
             1_225_715_511_430_411_i128.into()
         );
     }

--- a/shared/src/sources/balancer/swap.rs
+++ b/shared/src/sources/balancer/swap.rs
@@ -66,7 +66,7 @@ impl WeightedPoolRef<'_> {
 }
 
 impl BaselineSolvable for WeightedPoolRef<'_> {
-    fn get_amount_out(&self, out_token: H160, in_amount: U256, in_token: H160) -> Option<U256> {
+    fn get_amount_out(&self, out_token: H160, (in_amount, in_token): (U256, H160)) -> Option<U256> {
         // Note that the output of this function does not depend on the pool
         // specialization. All contract branches compute this amount with:
         // https://github.com/balancer-labs/balancer-v2-monorepo/blob/6c9e24e22d0c46cca6dd15861d3d33da61a60b98/pkg/core/contracts/pools/BaseMinimalSwapInfoPool.sol#L62-L75
@@ -87,7 +87,7 @@ impl BaselineSolvable for WeightedPoolRef<'_> {
         .flatten()
     }
 
-    fn get_amount_in(&self, in_token: H160, out_amount: U256, out_token: H160) -> Option<U256> {
+    fn get_amount_in(&self, in_token: H160, (out_amount, out_token): (U256, H160)) -> Option<U256> {
         // Note that the output of this function does not depend on the pool
         // specialization. All contract branches compute this amount with:
         // https://github.com/balancer-labs/balancer-v2-monorepo/blob/6c9e24e22d0c46cca6dd15861d3d33da61a60b98/pkg/core/contracts/pools/BaseMinimalSwapInfoPool.sol#L75-L88
@@ -152,14 +152,12 @@ impl WeightedPool {
 }
 
 impl BaselineSolvable for WeightedPool {
-    fn get_amount_out(&self, out_token: H160, in_amount: U256, in_token: H160) -> Option<U256> {
-        self.as_pool_ref()
-            .get_amount_out(out_token, in_amount, in_token)
+    fn get_amount_out(&self, out_token: H160, input: (U256, H160)) -> Option<U256> {
+        self.as_pool_ref().get_amount_out(out_token, input)
     }
 
-    fn get_amount_in(&self, in_token: H160, out_amount: U256, out_token: H160) -> Option<U256> {
-        self.as_pool_ref()
-            .get_amount_in(in_token, out_amount, out_token)
+    fn get_amount_in(&self, in_token: H160, output: (U256, H160)) -> Option<U256> {
+        self.as_pool_ref().get_amount_in(in_token, output)
     }
 
     fn get_spot_price(&self, base_token: H160, quote_token: H160) -> Option<BigRational> {
@@ -222,7 +220,7 @@ mod tests {
         );
 
         assert_eq!(
-            b.get_amount_out(crv, 227_937_106_828_652_254_870_i128.into(), sdvecrv_dao)
+            b.get_amount_out(crv, (227_937_106_828_652_254_870_i128.into(), sdvecrv_dao))
                 .unwrap(),
             488_192_591_864_344_551_330_i128.into()
         );
@@ -243,7 +241,8 @@ mod tests {
         );
 
         assert_eq!(
-            b.get_amount_in(weth, 5_000_000_i128.into(), tusd).unwrap(),
+            b.get_amount_in(weth, (5_000_000_i128.into(), tusd))
+                .unwrap(),
             1_225_715_511_430_411_i128.into()
         );
     }

--- a/shared/src/sources/uniswap/pool_fetching.rs
+++ b/shared/src/sources/uniswap/pool_fetching.rs
@@ -136,7 +136,7 @@ impl Pool {
 }
 
 impl BaselineSolvable for Pool {
-    fn get_amount_out(&self, out_token: H160, in_amount: U256, in_token: H160) -> Option<U256> {
+    fn get_amount_out(&self, out_token: H160, (in_amount, in_token): (U256, H160)) -> Option<U256> {
         self.get_amount_out(in_token, in_amount)
             .map(|(out_amount, token)| {
                 assert_eq!(token, out_token);
@@ -144,7 +144,7 @@ impl BaselineSolvable for Pool {
             })
     }
 
-    fn get_amount_in(&self, in_token: H160, out_amount: U256, out_token: H160) -> Option<U256> {
+    fn get_amount_in(&self, in_token: H160, (out_amount, out_token): (U256, H160)) -> Option<U256> {
         self.get_amount_in(out_token, out_amount)
             .map(|(in_amount, token)| {
                 assert_eq!(token, in_token);

--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -55,25 +55,21 @@ enum AmmOrder {
 }
 
 impl BaselineSolvable for Amm {
-    fn get_amount_out(&self, out_token: H160, in_amount: U256, in_token: H160) -> Option<U256> {
+    fn get_amount_out(&self, out_token: H160, input: (U256, H160)) -> Option<U256> {
         match &self.order {
-            AmmOrder::ConstantProduct(order) => {
-                amm_to_pool(order).get_amount_out(out_token, in_amount, in_token)
-            }
+            AmmOrder::ConstantProduct(order) => amm_to_pool(order).get_amount_out(out_token, input),
             AmmOrder::WeightedProduct(order) => amm_to_weighted_pool(order)
                 .ok()?
-                .get_amount_out(out_token, in_amount, in_token),
+                .get_amount_out(out_token, input),
         }
     }
 
-    fn get_amount_in(&self, in_token: H160, out_amount: U256, out_token: H160) -> Option<U256> {
+    fn get_amount_in(&self, in_token: H160, output: (U256, H160)) -> Option<U256> {
         match &self.order {
-            AmmOrder::ConstantProduct(order) => {
-                amm_to_pool(&order).get_amount_in(in_token, out_amount, out_token)
-            }
+            AmmOrder::ConstantProduct(order) => amm_to_pool(&order).get_amount_in(in_token, output),
             AmmOrder::WeightedProduct(order) => amm_to_weighted_pool(order)
                 .ok()?
-                .get_amount_in(in_token, out_amount, out_token),
+                .get_amount_in(in_token, output),
         }
     }
 
@@ -215,7 +211,7 @@ impl Solution {
         for amm in self.path {
             let buy_token = amm.tokens.other(&sell_token).expect("Inconsistent path");
             let buy_amount = amm
-                .get_amount_out(buy_token, sell_amount, sell_token)
+                .get_amount_out(buy_token, (sell_amount, sell_token))
                 .expect("Path was found, so amount must be calculateable");
             let execution = AmmOrderExecution {
                 input: (sell_token, sell_amount),


### PR DESCRIPTION
This PR fixes the parameter order for the Balancer V2 weighted pool `BaselineSolvable` implementation that was causing the panics in the Kaffeekranchen today.

I've also slightly modified the `BaselineSolvable` interface to make this mistake less likely in the future.

### Test Plan

Exiting unit tests
