### PR TITLE
Integrate archer network with driver

### DIFF
--- a/e2e/tests/eth_integration.rs
+++ b/e2e/tests/eth_integration.rs
@@ -13,7 +13,7 @@ use shared::{
 };
 use solver::{
     liquidity::uniswap::UniswapLikeLiquidity, liquidity_collector::LiquidityCollector,
-    metrics::NoopMetrics,
+    metrics::NoopMetrics, settlement_submission::SolutionSubmitter,
 };
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use web3::signing::SecretKeyRef;
@@ -202,7 +202,7 @@ async fn eth_integration(web3: Web3) {
             web3: web3.clone(),
         }),
     );
-    let solver = solver::solver::naive_solver(solver_account);
+    let solver = solver::solver::naive_solver(solver_account.clone());
     let liquidity_collector = LiquidityCollector {
         uniswap_like_liquidity: vec![uniswap_liquidity],
         orderbook_api: create_orderbook_api(&web3, weth.address()),
@@ -215,7 +215,6 @@ async fn eth_integration(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
-        Duration::from_secs(1),
         Duration::from_secs(30),
         native_token,
         Duration::from_secs(0),
@@ -224,10 +223,18 @@ async fn eth_integration(web3: Web3) {
         network_id,
         1,
         Duration::from_secs(30),
-        f64::MAX,
         None,
         block_stream,
         1.0,
+        SolutionSubmitter {
+            web3: web3.clone(),
+            contract: gpv2.settlement.clone(),
+            account: solver_account,
+            gas_price_estimator: Arc::new(web3.clone()),
+            target_confirm_time: Duration::from_secs(1),
+            gas_price_cap: f64::MAX,
+            transaction_strategy: solver::settlement_submission::TransactionStrategy::PublicMempool,
+        },
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -14,7 +14,7 @@ use shared::{
 };
 use solver::{
     liquidity::uniswap::UniswapLikeLiquidity, liquidity_collector::LiquidityCollector,
-    metrics::NoopMetrics,
+    metrics::NoopMetrics, settlement_submission::SolutionSubmitter,
 };
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use web3::signing::SecretKeyRef;
@@ -156,7 +156,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             web3: web3.clone(),
         }),
     );
-    let solver = solver::solver::naive_solver(solver_account);
+    let solver = solver::solver::naive_solver(solver_account.clone());
     let liquidity_collector = LiquidityCollector {
         uniswap_like_liquidity: vec![uniswap_liquidity],
         orderbook_api: create_orderbook_api(&web3, native_token),
@@ -177,7 +177,6 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
-        Duration::from_secs(1),
         Duration::from_secs(30),
         native_token,
         Duration::from_secs(0),
@@ -186,10 +185,18 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         network_id,
         1,
         Duration::from_secs(10),
-        f64::MAX,
         Some(market_makable_token_list),
         block_stream,
         1.0,
+        SolutionSubmitter {
+            web3: web3.clone(),
+            contract: gpv2.settlement.clone(),
+            account: solver_account,
+            gas_price_estimator: Arc::new(web3.clone()),
+            target_confirm_time: Duration::from_secs(1),
+            gas_price_cap: f64::MAX,
+            transaction_strategy: solver::settlement_submission::TransactionStrategy::PublicMempool,
+        },
     );
     driver.single_run().await.unwrap();
 

--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -4,11 +4,20 @@ mod gas_price_stream;
 pub mod public_mempool;
 pub mod retry;
 
-use crate::encoding::EncodedSettlement;
+use crate::{encoding::EncodedSettlement, settlement::Settlement};
+use anyhow::{anyhow, Result};
+use archer_api::ArcherApi;
 use contracts::GPv2Settlement;
-use ethcontract::errors::ExecutionError;
+use ethcontract::{errors::ExecutionError, Account};
+use gas_estimation::GasPriceEstimating;
 use primitive_types::U256;
-use std::time::Duration;
+use shared::Web3;
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+
+use self::archer_settlement::ArcherSolutionSubmitter;
 
 const ESTIMATE_GAS_LIMIT_FACTOR: f64 = 1.2;
 const GAS_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
