### PR TITLE
Reject orders selling WETH for ETH

### DIFF
--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -194,6 +194,7 @@ impl OrderbookServices {
             Duration::from_secs(120),
             bad_token_detector,
             Box::new(web3.clone()),
+            WETH9::at(web3, native_token),
         ));
         let maintenance = ServiceMaintenance {
             maintainers: vec![orderbook.clone(), db.clone(), event_updater],

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -293,6 +293,7 @@ async fn main() {
         args.min_order_validity_period,
         bad_token_detector,
         Box::new(web3.clone()),
+        native_token.clone(),
     ));
     let service_maintainer = ServiceMaintenance {
         maintainers: vec![


### PR DESCRIPTION
This PR just rejects orders that have `sell_token` as the native token (WETH on Mainnet and Rinkeby and WXDAI on xDai) with an appropriate error.

### Test Plan

Added a unit test to verify logic used in same token check.
