### PR TITLE
Multiple accounts in solvers, step 2: driver honors solver's account

### DIFF
--- a/e2e/tests/eth_integration.rs
+++ b/e2e/tests/eth_integration.rs
@@ -13,7 +13,7 @@ use shared::{
 };
 use solver::{
     liquidity::uniswap::UniswapLikeLiquidity, liquidity_collector::LiquidityCollector,
-    metrics::NoopMetrics,
+    metrics::NoopMetrics, solver::Solvers,
 };
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use web3::signing::SecretKeyRef;
@@ -213,7 +213,7 @@ async fn eth_integration(web3: Web3) {
         gpv2.settlement.clone(),
         liquidity_collector,
         price_estimator,
-        vec![solver],
+        Solvers::new(vec![solver]),
         Arc::new(web3.clone()),
         Duration::from_secs(1),
         Duration::from_secs(30),

--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -13,7 +13,7 @@ use shared::{
 };
 use solver::{
     liquidity::uniswap::UniswapLikeLiquidity, liquidity_collector::LiquidityCollector,
-    metrics::NoopMetrics,
+    metrics::NoopMetrics, solver::Solvers,
 };
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use web3::signing::SecretKeyRef;
@@ -189,7 +189,7 @@ async fn onchain_settlement(web3: Web3) {
         gpv2.settlement.clone(),
         liquidity_collector,
         price_estimator,
-        vec![solver],
+        Solvers::new(vec![solver]),
         Arc::new(web3.clone()),
         Duration::from_secs(1),
         Duration::from_secs(30),

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -14,7 +14,7 @@ use shared::{
 };
 use solver::{
     liquidity::uniswap::UniswapLikeLiquidity, liquidity_collector::LiquidityCollector,
-    metrics::NoopMetrics,
+    metrics::NoopMetrics, solver::Solvers,
 };
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use web3::signing::SecretKeyRef;
@@ -175,7 +175,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         gpv2.settlement.clone(),
         liquidity_collector,
         price_estimator,
-        vec![solver],
+        Solvers::new(vec![solver]),
         Arc::new(web3.clone()),
         Duration::from_secs(1),
         Duration::from_secs(30),

--- a/solver/src/driver/solver_settlements.rs
+++ b/solver/src/driver/solver_settlements.rs
@@ -1,79 +1,19 @@
+use crate::solver::SolverId;
 use crate::{encoding::EncodedSettlement, settlement::Settlement};
-use anyhow::Result;
+use derivative::Derivative;
 use ethcontract::U256;
 use num::BigRational;
 use primitive_types::H160;
 use shared::conversions::U256Ext;
 use std::{collections::HashMap, time::Duration};
 
-// Return None if the result is an error or there are no settlements remaining after removing
-// settlements with no trades.
-pub fn filter_bad_settlements(
-    (solver_name, solver_result): (&'static str, Result<Vec<Settlement>>),
-) -> Option<(&'static str, Vec<Settlement>)> {
-    let mut settlements = match solver_result {
-        Ok(settlements) => settlements,
-        Err(err) => {
-            tracing::error!("solver {} error: {:?}", solver_name, err);
-            return None;
-        }
-    };
-    settlements.retain(|settlement| !settlement.trades().is_empty());
-    if settlements.is_empty() {
-        return None;
-    }
-    Some((solver_name, settlements))
-}
-
-// A single solver produces multiple settlements
-#[derive(Debug)]
-pub struct SolverWithSettlements {
-    pub name: &'static str,
-    pub settlements: Vec<Settlement>,
-}
-
-impl From<SolverWithSettlements> for Vec<SettlementWithSolver> {
-    fn from(instance: SolverWithSettlements) -> Self {
-        let name = instance.name;
-        instance
-            .settlements
-            .into_iter()
-            .map(|settlement| SettlementWithSolver { name, settlement })
-            .collect()
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct SettlementWithSolver {
-    pub name: &'static str,
-    pub settlement: Settlement,
-}
-
-impl From<SettlementWithSolver> for EncodedSettlement {
-    fn from(instance: SettlementWithSolver) -> Self {
-        instance.settlement.into()
-    }
-}
-
-impl From<SettlementWithSolver> for Settlement {
-    fn from(instance: SettlementWithSolver) -> Self {
-        instance.settlement
-    }
-}
-
-impl SettlementWithSolver {
-    pub fn without_onchain_liquidity(&self) -> Self {
-        Self {
-            name: self.name,
-            settlement: self.settlement.without_onchain_liquidity(),
-        }
-    }
-}
-
 // Each individual settlement has an objective value.
-#[derive(Debug, Clone)]
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
 pub struct RatedSettlement {
-    pub settlement: SettlementWithSolver,
+    #[derivative(Debug(format_with = "SolverId::format"))]
+    pub solver_id: SolverId,
+    pub settlement: Settlement,
     pub surplus: BigRational,     // In wei.
     pub solver_fees: BigRational, // In wei.
     pub gas_estimate: U256,       // In gas units.
@@ -112,13 +52,14 @@ impl From<RatedSettlement> for EncodedSettlement {
 
 impl From<RatedSettlement> for Settlement {
     fn from(instance: RatedSettlement) -> Self {
-        instance.settlement.into()
+        instance.settlement
     }
 }
 
 impl RatedSettlement {
     pub fn without_onchain_liquidity(&self) -> Self {
         RatedSettlement {
+            solver_id: self.solver_id,
             settlement: self.settlement.without_onchain_liquidity(),
             surplus: self.surplus.clone(),
             solver_fees: self.solver_fees.clone(),
@@ -128,13 +69,17 @@ impl RatedSettlement {
     }
 }
 
-// Takes the settlements of a single solver and adds a merged settlement.
+/// Removes settlements that don't have any trades.
+pub fn filter_empty_settlements(settlements: &mut Vec<Settlement>) {
+    settlements.retain(|settlement| !settlement.trades().is_empty());
+}
+
+/// Takes the settlements of a single solver and adds a merged settlement.
 pub fn merge_settlements(
     max_merged_settlements: usize,
     prices: &HashMap<H160, BigRational>,
-    name: &'static str,
-    mut settlements: Vec<Settlement>,
-) -> SolverWithSettlements {
+    settlements: &mut Vec<Settlement>,
+) {
     settlements.sort_by_cached_key(|a| -a.total_surplus(prices));
 
     if let Some(settlement) =
@@ -142,7 +87,6 @@ pub fn merge_settlements(
     {
         settlements.push(settlement);
     }
-    SolverWithSettlements { name, settlements }
 }
 
 // Goes through the settlements in order and tries to merge a number of them. Keeps going on merge
@@ -174,15 +118,16 @@ fn merge_at_most_settlements(
     }
 }
 
+/// Removes settlements that only have recent orders.
+/// This increases chance to get a CoW.
 pub fn filter_settlements_without_old_orders(
     min_order_age: Duration,
-    settlements: &mut Vec<SettlementWithSolver>,
+    settlements: &mut Vec<Settlement>,
 ) {
     let settle_orders_older_than =
         chrono::offset::Utc::now() - chrono::Duration::from_std(min_order_age).unwrap();
     settlements.retain(|settlement| {
         settlement
-            .settlement
             .trades()
             .iter()
             .any(|trade| trade.order.order_meta_data.creation_date <= settle_orders_older_than)
@@ -236,12 +181,12 @@ mod tests {
             Settlement::with_trades(prices.clone(), vec![trade(executed_amount, order_uid)])
         };
 
-        let settlements = vec![
+        let mut settlements = vec![
             settlement(1.into(), 1),
             settlement(2.into(), 2),
             settlement(3.into(), 3),
         ];
-        let settlements = merge_settlements(2, &prices_rational, "", settlements).settlements;
+        merge_settlements(2, &prices_rational, &mut settlements);
 
         assert_eq!(settlements.len(), 4);
         assert!(settlements.iter().any(|settlement| {

--- a/solver/src/settlement_submission/retry.rs
+++ b/solver/src/settlement_submission/retry.rs
@@ -7,7 +7,7 @@ use ethcontract::{
     jsonrpc::types::Error as RpcError,
     transaction::{confirm::ConfirmParams, ResolveCondition},
     web3::error::Error as Web3Error,
-    GasPrice,
+    Account, GasPrice,
 };
 use primitive_types::U256;
 use transaction_retry::{TransactionResult, TransactionSending};
@@ -53,6 +53,7 @@ impl TransactionResult for SettleResult {
 }
 
 pub struct SettlementSender<'a> {
+    pub account: Account,
     pub contract: &'a GPv2Settlement,
     pub nonce: U256,
     pub gas_limit: f64,
@@ -64,6 +65,7 @@ impl<'a> TransactionSending for SettlementSender<'a> {
     async fn send(&self, gas_price: f64) -> Self::Output {
         tracing::info!("submitting solution transaction at gas price {}", gas_price);
         let mut method = settle_method_builder(self.contract, self.settlement.clone())
+            .from(self.account.clone())
             .nonce(self.nonce)
             .gas_price(GasPrice::Value(U256::from_f64_lossy(gas_price)))
             .gas(U256::from_f64_lossy(self.gas_limit));

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -1,23 +1,28 @@
-use crate::{liquidity::Liquidity, settlement::Settlement};
-use anyhow::Result;
+//! Provides access to different solving strategies over an abstract interface.
+
+use crate::liquidity::Liquidity;
+use crate::metrics::SolverMetrics;
+use crate::settlement::Settlement;
+use anyhow::{anyhow, Result};
 use baseline_solver::BaselineSolver;
 use contracts::GPv2Settlement;
 use ethcontract::{Account, H160, U256};
+use futures::future::join_all;
 use http_solver::{HttpSolver, SolverConfig};
 use matcha_solver::MatchaSolver;
 use naive_solver::NaiveSolver;
 use oneinch_solver::OneInchSolver;
 use paraswap_solver::ParaswapSolver;
 use reqwest::Url;
-use shared::{
-    conversions::U256Ext, price_estimate::PriceEstimating, token_info::TokenInfoFetching, Web3,
-};
+use shared::conversions::U256Ext;
+use shared::price_estimate::PriceEstimating;
+use shared::token_info::TokenInfoFetching;
+use shared::Web3;
 use single_order_solver::SingleOrderSolver;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Duration,
-};
+use std::collections::{HashMap, HashSet};
+use std::fmt::Formatter;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 use structopt::clap::arg_enum;
 
 mod baseline_solver;
@@ -33,23 +38,148 @@ mod solver_utils;
 // minus this duration to account for additional delay for example from the network.
 const TIMEOUT_SAFETY_BUFFER: Duration = Duration::from_secs(5);
 
-/// Interface that all solvers must implement
+/// Interface that all solvers must implement.
+///
 /// A `solve` method transforming a collection of `Liquidity` (sources) into a list of
 /// independent `Settlements`. Solvers are free to choose which types `Liquidity` they
-/// would like to include/process (i.e. those already supported here or their own private sources)
-/// The `name` method is included for logging purposes.
+/// would like to process, including their own private sources.
 #[async_trait::async_trait]
 pub trait Solver {
     /// The returned settlements should be independent (for example not reusing the same user
     /// order) so that they can be merged by the driver at its leisure.
     async fn solve(&self, orders: Vec<Liquidity>, gas_price: f64) -> Result<Vec<Settlement>>;
 
-    /// Solver's account that should be used to submit settlements.
+    /// Returns solver's account that should be used to submit settlements.
     fn account(&self) -> &Account;
 
-    /// Displayable name of the solver. Defaults to the type name.
+    /// Returns displayable name of the solver.
+    ///
+    /// This method is used in logging and metrics. By default, returns the type name.
     fn name(&self) -> &'static str {
         std::any::type_name::<Self>()
+    }
+}
+
+/// Solver ID can be used to identify a solver within a [`Solvers`] collection.
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+pub struct SolverId(usize);
+
+impl SolverId {
+    /// Create an object that can be formatted to display
+    /// solver ID's numerical value, name and address.
+    ///
+    /// Prefer this function over [`debug_raw`] if you have access
+    /// to the solvers collection.
+    pub fn debug(self, solvers: &Solvers) -> impl std::fmt::Debug + '_ {
+        struct SolverIdDebug<'a>(usize, &'a str, &'a Account);
+        impl std::fmt::Debug for SolverIdDebug<'_> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct("SolverId")
+                    .field("id", &self.0)
+                    .field("name", &self.1)
+                    .field("address", &self.2.address())
+                    .finish()
+            }
+        }
+
+        SolverIdDebug(self.0, solvers.name(self), solvers.account(self))
+    }
+
+    /// Create an object that can be formatted to display
+    /// solver ID's numerical value.
+    pub fn debug_raw(self) -> impl std::fmt::Debug {
+        struct SolverIdDebug(usize);
+        impl std::fmt::Debug for SolverIdDebug {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                f.debug_tuple("SolverId").field(&self.0).finish()
+            }
+        }
+
+        SolverIdDebug(self.0)
+    }
+
+    /// Format this ID as if using [`debug_raw`].
+    pub fn format(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        f.debug_tuple("SolverId").field(&self.0).finish()
+    }
+}
+
+/// A collection of solvers.
+pub struct Solvers {
+    solvers: Vec<Box<dyn Solver>>,
+}
+
+impl Solvers {
+    /// Create a new collection of solvers.
+    pub fn new(solvers: Vec<Box<dyn Solver>>) -> Self {
+        Solvers { solvers }
+    }
+
+    /// Returns solver by its ID.
+    ///
+    /// # Panics
+    ///
+    /// This method may panic or return an unspecified solver if given
+    /// solver ID does not belong to a solver from this collection.
+    pub fn solver(&self, id: SolverId) -> &dyn Solver {
+        self.solvers.get(id.0).expect("invalid solver ID").as_ref()
+    }
+
+    /// Returns solver's name by its ID.
+    ///
+    /// See [`solver`] method for more info.
+    pub fn name(&self, id: SolverId) -> &'static str {
+        self.solver(id).name()
+    }
+
+    /// Returns solver's account by its ID.
+    ///
+    /// See [`solver`] method for more info.
+    pub fn account(&self, id: SolverId) -> &Account {
+        self.solver(id).account()
+    }
+
+    /// Returns an iterator over all solvers in this collection, along with their IDs.
+    pub fn solvers(&self) -> impl std::iter::Iterator<Item = (SolverId, &dyn Solver)> {
+        self.solvers
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (SolverId(i), s.as_ref()))
+    }
+
+    /// Runs all solvers and returns whatever settlements they've produced.
+    ///
+    /// Optionally reports per-solver metrics.
+    pub async fn run(
+        &self,
+        liquidity: Vec<Liquidity>,
+        gas_price: f64,
+        time_limit: Duration,
+        metrics: Option<&dyn SolverMetrics>,
+    ) -> impl Iterator<Item = (SolverId, Result<Vec<Settlement>>)> {
+        join_all(self.solvers().map(|(id, solver)| {
+            let liquidity = liquidity.clone();
+            async move {
+                let start_time = Instant::now();
+
+                let result = match tokio::time::timeout(
+                    time_limit,
+                    solver.solve(liquidity, gas_price),
+                )
+                .await
+                {
+                    Ok(inner) => inner,
+                    Err(_timeout) => Err(anyhow!("solver timed out")),
+                };
+
+                if let Some(metrics) = metrics {
+                    metrics.settlement_computed(solver.name(), start_time);
+                }
+                (id, result)
+            }
+        }))
+        .await
+        .into_iter()
     }
 }
 
@@ -85,10 +215,9 @@ pub fn create(
     min_order_size_one_inch: U256,
     disabled_one_inch_protocols: Vec<String>,
     paraswap_slippage_bps: usize,
-) -> Result<Vec<Box<dyn Solver>>> {
+) -> Result<Solvers> {
     // Tiny helper function to help out with type inference. Otherwise, all
     // `Box::new(...)` expressions would have to be cast `as Box<dyn Solver>`.
-    #[allow(clippy::unnecessary_wraps)]
     fn boxed(solver: impl Solver + 'static) -> Result<Box<dyn Solver>> {
         Ok(Box::new(solver))
     }
@@ -161,7 +290,8 @@ pub fn create(
                 paraswap_slippage_bps,
             ))),
         })
-        .collect()
+        .collect::<Result<_>>()
+        .map(Solvers::new)
 }
 
 /// Returns a naive solver to be used e.g. in e2e tests.


### PR DESCRIPTION
Part of #827.

Refactor driver to support different accounts for solvers. We drop solver names from most places, and replace them with unique solver IDs. Driver can look up solver by its ID and get its name, address, and other info.

### Test Plan
Unittests are in progress. Proper testing suite will require contract mocking, I will add it later.