@@ -21,4 +30,70 @@ pub async fn estimate_gas(
         .tx
         .estimate_gas()
         .await
+}
+
+pub struct SolutionSubmitter {
+    pub web3: Web3,
+    pub contract: GPv2Settlement,
+    pub account: Account,
+    pub gas_price_estimator: Arc<dyn GasPriceEstimating>,
+    // for gas price estimation
+    pub target_confirm_time: Duration,
+    pub gas_price_cap: f64,
+    pub transaction_strategy: TransactionStrategy,
+}
+
+pub enum TransactionStrategy {
+    PublicMempool,
+    ArcherNetwork {
+        archer_api: ArcherApi,
+        max_confirm_time: Duration,
+    },
+}
+
+impl SolutionSubmitter {
+    /// Ok if transaction got mined in time.
+    /// Err if took too long or other inner errors.
+    pub async fn settle(&self, settlement: Settlement, gas_estimate: U256) -> Result<()> {
+        match &self.transaction_strategy {
+            TransactionStrategy::PublicMempool => {
+                public_mempool::submit(
+                    self.account.clone(),
+                    &self.contract,
+                    self.gas_price_estimator.as_ref(),
+                    self.target_confirm_time,
+                    self.gas_price_cap,
+                    settlement,
+                    gas_estimate,
+                )
+                .await
+            }
+            TransactionStrategy::ArcherNetwork {
+                archer_api,
+                max_confirm_time,
+            } => {
+                let submitter = ArcherSolutionSubmitter {
+                    web3: &self.web3,
+                    contract: &self.contract,
+                    account: &self.account,
+                    archer_api,
+                    gas_price_estimator: self.gas_price_estimator.as_ref(),
+                    gas_price_cap: self.gas_price_cap,
+                };
+                let result = submitter
+                    .submit(
+                        self.target_confirm_time,
+                        SystemTime::now() + *max_confirm_time,
+                        settlement,
+                        gas_estimate,
+                    )
+                    .await;
+                match result {
+                    Ok(Some(_)) => Ok(()),
+                    Ok(None) => Err(anyhow!("transaction did not get mined in time")),
+                    Err(err) => Err(err),
+                }
+            }
+        }
+    }
 }

--- a/solver/src/settlement_submission/archer_settlement.rs
+++ b/solver/src/settlement_submission/archer_settlement.rs
@@ -36,22 +36,19 @@ use futures::FutureExt;
 use gas_estimation::GasPriceEstimating;
 use primitive_types::{H256, U256};
 use shared::Web3;
-use std::{
-    sync::Arc,
-    time::{Duration, Instant, SystemTime},
-};
+use std::time::{Duration, Instant, SystemTime};
 use web3::types::TransactionId;
 
-pub struct ArcherSolutionSubmitter {
-    pub web3: Web3,
-    pub contract: GPv2Settlement,
-    pub account: Account,
-    pub archer_api: ArcherApi,
-    pub gas_price_estimator: Arc<dyn GasPriceEstimating>,
+pub struct ArcherSolutionSubmitter<'a> {
+    pub web3: &'a Web3,
+    pub contract: &'a GPv2Settlement,
+    pub account: &'a Account,
+    pub archer_api: &'a ArcherApi,
+    pub gas_price_estimator: &'a dyn GasPriceEstimating,
     pub gas_price_cap: f64,
 }
 
-impl ArcherSolutionSubmitter {
+impl<'a> ArcherSolutionSubmitter<'a> {
     /// Submit a settlement to the contract, updating the transaction with gas prices if they increase.
     ///
     /// Goes through the archerdao network so that failing transactions do not get mined and thus do
@@ -356,11 +353,11 @@ mod tests {
                 .unwrap();
 
         let submitter = ArcherSolutionSubmitter {
-            web3,
-            contract,
-            account,
-            archer_api,
-            gas_price_estimator: Arc::new(gas_price_estimator),
+            web3: &web3,
+            contract: &contract,
+            account: &account,
+            archer_api: &archer_api,
+            gas_price_estimator: &gas_price_estimator,
             gas_price_cap,
         };
 


### PR DESCRIPTION
Adds a configuration option to enable submission with the archer
network. This is accomplished by a new struct SolutionSubmitter which
provides a uniform interface over the two types of transaction
submission.

In future PRs we could try advanced strategies like using archer by default but falling back to normal transactions if archer failed X times in a row maybe because their api is down.

### Test Plan
e2e tests should still work with the default transaction submission. i am going to do another manual test for the archer case.