### PR TITLE
[Paraswap] Classify "getParaSwapPool" error as retryable

### DIFF
--- a/solver/src/solver/paraswap_solver.rs
+++ b/solver/src/solver/paraswap_solver.rs
@@ -93,6 +93,7 @@ impl From<ParaswapResponseError> for SettlementError {
                 ParaswapResponseError::PriceChange
                     | ParaswapResponseError::BuildingTransaction(_)
                     | ParaswapResponseError::TooMuchSlippageOnQuote
+                    | ParaswapResponseError::GetParaswapPool(_),
             ),
         }
     }

--- a/solver/src/solver/paraswap_solver/api.rs
+++ b/solver/src/solver/paraswap_solver/api.rs
@@ -78,6 +78,9 @@ pub enum ParaswapResponseError {
     #[error("Too much slippage on quote - Please Retry!")]
     TooMuchSlippageOnQuote,
 
+    #[error("Error getParaSwapPool - From Price Route {0}")]
+    GetParaswapPool(String),
+
     // Connectivity or non-response error
     #[error("Failed on send")]
     Send(reqwest::Error),
@@ -109,6 +112,9 @@ fn parse_paraswap_response_text(
             "Too much slippage on quote, please try again" => {
                 Err(ParaswapResponseError::TooMuchSlippageOnQuote)
             }
+            "Error getParaSwapPool" => Err(ParaswapResponseError::GetParaswapPool(
+                query_str.parse().unwrap(),
+            )),
             _ => Err(ParaswapResponseError::UnknownParaswapError(format!(
                 "uncatalogued error message {}",
                 message


### PR DESCRIPTION
Based on the short [conversation](https://gnosisinc.slack.com/archives/C0203Q9R4JJ/p1627988595002900) with the Paraswap team, we decided it was reasonable to classify the frequently occurring alert "Error getParaSwapPool" as retryable

I have decided to include the PriceRoute query string as part of the error log so that we could eventually collect some analytics on which pool results in this error most often. Based on the sample of data collected today it appears that `ParaSwapPoolX` are the culprits. 

https://jsonblob.com/72298c18-f448-11eb-9b1d-492114cedcb8 - ParaSwapPool3
https://jsonblob.com/abd6c153-f449-11eb-9b1d-7f77e44cffbd - ParaSwapPool4
https://jsonblob.com/fbb95849-f449-11eb-9b1d-5d80dfba4629 - ParaSwapPool4

In any case, this change should silence some of these errors and only bring them to the surface when absolutely necessary (after a few retries).

### Test Plan
No changed tests.
