### PR TITLE
[Matcha] Retryable Error Class

### DIFF
--- a/solver/src/solver/matcha_solver.rs
+++ b/solver/src/solver/matcha_solver.rs
@@ -21,8 +21,8 @@ pub mod api;
 
 use super::solver_utils::Slippage;
 use crate::interactions::allowances::{AllowanceManager, AllowanceManaging};
-use crate::solver::matcha_solver::api::MatchaApi;
-use anyhow::{ensure, Result};
+use crate::solver::matcha_solver::api::{MatchaApi, MatchaResponseError};
+use anyhow::{anyhow, ensure, Result};
 use contracts::GPv2Settlement;
 use ethcontract::{Account, Bytes};
 use maplit::hashmap;
@@ -31,6 +31,7 @@ use reqwest::Client;
 use super::single_order_solver::SingleOrderSolving;
 
 use self::api::{DefaultMatchaApi, SwapQuery, SwapResponse};
+use crate::solver::solver_utils::SettlementError;
 use crate::{
     encoding::EncodedInteraction,
     liquidity::LimitOrder,
@@ -80,54 +81,67 @@ impl MatchaSolver {
 #[async_trait::async_trait]
 impl SingleOrderSolving for MatchaSolver {
     async fn settle_order(&self, order: LimitOrder) -> Result<Option<Settlement>> {
-        let swap = match order.kind {
-            OrderKind::Sell => {
-                let query = SwapQuery {
-                    sell_token: order.sell_token,
-                    buy_token: order.buy_token,
-                    sell_amount: Some(order.sell_amount),
-                    buy_amount: None,
-                    slippage_percentage: Slippage::number_from_basis_points(
-                        STANDARD_MATCHA_SLIPPAGE_BPS,
-                    )
-                    .unwrap(),
-                    skip_validation: Some(true),
-                };
-
-                tracing::debug!("querying Matcha swap api with {:?}", query);
-                let swap = self.client.get_swap(query).await?;
-                tracing::debug!("proposed Matcha swap is {:?}", swap);
-
-                if swap.buy_amount < order.buy_amount {
-                    tracing::debug!("Order limit price not respected");
-                    return Ok(None);
+        let max_retries = 2;
+        for _ in 0..max_retries {
+            match self.try_settle_order(order.clone()).await {
+                Ok(settlement) => return Ok(settlement),
+                Err(err) if err.retryable => {
+                    tracing::debug!("Retrying Matcha settlement due to: {:?}", &err);
+                    continue;
                 }
-                swap
+                Err(err) => return Err(err.inner),
             }
-            OrderKind::Buy => {
-                let query = SwapQuery {
-                    sell_token: order.sell_token,
-                    buy_token: order.buy_token,
-                    sell_amount: None,
-                    buy_amount: Some(order.buy_amount),
-                    slippage_percentage: Slippage::number_from_basis_points(
-                        STANDARD_MATCHA_SLIPPAGE_BPS,
-                    )
-                    .unwrap(),
-                    skip_validation: Some(true),
-                };
+        }
+        // One last attempt, else throw converted error
+        self.try_settle_order(order).await.map_err(|err| err.inner)
+    }
 
-                tracing::debug!("querying Matcha swap api with {:?}", query);
-                let swap = self.client.get_swap(query).await?;
-                tracing::debug!("proposed Matcha swap is {:?}", swap);
+    fn account(&self) -> &Account {
+        &self.account
+    }
 
-                if swap.sell_amount > order.sell_amount {
-                    tracing::debug!("Order limit price not respected");
-                    return Ok(None);
-                }
-                swap
-            }
+    fn name(&self) -> &'static str {
+        "Matcha"
+    }
+}
+
+impl From<MatchaResponseError> for SettlementError {
+    fn from(err: MatchaResponseError) -> Self {
+        SettlementError {
+            inner: anyhow!("Matcha Response Error {:?}", err),
+            retryable: matches!(err, MatchaResponseError::ServerError(_)),
+        }
+    }
+}
+
+impl MatchaSolver {
+    async fn try_settle_order(
+        &self,
+        order: LimitOrder,
+    ) -> Result<Option<Settlement>, SettlementError> {
+        let (buy_amount, sell_amount) = match order.kind {
+            OrderKind::Buy => (Some(order.buy_amount), None),
+            OrderKind::Sell => (None, Some(order.sell_amount)),
         };
+        let query = SwapQuery {
+            sell_token: order.sell_token,
+            buy_token: order.buy_token,
+            sell_amount,
+            buy_amount,
+            slippage_percentage: Slippage::number_from_basis_points(STANDARD_MATCHA_SLIPPAGE_BPS)
+                .unwrap(),
+            skip_validation: Some(true),
+        };
+
+        tracing::debug!("querying Matcha swap api with {:?}", query);
+        let swap = self.client.get_swap(query).await?;
+        tracing::debug!("proposed Matcha swap is {:?}", swap);
+
+        if !swap_respects_limit_price(&swap, &order) {
+            tracing::debug!("Order limit price not respected");
+            return Ok(None);
+        }
+
         let mut settlement = Settlement::new(hashmap! {
             order.sell_token => swap.buy_amount,
             order.buy_token => swap.sell_amount,
@@ -144,13 +158,12 @@ impl SingleOrderSolving for MatchaSolver {
         settlement.encoder.append_to_execution_plan(swap);
         Ok(Some(settlement))
     }
+}
 
-    fn account(&self) -> &Account {
-        &self.account
-    }
-
-    fn name(&self) -> &'static str {
-        "Matcha"
+fn swap_respects_limit_price(swap: &SwapResponse, order: &LimitOrder) -> bool {
+    match order.kind {
+        OrderKind::Buy => swap.sell_amount <= order.sell_amount,
+        OrderKind::Sell => swap.buy_amount >= order.buy_amount,
     }
 }
 

--- a/solver/src/solver/matcha_solver/api.rs
+++ b/solver/src/solver/matcha_solver/api.rs
@@ -170,7 +170,7 @@ fn parse_matcha_response_text(
     match serde_json::from_str::<RawResponse>(response_text) {
         Ok(RawResponse::ResponseOk(response)) => Ok(response),
         Ok(RawResponse::ResponseErr { error: message }) => match &message[..] {
-            "ServerError" => Err(MatchaResponseError::ServerError(format!("{:?}", query))),
+            "Server Error" => Err(MatchaResponseError::ServerError(format!("{:?}", query))),
             _ => Err(MatchaResponseError::UnknownMatchaError(message)),
         },
         Err(err) => Err(MatchaResponseError::DeserializeError(err)),

--- a/solver/src/solver/matcha_solver/api.rs
+++ b/solver/src/solver/matcha_solver/api.rs
@@ -5,12 +5,13 @@
 //! <https://api.0x.org/>
 
 use crate::solver::solver_utils::{debug_bytes, deserialize_decimal_f64, Slippage};
-use anyhow::{Context, Result};
+use anyhow::Result;
 use derivative::Derivative;
 use ethcontract::{H160, U256};
 use model::u256_decimal;
 use reqwest::{Client, IntoUrl, Url};
 use serde::Deserialize;
+use thiserror::Error;
 use web3::types::Bytes;
 
 // Matcha requires an address as an affiliate.
@@ -97,7 +98,7 @@ pub struct SwapResponse {
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait MatchaApi {
-    async fn get_swap(&self, query: SwapQuery) -> Result<SwapResponse>;
+    async fn get_swap(&self, query: SwapQuery) -> Result<SwapResponse, MatchaResponseError>;
 }
 
 /// Matcha API Client implementation.
@@ -119,20 +120,60 @@ impl DefaultMatchaApi {
     }
 }
 
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawResponse {
+    ResponseOk(SwapResponse),
+    ResponseErr { error: String },
+}
+
+#[derive(Error, Debug)]
+pub enum MatchaResponseError {
+    #[error("ServerError from query {0}")]
+    ServerError(String),
+
+    #[error("uncatalogued error message: {0}")]
+    UnknownMatchaError(String),
+
+    #[error(transparent)]
+    DeserializeError(#[from] serde_json::Error),
+
+    // Recovered Response but failed on async call of response.text()
+    #[error(transparent)]
+    TextFetch(reqwest::Error),
+
+    // Connectivity or non-response error
+    #[error("Failed on send")]
+    Send(reqwest::Error),
+}
+
 #[async_trait::async_trait]
 impl MatchaApi for DefaultMatchaApi {
     /// Retrieves a swap for the specified parameters from the 1Inch API.
-    async fn get_swap(&self, query: SwapQuery) -> Result<SwapResponse> {
-        let text: String = self
-            .client
-            .get(query.into_url(&self.base_url))
-            .send()
-            .await
-            .context("SwapQuery failed")?
-            .text()
-            .await?;
-        serde_json::from_str::<SwapResponse>(&text)
-            .context(format!("SwapQuery result parsing failed: {}", text))
+    async fn get_swap(&self, query: SwapQuery) -> Result<SwapResponse, MatchaResponseError> {
+        let query_str = format!("{:?}", &query);
+        let response_result = self.client.get(query.into_url(&self.base_url)).send().await;
+        match response_result {
+            Ok(response) => match response.text().await {
+                Ok(response_text) => parse_matcha_response_text(&response_text, &query_str),
+                Err(text_fetch_err) => Err(MatchaResponseError::TextFetch(text_fetch_err)),
+            },
+            Err(send_err) => Err(MatchaResponseError::Send(send_err)),
+        }
+    }
+}
+
+fn parse_matcha_response_text(
+    response_text: &str,
+    query: &str,
+) -> Result<SwapResponse, MatchaResponseError> {
+    match serde_json::from_str::<RawResponse>(response_text) {
+        Ok(RawResponse::ResponseOk(response)) => Ok(response),
+        Ok(RawResponse::ResponseErr { error: message }) => match &message[..] {
+            "ServerError" => Err(MatchaResponseError::ServerError(format!("{:?}", query))),
+            _ => Err(MatchaResponseError::UnknownMatchaError(message)),
+        },
+        Err(err) => Err(MatchaResponseError::DeserializeError(err)),
     }
 }
 
@@ -156,9 +197,8 @@ mod tests {
             skip_validation: Some(true),
         };
 
-        let price_response: SwapResponse = matcha_client.get_swap(swap_query).await.unwrap();
-
-        println!("Price Response: {:?}", &price_response);
+        let price_response = matcha_client.get_swap(swap_query).await;
+        assert!(price_response.is_ok());
     }
 
     #[test]

--- a/solver/src/solver/matcha_solver/api.rs
+++ b/solver/src/solver/matcha_solver/api.rs
@@ -76,7 +76,7 @@ impl SwapQuery {
 }
 
 /// A Matcha API swap response.
-#[derive(Clone, Derivative, Deserialize, PartialEq)]
+#[derive(Clone, Default, Derivative, Deserialize, PartialEq)]
 #[derivative(Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SwapResponse {

--- a/solver/src/solver/paraswap_solver.rs
+++ b/solver/src/solver/paraswap_solver.rs
@@ -6,13 +6,14 @@ use self::api::{
 };
 use super::single_order_solver::SingleOrderSolving;
 use crate::solver::paraswap_solver::api::ParaswapResponseError;
+use crate::solver::solver_utils::SettlementError;
 use crate::{
     encoding::EncodedInteraction,
     interactions::allowances::{AllowanceManager, AllowanceManaging},
     liquidity::LimitOrder,
     settlement::{Interaction, Settlement},
 };
-use anyhow::{anyhow, Error, Result};
+use anyhow::{anyhow, Result};
 use contracts::GPv2Settlement;
 use derivative::Derivative;
 use ethcontract::{Account, Bytes, H160, U256};
@@ -65,21 +66,6 @@ impl ParaswapSolver {
             client: Box::new(DefaultParaswapApi { client }),
             slippage_bps,
             disabled_paraswap_dexs,
-        }
-    }
-}
-
-#[derive(Debug)]
-struct SettlementError {
-    inner: anyhow::Error,
-    retryable: bool,
-}
-
-impl From<anyhow::Error> for SettlementError {
-    fn from(err: Error) -> Self {
-        SettlementError {
-            inner: err,
-            retryable: false,
         }
     }
 }

--- a/solver/src/solver/solver_utils.rs
+++ b/solver/src/solver/solver_utils.rs
@@ -1,4 +1,4 @@
-use anyhow::{ensure, Result};
+use anyhow::{ensure, Error, Result};
 use serde::{
     de::{Deserializer, Error as _},
     Deserialize,
@@ -68,4 +68,19 @@ pub fn debug_bytes(
     formatter: &mut std::fmt::Formatter,
 ) -> Result<(), std::fmt::Error> {
     formatter.write_fmt(format_args!("0x{}", hex::encode(&bytes.0)))
+}
+
+#[derive(Debug)]
+pub struct SettlementError {
+    pub inner: anyhow::Error,
+    pub retryable: bool,
+}
+
+impl From<anyhow::Error> for SettlementError {
+    fn from(err: Error) -> Self {
+        SettlementError {
+            inner: err,
+            retryable: false,
+        }
+    }
 }


### PR DESCRIPTION
Due to recent and more frequent [alerts](https://gnosisinc.slack.com/archives/CUD4MUCUF/p1627923838009300) with the Matcha solver

```
Matcha inner solver error: SwapQuery result parsing failed: {"reason":"Server Error"}

Aug 2 (2x)
Aug 1 (3x)
July 31 (3x)
July 30 (2x)
```

We implement an error class `MatchaResponseError` (analogous to the work done for Paraswap Error Classification). At this moment we have only encountered "ServerError` and they do not appear together in groups so it seems like a reasonable decision to retry here.

With this in mind we follow the same pattern as in the Paraswap solver, classifying response errors and retrying to a max of 2 times before making one final attempt and finally returning whatever error was last. This should, at least, reduce the noise in our alert channel.

**Note:** This required a slight refactoring of the existing `settle_order`method that broke up the large match statement into smaller pieces. If this is an issue of readability, I would be happy to perform this refactor first.

### Test Plan
Added three unit tests for the retry cycle: retry till i) succeeds ii) exceeds, iii) don't retry.
