### PR TITLE
[Trivial] Deduplicate some contextual error logs

### DIFF
--- a/shared/src/current_block.rs
+++ b/shared/src/current_block.rs
@@ -105,7 +105,7 @@ where
             .eth()
             .block_number()
             .await
-            .context("failed to get current block")?
+            .context("failed to get current block number")?
             .as_u64())
     }
 

--- a/solver/src/liquidity_collector.rs
+++ b/solver/src/liquidity_collector.rs
@@ -24,7 +24,7 @@ impl LiquidityCollector {
             .orderbook_api
             .get_liquidity(inflight_trades)
             .await
-            .context("failed to get orderbook")?;
+            .context("failed to get orderbook liquidity")?;
         tracing::info!("got {} orders: {:?}", limit_orders.len(), limit_orders);
 
         let mut amms = vec![];
@@ -33,7 +33,7 @@ impl LiquidityCollector {
                 liquidity
                     .get_liquidity(limit_orders.iter(), at_block)
                     .await
-                    .context("failed to get pool")?
+                    .context("failed to get UniswapLike liquidity")?
                     .into_iter()
                     .map(Liquidity::ConstantProduct),
             );


### PR DESCRIPTION
Just noticed that we had some duplicated context error strings that were probably the result of copy paste. This clears them up and makes them more descriptive for their purpose.
