### PR TITLE
Forward buffers to http solver

### DIFF
--- a/model/src/u256_decimal.rs
+++ b/model/src/u256_decimal.rs
@@ -54,3 +54,44 @@ where
 
     deserializer.deserialize_str(Visitor {})
 }
+
+/// Converts an amount of units of an ERC20 token with the specified amount of
+/// decimals into its decimal representation as a string.
+///
+/// # Examples
+///
+/// ```rust
+/// use model::u256_decimal::format_units;
+///
+/// assert_eq!(format_units(42u64.into(), 0), "42");
+/// assert_eq!(format_units(1_337_000u64.into(), 6), "1.337000")
+/// ```
+pub fn format_units(amount: U256, decimals: usize) -> String {
+    let str_amount = amount.to_string();
+    if decimals == 0 {
+        str_amount
+    } else if str_amount.len() <= decimals {
+        format!("0.{:0>pad_left$}", str_amount, pad_left = decimals)
+    } else {
+        format!(
+            "{}.{}",
+            &str_amount[0..str_amount.len() - decimals],
+            &str_amount[str_amount.len() - decimals..]
+        )
+    }
+}
+
+#[test]
+fn test_format_units() {
+    assert_eq!(format_units(1_337u64.into(), 0), "1337");
+    assert_eq!(format_units(0u64.into(), 0), "0");
+    assert_eq!(format_units(0u64.into(), 1), "0.0");
+    assert_eq!(format_units(1u64.into(), 6), "0.000001");
+    assert_eq!(format_units(999_999u64.into(), 6), "0.999999");
+    assert_eq!(format_units(1_000_000u64.into(), 6), "1.000000");
+    assert_eq!(format_units(1_337_000u64.into(), 6), "1.337000");
+    assert_eq!(
+        format_units(1_337_000_004_200u64.into(), 6),
+        "1337000.004200"
+    )
+}

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -9,7 +9,7 @@ use crate::{
     settlement_submission::retry::is_transaction_failure,
     solver::Solver,
 };
-use ::model::{order::OrderKind, u256_decimal::format_units};
+use ::model::order::OrderKind;
 use anyhow::{ensure, Context, Result};
 use buffers::{BufferRetrievalError, BufferRetrieving};
 use ethcontract::{Account, U256};
@@ -145,16 +145,13 @@ impl HttpSolver {
                     .as_ref()
                     .ok()
                     .and_then(|price| price.to_f64());
-                let internal_buffer = buffers
-                    .get(address)
-                    .map(|buffer| format_units(*buffer, token_info.decimals.unwrap_or(0) as usize));
                 (
                     *address,
                     TokenInfoModel {
                         decimals: token_info.decimals,
                         external_price,
                         normalize_priority: Some(if &self.native_token == address { 1 } else { 0 }),
-                        internal_buffer,
+                        internal_buffer: buffers.get(address).copied(),
                     },
                 )
             })

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -92,6 +92,7 @@ pub struct TokenInfoModel {
     pub decimals: Option<u8>,
     pub external_price: Option<f64>,
     pub normalize_priority: Option<u64>,
+    pub internal_buffer: Option<String>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -300,11 +301,13 @@ mod tests {
                     decimals: Some(6),
                     external_price: Some(1.2),
                     normalize_priority: Some(1),
+                    internal_buffer: Some("1.337000".into()),
                 },
                 sell_token => TokenInfoModel {
                     decimals: Some(18),
                     external_price: Some(2345.0),
                     normalize_priority: Some(0),
+                    internal_buffer: Some("4.200000".into()),
                 }
             },
             orders: hashmap! { 0 => order_model },
@@ -321,12 +324,14 @@ mod tests {
             "0x0000000000000000000000000000000000000539": {
               "decimals": 6,
               "external_price": 1.2,
-              "normalize_priority": 1
+              "normalize_priority": 1,
+              "internal_buffer": "1.337000"
             },
             "0x000000000000000000000000000000000000a866": {
               "decimals": 18,
               "external_price": 2345.0,
-              "normalize_priority": 0
+              "normalize_priority": 0,
+              "internal_buffer": "4.200000"
             }
           },
           "orders": {

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -87,12 +87,14 @@ pub struct WeightedProductPoolParameters {
     pub reserves: HashMap<H160, PoolTokenData>,
 }
 
+#[serde_as]
 #[derive(Debug, Serialize)]
 pub struct TokenInfoModel {
     pub decimals: Option<u8>,
     pub external_price: Option<f64>,
     pub normalize_priority: Option<u64>,
-    pub internal_buffer: Option<String>,
+    #[serde_as(as = "Option<DecimalU256>")]
+    pub internal_buffer: Option<U256>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -301,13 +303,13 @@ mod tests {
                     decimals: Some(6),
                     external_price: Some(1.2),
                     normalize_priority: Some(1),
-                    internal_buffer: Some("1.337000".into()),
+                    internal_buffer: Some(U256::from(1337)),
                 },
                 sell_token => TokenInfoModel {
                     decimals: Some(18),
                     external_price: Some(2345.0),
                     normalize_priority: Some(0),
-                    internal_buffer: Some("4.200000".into()),
+                    internal_buffer: Some(U256::from(42)),
                 }
             },
             orders: hashmap! { 0 => order_model },
@@ -325,13 +327,13 @@ mod tests {
               "decimals": 6,
               "external_price": 1.2,
               "normalize_priority": 1,
-              "internal_buffer": "1.337000"
+              "internal_buffer": "1337"
             },
             "0x000000000000000000000000000000000000a866": {
               "decimals": 18,
               "external_price": 2345.0,
               "normalize_priority": 0,
-              "internal_buffer": "4.200000"
+              "internal_buffer": "42"
             }
           },
           "orders": {


### PR DESCRIPTION
Forwards buffers to the http solvers. This will make the http solver avoid sending solutions if the amounts are too large for proceeds+buffer.

Left to do in the solver: after seeing if these changes are working as expected, we should probably change the solver to default to zero buffer if `internal_buffer` is `None`, otherwise we'll still have unsettlable solutions for tokens that come from outside the settlement itself, like for example in the middle of a path. (Currently it defaults to infinite for backward compatibility.)

### Test Plan
Try to run the Mip solver along with the driver and see the instance saved by the solver. `internal_buffer` was compatible with the balances of the tokens at the time.
```
{
  "tokens": {
    "0xc778417e063141139fce010982780140aa0cd5ab": {
      "decimals": 18,
      "alias": null,
      "normalize_priority": 1,
      "external_price": "1.0",
      "internal_buffer": "7728170422400341"
    },
    "0x4dbcdf9b62e891a7cec5a2568c3f4faf9e8abe2b": {
      "decimals": 6,
      "alias": null,
      "normalize_priority": 0,
      "external_price": "4049235.153344708",
      "internal_buffer": "301719007662"
    }
  },
...
```
