### PR TITLE
Adding app_data storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,12 +146,18 @@ checksum = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
@@ -193,6 +205,43 @@ dependencies = [
  "radium 0.6.2",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake2s_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake3"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b64485778c4f16a6a5a9d335e80d449ac6c70cdd6a06d2af18a6f6f775a125b3"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "cc",
+ "cfg-if 0.1.10",
+ "constant_time_eq",
+ "crypto-mac 0.8.0",
+ "digest",
 ]
 
 [[package]]
@@ -274,6 +323,12 @@ checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -292,6 +347,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cid"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b8976b33648136e969aafa6eb33d58ff0d301fa0b4e8d513db58fd32cd81aa"
+dependencies = [
+ "multibase",
+ "multihash",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +371,12 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "contracts"
@@ -395,7 +467,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -405,7 +477,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -416,7 +488,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -429,7 +501,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -439,7 +511,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -448,6 +520,16 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
 
 [[package]]
 name = "crypto-mac"
@@ -543,6 +625,32 @@ checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
 dependencies = [
  "darling_core",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86927b7cd2fe88fa698b87404b287ab98d1a0063a34071d92e575b72d3029aca"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
+dependencies = [
+ "data-encoding",
  "syn",
 ]
 
@@ -651,7 +759,7 @@ version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -804,7 +912,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "winapi",
@@ -1005,7 +1113,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -1129,7 +1237,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.10.0",
  "digest",
 ]
 
@@ -1279,7 +1387,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1354,7 +1462,7 @@ checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec 0.5.2",
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
 ]
@@ -1392,7 +1500,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1505,7 +1613,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd9a2de7b4bd932854c776ce60880caf8fa41095a7907e3accc52ef6678895b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "downcast",
  "fragile",
  "lazy_static",
@@ -1520,7 +1628,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07174e9c5ffb2ff849187641c48fc66f5588f012f1d248e55c3a68cd462bd29"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1530,8 +1638,10 @@ dependencies = [
 name = "model"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bigdecimal",
  "chrono",
+ "cid",
  "derivative",
  "enum-utils",
  "ethabi",
@@ -1546,7 +1656,50 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "thiserror",
  "web3",
