### PR TITLE
Use native token for http solver price estimates

### DIFF
--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -261,7 +261,7 @@ impl HttpSolver {
         let (token_infos, price_estimates) = join!(
             self.token_info_fetcher.get_token_infos(tokens.as_slice()),
             self.price_estimator
-                .estimate_prices(tokens.as_slice(), tokens[0])
+                .estimate_prices(tokens.as_slice(), self.native_token)
         );
 
         let price_estimates: HashMap<H160, Result<BigRational, _>> =


### PR DESCRIPTION
This makes the prices more consistent and understandable.

### Test Plan
small enough change to not warrant