### PR TITLE
Contract upgrade - update order model(s)

### DIFF
--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -183,6 +183,7 @@ impl OrderbookServices {
         ));
         let orderbook = Arc::new(Orderbook::new(
             gpv2.domain_separator,
+            gpv2.settlement.address(),
             db.clone(),
             Box::new(Web3BalanceFetcher::new(
                 web3.clone(),

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -38,7 +38,12 @@ pub struct Order {
 
 impl Default for Order {
     fn default() -> Self {
-        Self::from_order_creation(OrderCreation::default(), &DomainSeparator::default()).unwrap()
+        Self::from_order_creation(
+            OrderCreation::default(),
+            &DomainSeparator::default(),
+            H160::default(),
+        )
+        .unwrap()
     }
 }
 
@@ -55,6 +60,7 @@ impl Order {
     pub fn from_order_creation(
         order_creation: OrderCreation,
         domain: &DomainSeparator,
+        settlement_contract: H160,
     ) -> Option<Self> {
         let owner = order_creation.signature.validate(
             order_creation.signing_scheme,
@@ -66,6 +72,7 @@ impl Order {
                 creation_date: chrono::offset::Utc::now(),
                 owner,
                 uid: order_creation.uid(domain, &owner),
+                settlement_contract,
                 ..Default::default()
             },
             order_creation,
@@ -190,6 +197,10 @@ pub struct OrderCreation {
     pub partially_fillable: bool,
     pub signature: Signature,
     pub signing_scheme: SigningScheme,
+    #[serde(default)]
+    pub sell_token_balance: BalanceFrom,
+    #[serde(default)]
+    pub buy_token_balance: BalanceTo,
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -215,6 +226,8 @@ impl Default for OrderCreation {
             partially_fillable: Default::default(),
             signing_scheme: SigningScheme::Eip712,
             signature: Default::default(),
+            sell_token_balance: Default::default(),
+            buy_token_balance: Default::default(),
         };
         result.signature = Signature::sign(
             result.signing_scheme,
@@ -345,6 +358,8 @@ pub struct OrderMetaData {
     pub executed_fee_amount: BigUint,
     pub invalidated: bool,
     pub status: OrderStatus,
+    #[serde(with = "h160_hexadecimal")]
+    pub settlement_contract: H160,
 }
 
 impl Default for OrderMetaData {
@@ -360,6 +375,7 @@ impl Default for OrderMetaData {
             executed_fee_amount: Default::default(),
             invalidated: Default::default(),
             status: OrderStatus::Open,
+            settlement_contract: H160::default(),
         }
     }
 }
@@ -460,6 +476,42 @@ impl Default for OrderKind {
     }
 }
 
+/// Location for which the sellAmount should be drawn upon order fulfilment
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Deserialize, Serialize, Hash, enum_utils::FromStr)]
+#[enumeration(case_insensitive)]
+#[serde(rename_all = "snake_case")]
+pub enum BalanceFrom {
+    /// Direct ERC20 allowances to the Vault relayer contract
+    Erc20,
+    /// ERC20 allowances to the Vault with GPv2 relayer approval
+    Internal,
+    /// Internal balances to the Vault with GPv2 relayer approval
+    External,
+}
+
+impl Default for BalanceFrom {
+    fn default() -> Self {
+        Self::Erc20
+    }
+}
+
+/// Location for which the buyAmount should be transferred to order's receiver to upon fulfilment
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Deserialize, Serialize, Hash, enum_utils::FromStr)]
+#[enumeration(case_insensitive)]
+#[serde(rename_all = "snake_case")]
+pub enum BalanceTo {
+    /// TransferAs: ERC20 token transfer
+    Erc20,
+    /// TransferAs: Vault internal balance transfer.
+    Internal,
+}
+
+impl Default for BalanceTo {
+    fn default() -> Self {
+        Self::Erc20
+    }
+}
+
 pub fn debug_app_data(
     app_data: &[u8; 32],
     formatter: &mut std::fmt::Formatter,
@@ -511,6 +563,9 @@ mod tests {
             "signature": "0x0200000000000000000000000000000000000000000000000000000000000003040000000000000000000000000000000000000000000000000000000000000501",
             "signingScheme": "eip712",
             "status": "open",
+            "settlementContract": "0x0000000000000000000000000000000000000002",
+            "sellTokenBalance": "external",
+            "buyTokenBalance": "internal",
         });
         let expected = Order {
             order_meta_data: OrderMetaData {
@@ -523,8 +578,8 @@ mod tests {
                 executed_sell_amount_before_fees: BigUint::from_bytes_be(&[4]),
                 executed_fee_amount: BigUint::from_bytes_be(&[1]),
                 invalidated: true,
-
                 status: OrderStatus::Open,
+                settlement_contract: H160::from_low_u64_be(2),
             },
             order_creation: OrderCreation {
                 sell_token: H160::from_low_u64_be(10),
@@ -549,6 +604,8 @@ mod tests {
                     .unwrap(),
                 },
                 signing_scheme: SigningScheme::Eip712,
+                sell_token_balance: BalanceFrom::External,
+                buy_token_balance: BalanceTo::Internal,
             },
         };
         let deserialized: Order = serde_json::from_value(value.clone()).unwrap();
@@ -588,6 +645,8 @@ mod tests {
                 partially_fillable: false,
                 signature: Signature::from_bytes(&signature),
                 signing_scheme: *signing_scheme,
+                sell_token_balance: Default::default(),
+                buy_token_balance: Default::default(),
             };
 
             let uid = order.uid(&domain_separator, &expected_owner);

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -500,9 +500,9 @@ impl Default for BalanceFrom {
 #[enumeration(case_insensitive)]
 #[serde(rename_all = "snake_case")]
 pub enum BalanceTo {
-    /// TransferAs: ERC20 token transfer
+    /// Pay trade proceeds as an ERC20 token transfer
     Erc20,
-    /// TransferAs: Vault internal balance transfer.
+    /// Pay trade proceeds as a Vault internal balance transfer
     Internal,
 }
 

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -438,6 +438,14 @@ components:
       description: Is this a buy order or sell order?
       type: string
       enum: [buy, sell]
+    SellTokenBalance:
+      description: Where should the sell token be drawn from?
+      type: string
+      enum: [ erc20, internal, external ]
+    BuyTokenBalance:
+      description: Where should the buy token be transfered to?
+      type: string
+      enum: [ erc20, internal ]
     OrderStatus:
       description: The current order status
       type: string
@@ -486,6 +494,12 @@ components:
           $ref: "#/components/schemas/Signature"
         signingScheme:
           $ref: "#/components/schemas/SigningScheme"
+        sellTokenBalance:
+          $ref: "#/components/schemas/SellTokenBalance"
+          default: "erc20"
+        buyTokenBalance:
+          $ref: "#/components/schemas/BuyTokenBalance"
+          default: "erc20"
         from:
           description: |
             If set, the backend enforces that this address matches what is decoded as the signer of

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -221,12 +221,11 @@ impl OrderStoring for Postgres {
                 o.uid, o.owner, o.creation_timestamp, o.sell_token, o.buy_token, o.sell_amount, \
                 o.buy_amount, o.valid_to, o.app_data, o.fee_amount, o.kind, o.partially_fillable, \
                 o.signature, o.receiver, o.signing_scheme, o.settlement_contract, o.balance_from, \
-                o.balance_to \
+                o.balance_to, \
                 COALESCE(SUM(t.buy_amount), 0) AS sum_buy, \
                 COALESCE(SUM(t.sell_amount), 0) AS sum_sell, \
                 COALESCE(SUM(t.fee_amount), 0) AS sum_fee, \
-                (COUNT(invalidations.*) > 0 OR o.cancellation_timestamp IS NOT NULL) AS invalidated, \
-
+                (COUNT(invalidations.*) > 0 OR o.cancellation_timestamp IS NOT NULL) AS invalidated \
             FROM \
                 orders o \
                 LEFT OUTER JOIN trades t ON o.uid = t.order_uid \

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Context, Result};
 use bigdecimal::{BigDecimal, Zero};
 use chrono::{DateTime, Utc};
 use futures::{stream::TryStreamExt, StreamExt};
-use hex_literal::hex;
+use model::order::{BalanceFrom, BalanceTo};
 use model::{
     order::{Order, OrderCreation, OrderKind, OrderMetaData, OrderStatus, OrderUid},
     Signature, SigningScheme,
@@ -70,6 +70,23 @@ pub enum DbBalanceFrom {
     External,
 }
 
+impl DbBalanceFrom {
+    pub fn from(order_kind: BalanceFrom) -> Self {
+        match order_kind {
+            BalanceFrom::Erc20 => Self::Erc20,
+            BalanceFrom::Internal => Self::Internal,
+            BalanceFrom::External => Self::External,
+        }
+    }
+    fn into(self) -> BalanceFrom {
+        match self {
+            Self::Erc20 => BalanceFrom::Erc20,
+            Self::Internal => BalanceFrom::Internal,
+            Self::External => BalanceFrom::External,
+        }
+    }
+}
+
 /// Location for which the buyAmount should be transferred to order's receiver to upon fulfilment
 #[derive(sqlx::Type)]
 #[sqlx(type_name = "BalanceTo")]
@@ -79,6 +96,21 @@ pub enum DbBalanceTo {
     Erc20,
     /// Pay trade proceeds as a Vault internal balance transfer
     Internal,
+}
+
+impl DbBalanceTo {
+    pub fn from(order_kind: BalanceTo) -> Self {
+        match order_kind {
+            BalanceTo::Erc20 => Self::Erc20,
+            BalanceTo::Internal => Self::Internal,
+        }
+    }
+    fn into(self) -> BalanceTo {
+        match self {
+            Self::Erc20 => BalanceTo::Erc20,
+            Self::Internal => BalanceTo::Internal,
+        }
+    }
 }
 
 #[derive(sqlx::Type)]
@@ -145,11 +177,9 @@ impl OrderStoring for Postgres {
             .bind(order.order_creation.partially_fillable)
             .bind(order.order_creation.signature.to_bytes().as_ref())
             .bind(DbSigningScheme::from(order.order_creation.signing_scheme))
-            // TODO - remove these in https://github.com/gnosis/gp-v2-services/issues/900
-            .bind(H160::from_slice(&hex!("3328f5f2cEcAF00a2443082B657CedEAf70bfAEf")).as_bytes())
-            .bind(DbBalanceFrom::Erc20)
-            .bind(DbBalanceTo::Erc20)
-            // End above TODO
+            .bind(order.order_meta_data.settlement_contract.as_bytes())
+            .bind(DbBalanceFrom::from(order.order_creation.sell_token_balance))
+            .bind(DbBalanceTo::from(order.order_creation.buy_token_balance))
             .execute(&self.pool)
             .await
             .map(|_| ())
@@ -194,7 +224,9 @@ impl OrderStoring for Postgres {
                 COALESCE(SUM(t.buy_amount), 0) AS sum_buy, \
                 COALESCE(SUM(t.sell_amount), 0) AS sum_sell, \
                 COALESCE(SUM(t.fee_amount), 0) AS sum_fee, \
-                (COUNT(invalidations.*) > 0 OR o.cancellation_timestamp IS NOT NULL) AS invalidated \
+                (COUNT(invalidations.*) > 0 OR o.cancellation_timestamp IS NOT NULL) AS invalidated, \
+                o.settlement_contract, o.balance_from, o.balance_to
+
             FROM \
                 orders o \
                 LEFT OUTER JOIN trades t ON o.uid = t.order_uid \
@@ -250,6 +282,9 @@ struct OrdersQueryRow {
     invalidated: bool,
     receiver: Option<Vec<u8>>,
     signing_scheme: DbSigningScheme,
+    settlement_contract: Vec<u8>,
+    balance_from: DbBalanceFrom,
+    balance_to: DbBalanceTo,
 }
 
 impl OrdersQueryRow {
@@ -300,6 +335,7 @@ impl OrdersQueryRow {
             executed_fee_amount,
             invalidated: self.invalidated,
             status,
+            settlement_contract: h160_from_vec(self.settlement_contract)?,
         };
         let order_creation = OrderCreation {
             sell_token: h160_from_vec(self.sell_token)?,
@@ -325,6 +361,8 @@ impl OrdersQueryRow {
                     .map_err(|_| anyhow!("signature has wrong length"))?,
             ),
             signing_scheme: self.signing_scheme.into(),
+            sell_token_balance: self.balance_from.into(),
+            buy_token_balance: self.balance_to.into(),
         };
         Ok(Order {
             order_meta_data,
@@ -386,6 +424,9 @@ mod tests {
             sum_fee: BigDecimal::default(),
             invalidated: false,
             signing_scheme: DbSigningScheme::Eip712,
+            settlement_contract: vec![0; 20],
+            balance_from: DbBalanceFrom::External,
+            balance_to: DbBalanceTo::Internal,
         };
 
         assert_eq!(order_row.calculate_status(), OrderStatus::Open);
@@ -554,6 +595,8 @@ mod tests {
                     partially_fillable: true,
                     signature: Default::default(),
                     signing_scheme: *signing_scheme,
+                    sell_token_balance: BalanceFrom::Erc20,
+                    buy_token_balance: BalanceTo::Internal,
                 },
             };
             db.insert_order(&order).await.unwrap();

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -220,12 +220,12 @@ impl OrderStoring for Postgres {
             SELECT \
                 o.uid, o.owner, o.creation_timestamp, o.sell_token, o.buy_token, o.sell_amount, \
                 o.buy_amount, o.valid_to, o.app_data, o.fee_amount, o.kind, o.partially_fillable, \
-                o.signature, o.receiver, o.signing_scheme, \
+                o.signature, o.receiver, o.signing_scheme, o.settlement_contract, o.balance_from, \
+                o.balance_to \
                 COALESCE(SUM(t.buy_amount), 0) AS sum_buy, \
                 COALESCE(SUM(t.sell_amount), 0) AS sum_sell, \
                 COALESCE(SUM(t.fee_amount), 0) AS sum_fee, \
                 (COUNT(invalidations.*) > 0 OR o.cancellation_timestamp IS NOT NULL) AS invalidated, \
-                o.settlement_contract, o.balance_from, o.balance_to
 
             FROM \
                 orders o \

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -286,6 +286,7 @@ async fn main() {
 
     let orderbook = Arc::new(Orderbook::new(
         domain_separator,
+        settlement_contract.address(),
         database.clone(),
         Box::new(balance_fetcher),
         fee_calculator.clone(),

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -51,6 +51,7 @@ pub enum OrderCancellationResult {
 
 pub struct Orderbook {
     domain_separator: DomainSeparator,
+    settlement_contract: H160,
     database: Arc<dyn OrderStoring>,
     balance_fetcher: Box<dyn BalanceFetching>,
     fee_validator: Arc<EthAwareMinFeeCalculator>,
@@ -60,8 +61,10 @@ pub struct Orderbook {
 }
 
 impl Orderbook {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         domain_separator: DomainSeparator,
+        settlement_contract: H160,
         database: Arc<dyn OrderStoring>,
         balance_fetcher: Box<dyn BalanceFetching>,
         fee_validator: Arc<EthAwareMinFeeCalculator>,
@@ -71,6 +74,7 @@ impl Orderbook {
     ) -> Self {
         Self {
             domain_separator,
+            settlement_contract,
             database,
             balance_fetcher,
             fee_validator,
@@ -97,7 +101,11 @@ impl Orderbook {
         {
             return Ok(AddOrderResult::InsufficientFee);
         }
-        let order = match Order::from_order_creation(order, &self.domain_separator) {
+        let order = match Order::from_order_creation(
+            order,
+            &self.domain_separator,
+            self.settlement_contract,
+        ) {
             Some(order) => order,
             None => return Ok(AddOrderResult::InvalidSignature),
         };

--- a/solver/src/liquidity/offchain_orderbook.rs
+++ b/solver/src/liquidity/offchain_orderbook.rs
@@ -347,6 +347,7 @@ pub mod tests {
                 ..Default::default()
             },
             &DomainSeparator::default(),
+            H160::default(),
         )
         .unwrap();
         assert!(inflight_order_filter(
@@ -364,6 +365,7 @@ pub mod tests {
                 ..Default::default()
             },
             &DomainSeparator::default(),
+            H160::default(),
         )
         .unwrap();
         let adjusted_order = inflight_order_filter(


### PR DESCRIPTION
Closes #900

We add 

- `settlement_contract: H160` to `OrderMetaData` and use it for order insertion.
- `sell_token_balance` and `buy_token_balance` added to the `OrderCreation` struct

We also update the API spec to include buy/sellTokenBalance default values of "owner" (this is mostly so not to introduce a breaking change with the front end and could be removed when they are ready). 

### Test Plan
Existing tests were adapted to include various uses of each of the new field values. Perhaps as part of this integration we could plan to include an e2e test for orders of these types. I don't believe this to be ready for such a test yet, so I have logged an issue (https://github.com/gnosis/gp-v2-services/issues/910) for it.
