### PR TITLE
Add skipped migration

### DIFF
--- a/database/sql/V010__skipped.sql
+++ b/database/sql/V010__skipped.sql
@@ -1,0 +1,2 @@
+-- V010 was accidentally skip, this empty placeholder file is just placed here
+-- so future us can remember why this version was missing.


### PR DESCRIPTION
This PR just adds an empty V010 migration with a comment explaining why it was skipped to avoid any confusion in the future as to why there is a missing version.

This will require **temporarily** migrating with `-outOfOrder=true` in staging to add the skipped empty migration. We can disable once the migration is applied (see test plan):

### Test Plan

Test that the migration works.

```
$ git checkout main
...
$ flyway migrate
Flyway Community Edition 7.5.3 by Redgate
Database: jdbc:postgresql://localhost/ (PostgreSQL 13.2)
Successfully validated 10 migrations (execution time 00:00.017s)
Creating Schema History table "public"."flyway_schema_history" ...
Current version of schema "public": << Empty Schema >>
Migrating schema "public" to version "001 - create orders"
Migrating schema "public" to version "002 - create trades"
Migrating schema "public" to version "003 - create invalidations"
Migrating schema "public" to version "004 - create fee measurements"
Migrating schema "public" to version "005 - extend fee measurements with order details"
Migrating schema "public" to version "006 - extend orders with invalidated timestamp"
Migrating schema "public" to version "007 - contracts upgrade"
Migrating schema "public" to version "008 - add ethsign signature"
Migrating schema "public" to version "009 - create settlements"
Migrating schema "public" to version "011 - extend orders for contract upgrade"
Successfully applied 10 migrations to schema "public" (execution time 00:00.160s)
$ git checkout add-skipped-migration
...
$ flyway migrate -outOfOrder=true
Flyway Community Edition 7.5.3 by Redgate
Database: jdbc:postgresql://localhost/ (PostgreSQL 13.2)
Successfully validated 11 migrations (execution time 00:00.021s)
Current version of schema "public": 011
WARNING: outOfOrder mode is active. Migration of schema "public" may not be reproducible.
Migrating schema "public" to version "010 - skipped" [out of order]
Successfully applied 1 migration to schema "public" (execution time 00:00.021s)
$ flyway migrate                
Flyway Community Edition 7.5.3 by Redgate
Database: jdbc:postgresql://localhost/ (PostgreSQL 13.2)
Successfully validated 11 migrations (execution time 00:00.022s)
Current version of schema "public": 011
Schema "public" is up to date. No migration necessary.
```