### PR TITLE
Implement Liveness Check

### DIFF
--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -33,7 +33,7 @@ pub fn serve_task(
 ) -> JoinHandle<()> {
     let filter = api::handle_all_routes(
         database,
-        orderbook,
+        orderbook.clone(),
         fee_calculator,
         price_estimator,
         metrics,
@@ -44,7 +44,7 @@ pub fn serve_task(
 
     tracing::info!(%metrics_address, "serving metrics");
     metrics_address.set_port(DEFAULT_METRICS_PORT);
-    serve_metrics(registry, metrics_address)
+    serve_metrics(registry, orderbook, metrics_address)
 }
 
 /**

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -13,8 +13,8 @@ use model::{
 };
 use primitive_types::{H160, U256};
 use shared::{
-    bad_token::BadTokenDetecting, maintenance::Maintaining, time::now_in_epoch_seconds,
-    web3_traits::CodeFetching,
+    bad_token::BadTokenDetecting, maintenance::Maintaining, metrics::LivenessChecking,
+    time::now_in_epoch_seconds, web3_traits::CodeFetching,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -227,6 +227,13 @@ impl Maintaining for Orderbook {
     async fn run_maintenance(&self) -> Result<()> {
         self.balance_fetcher.update().await;
         Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl LivenessChecking for Orderbook {
+    async fn is_alive(&self) -> bool {
+        self.get_solvable_orders().await.is_ok()
     }
 }
 

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -102,6 +102,7 @@ impl Driver {
                 Ok(()) => tracing::debug!("single run finished ok"),
                 Err(err) => tracing::error!("single run errored: {:?}", err),
             }
+            self.metrics.runloop_completed();
             tokio::time::sleep(self.settle_interval).await;
         }
     }

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -396,7 +396,7 @@ async fn main() {
         args.settle_interval,
         native_token_contract.address(),
         args.min_order_age,
-        metrics,
+        metrics.clone(),
         web3,
         network_id,
         args.max_merged_settlements,
@@ -416,7 +416,7 @@ async fn main() {
     };
     tokio::task::spawn(maintainer.run_maintenance_on_new_block(current_block_stream));
 
-    serve_metrics(registry, ([0, 0, 0, 0], args.metrics_port).into());
+    serve_metrics(registry, metrics, ([0, 0, 0, 0], args.metrics_port).into());
     driver.run_forever().await;
 }
 


### PR DESCRIPTION
Fixes #885 

This PR adds and implements a liveness checking trait which we can use in our kubernetes setup to monitor the health of our pods and in case of deadlocks automatically restart.

For the orderbook, we reuse our readiness check which is basically just verifying that we can fetch solvable orders.

For the solver we record the last time at which we have completed a single solver runloop. If larger than some thresholf (7 minutes for now) we fail the liveness check.

Once this PR is merged, we will need to add the liveness check in our staging environment and next week also to our prod environment.

### Test Plan
Running locally, `http://localhost:9587/liveness` for solver and `http://localhost:9586/liveness` for orderbook. Change MAX_RUNLOOP_DURATION to 3s and observe that depending on when the last runloop completed the query sometimes returns 200 and sometimes 503
