### PR TITLE
Deny Order Creation for "Banned Users"

### DIFF
--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -195,6 +195,7 @@ impl OrderbookServices {
             bad_token_detector,
             Box::new(web3.clone()),
             WETH9::at(web3, native_token),
+            vec![],
         ));
         let maintenance = ServiceMaintenance {
             maintainers: vec![orderbook.clone(), db.clone(), event_updater],

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -669,6 +669,7 @@ components:
               TransferEthToContract,
               UnsupportedToken,
               WrongOwner,
+              BannedUser,
               SameBuyAndSellToken,
               UnsupportedBuyTokenDestination,
               UnsupportedSellTokenSource,

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -37,6 +37,10 @@ pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
             ),
             StatusCode::BAD_REQUEST,
         ),
+        Ok(AddOrderResult::BannedUser(owner)) => (
+            super::error("BannedUser", format!("User account banned {}", owner)),
+            StatusCode::BAD_REQUEST,
+        ),
         Ok(AddOrderResult::DuplicatedOrder) => (
             super::error("DuplicatedOrder", "order already exists"),
             StatusCode::BAD_REQUEST,

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -93,6 +93,10 @@ struct Arguments {
     #[structopt(long, env = "UNSUPPORTED_TOKENS", use_delimiter = true)]
     pub unsupported_tokens: Vec<H160>,
 
+    /// List of account addresses to be denied from order creation
+    #[structopt(long, env = "BANNED_USERS", use_delimiter = true)]
+    pub banned_users: Vec<H160>,
+
     /// List of token addresses that shoud be allowed regardless of whether the bad token detector
     /// thinks they are bad. Base tokens are automatically allowed.
     #[structopt(long, env = "ALLOWED_TOKENS", use_delimiter = true)]
@@ -294,6 +298,7 @@ async fn main() {
         bad_token_detector,
         Box::new(web3.clone()),
         native_token.clone(),
+        args.banned_users,
     ));
     let service_maintainer = ServiceMaintenance {
         maintainers: vec![

--- a/solver/src/solver/oneinch_solver.rs
+++ b/solver/src/solver/oneinch_solver.rs
@@ -91,8 +91,7 @@ impl OneInchSolver {
         Ok(protocols)
     }
 
-    /// Settles a single sell order against a 1Inch swap using the spcified
-    /// protocols.
+    /// Settles a single sell order against a 1Inch swap using the specified protocols.
     async fn settle_order_with_protocols(
         &self,
         order: LimitOrder,


### PR DESCRIPTION
In some scenarios (e.g. DDoS attacks) we may want to prevent certain users from order placement.

This introduces exactly this functionality (configurable at runtime and defaulting to [])

### Test Plan
Could add a test that this happens upon request.
