### PR TITLE
Multiple accounts in solvers, step 1: solvers know their accounts

### DIFF
--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -156,7 +156,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             web3: web3.clone(),
         }),
     );
-    let solver = solver::solver::naive_solver();
+    let solver = solver::solver::naive_solver(solver_account);
     let liquidity_collector = LiquidityCollector {
         uniswap_like_liquidity: vec![uniswap_liquidity],
         orderbook_api: create_orderbook_api(&web3, native_token),

--- a/solver/src/lib.rs
+++ b/solver/src/lib.rs
@@ -10,6 +10,8 @@ pub mod settlement;
 pub mod settlement_simulation;
 pub mod settlement_submission;
 pub mod solver;
+#[cfg(test)]
+mod test;
 mod util;
 
 use anyhow::Result;

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -310,6 +310,7 @@ async fn main() {
     )
     .await;
     let solver = solver::solver::create(
+        account,
         web3.clone(),
         args.solvers,
         base_tokens,
@@ -325,7 +326,6 @@ async fn main() {
         args.solver_time_limit,
         args.min_order_size_one_inch,
         args.disabled_one_inch_protocols,
-        account.address(),
         args.paraswap_slippage_bps,
     )
     .expect("failure creating solvers");

--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -7,6 +7,7 @@ use super::driver::solver_settlements::RatedSettlement;
 use crate::{encoding::EncodedSettlement, pending_transactions::Fee};
 use anyhow::{Context, Result};
 use contracts::GPv2Settlement;
+use ethcontract::dyns::DynWeb3;
 use ethcontract::{dyns::DynTransport, errors::ExecutionError, Web3};
 use futures::stream::StreamExt;
 use gas_estimation::GasPriceEstimating;
@@ -101,7 +102,7 @@ pub async fn submit(
 async fn transaction_count(contract: &GPv2Settlement) -> Result<U256> {
     let defaults = contract.defaults();
     let address = defaults.from.as_ref().unwrap().address();
-    let web3 = contract.raw_instance().web3();
+    let web3: DynWeb3 = contract.raw_instance().web3();
     let count = web3.eth().transaction_count(address, None).await?;
     Ok(count)
 }

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use ::model::order::OrderKind;
 use anyhow::{ensure, Context, Result};
-use ethcontract::U256;
+use ethcontract::{Account, U256};
 use futures::join;
 use lazy_static::lazy_static;
 use num::{BigInt, BigRational, ToPrimitive};
@@ -59,6 +59,7 @@ impl SolverConfig {
 }
 
 pub struct HttpSolver {
+    account: Account,
     base: Url,
     client: Client,
     api_key: Option<String>,
@@ -74,6 +75,7 @@ pub struct HttpSolver {
 impl HttpSolver {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        account: Account,
         base: Url,
         api_key: Option<String>,
         config: SolverConfig,
@@ -87,6 +89,7 @@ impl HttpSolver {
         // Unwrap because we cannot handle client creation failing.
         let client = Client::builder().build().unwrap();
         Self {
+            account,
             base,
             client,
             api_key,
@@ -451,6 +454,10 @@ impl Solver for HttpSolver {
         settlement::convert_settlement(settled, context).map(|settlement| vec![settlement])
     }
 
+    fn account(&self) -> &Account {
+        &self.account
+    }
+
     fn name(&self) -> &'static str {
         "HTTPSolver"
     }
@@ -461,6 +468,7 @@ mod tests {
     use super::*;
     use crate::liquidity::{tests::CapturingSettlementHandler, ConstantProductOrder, LimitOrder};
     use ::model::TokenPair;
+    use ethcontract::Address;
     use maplit::hashmap;
     use num::rational::Ratio;
     use shared::price_estimate::mocks::FakePriceEstimator;
@@ -499,6 +507,7 @@ mod tests {
         let gas_price = 100.;
 
         let solver = HttpSolver::new(
+            Account::Local(Address::default(), None),
             url.parse().unwrap(),
             None,
             SolverConfig {

--- a/solver/src/solver/naive_solver.rs
+++ b/solver/src/solver/naive_solver.rs
@@ -6,10 +6,19 @@ use crate::{
     solver::Solver,
 };
 use anyhow::Result;
+use ethcontract::Account;
 use model::TokenPair;
 use std::collections::HashMap;
 
-pub struct NaiveSolver;
+pub struct NaiveSolver {
+    account: Account,
+}
+
+impl NaiveSolver {
+    pub fn new(account: Account) -> Self {
+        Self { account }
+    }
+}
 
 #[async_trait::async_trait]
 impl Solver for NaiveSolver {
@@ -22,6 +31,10 @@ impl Solver for NaiveSolver {
                 _ => None,
             });
         Ok(settle(limit_orders, uniswaps).await)
+    }
+
+    fn account(&self) -> &Account {
+        &self.account
     }
 
     fn name(&self) -> &'static str {

--- a/solver/src/solver/single_order_solver.rs
+++ b/solver/src/solver/single_order_solver.rs
@@ -7,6 +7,7 @@ use crate::{
     settlement::Settlement,
     solver::Solver,
 };
+use ethcontract::Account;
 
 #[async_trait::async_trait]
 /// Implementations of this trait know how to settle a single limit order (not taking advantage of batching multiple orders together)
@@ -14,7 +15,13 @@ pub trait SingleOrderSolving {
     /// Return a settlement for the given limit order (if possible)
     async fn settle_order(&self, order: LimitOrder) -> Result<Option<Settlement>>;
 
-    fn name(&self) -> &'static str;
+    /// Solver's account that should be used to submit settlements.
+    fn account(&self) -> &Account;
+
+    /// Displayable name of the solver. Defaults to the type name.
+    fn name(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
 }
 
 /// Maximum number of sell orders to consider for settlements.
@@ -71,6 +78,10 @@ impl<I: SingleOrderSolving + Send + Sync> Solver for SingleOrderSolver<I> {
                 }
             })
             .collect())
+    }
+
+    fn account(&self) -> &Account {
+        self.inner.account()
     }
 
     fn name(&self) -> &'static str {

--- a/solver/src/test.rs
+++ b/solver/src/test.rs
@@ -1,0 +1,12 @@
+///! Helper functions for unit tests.
+use ethcontract::Account;
+
+/// Create a dummy account.
+pub fn account() -> Account {
+    Account::Offline(
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+            .parse()
+            .unwrap(),
+        None,
+    )
+}


### PR DESCRIPTION
Part of #827

We want to have separate accounts for each solver. This will help us analytics, and also move us closer towards implementing solver competition.

In this PR, we make the first step towards this goal: now each solver knows its account.

In the next PR, we will refactor driver to use solver's account when submitting a settlement.

### Test Plan
No substantial changes so far, existing unit tests should cover it.
