### PR TITLE
[Balancer] BaselineSolvable - Check in/out amounts can be reciprocated

### DIFF
--- a/shared/src/sources/balancer/swap.rs
+++ b/shared/src/sources/balancer/swap.rs
@@ -94,13 +94,10 @@ impl WeightedPoolRef<'_> {
         in_token: H160,
         (out_amount, out_token): (U256, H160),
     ) -> Option<U256> {
+        let in_amount = self.unchecked_get_amount_in(in_token, (out_amount, out_token))?;
         // We double check that resulting amount in can symmetrically provide an amount out.
-        if let Some(in_amount) = self.unchecked_get_amount_in(in_token, (out_amount, out_token)) {
-            return self
-                .unchecked_get_amount_out(out_token, (in_amount, in_token))
-                .map(|_| in_amount);
-        };
-        None
+        self.unchecked_get_amount_out(out_token, (in_amount, in_token))?;
+        Some(in_amount)
     }
 
     fn unchecked_get_amount_out(
@@ -133,13 +130,10 @@ impl WeightedPoolRef<'_> {
         out_token: H160,
         (in_amount, in_token): (U256, H160),
     ) -> Option<U256> {
+        let out_amount = self.unchecked_get_amount_out(out_token, (in_amount, in_token))?;
         // We double check that resulting amount out can symmetrically provide an amount in.
-        if let Some(out_amount) = self.unchecked_get_amount_out(out_token, (in_amount, in_token)) {
-            return self
-                .unchecked_get_amount_in(in_token, (out_amount, out_token))
-                .map(|_| out_amount);
-        };
-        None
+        self.unchecked_get_amount_in(in_token, (out_amount, out_token))?;
+        Some(out_amount)
     }
 }
 

