### PR TITLE
Use balancer vault as a source of tokens for bad token detection

### DIFF
--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -18,7 +18,9 @@ use shared::{
     bad_token::{
         cache::CachingDetector,
         list_based::{ListBasedDetector, UnknownTokenStrategy},
-        trace_call::{AmmPairProviderFinder, TokenOwnerFinding, TraceCallDetector},
+        trace_call::{
+            AmmPairProviderFinder, BalancerVaultFinder, TokenOwnerFinding, TraceCallDetector,
+        },
     },
     current_block::current_block_stream,
     maintenance::ServiceMaintenance,
@@ -198,7 +200,7 @@ async fn main() {
     allowed_tokens.push(BUY_ETH_ADDRESS);
     let unsupported_tokens = args.unsupported_tokens;
 
-    let finders = pair_providers
+    let mut finders: Vec<Arc<dyn TokenOwnerFinding>> = pair_providers
         .iter()
         .map(|provider| -> Arc<dyn TokenOwnerFinding> {
             Arc::new(AmmPairProviderFinder {
@@ -207,6 +209,9 @@ async fn main() {
             })
         })
         .collect();
+    if let Some(finder) = BalancerVaultFinder::new(&web3).await.unwrap() {
+        finders.push(Arc::new(finder));
+    }
     let trace_call_detector = TraceCallDetector {
         web3: web3.clone(),
         finders,

--- a/shared/src/bad_token/trace_call.rs
+++ b/shared/src/bad_token/trace_call.rs
@@ -6,7 +6,8 @@ use crate::{
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use contracts::ERC20;
 use ethcontract::{
-    batch::CallBatch, dyns::DynTransport, transaction::TransactionBuilder, PrivateKey,
+    batch::CallBatch, dyns::DynTransport, errors::DeployError, transaction::TransactionBuilder,
+    PrivateKey,
 };
 use model::TokenPair;
 use primitive_types::{H160, U256};
@@ -38,6 +39,32 @@ impl TokenOwnerFinding for AmmPairProviderFinder {
             .filter_map(|&base_token| TokenPair::new(base_token, token))
             .map(|pair| self.inner.pair_address(&pair))
             .collect())
+    }
+}
+
+/// The balancer vault contract contains all the balances of all pools.
+pub struct BalancerVaultFinder {
+    address: H160,
+}
+
+impl BalancerVaultFinder {
+    /// Ok(None) if the vault isn't deployed on this network.
+    /// Err if communication with the node failed.
+    pub async fn new(web3: &Web3) -> Result<Option<Self>> {
+        match contracts::BalancerV2Vault::deployed(web3).await {
+            Ok(contract) => Ok(Some(Self {
+                address: contract.address(),
+            })),
+            Err(DeployError::NotFound(_)) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TokenOwnerFinding for BalancerVaultFinder {
+    async fn find_candidate_owners(&self, _: H160) -> Result<Vec<H160>> {
+        Ok(vec![self.address])
     }
 }
 


### PR DESCRIPTION
The Vault has the balances for all pools so it makes sense to use it as a source for bad token detection.

### Test Plan
manually tested that bad token detector categorizes https://etherscan.io/token/0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6 as good with this PR but not without it (there is no sushi and uniswap liquidity).
Note that this doesn't mean that the token can be traded. While the token itself is "good" we still cannot determine it's price in the native token (ETH) because the liquidity supported by the baseline solver is not good enough. Even with the existing balancer integration it won't be because we do not support stable pools.