### PR TITLE
App Data Step 2: Api to push and retrieve app_data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,12 +146,18 @@ checksum = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
@@ -193,6 +205,43 @@ dependencies = [
  "radium 0.6.2",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake2s_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake3"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b64485778c4f16a6a5a9d335e80d449ac6c70cdd6a06d2af18a6f6f775a125b3"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "cc",
+ "cfg-if 0.1.10",
+ "constant_time_eq",
+ "crypto-mac 0.8.0",
+ "digest",
 ]
 
 [[package]]
@@ -274,6 +323,12 @@ checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -292,6 +347,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cid"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b8976b33648136e969aafa6eb33d58ff0d301fa0b4e8d513db58fd32cd81aa"
+dependencies = [
+ "multibase",
+ "multihash",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +371,12 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "contracts"
@@ -395,7 +467,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -405,7 +477,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -416,7 +488,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -429,7 +501,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -439,7 +511,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -448,6 +520,16 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
 
 [[package]]
 name = "crypto-mac"
@@ -543,6 +625,32 @@ checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
 dependencies = [
  "darling_core",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86927b7cd2fe88fa698b87404b287ab98d1a0063a34071d92e575b72d3029aca"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
+dependencies = [
+ "data-encoding",
  "syn",
 ]
 
@@ -651,7 +759,7 @@ version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -804,7 +912,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "winapi",
@@ -1005,7 +1113,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -1129,7 +1237,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.10.0",
  "digest",
 ]
 
@@ -1279,7 +1387,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1354,7 +1462,7 @@ checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec 0.5.2",
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
 ]
@@ -1392,7 +1500,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1505,7 +1613,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd9a2de7b4bd932854c776ce60880caf8fa41095a7907e3accc52ef6678895b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "downcast",
  "fragile",
  "lazy_static",
@@ -1520,7 +1628,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07174e9c5ffb2ff849187641c48fc66f5588f012f1d248e55c3a68cd462bd29"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1530,8 +1638,10 @@ dependencies = [
 name = "model"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bigdecimal",
  "chrono",
+ "cid",
  "derivative",
  "enum-utils",
  "ethabi",
@@ -1547,6 +1657,48 @@ dependencies = [
  "serde_json",
  "serde_with",
  "web3",
+]
+
+[[package]]
+name = "multibase"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
+dependencies = [
+ "base-x",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
+name = "multihash"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
+dependencies = [
+ "blake2b_simd",
+ "blake2s_simd",
+ "blake3",
+ "digest",
+ "generic-array",
+ "multihash-derive",
+ "sha2",
+ "sha3",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -1741,7 +1893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -1835,7 +1987,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -1973,6 +2125,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+dependencies = [
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,7 +2185,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
  "memchr",
@@ -2453,7 +2615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -2466,7 +2628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -2789,6 +2951,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2800,7 +2974,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "rand",
  "redox_syscall",
@@ -2977,6 +3151,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,7 +3171,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -3184,6 +3367,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unsigned-varint"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f8d425fafb8cd76bc3f22aace4af471d3156301d7508f2107e98fbeae10bc7f"
+
+[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,7 +3469,7 @@ version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -3307,7 +3496,7 @@ version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/model/src/h256_hexadecimal.rs
+++ b/model/src/h256_hexadecimal.rs
@@ -1,0 +1,70 @@
+use primitive_types::H256;
+use serde::{de, Deserializer, Serializer};
+use serde_with::{DeserializeAs, SerializeAs};
+use std::fmt;
+
+pub struct HexadecimalH256;
+
+impl<'de> DeserializeAs<'de, H256> for HexadecimalH256 {
+    fn deserialize_as<D>(deserializer: D) -> Result<H256, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize(deserializer)
+    }
+}
+
+impl<'de> SerializeAs<H256> for HexadecimalH256 {
+    fn serialize_as<S>(source: &H256, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize(source, serializer)
+    }
+}
+
+pub fn serialize<S>(value: &H256, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut bytes = [0u8; 2 + 32 * 2];
+    bytes[..2].copy_from_slice(b"0x");
+    // Can only fail if the buffer size does not match but we know it is correct.
+    hex::encode_to_slice(value, &mut bytes[2..]).unwrap();
+    // Hex encoding is always valid utf8.
+    let s = std::str::from_utf8(&bytes).unwrap();
+    serializer.serialize_str(s)
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<H256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Visitor {}
+    impl<'de> de::Visitor<'de> for Visitor {
+        type Value = H256;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(formatter, "an ethereum address as a hex encoded string")
+        }
+
+        fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            let s = s.strip_prefix("0x").ok_or_else(|| {
+                de::Error::custom(format!(
+                    "{:?} can't be decoded as hex H256 because it does not start with '0x'",
+                    s
+                ))
+            })?;
+            let mut value = H256::zero();
+            hex::decode_to_slice(s, value.as_mut()).map_err(|err| {
+                de::Error::custom(format!("failed to decode {:?} as hex H256: {}", s, err))
+            })?;
+            Ok(value)
+        }
+    }
+
+    deserializer.deserialize_str(Visitor {})
+}

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod app_data;
 pub mod appdata_hexadecimal;
 pub mod h160_hexadecimal;
