### PR TITLE
[Easy] Parswap - retry on "Too much slippage..." error

### DIFF
--- a/solver/src/solver/paraswap_solver.rs
+++ b/solver/src/solver/paraswap_solver.rs
@@ -90,7 +90,9 @@ impl From<ParaswapResponseError> for SettlementError {
             inner: anyhow!("Paraswap Response Error {:?}", err),
             retryable: matches!(
                 err,
-                ParaswapResponseError::PriceChange | ParaswapResponseError::BuildingTransaction(_)
+                ParaswapResponseError::PriceChange
+                    | ParaswapResponseError::BuildingTransaction(_)
+                    | ParaswapResponseError::TooMuchSlippageOnQuote
             ),
         }
     }

--- a/solver/src/solver/paraswap_solver/api.rs
+++ b/solver/src/solver/paraswap_solver/api.rs
@@ -75,6 +75,9 @@ pub enum ParaswapResponseError {
     #[error("Suspected Rate Change - Please Retry!")]
     PriceChange,
 
+    #[error("Too much slippage on quote - Please Retry!")]
+    TooMuchSlippageOnQuote,
+
     // Connectivity or non-response error
     #[error("Failed on send")]
     Send(reqwest::Error),
@@ -102,6 +105,9 @@ fn parse_paraswap_response_text(
             )),
             "It seems like the rate has changed, please re-query the latest Price" => {
                 Err(ParaswapResponseError::PriceChange)
+            }
+            "Too much slippage on quote, please try again" => {
+                Err(ParaswapResponseError::TooMuchSlippageOnQuote)
             }
             _ => Err(ParaswapResponseError::UnknownParaswapError(format!(
                 "uncatalogued error message {}",


### PR DESCRIPTION
Addresses the recent alerts of the form 
```
UnknownParaswapError("uncatalogued error message Too much slippage on quote, please try again")
```

As the error message indicates, we categorize this error message as "retryable" for Paraswap's `try_settle_order`

A sample of recent alerts with this error message:

https://gnosisinc.slack.com/archives/CUD4MUCUF/p1627968537017600
https://gnosisinc.slack.com/archives/CUD4MUCUF/p1627917668005100
https://gnosisinc.slack.com/archives/CUD4MUCUF/p1627428152007900
https://gnosisinc.slack.com/archives/CUD4MUCUF/p1627343158003800


### Test Plan
As this is just another retryable error and we already have tests demonstrating that the retry logic works, no new test is needed here.
