### PR TITLE
Remove iteteration over AMM tokens

### DIFF
--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -120,7 +120,7 @@ pub struct SettledBatchAuctionModel {
 impl SettledBatchAuctionModel {
     pub fn has_execution_plan(&self) -> bool {
         // Its a bit weird that we expect all entries to contain an execution plan. Could make
-        // exec_plan not optional and assert that the vector of execution updates is non-empty
+        // execution plan required and assert that the vector of execution updates is non-empty
         self.amms
             .values()
             .flat_map(|u| &u.execution)


### PR DESCRIPTION
Fixes #892

Not sure yet if prices for irrelevant intermediary tokens are actually necessary to pass into a settlement, but e2e here should tell us.

### Test Plan
May need to create a new e2e test that involves an amm token which is not actually traded directly.
