### PR TITLE
Pass deadline into solvers

### DIFF
--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -28,7 +28,11 @@ use ethcontract::H160;
 use hex::{FromHex, FromHexError};
 use model::h160_hexadecimal;
 use serde::Deserialize;
-use std::{str::FromStr, time::Duration};
+use std::{
+    future::Future,
+    str::FromStr,
+    time::{Duration, Instant},
+};
 
 pub type Web3 =
     web3::Web3<transport::instrumented::MetricTransport<transport::http::HttpTransport>>;
@@ -52,4 +56,13 @@ pub fn http_client(timeout: Duration) -> reqwest::Client {
         .user_agent("gp-v2-services/2.0.0")
         .build()
         .unwrap()
+}
+
+/// Run a future and callback with the time the future took. The call back can for example log the
+/// time.
+pub async fn measure_time<T>(future: impl Future<Output = T>, timer: impl FnOnce(Duration)) -> T {
+    let start = Instant::now();
+    let result = future.await;
+    timer(start.elapsed());
+    result
 }

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -350,7 +350,6 @@ async fn main() {
         network_name.to_string(),
         chain_id,
         args.shared.fee_discount_factor,
-        args.solver_time_limit,
         args.min_order_size_one_inch,
         args.disabled_one_inch_protocols,
         args.paraswap_slippage_bps,

--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -23,6 +23,7 @@ use shared::{
 use std::{
     collections::{HashMap, HashSet},
     convert::TryFrom as _,
+    time::Instant,
 };
 
 pub struct BaselineSolver {
@@ -32,7 +33,12 @@ pub struct BaselineSolver {
 
 #[async_trait::async_trait]
 impl Solver for BaselineSolver {
-    async fn solve(&self, liquidity: Vec<Liquidity>, _gas_price: f64) -> Result<Vec<Settlement>> {
+    async fn solve(
+        &self,
+        liquidity: Vec<Liquidity>,
+        _gas_price: f64,
+        _deadline: Instant,
+    ) -> Result<Vec<Settlement>> {
         Ok(self.solve(liquidity))
     }
 

--- a/solver/src/solver/naive_solver.rs
+++ b/solver/src/solver/naive_solver.rs
@@ -8,7 +8,7 @@ use crate::{
 use anyhow::Result;
 use ethcontract::Account;
 use model::TokenPair;
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Instant};
 
 pub struct NaiveSolver {
     account: Account,
@@ -22,7 +22,12 @@ impl NaiveSolver {
 
 #[async_trait::async_trait]
 impl Solver for NaiveSolver {
-    async fn solve(&self, liquidity: Vec<Liquidity>, _gas_price: f64) -> Result<Vec<Settlement>> {
+    async fn solve(
+        &self,
+        liquidity: Vec<Liquidity>,
+        _gas_price: f64,
+        _deadline: Instant,
+    ) -> Result<Vec<Settlement>> {
         let uniswaps = extract_deepest_amm_liquidity(&liquidity);
         let limit_orders = liquidity
             .into_iter()


### PR DESCRIPTION
This allows solver implementations to react to the deadline. The
motivating issue for this is that in the http_solver we first do some
async work and then send the http request which also contains a timeout
that the python solver should obey. We were not taking our initial work
into account here which could cause the python solver to take too long
to respond which would make the driver complain that the solver timed
out.
By knowing the deadline we can adjust the timeout passed to python and
avoid this problem. Similarily the single order solver is smarter now
because it can enforce the timeout on the individual orders it solves
instead of making the whole settlement fail if one of the orders take
too long.
Finally we add some debug logging to the http solver so we can see which
async operation takes how long.

### Test Plan
CI.