### PR TITLE
Use websocket based gasnow estimator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,6 +982,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio",
+ "tokio-tungstenite 0.15.0",
  "tracing",
  "url",
  "web3",
@@ -2993,7 +2995,22 @@ dependencies = [
  "log",
  "pin-project",
  "tokio",
- "tungstenite",
+ "tungstenite 0.13.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "pin-project",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite 0.14.0",
 ]
 
 [[package]]
@@ -3135,6 +3152,26 @@ dependencies = [
  "httparse",
  "input_buffer",
  "log",
+ "rand",
+ "sha-1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
  "rand",
  "sha-1",
  "thiserror",
@@ -3305,7 +3342,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.14.0",
  "tokio-util",
  "tower-service",
  "tracing",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -14,7 +14,7 @@ contracts = { path = "../contracts" }
 derivative = "2.2"
 ethcontract = { version = "0.14.0", default-features = false }
 futures = "0.3"
-gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.3.0", features = ["web3_"] }
+gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.3.0", features = ["web3_", "tokio_"] }
 hex = { version = "0.4", default-features = false }
 hex-literal = "0.3"
 itertools = "0.10"

--- a/shared/src/gas_price_estimation.rs
+++ b/shared/src/gas_price_estimation.rs
@@ -1,11 +1,14 @@
 use crate::Web3;
 use anyhow::{anyhow, Context, Result};
 use gas_estimation::{
-    EthGasStation, GasNowGasStation, GasPriceEstimating, GnosisSafeGasStation,
+    EthGasStation, GasNowWebSocketGasStation, GasPriceEstimating, GnosisSafeGasStation,
     PriorityGasPriceEstimating, Transport,
 };
 use serde::de::DeserializeOwned;
-use std::sync::{Arc, Mutex};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 use structopt::clap::arg_enum;
 
 arg_enum! {
@@ -57,7 +60,14 @@ pub async fn create_priority_estimator(
                 if !is_mainnet(&network_id) {
                     return Err(anyhow!("GasNow only supports mainnet"));
                 }
-                estimators.push(Box::new(GasNowGasStation::new(client.clone())))
+                let mut estimator = GasNowWebSocketGasStation::new(Duration::from_secs(30));
+                if tokio::time::timeout(Duration::from_secs(15), estimator.wait_for_first_update())
+                    .await
+                    .is_err()
+                {
+                    return Err(anyhow!("gas now estimator did not initialize in time"));
+                };
+                estimators.push(Box::new(estimator));
             }
             GasEstimatorType::GnosisSafe => estimators.push(Box::new(
                 GnosisSafeGasStation::with_network_id(&network_id, client.clone())?,

--- a/shared/src/gas_price_estimation.rs
+++ b/shared/src/gas_price_estimation.rs
@@ -60,7 +60,8 @@ pub async fn create_priority_estimator(
                 if !is_mainnet(&network_id) {
                     return Err(anyhow!("GasNow only supports mainnet"));
                 }
-                let mut estimator = GasNowWebSocketGasStation::new(Duration::from_secs(30));
+                let max_update_age = Duration::from_secs(30);
+                let mut estimator = GasNowWebSocketGasStation::new(max_update_age);
                 if tokio::time::timeout(Duration::from_secs(15), estimator.wait_for_first_update())
                     .await
                     .is_err()


### PR DESCRIPTION
Better caching behavior. Won't make end users wait when gas cache is out of date.

I hard coded the config values here because I don't foresee we will need to adjust them.

### Test Plan
manually run
