### PR TITLE
[Easy] alternate selector for anyhow errors

### DIFF
--- a/shared/src/maintenance.rs
+++ b/shared/src/maintenance.rs
@@ -19,7 +19,7 @@ impl Maintaining for ServiceMaintenance {
     async fn run_maintenance(&self) -> Result<()> {
         for result in join_all(self.maintainers.iter().map(|m| m.run_maintenance())).await {
             if let Err(err) = result {
-                tracing::error!("Service Maintenance Error: {:?}", err);
+                tracing::error!("Service Maintenance Error: {:#}", err);
             }
         }
         Ok(())

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -100,7 +100,7 @@ impl Driver {
         loop {
             match self.single_run().await {
                 Ok(()) => tracing::debug!("single run finished ok"),
-                Err(err) => tracing::error!("single run errored: {:?}", err),
+                Err(err) => tracing::error!("single run errored: {:#}", err),
             }
             self.metrics.runloop_completed();
             tokio::time::sleep(self.settle_interval).await;
@@ -267,7 +267,7 @@ impl Driver {
                 Err(err) => err,
             };
             tracing::error!(
-                "{} settlement simulation failed at submission and block {}:\n{:?}",
+                "{} settlement simulation failed at submission and block {}:\n{:#}",
                 settlement.name,
                 current_block_during_liquidity_fetch,
                 error_at_earlier_block,

--- a/solver/src/solver/single_order_solver.rs
+++ b/solver/src/solver/single_order_solver.rs
@@ -73,7 +73,7 @@ impl<I: SingleOrderSolving + Send + Sync> Solver for SingleOrderSolver<I> {
                     // It could be that the inner solver can't match an order and would
                     // return an error for whatever reason. In that case, we want
                     // to continue trying to solve for other orders.
-                    tracing::error!("{} inner solver error: {:?}", self.name(), err);
+                    tracing::error!("{} inner solver error: {:#}", self.name(), err);
                     None
                 }
             })


### PR DESCRIPTION
Since the recent release we have been seeing very verbose stack back traces when using the Debug representation of anyhow errors. This results in the change of display formatting with the recent version bump of anyhow 

New display representations are defined [here](https://docs.rs/anyhow/1.0.42/anyhow/struct.Error.html#display-representations) (thanks @vkgnosis for digging this up!). I have decided to go with `{:#}` since it is the most descriptive available without disabling backtrace for other purposes. As always, alternate suggestions welcome.

Below are examples of what we have been seeing since recent release

### Examples 

**Logs Before Release**
```
ERROR solver::solver::single_order_solver: ParaSwap inner solver error: PriceQuery result parsing failed: {"error":"computePrice Error"}
Caused by:
   missing field priceRoute at line 1 column 30
```
**Logs After Release**

<details><summary>Very Long</summary>
ERROR solver::solver::single_order_solver: ParaSwap inner solver error: PriceQuery result parsing failed: {"error":"computePrice Error"}
Caused by:
   missing field priceRoute at line 1 column 30
Stack backtrace:
  0: <E as anyhow::context::ext::StdError>::ext_context
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/anyhow-1.0.42/src/context.rs:27:29
  1: anyhow::context::<impl anyhow::Context<T,E> for core::result::Result<T,E>>::context::{{closure}}
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/anyhow-1.0.42/src/context.rs:50:30
  2: core::result::Result<T,E>::map_err
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/core/src/result.rs:835:27
  3: anyhow::context::<impl anyhow::Context<T,E> for core::result::Result<T,E>>::context
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/anyhow-1.0.42/src/context.rs:50:9
  4: <solver::solver::paraswap_solver::api::DefaultParaswapApi as solver::solver::paraswap_solver::api::ParaswapApi>::price::{{closure}}
            at ./usr/src/oba-services/solver/src/solver/paraswap_solver/api.rs:42:9
  5: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/core/src/future/mod.rs:80:19
  6: <core::pin::Pin<P> as core::future::future::Future>::poll
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/core/src/future/future.rs:119:9
  7: solver::solver::paraswap_solver::ParaswapSolver::get_price_for_order::{{closure}}
            at ./usr/src/oba-services/solver/src/solver/paraswap_solver.rs:181:30
  8: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/core/src/future/mod.rs:80:19
  9: solver::solver::paraswap_solver::ParaswapSolver::try_settle_order::{{closure}}
            at ./usr/src/oba-services/solver/src/solver/paraswap_solver.rs:135:40
 10: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/core/src/future/mod.rs:80:19
 11: <solver::solver::paraswap_solver::ParaswapSolver as solver::solver::single_order_solver::SingleOrderSolving>::settle_order::{{closure}}
            at ./usr/src/oba-services/solver/src/solver/paraswap_solver.rs:104:19
 12: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/core/src/future/mod.rs:80:19
 13: <core::pin::Pin<P> as core::future::future::Future>::poll
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/core/src/future/future.rs:119:9
 14: <futures_util::future::maybe_done::MaybeDone<Fut> as core::future::future::Future>::poll
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.16/src/future/maybe_done.rs:95:38
 15: <futures_util::future::join_all::JoinAll<F> as core::future::future::Future>::poll
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.16/src/future/join_all.rs:97:16
 16: <solver::solver::single_order_solver::SingleOrderSolver<I> as solver::solver::Solver>::solve::{{closure}}
            at ./usr/src/oba-services/solver/src/solver/single_order_solver.rs:59:27
 17: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/core/src/future/mod.rs:80:19
 18: <core::pin::Pin<P> as core::future::future::Future>::poll
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/core/src/future/future.rs:119:9
 19: <tokio::time::timeout::Timeout<T> as core::future::future::Future>::poll
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.9.0/src/time/timeout.rs:149:33
 20: solver::driver::Driver::run_solvers::{{closure}}::{{closure}}::{{closure}}
            at ./usr/src/oba-services/solver/src/driver.rs:121:36
 21: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/core/src/future/mod.rs:80:19
 22: <futures_util::future::maybe_done::MaybeDone<Fut> as core::future::future::Future>::poll
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.16/src/future/maybe_done.rs:95:38
 23: <futures_util::future::join_all::JoinAll<F> as core::future::future::Future>::poll
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.16/src/future/join_all.rs:97:16
 24: solver::driver::Driver::run_solvers::{{closure}}
            at ./usr/src/oba-services/solver/src/driver.rs:116:9
 25: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/core/src/future/mod.rs:80:19
 26: solver::driver::Driver::single_run::{{closure}}
            at ./usr/src/oba-services/solver/src/driver.rs:379:27
 27: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/core/src/future/mod.rs:80:19
 28: solver::driver::Driver::run_forever::{{closure}}
            at ./usr/src/oba-services/solver/src/driver.rs:101:19
 29: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/core/src/future/mod.rs:80:19
 30: solver::main::{{closure}}
            at ./usr/src/oba-services/solver/src/main.rs:420:5
 31: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/core/src/future/mod.rs:80:19
 32: tokio::park::thread::CachedParkThread::block_on::{{closure}}
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.9.0/src/park/thread.rs:263:54
 33: tokio::coop::with_budget::{{closure}}
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.9.0/src/coop.rs:106:9
 34: std::thread::local::LocalKey<T>::try_with
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/std/src/thread/local.rs:399:16
 35: std::thread::local::LocalKey<T>::with
            at ./rustc/2827db2b137e899242e81f1beea39ae26e245153/library/std/src/thread/local.rs:375:9
 36: tokio::coop::with_budget
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.9.0/src/coop.rs:99:5
 37: tokio::coop::budget
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.9.0/src/coop.rs:76:5
 38: tokio::park::thread::CachedParkThread::block_on
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.9.0/src/park/thread.rs:263:31
 39: tokio::runtime::enter::Enter::block_on
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.9.0/src/runtime/enter.rs:151:13
 40: tokio::runtime::thread_pool::ThreadPool::block_on
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.9.0/src/runtime/thread_pool/mod.rs:71:9
 41: tokio::runtime::Runtime::block_on
            at ./root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.9.0/src/runtime/mod.rs:452:43
 42: solver::main
 ...
</details>

**Expected Logs From This PR**

```
ERROR solver::solver::single_order_solver: ParaSwap inner solver error: PriceQuery result parsing failed: {"error":"computePrice Error"}: missing field priceRoute at line 1 column 30
```

Unfortunately, according to the docs linked above, we cannot recover the what we had before without disabling stack trace globally.

Finally, after a quick search through the history of our prod alerts channel, there were only ever 3 times that the backtrace was ever logged:

1. May 19th (2x) - ERROR shared::tracing: thread 'tokio-runtime-worker' panicked at 'supplied instant is later than self', library/std/src/time.rs:281:48:
2. May 31 - ERROR shared::tracing: thread 'main' panicked at 'token is allowed and denied', shared/src/bad_token/list_based.rs:26:9:

So, arguably, we could disable it... but we might regret it. 

### Test Plan
Once merged, we can recreate some of these errors in the dev alerts channel and see if they meet expectations.