+pub mod h256_hexadecimal;
 pub mod order;
 pub mod ratio_as_decimal;
 pub mod trade;

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -399,7 +399,7 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/AppDataJson"
-    /api/v1/app_data/{AppDataHash}:
+  /api/v1/app_data/{AppDataHash}:
     get:
       summary: Get existing app_data via hash.
       parameters:

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -374,6 +374,51 @@ paths:
           description: Token non-existent or not connected to native token
         500:
           description: Unexpected internal error while processing the request
+  /api/v1/app_data:
+    post:
+      summary: Create a new app_data or just get the hash for an app_data.
+      responses:
+        200:
+          description: AppData was already available.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppDataHash"
+        201:
+          description: AppData has been created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppDataHash"
+        500:
+          description: Error adding a the appData
+      requestBody:
+        description: The AppData to create.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AppDataJson"
+    /api/v1/app_data/{AppDataHash}:
+    get:
+      summary: Get existing app_data via hash.
+      parameters:
+        - in: path
+          name: AppDataHash
+          schema:
+            $ref: "#/components/schemas/AppDataHash"
+          required: true
+      responses:
+        200:
+          description: AppData
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AppDataJson"
+        404:
+          description: AppData was not found
 components:
   schemas:
     TransactionHash:
@@ -506,6 +551,22 @@ components:
         - partiallyFillable
         - signature
         - signingScheme
+    AppDataJson:
+      description: |
+       Extra data for transporting app data and referrer for each order-placement. 
+       The data is supposed to be provided as a valid json.
+      type: object
+      properties:
+        appCode: 
+          description: Individual code per UI.
+          type: string
+        version:
+          description: Version encoding used.
+          type: string
+        metaData: 
+          description: Additional MetaData.
+          type: object
+          $ref: "#/components/schemas/MetaDataJson"
     OrderMetaData:
       description: |
         Extra order data that is returned to users when querying orders
@@ -626,6 +687,18 @@ components:
         - sellAmountBeforeFees
         - buyAmount
         - transactionHash
+    AppDataHash:
+      description: |
+        Unique identifier for the AppData: The 32 bytes sha hash encoded as hex with `0x` prefix.
+      type: string
+    MetaDataJson:
+      description: |
+       Extra meta data of the app data.
+      type: object
+      properties:
+        referrer: 
+          description: Referrer as 32 bytes with additional 0x prefix.
+          type: string
     UID:
       description: |
         Unique identifier for the order: 56 bytes encoded as hex with `0x` prefix.

