### PR TITLE
Fix pool maximum amount

### DIFF
--- a/shared/src/sources/uniswap/pool_fetching.rs
+++ b/shared/src/sources/uniswap/pool_fetching.rs
@@ -14,7 +14,7 @@ pub const MAX_BATCH_SIZE: usize = 100;
 const POOL_SWAP_GAS_COST: usize = 60_000;
 
 lazy_static::lazy_static! {
-    static ref POOL_MAX_RESERVES: U256 = U256::from((1u128 << 96) - 1);
+    static ref POOL_MAX_RESERVES: U256 = U256::from((1u128 << 112) - 1);
 }
 
 /// This type denotes `(reserve_a, reserve_b, token_b)` where


### PR DESCRIPTION
I accidentally confused the reserve size as 96 bits when it is in fact 112 bits. This PR just fixes that.

### Test Plan

Tests still pass.
