### PR TITLE
HTTP solver - dont pass empty pools

### DIFF
--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -278,11 +278,15 @@ impl HttpSolver {
         let weighted_product_orders = self.map_amm_orders_for_solver(orders.2);
         let token_models = self.token_models(&token_infos, &price_estimates);
         let order_models = self.order_models(&limit_orders, gas_price);
-        let amm_models = self.amm_models(
-            &constant_product_orders,
-            &weighted_product_orders,
-            gas_price,
-        );
+        let amm_models = self
+            .amm_models(
+                &constant_product_orders,
+                &weighted_product_orders,
+                gas_price,
+            )
+            .into_iter()
+            .filter(|(_, model)| !model.is_empty())
+            .collect();
         let model = BatchAuctionModel {
             tokens: token_models,
             orders: order_models,

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -285,7 +285,7 @@ impl HttpSolver {
                 gas_price,
             )
             .into_iter()
-            .filter(|(_, model)| !model.is_empty())
+            .filter(|(_, model)| !model.has_sufficient_reserves())
             .collect();
         let model = BatchAuctionModel {
             tokens: token_models,

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -285,7 +285,7 @@ impl HttpSolver {
                 gas_price,
             )
             .into_iter()
-            .filter(|(_, model)| !model.has_sufficient_reserves())
+            .filter(|(_, model)| model.has_sufficient_reserves())
             .collect();
         let model = BatchAuctionModel {
             tokens: token_models,

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -41,6 +41,23 @@ pub struct AmmModel {
     pub mandatory: bool,
 }
 
+impl AmmModel {
+    pub fn is_empty(&self) -> bool {
+        // Note that we consider a pool non-empty if any of the token balances is positive
+        // (while the http solver requires at least two)
+        match &self.parameters {
+            AmmParameters::ConstantProduct(parameters) => parameters
+                .reserves
+                .values()
+                .any(|balance| balance.gt(&U256::zero())),
+            AmmParameters::WeightedProduct(parameters) => parameters
+                .reserves
+                .values()
+                .any(|data| data.balance.gt(&U256::zero())),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum AmmParameters {

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -42,17 +42,17 @@ pub struct AmmModel {
 }
 
 impl AmmModel {
-    pub fn is_empty(&self) -> bool {
+    pub fn has_sufficient_reserves(&self) -> bool {
         let non_zero_balance_count = match &self.parameters {
             AmmParameters::ConstantProduct(parameters) => parameters
                 .reserves
                 .values()
-                .filter(|balance| balance.gt(&&U256::zero()))
+                .filter(|&balance| balance.gt(&U256::zero()))
                 .count(),
             AmmParameters::WeightedProduct(parameters) => parameters
                 .reserves
                 .values()
-                .filter(|data| data.balance.gt(&&U256::zero()))
+                .filter(|&data| data.balance.gt(&U256::zero()))
                 .count(),
         };
         // HTTP solver requires at least two non-zero reserves.

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -43,18 +43,20 @@ pub struct AmmModel {
 
 impl AmmModel {
     pub fn is_empty(&self) -> bool {
-        // Note that we consider a pool non-empty if any of the token balances is positive
-        // (while the http solver requires at least two)
-        match &self.parameters {
+        let non_zero_balance_count = match &self.parameters {
             AmmParameters::ConstantProduct(parameters) => parameters
                 .reserves
                 .values()
-                .any(|balance| balance.gt(&U256::zero())),
+                .filter(|balance| balance.gt(&&U256::zero()))
+                .count(),
             AmmParameters::WeightedProduct(parameters) => parameters
                 .reserves
                 .values()
-                .any(|data| data.balance.gt(&U256::zero())),
-        }
+                .filter(|data| data.balance.gt(&&U256::zero()))
+                .count(),
+        };
+        // HTTP solver requires at least two non-zero reserves.
+        non_zero_balance_count >= 2
     }
 }
 


### PR DESCRIPTION
When testing we found that some balancer pools were empty and this made the http solver mad.