+]
+
+[[package]]
+name = "multibase"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
+dependencies = [
+ "base-x",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
+name = "multihash"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
+dependencies = [
+ "blake2b_simd",
+ "blake2s_simd",
+ "blake3",
+ "digest",
+ "generic-array",
+ "multihash-derive",
+ "sha2",
+ "sha3",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -1741,7 +1894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -1835,7 +1988,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -1973,6 +2126,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+dependencies = [
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,7 +2186,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
  "memchr",
@@ -2453,7 +2616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -2466,7 +2629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -2789,6 +2952,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2800,7 +2975,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "rand",
  "redox_syscall",
@@ -2977,6 +3152,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,7 +3172,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -3184,6 +3368,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unsigned-varint"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f8d425fafb8cd76bc3f22aace4af471d3156301d7508f2107e98fbeae10bc7f"
+
+[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,7 +3470,7 @@ version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -3307,7 +3497,7 @@ version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/database/sql/V010__create_meta_data.sql
+++ b/database/sql/V010__create_meta_data.sql
@@ -1,0 +1,17 @@
+-- Bytes are stored in `bytea` which is a variable size byte string. There is no way to specify a
+-- fixed size.
+
+CREATE TYPE MetaDataKind AS ENUM ('referrer');
+
+CREATE TABLE meta_data (
+    version bytea NOT NULL,
+    kind MetaDataKind NOT NULL,
+    referrer bytea NOT NULL,
+    position bigint NOT NULL,
+    app_data_cid bytea NOT NULL,
+    PRIMARY KEY (app_data_cid, position)
+);
+
+-- Get a referrer's meta_data.
+CREATE INDEX referrer_meta_data ON meta_data USING HASH (referrer);
+

--- a/database/sql/V011__create_app_data.sql
+++ b/database/sql/V011__create_app_data.sql
@@ -1,0 +1,5 @@
+CREATE TABLE app_data (
+    app_data_cid bytea PRIMARY KEY,
+    version bytea NOT NULL,
+    app_code bytea NOT NULL
+);

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+anyhow = "1.0"
+cid = "0.7"
 bigdecimal = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 derivative = "2.2"
@@ -15,6 +17,7 @@ hex = { version = "0.4", default-features = false }
 hex-literal = "0.3"
 lazy_static = "1.4"
 maplit = "1.0"
+thiserror = "1.0"
 num = "0.4"
 num-bigint = "0.3"
 primitive-types = { version = "0.9" }
@@ -22,6 +25,4 @@ secp256k1 = "0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = { version = "1.9", default-features = false, features = ["macros"] }
 web3 = { version = "0.16", default-features = false, features = ["signing"] }
-
-[dev-dependencies]
 serde_json = "1.0"

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod appdata_hexadecimal;
 pub mod h160_hexadecimal;
+pub mod meta_data;
 pub mod order;
 pub mod ratio_as_decimal;
 pub mod trade;

--- a/model/src/meta_data.rs
+++ b/model/src/meta_data.rs
@@ -1,0 +1,97 @@
+//! Contains the app_data file structures, which will also be stored in the data base and on ipfs
+
+use crate::h160_hexadecimal::{self};
+use anyhow::Result;
+use cid::multihash::{Code, MultihashDigest};
+use cid::Cid;
+use primitive_types::H160;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use thiserror::Error;
+
+#[derive(Error, Debug, Copy, Eq, PartialEq, Clone, Deserialize, Serialize, Hash)]
+pub enum MetaDataKind {
+    #[error("Referrer not found")]
+    Referrer,
+}
+
+#[serde_as]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct MetaData {
+    pub version: String,
+    pub kind: MetaDataKind,
+    #[serde(with = "h160_hexadecimal")]
+    pub referrer: H160,
+}
+
+#[serde_as]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct AppData {
+    pub version: String,
+    pub app_code: String,
+    pub meta_data: Vec<MetaData>,
+}
+const RAW: u64 = 0x55;
+impl AppData {
+    // following function calculates the cid. The cid is used by IPFS as data identifier
+    pub fn cid(&self) -> Result<String> {
+        let string = serde_json::to_string(self)?;
+        let hash = Code::Sha2_256.digest(&string.into_bytes());
+        let cid = Cid::new_v1(RAW, hash);
+        Ok(cid.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    #[test]
+    fn deserialization_and_back() {
+        let value = json!(
+        {
+            "version": "1.0.0",
+            "appCode": "CowSwap",
+            "metaData": [{
+              "version": "1.2.3",
+              "kind": "Referrer",
+              "referrer": "0x424a46612794dbb8000194937834250dc723ffa5",
+            }]
+        }
+        );
+        let expected = AppData {
+            version: String::from("1.0.0"),
+            app_code: String::from("CowSwap"),
+            meta_data: vec![MetaData {
+                version: String::from("1.2.3"),
+                kind: MetaDataKind::Referrer,
+                referrer: "0x424a46612794dbb8000194937834250dc723ffa5"
+                    .parse()
+                    .unwrap(),
+            }],
+        };
+        let deserialized: AppData = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(deserialized, expected);
+        let serialized = serde_json::to_value(expected).unwrap();
+        assert_eq!(serialized, value);
+    }
+    #[test]
+    fn test_cid_calculation() {
+        let app_data = AppData {
+            version: String::from("1.0.0"),
+            app_code: String::from("CowSwap"),
+            meta_data: vec![MetaData {
+                version: String::from("1.2.3"),
+                kind: MetaDataKind::Referrer,
+                referrer: "0x424a46612794dbb8000194937834250dc723ffa5"
+                    .parse()
+                    .unwrap(),
+            }],
+        };
+        // Todo: confirm that this is really the expected hash
+        let expected = String::from("bafkreigltot3w7t6tzq5ke6tefwgzdiw6squ7okwebkooo6uf6i65ql354");
+        assert_eq!(app_data.cid().unwrap(), expected);
+    }
+}

--- a/orderbook/src/database.rs
+++ b/orderbook/src/database.rs
@@ -1,3 +1,4 @@
+pub mod app_data;
 pub mod events;
 pub mod fees;
 pub mod instrumented;
@@ -14,12 +15,14 @@ use std::collections::HashMap;
 // enough anyway.
 
 // The names of all tables we use in the db.
-const ALL_TABLES: [&str; 5] = [
+const ALL_TABLES: [&str; 7] = [
     "orders",
     "trades",
     "invalidations",
     "min_fee_measurements",
     "settlements",
+    "app_data",
+    "meta_data",
 ];
 
 // The pool uses an Arc internally.

--- a/orderbook/src/database.rs
+++ b/orderbook/src/database.rs
@@ -77,7 +77,7 @@ mod tests {
         db.clear().await.unwrap();
 
         let counts = db.count_rows_in_tables().await.unwrap();
-        assert_eq!(counts.len(), 5);
+        assert_eq!(counts.len(), 7);
         assert!(counts.iter().all(|(_, count)| *count == 0));
 
         db.insert_order(&Default::default()).await.unwrap();

--- a/orderbook/src/database/app_data.rs
+++ b/orderbook/src/database/app_data.rs
@@ -1,0 +1,280 @@
+use super::*;
+use crate::conversions::*;
+use anyhow::Result;
+use futures::stream::TryStreamExt;
+use futures::StreamExt;
+use model::meta_data::{AppData, MetaData, MetaDataKind};
+use std::borrow::Cow;
+
+#[async_trait::async_trait]
+pub trait AppDataStoring: Send + Sync {
+    async fn insert_app_data(&self, app_data: &AppData) -> Result<(), InsertionError>;
+    async fn get_complete_app_data(&self, filter: &AppDataFilter) -> Result<Option<AppData>>;
+    fn app_data<'a>(&'a self, filter: &'a AppDataFilter) -> BoxStream<'a, Result<AppData>>;
+    fn meta_data<'a>(&'a self, filter: &'a AppDataFilter) -> BoxStream<'a, Result<MetaData>>;
+}
+
+/// Any default value means that this field is unfiltered.
+#[derive(Clone, Default)]
+pub struct AppDataFilter {
+    pub app_data_cid: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum InsertionError {
+    DuplicatedRecord,
+    AnyhowError(anyhow::Error),
+    DbError(sqlx::Error),
+}
+
+impl From<sqlx::Error> for InsertionError {
+    fn from(err: sqlx::Error) -> Self {
+        Self::DbError(err)
+    }
+}
+
+impl From<anyhow::Error> for InsertionError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::AnyhowError(err)
+    }
+}
+#[derive(sqlx::Type)]
+#[sqlx(type_name = "MetaDataKind")]
+#[sqlx(rename_all = "lowercase")]
+pub enum DbMetaDataKind {
+    Referrer,
+}
+
+impl DbMetaDataKind {
+    pub fn from(kind: MetaDataKind) -> Self {
+        match kind {
+            MetaDataKind::Referrer => Self::Referrer,
+        }
+    }
+
+    fn into(self) -> MetaDataKind {
+        match self {
+            Self::Referrer => MetaDataKind::Referrer,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AppDataStoring for Postgres {
+    async fn insert_app_data(&self, app_data: &AppData) -> Result<(), InsertionError> {
+        const QUERY: &str = "\
+            INSERT INTO app_data (\
+                app_data_cid, version, app_code)\
+                VALUES ($1, $2, $3);";
+        let app_data_cid = app_data.cid()?;
+        sqlx::query(QUERY)
+            .bind(app_data_cid.clone().as_bytes())
+            .bind(app_data.version.as_bytes())
+            .bind(app_data.app_code.as_bytes())
+            .execute(&self.pool)
+            .await
+            .map(|_| ())
+            .map_err(|err| {
+                if let sqlx::Error::Database(db_err) = &err {
+                    if let Some(Cow::Borrowed("23505")) = db_err.code() {
+                        return InsertionError::DuplicatedRecord;
+                    }
+                }
+                InsertionError::DbError(err)
+            })?;
+        for (i, meta_data) in app_data.meta_data.iter().enumerate() {
+            const QUERY: &str = "\
+            INSERT INTO meta_data ( \
+                version, kind, referrer, position, app_data_cid)\
+                VALUES ($1, $2, $3, $4, $5);";
+            sqlx::query(QUERY)
+                .bind(meta_data.version.as_bytes())
+                .bind(DbMetaDataKind::from(meta_data.kind))
+                .bind(meta_data.referrer.as_ref())
+                .bind(i as u32)
+                .bind(app_data_cid.as_bytes())
+                .execute(&self.pool)
+                .await
+                .map(|_| ())
+                .map_err(|err| {
+                    if let sqlx::Error::Database(db_err) = &err {
+                        if let Some(Cow::Borrowed("23505")) = db_err.code() {
+                            return InsertionError::DuplicatedRecord;
+                        }
+                    }
+                    InsertionError::DbError(err)
+                })?;
+        }
+        Ok(())
+    }
+
+    async fn get_complete_app_data(&self, filter: &AppDataFilter) -> Result<Option<AppData>> {
+        let meta_data = self.meta_data(filter).try_collect::<Vec<_>>().await?;
+        let app_data_query_result = self.app_data(filter).try_collect::<Vec<_>>().await?;
+        if let Some(app_data) = app_data_query_result.get(0) {
+            Ok(Some(AppData {
+                version: app_data.version.clone(),
+                app_code: app_data.app_code.clone(),
+                meta_data,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn app_data<'a>(&'a self, filter: &'a AppDataFilter) -> BoxStream<'a, Result<AppData>> {
+        if let Some(app_data_cid) = &filter.app_data_cid {
+            const QUERY: &str = "\
+            SELECT version, app_code FROM app_data \
+                WHERE app_data_cid = $1;";
+
+            sqlx::query_as(QUERY)
+                .bind(app_data_cid.as_bytes())
+                .fetch(&self.pool)
+                .err_into()
+                .and_then(|row: AppDataQueryRow| async move { row.into_app_data() })
+                .boxed()
+        } else {
+            const QUERY: &str = "\
+            SELECT version, app_code FROM app_data;";
+
+            sqlx::query_as(QUERY)
+                .fetch(&self.pool)
+                .err_into()
+                .and_then(|row: AppDataQueryRow| async move { row.into_app_data() })
+                .boxed()
+        }
+    }
+    fn meta_data<'a>(&'a self, filter: &'a AppDataFilter) -> BoxStream<'a, Result<MetaData>> {
+        if let Some(app_data_cid) = &filter.app_data_cid {
+            const QUERY: &str = "\
+            SELECT version, kind, referrer FROM meta_data \
+                WHERE \
+                app_data_cid = $1 \
+                ORDER BY position ASC;";
+
+            sqlx::query_as(QUERY)
+                .bind(app_data_cid.as_bytes())
+                .fetch(&self.pool)
+                .err_into()
+                .and_then(|row: MetaDataQueryRow| async move { row.into_meta_data() })
+                .boxed()
+        } else {
+            const QUERY: &str = "\
+            SELECT version, kind, referrer FROM meta_data \
+                ORDER BY app_data_cid, position ASC;";
+            sqlx::query_as(QUERY)
+                .fetch(&self.pool)
+                .err_into()
+                .and_then(|row: MetaDataQueryRow| async move { row.into_meta_data() })
+                .boxed()
+        }
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct AppDataQueryRow {
+    version: Vec<u8>,
+    app_code: Vec<u8>,
+}
+
+#[derive(sqlx::FromRow)]
+struct MetaDataQueryRow {
+    version: Vec<u8>,
+    kind: DbMetaDataKind,
+    referrer: Vec<u8>,
+}
+
+impl AppDataQueryRow {
+    fn into_app_data(self) -> Result<AppData> {
+        let version = String::from_utf8(self.version)?;
+        let app_code = String::from_utf8(self.app_code)?;
+        Ok(AppData {
+            version,
+            app_code,
+            meta_data: Vec::new(),
+        })
+    }
+}
+impl MetaDataQueryRow {
+    fn into_meta_data(self) -> Result<MetaData> {
+        let version = String::from_utf8(self.version)?;
+        let kind = self.kind.into();
+        let referrer = h160_from_vec(self.referrer)?;
+        Ok(MetaData {
+            version,
+            kind,
+            referrer,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_insert_same_order_twice_fails() {
+        let db = Postgres::new("postgresql://").unwrap();
+        db.clear().await.unwrap();
+        let app_data = AppData {
+            version: String::from("1.0.0"),
+            app_code: String::from("CowSwap"),
+            meta_data: vec![MetaData {
+                version: String::from("1.2.3"),
+                kind: MetaDataKind::Referrer,
+                referrer: "0x424a46612794dbb8000194937834250dc723ffa5"
+                    .parse()
+                    .unwrap(),
+            }],
+        };
+        db.insert_app_data(&app_data).await.unwrap();
+        match db.insert_app_data(&app_data).await {
+            Err(InsertionError::DuplicatedRecord) => (),
+            _ => panic!("Expecting DuplicatedRecord error"),
+        };
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_meta_data_roundtrip() {
+        let db = Postgres::new("postgresql://").unwrap();
+        db.clear().await.unwrap();
+        let filter = AppDataFilter::default();
+        assert!(db.meta_data(&filter).boxed().next().await.is_none());
+        assert!(db.app_data(&filter).boxed().next().await.is_none());
+        let app_data = AppData {
+            version: String::from("1.0.0"),
+            app_code: String::from("CowSwap"),
+            meta_data: vec![
+                MetaData {
+                    version: String::from("1.2.3"),
+                    kind: MetaDataKind::Referrer,
+                    referrer: "0x424a46612794dbb8000194937834250dc723ffa5"
+                        .parse()
+                        .unwrap(),
+                },
+                MetaData {
+                    version: String::from("1.2.5"),
+                    kind: MetaDataKind::Referrer,
+                    referrer: "0x424a46612794dbb8000194937834250dc723ffa5"
+                        .parse()
+                        .unwrap(),
+                },
+            ],
+        };
+        db.insert_app_data(&app_data).await.unwrap();
+        let new_filter = AppDataFilter {
+            app_data_cid: Some(app_data.cid().unwrap()),
+        };
+        assert_eq!(
+            db.get_complete_app_data(&new_filter)
+                .await
+                .unwrap()
+                .unwrap(),
+            app_data
+        );
+    }
+}


### PR DESCRIPTION
This PR adds the DB schema for storing app_data.

The app_data format was predefined [here](https://docs.google.com/document/d/1PsdWn9WPFf2BNeoJNtClyra8jNvWk_bJ-g33TbpUf8s/edit?ts=60ee0b05#): See sections Apps and Referred users. I used the CID (ipfs hash) as the unique identifier for all app_data's.


### Test Plan
Unit tests only. I also double-checked that ignored tests are already passing.

### Architecture design
I wasn't 100% sure whether the coded solution is the best way to store an AppData object containing a vector of another object: MetaData. I stored just MetaData and AppData as separate objects and then later merge them with two separate queries. Maybe there is a smarter way to do it.

###
This is only the first PR, an API endpoint for these objects will come next.