### PR TITLE
HTTP solver response index shift

### DIFF
--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -117,14 +117,6 @@ pub struct ConstantProductOrder {
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
 }
 
-impl PartialEq for ConstantProductOrder {
-    fn eq(&self, other: &Self) -> bool {
-        self.tokens.eq(&other.tokens)
-            && self.reserves.eq(&other.reserves)
-            && self.fee.eq(&other.fee)
-    }
-}
-
 impl std::fmt::Debug for ConstantProductOrder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Constant Product AMM {:?}", self.tokens)
@@ -137,12 +129,6 @@ pub struct WeightedProductOrder {
     pub reserves: HashMap<H160, PoolTokenState>,
     pub fee: BigRational,
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
-}
-
-impl PartialEq for WeightedProductOrder {
-    fn eq(&self, other: &Self) -> bool {
-        self.reserves.eq(&other.reserves) && self.fee.eq(&other.fee)
-    }
 }
 
 impl WeightedProductOrder {

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -117,6 +117,14 @@ pub struct ConstantProductOrder {
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
 }
 
+impl PartialEq for ConstantProductOrder {
+    fn eq(&self, other: &Self) -> bool {
+        self.tokens.eq(&other.tokens)
+            && self.reserves.eq(&other.reserves)
+            && self.fee.eq(&other.fee)
+    }
+}
+
 impl std::fmt::Debug for ConstantProductOrder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Constant Product AMM {:?}", self.tokens)
@@ -129,6 +137,12 @@ pub struct WeightedProductOrder {
     pub reserves: HashMap<H160, PoolTokenState>,
     pub fee: BigRational,
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
+}
+
+impl PartialEq for WeightedProductOrder {
+    fn eq(&self, other: &Self) -> bool {
+        self.reserves.eq(&other.reserves) && self.fee.eq(&other.fee)
+    }
 }
 
 impl WeightedProductOrder {

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -160,23 +160,23 @@ fn match_prepared_and_settled_amms(
         })
         .sorted_by(|a, b| a.1.exec_plan.cmp(&b.1.exec_plan))
     {
-        // Recall, prepared amm for weighted products are shifted by the constant product amms
-        let shift = prepared_constant_product_orders.len();
-        let shifted_index = index % shift;
         let (input, output) = (
             (settled.buy_token, settled.exec_buy_amount),
             (settled.sell_token, settled.exec_sell_amount),
         );
-        if prepared_constant_product_orders.contains_key(&index) {
+        // Recall, prepared amm for weighted products are shifted by the constant product amms
+        let shift = prepared_constant_product_orders.len();
+        if index < shift && prepared_constant_product_orders.contains_key(&index) {
             constant_product_executions.push(ExecutedConstantProductAmms {
                 order: prepared_constant_product_orders.remove(&index).unwrap(),
                 input,
                 output,
             });
-        } else if prepared_weighted_product_orders.contains_key(&shifted_index) {
+        } else if index >= shift && prepared_weighted_product_orders.contains_key(&(index - shift))
+        {
             weighted_product_executions.push(ExecutedWeightedProductAmms {
                 order: prepared_weighted_product_orders
-                    .remove(&shifted_index)
+                    .remove(&(index - shift))
                     .unwrap(),
                 input,
                 output,

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -54,14 +54,12 @@ impl ExecutedLimitOrder {
     }
 }
 
-#[derive(Debug)]
 struct ExecutedConstantProductAmms {
     order: ConstantProductOrder,
     input: (H160, U256),
     output: (H160, U256),
 }
 
-#[derive(Debug)]
 struct ExecutedWeightedProductAmms {
     order: WeightedProductOrder,
     input: (H160, U256),

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -54,14 +54,14 @@ impl ExecutedLimitOrder {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 struct ExecutedConstantProductAmms {
     order: ConstantProductOrder,
     input: (H160, U256),
     output: (H160, U256),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 struct ExecutedWeightedProductAmms {
     order: WeightedProductOrder,
     input: (H160, U256),
@@ -512,21 +512,31 @@ mod tests {
         );
         assert!(matched_settlements.is_ok());
         let (prepared_cps, prepared_wps) = matched_settlements.unwrap();
+
+        assert_eq!(prepared_cps[0].order.tokens, cpo_0.tokens);
+        assert_eq!(prepared_cps[0].order.reserves, cpo_0.reserves);
+        assert_eq!(prepared_cps[0].order.fee, cpo_0.fee);
         assert_eq!(
-            prepared_cps[0],
-            ExecutedConstantProductAmms {
-                order: cpo_0,
-                input: (token_b, U256::from(354009510372389956u128)),
-                output: (token_a, U256::from(932415220613609833982u128))
-            }
+            prepared_cps[0].input,
+            (token_b, U256::from(354009510372389956u128))
         );
         assert_eq!(
-            prepared_wps[0],
-            ExecutedWeightedProductAmms {
-                order: weighted_product_order,
-                input: (token_c, U256::from(996570293625184642u128)),
-                output: (token_b, U256::from(354009510372384890u128))
-            }
+            prepared_cps[0].output,
+            (token_a, U256::from(932415220613609833982u128))
+        );
+
+        assert_eq!(
+            prepared_wps[0].order.reserves,
+            weighted_product_order.reserves
+        );
+        assert_eq!(prepared_wps[0].order.fee, weighted_product_order.fee);
+        assert_eq!(
+            prepared_wps[0].input,
+            (token_c, U256::from(996570293625184642u128))
+        );
+        assert_eq!(
+            prepared_wps[0].output,
+            (token_b, U256::from(354009510372384890u128))
         );
     }
 }


### PR DESCRIPTION
Fixes #837

We should have been accounting for the index shift both on request and response.


### Test Plan
Included regression test on the instance and solution data supplied in the issue
