### PR TITLE
[easy] Print solver type instead of http solver

### DIFF
--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -98,8 +98,9 @@ pub fn create(
         .expect("solver_timeout too low");
 
     // Helper function to create http solver instances.
-    let create_http_solver = |url: Url| -> HttpSolver {
+    let create_http_solver = |url: Url, name: &'static str| -> HttpSolver {
         HttpSolver::new(
+            name,
             account.clone(),
             url,
             None,
@@ -123,8 +124,11 @@ pub fn create(
             SolverType::Baseline => {
                 boxed(BaselineSolver::new(account.clone(), base_tokens.clone()))
             }
-            SolverType::Mip => boxed(create_http_solver(mip_solver_url.clone())),
-            SolverType::Quasimodo => boxed(create_http_solver(quasimodo_solver_url.clone())),
+            SolverType::Mip => boxed(create_http_solver(mip_solver_url.clone(), &"Mip")),
+            SolverType::Quasimodo => boxed(create_http_solver(
+                quasimodo_solver_url.clone(),
+                &"Quasimodo",
+            )),
             SolverType::OneInch => {
                 let one_inch_solver: SingleOrderSolver<_> = OneInchSolver::with_disabled_protocols(
                     account.clone(),

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -59,6 +59,7 @@ impl SolverConfig {
 }
 
 pub struct HttpSolver {
+    name: &'static str,
     account: Account,
     base: Url,
     client: Client,
@@ -75,6 +76,7 @@ pub struct HttpSolver {
 impl HttpSolver {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        name: &'static str,
         account: Account,
         base: Url,
         api_key: Option<String>,
@@ -89,6 +91,7 @@ impl HttpSolver {
         // Unwrap because we cannot handle client creation failing.
         let client = Client::builder().build().unwrap();
         Self {
+            name,
             account,
             base,
             client,
@@ -457,6 +460,10 @@ impl Solver for HttpSolver {
     fn account(&self) -> &Account {
         &self.account
     }
+
+    fn name(&self) -> &'static str {
+        &self.name
+    }
 }
 
 #[cfg(test)]
@@ -503,6 +510,7 @@ mod tests {
         let gas_price = 100.;
 
         let solver = HttpSolver::new(
+            &"Test Solver",
             Account::Local(Address::default(), None),
             url.parse().unwrap(),
             None,

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -457,10 +457,6 @@ impl Solver for HttpSolver {
     fn account(&self) -> &Account {
         &self.account
     }
-
-    fn name(&self) -> &'static str {
-        "HTTPSolver"
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
removes the custom name trait implementation, hence the name implementation will fall back to printing the solver type. This allows us to differentiate between quasimodo solver and mip solver