### PR TITLE
Allow 'null' ref-token in HTTP solver settlements

### DIFF
--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -116,7 +116,7 @@ pub struct SettledBatchAuctionModel {
     pub orders: HashMap<usize, ExecutedOrderModel>,
     #[serde(default)]
     pub amms: HashMap<usize, UpdatedAmmModel>,
-    pub ref_token: H160,
+    pub ref_token: Option<H160>,
     pub prices: HashMap<H160, Price>,
 }
 
@@ -421,5 +421,22 @@ mod tests {
             }
         "#;
         assert!(serde_json::from_str::<SettledBatchAuctionModel>(empty_solution).is_ok());
+    }
+
+    #[test]
+    fn decode_trivial_solution_without_ref_token() {
+        let x = r#"
+            {
+                "tokens": {},
+                "orders": {},
+                "metadata": {
+                    "environment": null
+                },
+                "ref_token": null,
+                "prices": {},
+                "uniswaps": {}
+            }
+        "#;
+        assert!(serde_json::from_str::<SettledBatchAuctionModel>(x).is_ok());
     }
 }

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -285,7 +285,7 @@ mod tests {
         let settled = SettledBatchAuctionModel {
             orders: hashmap! { 0 => executed_order },
             amms: hashmap! { 0 => updated_uniswap, 1 => updated_balancer },
-            ref_token: t0,
+            ref_token: Some(t0),
             prices: hashmap! { t0 => Price(10.0), t1 => Price(11.0) },
         };
 


### PR DESCRIPTION
This PR modifies the HTTP solver model to allow parsing solutions with a `null` ref-token which happens when the solver returns trivial solutions in certain cases.

This PR is trivial since we don't actually use the reference token anywhere (except for one test).

### Test Plan

Added new unit test.
