### PR TITLE
Improve `Order` debug implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,6 +1531,7 @@ version = "0.1.0"
 dependencies = [
  "bigdecimal",
  "chrono",
+ "derivative",
  "enum-utils",
  "ethabi",
  "hex",

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 bigdecimal = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
+derivative = "2.2"
 ethabi = "14.0"
 enum-utils = "0.1"
 hex = { version = "0.4", default-features = false }


### PR DESCRIPTION
This PR just modifies the `Order` debug implementation so that its a bit easier to read by:
- writing the `app_data` in hex format
- writing `BigUint` values in decimal format.

### Test Plan

Small `ignore` test to see what it looks like:
```
$ cargo test -p model -- --nocapture --ignored debug_order_data
...
[model/src/order.rs:695] Order::default() = Order {
    order_meta_data: OrderMetaData {
        creation_date: 2021-07-09T16:58:25.695069509Z,
        owner: 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf,
        uid: 0xf97a6cdce9bd7a8381073d85177f74c238a8efa0a548a43584bbdac67cfc10487e5f4552091a69125d5dfcb7b8c2659029395bdfffffffff,
        available_balance: None,
        executed_buy_amount: 0,
        executed_sell_amount: 0,
        executed_sell_amount_before_fees: 0,
        executed_fee_amount: 0,
        invalidated: false,
        status: Open,
    },
    order_creation: OrderCreation {
        sell_token: 0x0000000000000000000000000000000000000000,
        buy_token: 0x0000000000000000000000000000000000000000,
        receiver: None,
        sell_amount: 0,
        buy_amount: 0,
        valid_to: 4294967295,
        app_data: 0x0000000000000000000000000000000000000000000000000000000000000000,
        fee_amount: 0,
        kind: Buy,
        partially_fillable: false,
        signature: Signature {
            r: 0x167d7164f75d6df2cc014b0fc431903561929bad0c06116deccea87a90c872f6,
            s: 0x12a027fb4c0984f68500129f9f8e10f8fbe6dc0034ce4d41b0e5932c5ab1ec48,
            v: 28,
        },
        signing_scheme: Eip712,
    },
}
...
```

<details><summary>Compared to before:</summary>

```
[model/src/order.rs:687] Order::default() = Order {
    order_meta_data: OrderMetaData {
        creation_date: 2021-07-09T17:01:39.996280311Z,
        owner: 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf,
        uid: 0xf97a6cdce9bd7a8381073d85177f74c238a8efa0a548a43584bbdac67cfc10487e5f4552091a69125d5dfcb7b8c2659029395bdfffffffff,
        available_balance: None,
        executed_buy_amount: BigUint {
            data: [],
        },
        executed_sell_amount: BigUint {
            data: [],
        },
        executed_sell_amount_before_fees: BigUint {
            data: [],
        },
        executed_fee_amount: BigUint {
            data: [],
        },
        invalidated: false,
        status: Open,
    },
    order_creation: OrderCreation {
        sell_token: 0x0000000000000000000000000000000000000000,
        buy_token: 0x0000000000000000000000000000000000000000,
        receiver: None,
        sell_amount: 0,
        buy_amount: 0,
        valid_to: 4294967295,
        app_data: [
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
        ],
        fee_amount: 0,
        kind: Buy,
        partially_fillable: false,
        signature: Signature {
            r: 0x167d7164f75d6df2cc014b0fc431903561929bad0c06116deccea87a90c872f6,
            s: 0x12a027fb4c0984f68500129f9f8e10f8fbe6dc0034ce4d41b0e5932c5ab1ec48,
            v: 28,
        },
        signing_scheme: Eip712,
    },
}
```

</details>