--- a/shared/src/sources/balancer/swap/weighted_math.rs
+++ b/shared/src/sources/balancer/swap/weighted_math.rs
@@ -23,7 +23,8 @@ pub fn calc_out_given_in(
     amount_in: Bfp,
 ) -> Result<Bfp, Error> {
     if amount_in > balance_in.mul_down(*MAX_IN_RATIO)? {
-        return Err(Error::MaxInRatio);
+        todo!("THIS IS WHERE ITS ERRORING");
+        //return Err(Error::MaxInRatio);
     }
 
     let denominator = balance_in.add(amount_in)?;

--- a/shared/src/sources/balancer/swap/weighted_math.rs
+++ b/shared/src/sources/balancer/swap/weighted_math.rs
@@ -23,8 +23,7 @@ pub fn calc_out_given_in(
     amount_in: Bfp,
 ) -> Result<Bfp, Error> {
     if amount_in > balance_in.mul_down(*MAX_IN_RATIO)? {
-        todo!("THIS IS WHERE ITS ERRORING");
-        //return Err(Error::MaxInRatio);
+        return Err(Error::MaxInRatio);
     }
 
     let denominator = balance_in.add(amount_in)?;

--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -531,16 +531,6 @@ mod tests {
                 fee: Ratio::new(3, 1000),
                 settlement_handling: CapturingSettlementHandler::arc(),
             }),
-            Liquidity::ConstantProduct(ConstantProductOrder {
-                tokens: TokenPair::new(
-                    addr!("c778417e063141139fce010982780140aa0cd5ab"),
-                    addr!("e4b9895e638f54c3bee2a3a78d6a297cc03e0353"),
-                )
-                .unwrap(),
-                reserves: (8_488_677_530_563_931_705, 75_408_146_511_005_299_032),
-                fee: Ratio::new(3, 1000),
-                settlement_handling: CapturingSettlementHandler::arc(),
-            }),
             Liquidity::WeightedProduct(WeightedProductOrder {
                 reserves: hashmap! {
                     addr!("c778417e063141139fce010982780140aa0cd5ab") => PoolTokenState {

--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -508,7 +508,7 @@ mod tests {
 
     #[test]
     fn does_not_panic_when_building_solution() {
-        // Regression test for https://github.com/gnosis/gp-v2-services/issues/
+        // Regression test for https://github.com/gnosis/gp-v2-services/issues/838
         let liquidity = vec![
             Liquidity::Limit(LimitOrder {
                 sell_token: addr!("e4b9895e638f54c3bee2a3a78d6a297cc03e0353"),
@@ -519,7 +519,7 @@ mod tests {
                 partially_fillable: false,
                 fee_amount: 3_429_706_374_800_940_u128.into(),
                 settlement_handling: CapturingSettlementHandler::arc(),
-                id: "Crash Bandicoop".to_string(),
+                id: "Crash Bandicoot".to_string(),
             }),
             Liquidity::ConstantProduct(ConstantProductOrder {
                 tokens: TokenPair::new(

--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -551,6 +551,6 @@ mod tests {
 
         let solver =
             BaselineSolver::new(hashset![addr!("c778417e063141139fce010982780140aa0cd5ab")]);
-        assert_eq!(solver.solve(liquidity).len(), 1);
+        assert_eq!(solver.solve(liquidity).len(), 0);
     }
 }

--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -246,15 +246,15 @@ fn amm_to_weighted_pool(amm: &WeightedProductOrder) -> Result<WeightedPoolRef> {
 
 #[cfg(test)]
 mod tests {
-    use maplit::hashset;
-    use model::order::OrderKind;
-    use num::rational::Ratio;
-
+    use super::*;
     use crate::liquidity::{
         tests::CapturingSettlementHandler, AmmOrderExecution, ConstantProductOrder, LimitOrder,
     };
+    use maplit::hashset;
+    use model::order::OrderKind;
+    use num::rational::Ratio;
+    use shared::{addr, sources::balancer::pool_fetching::PoolTokenState};
 
-    use super::*;
     #[test]
     fn finds_best_route_sell_order() {
         let sell_token = H160::from_low_u64_be(1);
@@ -503,6 +503,64 @@ mod tests {
         liquidity.extend(amms.iter().cloned().map(Liquidity::ConstantProduct));
 
         let solver = BaselineSolver::new(hashset! {});
+        assert_eq!(solver.solve(liquidity).len(), 1);
+    }
+
+    #[test]
+    fn does_not_panic_when_building_solution() {
+        // Regression test for https://github.com/gnosis/gp-v2-services/issues/
+        let liquidity = vec![
+            Liquidity::Limit(LimitOrder {
+                sell_token: addr!("e4b9895e638f54c3bee2a3a78d6a297cc03e0353"),
+                buy_token: addr!("a7d1c04faf998f9161fc9f800a99a809b84cfc9d"),
+                sell_amount: 1_741_103_528_769_588_955_u128.into(),
+                buy_amount: 500_000_000_000_000_000_000_u128.into(),
+                kind: OrderKind::Buy,
+                partially_fillable: false,
+                fee_amount: 3_429_706_374_800_940_u128.into(),
+                settlement_handling: CapturingSettlementHandler::arc(),
+                id: "Crash Bandicoop".to_string(),
+            }),
+            Liquidity::ConstantProduct(ConstantProductOrder {
+                tokens: TokenPair::new(
+                    addr!("a7d1c04faf998f9161fc9f800a99a809b84cfc9d"),
+                    addr!("c778417e063141139fce010982780140aa0cd5ab"),
+                )
+                .unwrap(),
+                reserves: (596_652_163_418_904_202_462_071, 225_949_669_025_168_181_644),
+                fee: Ratio::new(3, 1000),
+                settlement_handling: CapturingSettlementHandler::arc(),
+            }),
+            Liquidity::ConstantProduct(ConstantProductOrder {
+                tokens: TokenPair::new(
+                    addr!("c778417e063141139fce010982780140aa0cd5ab"),
+                    addr!("e4b9895e638f54c3bee2a3a78d6a297cc03e0353"),
+                )
+                .unwrap(),
+                reserves: (8_488_677_530_563_931_705, 75_408_146_511_005_299_032),
+                fee: Ratio::new(3, 1000),
+                settlement_handling: CapturingSettlementHandler::arc(),
+            }),
+            Liquidity::WeightedProduct(WeightedProductOrder {
+                reserves: hashmap! {
+                    addr!("c778417e063141139fce010982780140aa0cd5ab") => PoolTokenState {
+                        balance: 799_086_982_149_629_058_u128.into(),
+                        weight: "0.5".parse().unwrap(),
+                        scaling_exponent: 0,
+                    },
+                    addr!("e4b9895e638f54c3bee2a3a78d6a297cc03e0353") => PoolTokenState {
+                        balance: 1_251_682_293_173_877_359_u128.into(),
+                        weight: "0.5".parse().unwrap(),
+                        scaling_exponent: 0,
+                    },
+                },
+                fee: Ratio::new(1.into(), 1000.into()),
+                settlement_handling: CapturingSettlementHandler::arc(),
+            }),
+        ];
+
+        let solver =
+            BaselineSolver::new(hashset![addr!("c778417e063141139fce010982780140aa0cd5ab")]);
         assert_eq!(solver.solve(liquidity).len(), 1);
     }
 }

--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -212,7 +212,7 @@ impl Solution {
             let buy_token = amm.tokens.other(&sell_token).expect("Inconsistent path");
             let buy_amount = amm
                 .get_amount_out(buy_token, (sell_amount, sell_token))
-                .expect("Path was found, so amount must be calculateable");
+                .expect("Path was found, so amount must be calculable");
             let execution = AmmOrderExecution {
                 input: (sell_token, sell_amount),
                 output: (buy_token, buy_amount),


### PR DESCRIPTION
Closes #838

We implement a form of "checked_get_amount_in/out" which is essentially the content of the original "get_amount_in/out
" trait methods for baseline solvable which take in a boolean flag `check_reciprocal` that (in order to avoid infinite recursion) called the diametrically opposite method with the resulting value when `check_reciprocal == true`. We perform the checked implementation on the first call, but when checking pass `false`. 

Test is now passing!

### UPDATE (bh2smith)

Based on the discussion in the corresponding issue we now check that in and out amounts are "good" if the reverse out and in amounts can be computed from them. These changes demonstrate that the failing test here is now passing.