### PR TITLE
Make bad token detector more generic over amm pool sources

### DIFF
--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -18,7 +18,9 @@ use shared::{
     bad_token::{
         cache::CachingDetector,
         list_based::{ListBasedDetector, UnknownTokenStrategy},
-        trace_call::{AmmPairProviderFinder, TokenOwnerFinding, TraceCallDetector},
+        trace_call::{
+            AmmPairProviderFinder, BalancerVaultFinder, TokenOwnerFinding, TraceCallDetector,
+        },
     },
     current_block::current_block_stream,
     maintenance::ServiceMaintenance,
@@ -198,7 +200,7 @@ async fn main() {
     allowed_tokens.push(BUY_ETH_ADDRESS);
     let unsupported_tokens = args.unsupported_tokens;
 
-    let finders = pair_providers
+    let mut finders: Vec<Arc<dyn TokenOwnerFinding>> = pair_providers
         .iter()
         .map(|provider| -> Arc<dyn TokenOwnerFinding> {
             Arc::new(AmmPairProviderFinder {
@@ -207,6 +209,9 @@ async fn main() {
             })
         })
         .collect();
+    if let Some(finder) = BalancerVaultFinder::new(&web3).await.unwrap() {
+        finders.push(Arc::new(finder));
+    }
     let trace_call_detector = TraceCallDetector {
         web3: web3.clone(),
         finders,

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -18,7 +18,7 @@ use shared::{
     bad_token::{
         cache::CachingDetector,
         list_based::{ListBasedDetector, UnknownTokenStrategy},
-        trace_call::TraceCallDetector,
+        trace_call::{AmmPairProviderFinder, TokenOwnerFinding, TraceCallDetector},
     },
     current_block::current_block_stream,
     maintenance::ServiceMaintenance,
@@ -198,9 +198,18 @@ async fn main() {
     allowed_tokens.push(BUY_ETH_ADDRESS);
     let unsupported_tokens = args.unsupported_tokens;
 
+    let finders = pair_providers
+        .iter()
+        .map(|provider| -> Arc<dyn TokenOwnerFinding> {
+            Arc::new(AmmPairProviderFinder {
+                inner: provider.clone(),
+                base_tokens: base_tokens.iter().copied().collect(),
+            })
+        })
+        .collect();
     let trace_call_detector = TraceCallDetector {
         web3: web3.clone(),
-        pools: pair_providers.clone(),
+        finders,
         base_tokens: base_tokens.clone(),
         settlement_contract: settlement_contract.address(),
     };

--- a/shared/src/bad_token/trace_call.rs
+++ b/shared/src/bad_token/trace_call.rs
@@ -6,7 +6,8 @@ use crate::{
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use contracts::ERC20;
 use ethcontract::{
-    batch::CallBatch, dyns::DynTransport, transaction::TransactionBuilder, PrivateKey,
+    batch::CallBatch, dyns::DynTransport, errors::DeployError, transaction::TransactionBuilder,
+    PrivateKey,
 };
 use model::TokenPair;
 use primitive_types::{H160, U256};
@@ -38,6 +39,32 @@ impl TokenOwnerFinding for AmmPairProviderFinder {
             .filter_map(|&base_token| TokenPair::new(base_token, token))
             .map(|pair| self.inner.pair_address(&pair))
             .collect())
+    }
+}
+
+/// The balancer vault contract contains all the balances of all pools.
+pub struct BalancerVaultFinder {
+    address: H160,
+}
+
+impl BalancerVaultFinder {
+    /// Ok(None) if the vault isn't deployed on this network.
+    /// Err if communication with the node failed.
+    pub async fn new(web3: &Web3) -> Result<Option<Self>> {
+        match contracts::BalancerV2Vault::deployed(web3).await {
+            Ok(contract) => Ok(Some(Self {
+                address: contract.address(),
+            })),
+            Err(DeployError::NotFound(_)) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TokenOwnerFinding for BalancerVaultFinder {
+    async fn find_candidate_owners(&self, _: H160) -> Result<Vec<H160>> {
+        Ok(vec![self.address])
     }
 }
 

--- a/shared/src/bad_token/trace_call.rs
+++ b/shared/src/bad_token/trace_call.rs
@@ -16,6 +16,31 @@ use web3::{
     types::{BlockTrace, CallRequest, Res},
 };
 
+/// To detect bad tokens we need to find some address on the network that owns the token so that we
+/// can use it in our simulations.
+#[async_trait::async_trait]
+pub trait TokenOwnerFinding: Send + Sync {
+    /// Find candidate addresses that might own the token.
+    async fn find_candidate_owners(&self, token: H160) -> Result<Vec<H160>>;
+}
+
+pub struct AmmPairProviderFinder {
+    pub inner: Arc<dyn AmmPairProvider>,
+    pub base_tokens: Vec<H160>,
+}
+
+#[async_trait::async_trait]
+impl TokenOwnerFinding for AmmPairProviderFinder {
+    async fn find_candidate_owners(&self, token: H160) -> Result<Vec<H160>> {
+        Ok(self
+            .base_tokens
+            .iter()
+            .filter_map(|&base_token| TokenPair::new(base_token, token))
+            .map(|pair| self.inner.pair_address(&pair))
+            .collect())
+    }
+}
+
 /// Detects whether a token is "bad" (works in unexpected ways that are problematic for solving) by
 /// simulating several transfers of a token. To find an initial address to transfer from we use
 /// the amm pair providers.
@@ -25,7 +50,7 @@ use web3::{
 /// - a transfer loses total balance
 pub struct TraceCallDetector {
     pub web3: Web3,
-    pub pools: Vec<Arc<dyn AmmPairProvider>>,
+    pub finders: Vec<Arc<dyn TokenOwnerFinding>>,
     pub base_tokens: HashSet<H160>,
     pub settlement_contract: H160,
 }
@@ -86,16 +111,24 @@ impl TraceCallDetector {
     // Ok(None) if there is no pool or getting the balance fails.
     // Ok(address, balance) for an address that has this amount of balance of the token.
     async fn find_largest_pool_owning_token(&self, token: H160) -> Result<Option<(H160, U256)>> {
+        let mut candidates = HashSet::new();
+        for result in futures::future::join_all(
+            self.finders
+                .iter()
+                .map(|finder| finder.find_candidate_owners(token)),
+        )
+        .await
+        {
+            candidates.extend(match result {
+                Ok(candidates) => candidates,
+                Err(err) => {
+                    tracing::error!("token owner finding failed: {:?}", err);
+                    continue;
+                }
+            });
+        }
+
         const BATCH_SIZE: usize = 100;
-
-        let pairs = self
-            .base_tokens
-            .iter()
-            .filter_map(move |&base_token| TokenPair::new(base_token, token));
-        let candidates = pairs
-            .flat_map(|pair| self.pools.iter().map(move |pool| pool.pair_address(&pair)))
-            .collect::<HashSet<_>>();
-
         let instance = ERC20::at(&self.web3, token);
         let mut batch = CallBatch::new(self.web3.transport());
         let futures = candidates
@@ -552,15 +585,23 @@ mod tests {
             factory: contracts::UniswapV2Factory::deployed(&web3).await.unwrap(),
             chain_id,
         });
+        let uniswap = Arc::new(AmmPairProviderFinder {
+            inner: uniswap,
+            base_tokens: base_tokens.to_vec(),
+        });
         let sushiswap = Arc::new(SushiswapPairProvider {
             factory: contracts::SushiswapV2Factory::deployed(&web3)
                 .await
                 .unwrap(),
         });
+        let sushiswap = Arc::new(AmmPairProviderFinder {
+            inner: sushiswap,
+            base_tokens: base_tokens.to_vec(),
+        });
         let token_cache = TraceCallDetector {
             web3,
             settlement_contract: settlement.address(),
-            pools: vec![uniswap, sushiswap],
+            finders: vec![uniswap, sushiswap],
             base_tokens: base_tokens.iter().copied().collect(),
         };
 


### PR DESCRIPTION
Currently we use AmmPairProvider which is only implemented for Sushiswap
and UniswapV2. We introduce a trait to be more generic and can in the
future be implemented for more sources.

The plan is to use this to consider BalancerV2 pools as well.

### Test Plan
mainnet node test still works.