### PR TITLE
Retrieve buffers for instance submission

### DIFF
--- a/shared/src/token_info.rs
+++ b/shared/src/token_info.rs
@@ -32,12 +32,11 @@ pub trait TokenInfoFetching: Send + Sync {
 #[async_trait]
 impl TokenInfoFetching for TokenInfoFetcher {
     async fn get_token_infos(&self, addresses: &[H160]) -> HashMap<H160, TokenInfo> {
-        let web3 = Web3::new(self.web3.transport().clone());
         let mut batch = CallBatch::new(self.web3.transport());
         let futures = addresses
             .iter()
             .map(|address| {
-                let erc20 = ERC20::at(&web3, *address);
+                let erc20 = ERC20::at(&self.web3, *address);
                 erc20.methods().decimals().batch_call(&mut batch)
             })
             .collect::<Vec<_>>();

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use baseline_solver::BaselineSolver;
 use contracts::GPv2Settlement;
 use ethcontract::{Account, H160, U256};
-use http_solver::{HttpSolver, SolverConfig};
+use http_solver::{buffers::BufferRetriever, HttpSolver, SolverConfig};
 use matcha_solver::MatchaSolver;
 use naive_solver::NaiveSolver;
 use oneinch_solver::OneInchSolver;
@@ -99,6 +99,10 @@ pub fn create(
         .checked_sub(TIMEOUT_SAFETY_BUFFER)
         .expect("solver_timeout too low");
 
+    let buffer_retriever = Arc::new(BufferRetriever::new(
+        web3.clone(),
+        settlement_contract.address(),
+    ));
     // Helper function to create http solver instances.
     let create_http_solver = |url: Url, name: &'static str| -> HttpSolver {
         HttpSolver::new(
@@ -113,6 +117,7 @@ pub fn create(
             native_token,
             token_info_fetcher.clone(),
             price_estimator.clone(),
+            buffer_retriever.clone(),
             network_id.clone(),
             chain_id,
             fee_discount_factor,

--- a/solver/src/solver/http_solver/buffers.rs
+++ b/solver/src/solver/http_solver/buffers.rs
@@ -1,6 +1,7 @@
 use contracts::ERC20;
 use ethcontract::{batch::CallBatch, errors::MethodError, H160, U256};
-use futures::future::join_all;
+use futures::{future::join_all, join};
+use model::order::BUY_ETH_ADDRESS;
 use shared::Web3;
 use std::collections::HashMap;
 
@@ -23,21 +24,37 @@ impl BufferRetriever {
     }
 }
 
+#[derive(Debug)]
+pub enum BufferRetrievalError {
+    Eth(web3::Error),
+    Erc20(MethodError),
+}
+
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait BufferRetrieving: Send + Sync {
-    async fn get_buffers(&self, tokens: &[H160]) -> HashMap<H160, Result<U256, MethodError>>;
+    async fn get_buffers(
+        &self,
+        tokens: &[H160],
+    ) -> HashMap<H160, Result<U256, BufferRetrievalError>>;
 }
 
 #[async_trait::async_trait]
 impl BufferRetrieving for BufferRetriever {
-    async fn get_buffers(&self, tokens: &[H160]) -> HashMap<H160, Result<U256, MethodError>> {
+    async fn get_buffers(
+        &self,
+        tokens: &[H160],
+    ) -> HashMap<H160, Result<U256, BufferRetrievalError>> {
         let mut batch = CallBatch::new(self.web3.transport());
-
-        let futures = tokens
+        let tokens_without_eth: Vec<_> = tokens
             .iter()
-            .map(|address| {
-                let erc20 = ERC20::at(&self.web3, *address);
+            .filter(|&&address| address != BUY_ETH_ADDRESS)
+            .collect();
+
+        let futures = tokens_without_eth
+            .iter()
+            .map(|&&address| {
+                let erc20 = ERC20::at(&self.web3, address);
                 erc20
                     .methods()
                     .balance_of(self.settlement_contract)
@@ -45,12 +62,34 @@ impl BufferRetrieving for BufferRetriever {
             })
             .collect::<Vec<_>>();
 
-        batch.execute_all(MAX_BATCH_SIZE).await;
+        let mut buffers = HashMap::new();
 
-        tokens
-            .iter()
-            .zip(join_all(futures).await.into_iter())
-            .map(|(&address, balance)| (address, balance))
+        if tokens_without_eth.len() == tokens.len() {
+            batch.execute_all(MAX_BATCH_SIZE).await;
+        } else {
+            let (_, eth_balance) = join!(
+                batch.execute_all(MAX_BATCH_SIZE),
+                self.web3.eth().balance(self.settlement_contract, None)
+            );
+            buffers.insert(
+                BUY_ETH_ADDRESS,
+                eth_balance.map_err(BufferRetrievalError::Eth),
+            );
+        }
+
+        buffers
+            .into_iter()
+            .chain(
+                tokens_without_eth
+                    .into_iter()
+                    .zip(join_all(futures).await.into_iter())
+                    .map(|(&address, balance)| {
+                        (
+                            address,
+                            balance.map_err(BufferRetrievalError::Erc20),
+                        )
+                    }),
+            )
             .collect()
     }
 }
@@ -60,7 +99,6 @@ mod test {
     use super::*;
     use contracts::GPv2Settlement;
     use hex_literal::hex;
-    use model::order::BUY_ETH_ADDRESS;
     use shared::transport::create_test_transport;
 
     #[tokio::test]
@@ -81,7 +119,37 @@ mod test {
         println!("Buffers: {:#?}", buffers);
         assert!(buffers.get(&weth).unwrap().is_ok());
         assert!(buffers.get(&dai).unwrap().is_ok());
-        assert!(buffers.get(&BUY_ETH_ADDRESS).unwrap().is_err());
+        assert!(buffers.get(&BUY_ETH_ADDRESS).unwrap().is_ok());
         assert!(buffers.get(&not_a_token).unwrap().is_err());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn retrieving_buffers_not_affected_by_eth() {
+        let web3 = Web3::new(create_test_transport(
+            &std::env::var("NODE_URL_RINKEBY").unwrap(),
+        ));
+        let settlement_contract = GPv2Settlement::deployed(&web3).await.unwrap();
+        let weth = H160(hex!("c778417E063141139Fce010982780140Aa0cD5Ab"));
+        let dai = H160(hex!("c7ad46e0b8a400bb3c915120d284aafba8fc4735"));
+        let not_a_token = H160(hex!("badbadbadbadbadbadbadbadbadbadbadbadbadb"));
+
+        let buffer_retriever = BufferRetriever::new(web3, settlement_contract.address());
+        let buffers_with_eth = buffer_retriever
+            .get_buffers(&[weth, dai, not_a_token])
+            .await;
+        let buffers_without_eth = buffer_retriever
+            .get_buffers(&[weth, dai, not_a_token, BUY_ETH_ADDRESS])
+            .await;
+        assert_eq!(
+            buffers_with_eth.get(&weth).unwrap().as_ref().unwrap(),
+            buffers_without_eth.get(&weth).unwrap().as_ref().unwrap()
+        );
+        assert_eq!(
+            buffers_with_eth.get(&dai).unwrap().as_ref().unwrap(),
+            buffers_without_eth.get(&dai).unwrap().as_ref().unwrap()
+        );
+        assert!(buffers_with_eth.get(&not_a_token).unwrap().is_err());
+        assert!(buffers_without_eth.get(&not_a_token).unwrap().is_err());
     }
 }

--- a/solver/src/solver/http_solver/buffers.rs
+++ b/solver/src/solver/http_solver/buffers.rs
@@ -1,0 +1,66 @@
+use contracts::ERC20;
+use ethcontract::{batch::CallBatch, H160, U256};
+use futures::future::join_all;
+use shared::Web3;
+use std::collections::HashMap;
+
+const MAX_BATCH_SIZE: usize = 100;
+
+#[derive(Clone)]
+/// Computes the amount of "buffer" ERC20 balance that the http solver can use
+/// to offset possible rounding errors in computing the amounts in a solution.
+pub struct BufferRetriever {
+    web3: Web3,
+    settlement_contract: H160,
+}
+
+impl BufferRetriever {
+    pub fn new(web3: Web3, settlement_contract: H160) -> Self {
+        Self {
+            web3,
+            settlement_contract,
+        }
+    }
+}
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait::async_trait]
+pub trait BufferRetrieving: Send + Sync {
+    async fn get_buffers(&self, tokens: &[H160]) -> HashMap<H160, U256>;
+}
+
+#[async_trait::async_trait]
+impl BufferRetrieving for BufferRetriever {
+    async fn get_buffers(&self, tokens: &[H160]) -> HashMap<H160, U256> {
+        let web3 = Web3::new(self.web3.transport().clone());
+        let mut batch = CallBatch::new(self.web3.transport());
+
+        let futures = tokens
+            .iter()
+            .map(|address| {
+                let erc20 = ERC20::at(&web3, *address);
+                erc20
+                    .methods()
+                    .balance_of(self.settlement_contract)
+                    .batch_call(&mut batch)
+            })
+            .collect::<Vec<_>>();
+
+        batch.execute_all(MAX_BATCH_SIZE).await;
+
+        tokens
+            .iter()
+            .zip(join_all(futures).await.into_iter())
+            .filter_map(|(address, balance)| {
+                if balance.is_err() {
+                    tracing::debug!(
+                        "Failed to fetch settlement contract balance for token {} with error {}",
+                        address,
+                        balance.as_ref().unwrap_err()
+                    );
+                }
+                Some((*address, balance.ok()?))
+            })
+            .collect()
+    }
+}

--- a/solver/src/solver/http_solver/buffers.rs
+++ b/solver/src/solver/http_solver/buffers.rs
@@ -32,13 +32,12 @@ pub trait BufferRetrieving: Send + Sync {
 #[async_trait::async_trait]
 impl BufferRetrieving for BufferRetriever {
     async fn get_buffers(&self, tokens: &[H160]) -> HashMap<H160, U256> {
-        let web3 = Web3::new(self.web3.transport().clone());
         let mut batch = CallBatch::new(self.web3.transport());
 
         let futures = tokens
             .iter()
             .map(|address| {
-                let erc20 = ERC20::at(&web3, *address);
+                let erc20 = ERC20::at(&self.web3, *address);
                 erc20
                     .methods()
                     .balance_of(self.settlement_contract)

--- a/solver/src/solver/http_solver/buffers.rs
+++ b/solver/src/solver/http_solver/buffers.rs
@@ -84,10 +84,7 @@ impl BufferRetrieving for BufferRetriever {
                     .into_iter()
                     .zip(join_all(futures).await.into_iter())
                     .map(|(&address, balance)| {
-                        (
-                            address,
-                            balance.map_err(BufferRetrievalError::Erc20),
-                        )
+                        (address, balance.map_err(BufferRetrievalError::Erc20))
                     }),
             )
             .collect()


### PR DESCRIPTION
Adds a new component to the HTTP solver that retrieves the ERC20 buffers available to the solver. This is useful to take advantage of a recent change to the Mip solver: the solution is checked in the solver for correctness and is not sent to the driver if it cannot be matched after considering the buffers.

For now the retrieved buffer is unused. Later, it will be included in the data sent to the various solvers.

### Test Plan

Ignored unit tests:

```
$ export NODE_URL_RINKEBY=...
$ cargo test -- solver::http_solver::buffers --ignored --nocapture
running 2 tests
Buffers: {
    0xc7ad46e0b8a400bb3c915120d284aafba8fc4735: Ok(
        58476096465432915195333071331,
    ),
    0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee: Ok(
        9,
    ),
    0xc778417e063141139fce010982780140aa0cd5ab: Ok(
        157146118900631341,
    ),
    0xbadbadbadbadbadbadbadbadbadbadbadbadbadb: Err(
        Erc20(
            MethodError {
                signature: "balanceOf(address):(uint256)",
                inner: AbiDecode(
                    InvalidName(
                        "please ensure the contract and method you're calling exist! failed to decode empty bytes. if you're using jsonrpc this is likely due to jsonrpc returning `0x` in case contract or method don't exist",
                    ),
                ),
            },
        ),
    ),
}
test solver::http_solver::buffers::test::retrieves_buffers_on_rinkeby ... ok
test solver::http_solver::buffers::test::retrieving_buffers_not_affected_by_eth ... ok
```