### PR TITLE
Update order flag encoding

### DIFF
--- a/solver/src/encoding.rs
+++ b/solver/src/encoding.rs
@@ -1,6 +1,6 @@
 use ethcontract::Bytes;
 use model::{
-    order::{OrderCreation, OrderKind},
+    order::{BalanceFrom, BalanceTo, OrderCreation, OrderKind},
     SigningScheme,
 };
 use primitive_types::{H160, U256};
@@ -44,16 +44,23 @@ pub fn encode_trade(
 fn order_flags(order: &OrderCreation) -> U256 {
     let mut result = 0u8;
     result |= match order.kind {
-        OrderKind::Sell => 0,
+        OrderKind::Sell => 0b0,
         OrderKind::Buy => 0b1,
     };
-    if order.partially_fillable {
-        result |= 0b10;
-    };
+    result |= (order.partially_fillable as u8) << 1;
+    result |= match order.sell_token_balance {
+        BalanceFrom::Erc20 => 0b00,
+        BalanceFrom::External => 0b10,
+        BalanceFrom::Internal => 0b11,
+    } << 2;
+    result |= match order.buy_token_balance {
+        BalanceTo::Erc20 => 0b0,
+        BalanceTo::Internal => 0b1,
+    } << 4;
     result |= match order.signing_scheme {
-        SigningScheme::Eip712 => 0,
-        SigningScheme::EthSign => 0b100,
-    };
+        SigningScheme::Eip712 => 0b00,
+        SigningScheme::EthSign => 0b01,
+    } << 5;
     result.into()
 }
 
@@ -69,4 +76,72 @@ pub struct EncodedSettlement {
     pub clearing_prices: Vec<U256>,
     pub trades: Vec<EncodedTrade>,
     pub interactions: [Vec<EncodedInteraction>; 3],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn order_flag_permutations() {
+        for (order, flags) in &[
+            (
+                OrderCreation {
+                    kind: OrderKind::Sell,
+                    partially_fillable: false,
+                    sell_token_balance: BalanceFrom::Erc20,
+                    buy_token_balance: BalanceTo::Erc20,
+                    signing_scheme: SigningScheme::Eip712,
+                    ..Default::default()
+                },
+                0b0000000,
+            ),
+            (
+                OrderCreation {
+                    kind: OrderKind::Sell,
+                    partially_fillable: true,
+                    sell_token_balance: BalanceFrom::Erc20,
+                    buy_token_balance: BalanceTo::Internal,
+                    signing_scheme: SigningScheme::Eip712,
+                    ..Default::default()
+                },
+                0b0010010,
+            ),
+            (
+                OrderCreation {
+                    kind: OrderKind::Buy,
+                    partially_fillable: false,
+                    sell_token_balance: BalanceFrom::External,
+                    buy_token_balance: BalanceTo::Erc20,
+                    signing_scheme: SigningScheme::Eip712,
+                    ..Default::default()
+                },
+                0b0001001,
+            ),
+            (
+                OrderCreation {
+                    kind: OrderKind::Sell,
+                    partially_fillable: false,
+                    sell_token_balance: BalanceFrom::Internal,
+                    buy_token_balance: BalanceTo::Erc20,
+                    signing_scheme: SigningScheme::EthSign,
+                    ..Default::default()
+                },
+                0b0101100,
+            ),
+            (
+                OrderCreation {
+                    kind: OrderKind::Buy,
+                    partially_fillable: true,
+                    sell_token_balance: BalanceFrom::Internal,
+                    buy_token_balance: BalanceTo::Internal,
+                    signing_scheme: SigningScheme::EthSign,
+                    ..Default::default()
+                },
+                0b0111111,
+            ),
+        ] {
+            assert_eq!(order_flags(order), U256::from(*flags));
+        }
+    }
 }


### PR DESCRIPTION
Fixes #902 

This PR updates the order flag encoding required for the updated SCs.

### Test Plan

<details><summary>Test cases were generated using the following code</summary>

```ts
import { OrderBalance, OrderKind, SigningScheme, TradeFlags, encodeTradeFlags, } from "./src/ts";

const permutations: TradeFlags[] = [];
for (const signingScheme of [SigningScheme.EIP712, SigningScheme.ETHSIGN, /* SigningScheme.EIP1271, SigningScheme.PRESIGN */])
for (const buyTokenBalance of [OrderBalance.ERC20, OrderBalance.INTERNAL])
for (const sellTokenBalance of [OrderBalance.ERC20, OrderBalance.EXTERNAL, OrderBalance.INTERNAL])
for (const partiallyFillable of [false, true])
for (const kind of [OrderKind.SELL, OrderKind.BUY])
  permutations.push({
    kind,
    partiallyFillable,
    sellTokenBalance,
    buyTokenBalance,
    signingScheme,
  });

function n(name: string): string {
  return name.replace(/(^.)/, (s) => s.toUpperCase());
}
function s(scheme: SigningScheme): string {
  switch (scheme) {
    case SigningScheme.EIP712: return "Eip712";
    case SigningScheme.ETHSIGN: return "EthSign";
    default: throw new Error("unsupported");
  }
}

console.log(`
    #[test]
    fn order_flag_permutations() {
        for (order, flags) in &[
            ${permutations.map((flags) => `(
                OrderCreation {
                    kind: OrderKind::${n(flags.kind)},
                    partially_fillable: ${flags.partiallyFillable},
                    sell_token_balance: BalanceFrom::${n(flags.sellTokenBalance!)},
                    buy_token_balance: BalanceTo::${n(flags.buyTokenBalance!)},
                    signing_scheme: SigningScheme::${s(flags.signingScheme)},
                    ..Default::default()
                },
                0b${encodeTradeFlags(flags).toString(2).padStart(7, "0")},
            ),`).join("\n            ")}
        ] {
            assert_eq!(order_flags(order), U256::from(*flags));
        }
    }
`);
```

</details>

A few permutations were hand-picked such that each value appears at least once. Can be executed manually with `cargo test -p solver -- order_flag_permutations`.

Note that CI is expected to fail because we are in a limbo state where part of the services are for the upgraded SCs, but they have not been enabled yet.