### PR TITLE
Respected Execution Plan Ordering

### DIFF
--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -120,7 +120,7 @@ pub struct SettledBatchAuctionModel {
 impl SettledBatchAuctionModel {
     pub fn has_execution_plan(&self) -> bool {
         // Its a bit weird that we expect all entries to contain an execution plan. Could make
-        // exec_plan not optional and assert that the vector of execution updates is non-empty
+        // execution plan required and assert that the vector of execution updates is non-empty
         self.amms
             .values()
             .flat_map(|u| &u.execution)


### PR DESCRIPTION
Fixes #889

Previously we had been losing the execution plan ordering by returning two separate vectors of executed Amms. Now, however, we return a single vector of a new enum which holds both types of executed amms.

### Test Plan
Existing tests adapted to new types.
