### PR TITLE
Fix OpenAPI sell and buy token balance property names

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -494,10 +494,10 @@ components:
           $ref: "#/components/schemas/Signature"
         signingScheme:
           $ref: "#/components/schemas/SigningScheme"
-        sellTokenSource:
+        sellTokenBalance:
           $ref: "#/components/schemas/SellTokenSource"
           default: "erc20"
-        buyTokenDestination:
+        buyTokenBalance:
           $ref: "#/components/schemas/BuyTokenDestination"
           default: "erc20"
         from:


### PR DESCRIPTION
This PR just fixes the property names in the OpenAPI spec. The API already expects `*TokenBalance` properties, and this is likely just a left-over name from the renaming fiasco:

https://github.com/gnosis/gp-v2-services/blob/459a3f9f9ba7bc83a5b64896e66e02ceaf062763/model/src/order.rs#L200-L203

