### PR TITLE
[Balancer] Filter paused pools on fetch

### DIFF
--- a/shared/src/sources/balancer/pool_fetching.rs
+++ b/shared/src/sources/balancer/pool_fetching.rs
@@ -126,7 +126,10 @@ impl WeightedPoolFetching for BalancerPoolFetcher {
             .await;
         let fetched_pools = self.pool_reserve_cache.fetch(pool_ids, at_block).await?;
         // We return only those pools which are not paused.
-        Ok(fetched_pools.into_iter().filter(|pool| !pool.paused).collect())
+        Ok(fetched_pools
+            .into_iter()
+            .filter(|pool| !pool.paused)
+            .collect())
     }
 }
 

--- a/shared/src/sources/balancer/swap.rs
+++ b/shared/src/sources/balancer/swap.rs
@@ -237,7 +237,7 @@ mod tests {
             pool_address: H160::zero(),
             reserves,
             swap_fee_percentage: Bfp::from_wei(swap_fee_percentage),
-            paused: false,
+            paused: true,
         }
     }
 

--- a/shared/src/sources/balancer/swap.rs
+++ b/shared/src/sources/balancer/swap.rs
@@ -237,6 +237,7 @@ mod tests {
             pool_address: H160::zero(),
             reserves,
             swap_fee_percentage: Bfp::from_wei(swap_fee_percentage),
+            paused: false,
         }
     }
 

--- a/solver/src/liquidity/balancer.rs
+++ b/solver/src/liquidity/balancer.rs
@@ -195,7 +195,7 @@ mod tests {
                         scaling_exponent: 0,
                     },
                 },
-                paused: false,
+                paused: true,
             },
             WeightedPool {
                 pool_id: H256([0x91; 32]),

--- a/solver/src/liquidity/balancer.rs
+++ b/solver/src/liquidity/balancer.rs
@@ -195,6 +195,7 @@ mod tests {
                         scaling_exponent: 0,
                     },
                 },
+                paused: false,
             },
             WeightedPool {
                 pool_id: H256([0x91; 32]),
@@ -212,6 +213,7 @@ mod tests {
                         scaling_exponent: 0,
                     },
                 },
+                paused: true,
             },
         ];
 


### PR DESCRIPTION
As a straightforward and simple solution to #856 we simply fetch the pause state of the pool at the same time we fetch the reserves. This can be done more efficiently in the future by taking advantage of the pool's pause window, so this doesn't exactly close the issue but temporarily mitigates it with very few code changes.

### Test Plan
I noticed when updating the current tests that we never actually test the Balancer pool's fetch method, but merely mock it and work with expected results (this can be seen from the fact that I introduced a paused pool to the updated test. 

I am not sure if this was intended (for some reason) or merely missed, so I will look into actually testing the fetch method with this PR.

_UPDATE_ Added unit test for filtering helper method.