--- a/orderbook/src/api/create_app_data.rs
+++ b/orderbook/src/api/create_app_data.rs
@@ -1,0 +1,111 @@
+use crate::api::extract_payload;
+use crate::database::app_data::AppDataStoring;
+use crate::database::app_data::InsertionError;
+use anyhow::Result;
+use model::app_data::AppData;
+use primitive_types::H256;
+use std::{convert::Infallible, sync::Arc};
+use warp::{hyper::StatusCode, Filter, Rejection, Reply};
+
+pub fn create_app_data_request() -> impl Filter<Extract = (AppData,), Error = Rejection> + Clone {
+    warp::path!("app_data")
+        .and(warp::post())
+        .and(extract_payload())
+}
+
+pub fn create_app_data_response(result: Result<H256, InsertionError>) -> impl Reply {
+    let (body, status_code) = match result {
+        Ok(hash) => (warp::reply::json(&hash), StatusCode::CREATED),
+        Err(InsertionError::DuplicatedRecord(hash)) => (warp::reply::json(&hash), StatusCode::OK),
+        Err(InsertionError::AnyhowError(err)) => (
+            super::error("Unknown error", format!("Error is {:?}", err)),
+            StatusCode::BAD_REQUEST,
+        ),
+        Err(InsertionError::DbError(err)) => (
+            super::error("DB error", format!("Error from DB is {:?}", err)),
+            StatusCode::BAD_REQUEST,
+        ),
+    };
+    warp::reply::with_status(body, status_code)
+}
+
+pub fn create_app_data(
+    database: Arc<dyn AppDataStoring>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    create_app_data_request().and_then(move |app_data| {
+        let database = database.clone();
+        async move {
+            let result = database.insert_app_data(&app_data).await;
+            if let Err(err) = &result {
+                match err {
+                    InsertionError::DuplicatedRecord(_hash) => (),
+                    _ => tracing::error!(?err, ?app_data, "add_app_data error"),
+                };
+            }
+            Result::<_, Infallible>::Ok(create_app_data_response(result))
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::response_body;
+    use model::app_data::{AppData, MetaData};
+    use serde_json::json;
+    use warp::test::request;
+
+    #[tokio::test]
+    async fn create_app_data_request_ok() {
+        let filter = create_app_data_request();
+        let app_data_payload = json!(
+        {
+            "version": "1.0.0",
+            "appCode": "CowSwap",
+            "metaData": {
+              "referrer": "0x424a46612794dbb8000194937834250dc723ffa5",
+            }
+        }
+        );
+        let request = request()
+            .path("/app_data")
+            .method("POST")
+            .header("content-type", "application/json")
+            .json(&app_data_payload);
+        let result = request.filter(&filter).await.unwrap();
+        let app_data = AppData {
+            version: String::from("1.0.0"),
+            app_code: String::from("CowSwap"),
+            meta_data: MetaData {
+                referrer: "0x424a46612794dbb8000194937834250dc723ffa5"
+                    .parse()
+                    .unwrap(),
+            },
+        };
+        assert_eq!(result, app_data);
+    }
+
+    #[tokio::test]
+    async fn create_order_response_created() {
+        let hash = H256::from([1u8; 32]);
+        let response = create_app_data_response(Ok(hash)).into_response();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = response_body(response).await;
+        let body: serde_json::Value = serde_json::from_slice(body.as_slice()).unwrap();
+        let expected = json!("0x0101010101010101010101010101010101010101010101010101010101010101");
+        assert_eq!(body, expected);
+    }
+
+    #[tokio::test]
+    async fn create_app_data_response_duplicate() {
+        let response =
+            create_app_data_response(Err(InsertionError::DuplicatedRecord(H256::zero())))
+                .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body(response).await;
+        let body: serde_json::Value = serde_json::from_slice(body.as_slice()).unwrap();
+        let expected_msg =
+            json!("0x0000000000000000000000000000000000000000000000000000000000000000");
+        assert_eq!(body, expected_msg);
+    }
+}

--- a/orderbook/src/api/get_app_data_by_hash.rs
+++ b/orderbook/src/api/get_app_data_by_hash.rs
@@ -1,0 +1,94 @@
+use crate::api::convert_get_app_data_error_to_reply;
+use crate::database::app_data::AppDataFilter;
+use crate::database::app_data::AppDataStoring;
+use anyhow::Result;
+use futures::TryStreamExt;
+use model::app_data::AppData;
+use shared::H256Wrapper;
+
+use std::{convert::Infallible, sync::Arc};
+use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
+
+pub fn get_app_data_by_hash_request(
+) -> impl Filter<Extract = (AppDataFilter,), Error = Rejection> + Clone {
+    warp::path!("app_data" / H256Wrapper)
+        .and(warp::get())
+        .map(|hash: H256Wrapper| AppDataFilter {
+            app_data_hash: Some(hash.0),
+            referrer: None,
+        })
+}
+
+pub fn get_app_data_by_hash_response(result: Result<Vec<AppData>>) -> impl Reply {
+    let app_data = match result {
+        Ok(app_data) => app_data,
+        Err(err) => {
+            return Ok(convert_get_app_data_error_to_reply(err));
+        }
+    };
+    Ok(match app_data.first() {
+        Some(app_data) => reply::with_status(reply::json(&app_data), StatusCode::OK),
+        None => reply::with_status(
+            super::error("NotFound", "AppDataHash was not found"),
+            StatusCode::NOT_FOUND,
+        ),
+    })
+}
+
+pub fn get_app_data_by_hash(
+    database: Arc<dyn AppDataStoring>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    get_app_data_by_hash_request().and_then(move |app_data_filter| {
+        let database = database.clone();
+        async move {
+            let result = database
+                .app_data(&app_data_filter)
+                .try_collect::<Vec<_>>()
+                .await;
+            Result::<_, Infallible>::Ok(get_app_data_by_hash_response(result))
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::response_body;
+    use warp::test::request;
+
+    #[tokio::test]
+    async fn get_app_data_by_hash_request_ok() {
+        let app_data_hash =
+            String::from("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let path_string = format!("/app_data/{}", app_data_hash);
+        let request = request().path(&path_string).method("GET");
+        let filter = get_app_data_by_hash_request();
+        let result = request.filter(&filter).await.unwrap();
+        let expected: primitive_types::H256 = app_data_hash.parse().unwrap();
+        assert_eq!(result.app_data_hash, Some(expected));
+    }
+
+    #[tokio::test]
+    async fn get_app_data_by_hash_response_ok() {
+        let app_data = AppData {
+            version: String::from("1.0.0"),
+            app_code: String::from("CowSwap"),
+            meta_data: model::app_data::MetaData {
+                referrer: "0x424a46612794dbb8000194937834250dc723ffa5"
+                    .parse()
+                    .unwrap(),
+            },
+        };
+        let response = get_app_data_by_hash_response(Ok(vec![app_data.clone()])).into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body(response).await;
+        let response: AppData = serde_json::from_slice(body.as_slice()).unwrap();
+        assert_eq!(response, app_data);
+    }
+
+    #[tokio::test]
+    async fn get_app_data_by_hash_response_non_existent() {
+        let response = get_app_data_by_hash_response(Ok(Vec::new())).into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -10,7 +10,6 @@ pub mod orderbook;
 use crate::orderbook::Orderbook;
 use anyhow::{anyhow, Context as _, Result};
 use contracts::GPv2Settlement;
-use database::trades::TradeRetrieving;
 use fee::EthAwareMinFeeCalculator;
 use metrics::Metrics;
 use model::DomainSeparator;
@@ -23,7 +22,7 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::{task, task::JoinHandle};
 
 pub fn serve_task(
-    database: Arc<dyn TradeRetrieving>,
+    database: Arc<database::instrumented::Instrumented>,
     orderbook: Arc<Orderbook>,
     fee_calculator: Arc<EthAwareMinFeeCalculator>,
     price_estimator: Arc<dyn PriceEstimating>,

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -287,7 +287,7 @@ async fn main() {
 
     let serve_task = serve_task(
         database.clone(),
-        orderbook.clone(),
+        orderbook,
         fee_calculator,
         price_estimator,
         args.bind_address,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -25,9 +25,10 @@ pub mod tracing;
 pub mod transport;
 pub mod web3_traits;
 
-use ethcontract::H160;
+use ethcontract::{H160, H256};
 use hex::{FromHex, FromHexError};
 use model::h160_hexadecimal;
+use model::h256_hexadecimal;
 use serde::Deserialize;
 use std::str::FromStr;
 
@@ -43,5 +44,17 @@ impl FromStr for H160Wrapper {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.strip_prefix("0x").unwrap_or(s);
         Ok(H160Wrapper(H160(FromHex::from_hex(s)?)))
+    }
+}
+
+/// Wraps H256 with FromStr and Deserialize that can handle a `0x` prefix.
+#[derive(Deserialize)]
+#[serde(transparent)]
+pub struct H256Wrapper(#[serde(with = "h256_hexadecimal")] pub H256);
+impl FromStr for H256Wrapper {
+    type Err = FromHexError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.strip_prefix("0x").unwrap_or(s);
+        Ok(H256Wrapper(H256(FromHex::from_hex(s)?)))
     }
 }


### PR DESCRIPTION
This Pr implements the api-infrasturcture for the app_data for a simple pushing and retrieving of the data.


### Test Plan
Unit tests.
I also run the 
```
cargo run --bin orderbook -- --node-url "https://staging-openethereum.mainnet.gnosisdev.com"
```
and in a second terminal
```
 ~ curl -X POST "http://127.0.0.1:8080/api/v1/app_data" -H  "accept: application/json" -H  "Content-Type: application/json" --data "@/Users/alexherrmann/gnosis/test.json"
```
and retrieved:  
"0x2efa116afc4535bff2a63ba1dcd284056334dc76f7c09ee15a9422cae1e2852a"%     