### PR TITLE
Added support for Balancer Vault external balances

### DIFF
--- a/orderbook/src/account_balances.rs
+++ b/orderbook/src/account_balances.rs
@@ -1,9 +1,13 @@
-use anyhow::Result;
-use contracts::ERC20;
+use anyhow::{bail, Result};
+use contracts::{BalancerV2Vault, ERC20};
 use ethcontract::batch::CallBatch;
-use futures::future::{join3, join_all};
+use futures::{
+    future::{self, join_all, BoxFuture},
+    FutureExt as _,
+};
+use model::order::SellTokenSource;
 use primitive_types::{H160, U256};
-use shared::Web3;
+use shared::{Web3, Web3Transport};
 use std::{collections::HashMap, sync::Mutex};
 use web3::types::{BlockId, BlockNumber, CallRequest};
 
@@ -13,14 +17,14 @@ const MAX_BATCH_SIZE: usize = 100;
 #[async_trait::async_trait]
 pub trait BalanceFetching: Send + Sync {
     // Register owner and address for balance updates in the background
-    async fn register(&self, owner: H160, token: H160);
+    async fn register(&self, owner: H160, token: H160, source: SellTokenSource);
 
     // Register multiple owner and addresses for balance updates in the background
-    async fn register_many(&self, owner_token_list: Vec<(H160, H160)>);
+    async fn register_many(&self, owner_token_list: Vec<(H160, H160, SellTokenSource)>);
 
     // Returns the latest balance available to the allowance manager for the given owner and token.
     // Should be non-blocking. Returns None if balance has never been fetched.
-    fn get_balance(&self, owner: H160, token: H160) -> Option<U256>;
+    fn get_balance(&self, owner: H160, token: H160, source: SellTokenSource) -> Option<U256>;
 
     // Called periodically to perform potential updates on registered balances
     async fn update(&self);
@@ -30,11 +34,18 @@ pub trait BalanceFetching: Send + Sync {
     // allowance manager or if the token does not allow freely transferring amounts around for
     // for example if it is paused or takes a fee on transfer.
     // If the node supports the trace_callMany we can perform more extensive tests.
-    async fn can_transfer(&self, token: H160, from: H160, amount: U256) -> Result<bool>;
+    async fn can_transfer(
+        &self,
+        token: H160,
+        from: H160,
+        amount: U256,
+        source: SellTokenSource,
+    ) -> Result<bool>;
 }
 
 pub struct Web3BalanceFetcher {
     web3: Web3,
+    vault: Option<BalancerV2Vault>,
     vault_relayer: H160,
     settlement_contract: H160,
     // Mapping of address, token to balance, allowance
@@ -45,6 +56,7 @@ pub struct Web3BalanceFetcher {
 struct SubscriptionKey {
     owner: H160,
     token: H160,
+    source: SellTokenSource,
 }
 
 #[derive(Clone, Default)]
@@ -54,9 +66,15 @@ struct SubscriptionValue {
 }
 
 impl Web3BalanceFetcher {
-    pub fn new(web3: Web3, vault_relayer: H160, settlement_contract: H160) -> Self {
+    pub fn new(
+        web3: Web3,
+        vault: Option<BalancerV2Vault>,
+        vault_relayer: H160,
+        settlement_contract: H160,
+    ) -> Self {
         Self {
             web3,
+            vault,
             vault_relayer,
             settlement_contract,
             balances: Default::default(),
@@ -83,35 +101,35 @@ impl Web3BalanceFetcher {
         let calls = subscriptions
             .into_iter()
             .map(|subscription| {
-                let instance = ERC20::at(&self.web3, subscription.token);
-                join3(
-                    instance
-                        .balance_of(subscription.owner)
-                        .batch_call(&mut batch),
-                    instance
-                        .allowance(subscription.owner, self.vault_relayer)
-                        .batch_call(&mut batch),
-                    std::future::ready(subscription),
-                )
+                let token = ERC20::at(&self.web3, subscription.token);
+                let value = match (subscription.source, &self.vault) {
+                    (SellTokenSource::Erc20, _) => erc20_balance_query(
+                        &mut batch,
+                        token,
+                        subscription.owner,
+                        self.vault_relayer,
+                    ),
+                    (SellTokenSource::External, Some(vault)) => vault_external_balance_query(
+                        &mut batch,
+                        vault.clone(),
+                        token,
+                        subscription.owner,
+                        self.vault_relayer,
+                    ),
+                    _ => async { SubscriptionValue::default() }.boxed(),
+                };
+                future::join(future::ready(subscription), value)
             })
             .collect::<Vec<_>>();
 
         batch.execute_all(usize::MAX).await;
 
         let call_results = join_all(calls).await;
-        let mut guard = self.balances.lock().expect("thread holding mutex panicked");
-        for (balance, allowance, subscription) in call_results {
-            let entry = guard.entry(subscription).or_default();
+        self.balances
+            .lock()
+            .expect("thread holding mutex panicked")
+            .extend(call_results);
 
-            match balance {
-                Ok(balance) => entry.balance = Some(balance),
-                Err(_) => tracing::warn!("Couldn't fetch balance for {:?}", subscription),
-            }
-            match allowance {
-                Ok(allowance) => entry.allowance = Some(allowance),
-                Err(_) => tracing::warn!("Couldn't fetch allowance for {:?}", subscription),
-            }
-        }
         Ok(())
     }
 
@@ -134,26 +152,118 @@ impl Web3BalanceFetcher {
             .map(|bytes| is_empty_or_truthy(bytes.0.as_slice()))
             .unwrap_or(false)
     }
+
+    async fn can_manage_user_balance_call(&self, token: H160, from: H160, amount: U256) -> bool {
+        let vault = match self.vault.as_ref() {
+            Some(vault) => vault,
+            None => return false,
+        };
+
+        const USER_BALANCE_OP_TRANSFER_EXTERNAL: u8 = 3;
+        vault
+            .manage_user_balance(vec![(
+                USER_BALANCE_OP_TRANSFER_EXTERNAL,
+                token,
+                amount,
+                from,
+                self.settlement_contract,
+            )])
+            .call()
+            .await
+            .is_ok()
+    }
+}
+
+fn erc20_balance_query<'a>(
+    batch: &mut CallBatch<&'a Web3Transport>,
+    token: ERC20,
+    owner: H160,
+    spender: H160,
+) -> BoxFuture<'a, SubscriptionValue> {
+    let balance = token.balance_of(owner).batch_call(batch);
+    let allowance = token.allowance(owner, spender).batch_call(batch);
+
+    async move {
+        let (balance, allowance) = futures::join!(balance, allowance);
+
+        let mut value = SubscriptionValue::default();
+        match balance {
+            Ok(balance) => value.balance = Some(balance),
+            Err(_) => tracing::warn!(
+                "Couldn't fetch {:?} balance for {:?}",
+                token.address(),
+                owner
+            ),
+        }
+        match allowance {
+            Ok(allowance) => value.allowance = Some(allowance),
+            Err(_) => tracing::warn!(
+                "Couldn't fetch {:?} allowance from {:?} to {:?}",
+                token.address(),
+                owner,
+                spender
+            ),
+        }
+
+        value
+    }
+    .boxed()
+}
+
+fn vault_external_balance_query<'a>(
+    batch: &mut CallBatch<&'a Web3Transport>,
+    vault: BalancerV2Vault,
+    token: ERC20,
+    owner: H160,
+    relayer: H160,
+) -> BoxFuture<'a, SubscriptionValue> {
+    let erc20 = erc20_balance_query(batch, token, owner, vault.address());
+    let approval = vault.has_approved_relayer(owner, relayer).batch_call(batch);
+
+    async move {
+        let (value, approval) = futures::join!(erc20, approval);
+        match approval {
+            Ok(true) => value,
+            Ok(false) => SubscriptionValue {
+                allowance: Some(0.into()),
+                ..value
+            },
+            Err(_) => {
+                tracing::warn!(
+                    "Couldn't fetch vault approval from {:?} to {:?}",
+                    owner,
+                    relayer
+                );
+                SubscriptionValue::default()
+            }
+        }
+    }
+    .boxed()
 }
 
 #[async_trait::async_trait]
 impl BalanceFetching for Web3BalanceFetcher {
-    async fn register(&self, owner: H160, token: H160) {
-        self.register_many(vec![(owner, token)]).await;
+    async fn register(&self, owner: H160, token: H160, source: SellTokenSource) {
+        self.register_many(vec![(owner, token, source)]).await;
     }
 
-    async fn register_many(&self, owner_token_list: Vec<(H160, H160)>) {
+    async fn register_many(&self, owner_token_list: Vec<(H160, H160, SellTokenSource)>) {
         for chunk in owner_token_list.chunks(MAX_BATCH_SIZE) {
-            let subscriptions = chunk.iter().map(|(owner, token)| SubscriptionKey {
+            let subscriptions = chunk.iter().map(|(owner, token, source)| SubscriptionKey {
                 owner: *owner,
                 token: *token,
+                source: *source,
             });
             let _ = self._register_many(subscriptions).await;
         }
     }
 
-    fn get_balance(&self, owner: H160, token: H160) -> Option<U256> {
-        let subscription = SubscriptionKey { owner, token };
+    fn get_balance(&self, owner: H160, token: H160, source: SellTokenSource) -> Option<U256> {
+        let subscription = SubscriptionKey {
+            owner,
+            token,
+            source,
+        };
         let SubscriptionValue { balance, allowance } = self
             .balances
             .lock()
@@ -172,8 +282,21 @@ impl BalanceFetching for Web3BalanceFetcher {
         let _ = self._register_many(subscriptions.into_iter()).await;
     }
 
-    async fn can_transfer(&self, token: H160, from: H160, amount: U256) -> Result<bool> {
-        Ok(self.can_transfer_call(token, from, amount).await)
+    async fn can_transfer(
+        &self,
+        token: H160,
+        from: H160,
+        amount: U256,
+        source: SellTokenSource,
+    ) -> Result<bool> {
+        let success = match source {
+            SellTokenSource::Erc20 => self.can_transfer_call(token, from, amount).await,
+            SellTokenSource::External => {
+                self.can_manage_user_balance_call(token, from, amount).await
+            }
+            SellTokenSource::Internal => bail!("internal Vault balances not supported"),
+        };
+        Ok(success)
     }
 }
 
@@ -188,7 +311,7 @@ fn is_empty_or_truthy(bytes: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use contracts::ERC20Mintable;
+    use contracts::{BalancerV2Authorizer, ERC20Mintable};
     use ethcontract::prelude::Account;
     use hex_literal::hex;
     use shared::transport::create_env_test_transport;
@@ -199,13 +322,18 @@ mod tests {
         let http = create_env_test_transport();
         let web3 = Web3::new(http);
         let settlement = contracts::GPv2Settlement::deployed(&web3).await.unwrap();
-        let allowance = settlement.vault_relayer().call().await.unwrap();
-        let fetcher = Web3BalanceFetcher::new(web3, allowance, settlement.address());
+        let vault_relayer = settlement.vault_relayer().call().await.unwrap();
+        let fetcher = Web3BalanceFetcher::new(web3, None, vault_relayer, settlement.address());
         let owner = H160(hex!("07c2af75788814BA7e5225b2F5c951eD161cB589"));
         let token = H160(hex!("dac17f958d2ee523a2206206994597c13d831ec7"));
 
-        fetcher.register(owner, token).await;
-        assert!(fetcher.get_balance(owner, token).unwrap() >= U256::from(1000));
+        fetcher.register(owner, token, SellTokenSource::Erc20).await;
+        assert!(
+            fetcher
+                .get_balance(owner, token, SellTokenSource::Erc20)
+                .unwrap()
+                >= U256::from(1000)
+        );
 
         let call_result = fetcher.can_transfer_call(token, owner, 1000.into()).await;
         assert!(call_result);
@@ -217,14 +345,19 @@ mod tests {
         let http = create_env_test_transport();
         let web3 = Web3::new(http);
         let settlement = contracts::GPv2Settlement::deployed(&web3).await.unwrap();
-        let allowance = settlement.vault_relayer().call().await.unwrap();
-        let fetcher = Web3BalanceFetcher::new(web3, allowance, settlement.address());
+        let vault_relayer = settlement.vault_relayer().call().await.unwrap();
+        let fetcher = Web3BalanceFetcher::new(web3, None, vault_relayer, settlement.address());
         let owner = H160(hex!("78045485dc4ad96f60937dad4b01b118958761ae"));
         // Token takes a fee.
         let token = H160(hex!("bae5f2d8a1299e5c4963eaff3312399253f27ccb"));
 
-        fetcher.register(owner, token).await;
-        assert!(fetcher.get_balance(owner, token).unwrap() >= U256::from(1000));
+        fetcher.register(owner, token, SellTokenSource::Erc20).await;
+        assert!(
+            fetcher
+                .get_balance(owner, token, SellTokenSource::Erc20)
+                .unwrap()
+                >= U256::from(1000)
+        );
 
         let call_result = fetcher.can_transfer_call(token, owner, 1000.into()).await;
         // The non trace method is less accurate and thinks the transfer is ok even though it isn't.
@@ -233,7 +366,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn watch_testnet_balance() {
+    async fn watch_testnet_erc20_balance() {
         let http = create_env_test_transport();
         let web3 = Web3::new(http);
 
@@ -247,16 +380,25 @@ mod tests {
             .await
             .expect("MintableERC20 deployment failed");
 
-        let fetcher =
-            Web3BalanceFetcher::new(web3, allowance_target.address(), H160::from_low_u64_be(1));
+        let fetcher = Web3BalanceFetcher::new(
+            web3,
+            None,
+            allowance_target.address(),
+            H160::from_low_u64_be(1),
+        );
 
         // Not available until registered
-        assert_eq!(fetcher.get_balance(trader.address(), token.address()), None,);
+        assert_eq!(
+            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::Erc20),
+            None,
+        );
 
-        fetcher.register(trader.address(), token.address()).await;
+        fetcher
+            .register(trader.address(), token.address(), SellTokenSource::Erc20)
+            .await;
 
         assert_eq!(
-            fetcher.get_balance(trader.address(), token.address()),
+            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::Erc20),
             Some(U256::zero()),
         );
 
@@ -268,7 +410,7 @@ mod tests {
             .unwrap();
         fetcher.update().await;
         assert_eq!(
-            fetcher.get_balance(trader.address(), token.address()),
+            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::Erc20),
             Some(U256::zero()),
         );
 
@@ -280,7 +422,7 @@ mod tests {
             .unwrap();
         fetcher.update().await;
         assert_eq!(
-            fetcher.get_balance(trader.address(), token.address()),
+            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::Erc20),
             Some(100.into()),
         );
 
@@ -292,8 +434,112 @@ mod tests {
             .unwrap();
         fetcher.update().await;
         assert_eq!(
-            fetcher.get_balance(trader.address(), token.address()),
+            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::Erc20),
             Some(U256::zero()),
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn watch_testnet_vault_external_balance() {
+        let http = create_env_test_transport();
+        let web3 = Web3::new(http);
+
+        let accounts: Vec<H160> = web3.eth().accounts().await.expect("get accounts failed");
+        let admin = Account::Local(accounts[0], None);
+        let trader = Account::Local(accounts[1], None);
+        let allowance_target = Account::Local(accounts[2], None);
+
+        let authorizer = BalancerV2Authorizer::builder(&web3, admin.address())
+            .deploy()
+            .await
+            .expect("BalancerV2Authorizer deployment failed");
+        let vault = BalancerV2Vault::builder(
+            &web3,
+            authorizer.address(),
+            H160([0xef; 20]), // WETH address - not important for this test.
+            0.into(),
+            0.into(),
+        )
+        .deploy()
+        .await
+        .expect("BalancerV2Vault deployment failed");
+
+        let token = ERC20Mintable::builder(&web3)
+            .deploy()
+            .await
+            .expect("MintableERC20 deployment failed");
+
+        let fetcher = Web3BalanceFetcher::new(
+            web3,
+            None,
+            allowance_target.address(),
+            H160::from_low_u64_be(1),
+        );
+
+        // Not available until registered
+        assert_eq!(
+            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::External),
+            None,
+        );
+
+        fetcher
+            .register(trader.address(), token.address(), SellTokenSource::External)
+            .await;
+
+        assert_eq!(
+            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::External),
+            Some(U256::zero()),
+        );
+
+        // Balance without allowance and approval should not affect available balance
+        token
+            .mint(trader.address(), 100.into())
+            .send()
+            .await
+            .unwrap();
+        fetcher.update().await;
+        assert_eq!(
+            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::External),
+            Some(U256::zero()),
+        );
+
+        // Balance without approval should not affect available balance
+        token
+            .approve(allowance_target.address(), 200.into())
+            .from(trader.clone())
+            .send()
+            .await
+            .unwrap();
+        fetcher.update().await;
+        assert_eq!(
+            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::External),
+            Some(U256::zero()),
+        );
+
+        // Approving allowance_target as a relayer increase available balance
+        vault
+            .set_relayer_approval(trader.address(), allowance_target.address(), true)
+            .from(trader.clone())
+            .send()
+            .await
+            .unwrap();
+        fetcher.update().await;
+        assert_eq!(
+            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::External),
+            Some(100.into()),
+        );
+
+        // Spending balance should decrease available balance
+        token
+            .transfer(allowance_target.address(), 50.into())
+            .send()
+            .await
+            .unwrap();
+        fetcher.update().await;
+        assert_eq!(
+            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::External),
+            Some(50.into()),
         );
     }
 }

--- a/orderbook/src/account_balances.rs
+++ b/orderbook/src/account_balances.rs
@@ -84,11 +84,14 @@ impl Web3BalanceFetcher {
     async fn _register_many(&self, subscriptions: Vec<SubscriptionKey>) -> Result<()> {
         let mut batch = CallBatch::new(self.web3.transport());
 
-        // Make sure subscriptions are registered for next update even if batch call fails
+        // Make sure subscriptions are registered for next update even if batch call fails.
+        // Note that we only add an entry if one does not already exist, this allows calls
+        // to `get_balance` to immediately return the previously cached value during the
+        // update.
         {
             let mut guard = self.balances.lock().expect("thread holding mutex panicked");
             for subscription in &subscriptions {
-                guard.insert(*subscription, Default::default());
+                guard.entry(*subscription).or_default();
             }
         }
 

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -1,4 +1,4 @@
-use contracts::{GPv2Settlement, WETH9};
+use contracts::{BalancerV2Vault, GPv2Settlement, WETH9};
 use model::{
     order::{OrderUid, BUY_ETH_ADDRESS},
     DomainSeparator,
@@ -141,7 +141,7 @@ async fn main() {
     let settlement_contract = GPv2Settlement::deployed(&web3)
         .await
         .expect("Couldn't load deployed settlement");
-    let gp_allowance = settlement_contract
+    let vault_relayer = settlement_contract
         .vault_relayer()
         .call()
         .await
@@ -155,6 +155,19 @@ async fn main() {
         .await
         .expect("Could not get chainId")
         .as_u64();
+
+    let vault = match chain_id {
+        1 | 4 => Some(
+            BalancerV2Vault::deployed(&web3)
+                .await
+                .expect("couldn't load deployed vault contract"),
+        ),
+        _ => {
+            // The Vault is not deployed on all networks we support, so allow it
+            // to be `None` for those networks.
+            None
+        }
+    };
 
     verify_deployed_contract_constants(&settlement_contract, chain_id)
         .await
@@ -182,8 +195,12 @@ async fn main() {
         database.as_ref().clone(),
         sync_start,
     );
-    let balance_fetcher =
-        Web3BalanceFetcher::new(web3.clone(), gp_allowance, settlement_contract.address());
+    let balance_fetcher = Web3BalanceFetcher::new(
+        web3.clone(),
+        vault,
+        vault_relayer,
+        settlement_contract.address(),
+    );
 
     let gas_price_estimator = Arc::new(
         shared::gas_price_estimation::create_priority_estimator(

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -105,7 +105,10 @@ impl Orderbook {
                 order.buy_token_balance,
             ));
         }
-        if order.sell_token_balance != SellTokenSource::Erc20 {
+        if !matches!(
+            order.sell_token_balance,
+            SellTokenSource::Erc20 | SellTokenSource::External
+        ) {
             return Ok(AddOrderResult::UnsupportedSellTokenSource(
                 order.sell_token_balance,
             ));
@@ -159,7 +162,12 @@ impl Orderbook {
         };
         if !self
             .balance_fetcher
-            .can_transfer(order.order_creation.sell_token, owner, min_balance)
+            .can_transfer(
+                order.order_creation.sell_token,
+                owner,
+                min_balance,
+                order.order_creation.sell_token_balance,
+            )
             .await
             .unwrap_or(false)
         {
@@ -179,7 +187,11 @@ impl Orderbook {
             _ => (),
         }
         self.balance_fetcher
-            .register(owner, order.order_creation.sell_token)
+            .register(
+                owner,
+                order.order_creation.sell_token,
+                order.order_creation.sell_token_balance,
+            )
             .await;
         Ok(AddOrderResult::Added(order.order_meta_data.uid))
     }
@@ -296,12 +308,16 @@ async fn filter_unsupported_tokens(
 async fn track_and_get_balances(
     fetcher: &dyn BalanceFetching,
     orders: &[Order],
-) -> HashMap<(H160, H160), U256> {
-    let mut balances = HashMap::<(H160, H160), U256>::new();
-    let mut untracked = HashSet::<(H160, H160)>::new();
+) -> HashMap<(H160, H160, SellTokenSource), U256> {
+    let mut balances = HashMap::<(H160, H160, SellTokenSource), U256>::new();
+    let mut untracked = HashSet::<(H160, H160, SellTokenSource)>::new();
     for order in orders {
-        let key = (order.order_meta_data.owner, order.order_creation.sell_token);
-        match fetcher.get_balance(key.0, key.1) {
+        let key = (
+            order.order_meta_data.owner,
+            order.order_creation.sell_token,
+            order.order_creation.sell_token_balance,
+        );
+        match fetcher.get_balance(key.0, key.1, key.2) {
             Some(balance) => {
                 balances.insert(key, balance);
             }
@@ -315,15 +331,22 @@ async fn track_and_get_balances(
         .await;
     balances.extend(untracked.into_iter().filter_map(|key| {
         fetcher
-            .get_balance(key.0, key.1)
+            .get_balance(key.0, key.1, key.2)
             .map(|balance| (key, balance))
     }));
     balances
 }
 
-fn set_available_balances(orders: &mut [Order], balances: &HashMap<(H160, H160), U256>) {
+fn set_available_balances(
+    orders: &mut [Order],
+    balances: &HashMap<(H160, H160, SellTokenSource), U256>,
+) {
     for order in orders.iter_mut() {
-        let key = &(order.order_meta_data.owner, order.order_creation.sell_token);
+        let key = &(
+            order.order_meta_data.owner,
+            order.order_creation.sell_token,
+            order.order_creation.sell_token_balance,
+        );
         order.order_meta_data.available_balance = balances.get(key).cloned();
     }
 }
@@ -331,11 +354,18 @@ fn set_available_balances(orders: &mut [Order], balances: &HashMap<(H160, H160),
 // The order book has to make a choice for which orders to include when a user has multiple orders
 // selling the same token but not enough balance for all of them.
 // Assumes balance fetcher is already tracking all balances.
-fn solvable_orders(mut orders: Vec<Order>, balances: &HashMap<(H160, H160), U256>) -> Vec<Order> {
-    let mut orders_map = HashMap::<(H160, H160), Vec<Order>>::new();
+fn solvable_orders(
+    mut orders: Vec<Order>,
+    balances: &HashMap<(H160, H160, SellTokenSource), U256>,
+) -> Vec<Order> {
+    let mut orders_map = HashMap::<(H160, H160, SellTokenSource), Vec<Order>>::new();
     orders.sort_by_key(|order| std::cmp::Reverse(order.order_meta_data.creation_date));
     for order in orders {
-        let key = (order.order_meta_data.owner, order.order_creation.sell_token);
+        let key = (
+            order.order_meta_data.owner,
+            order.order_creation.sell_token,
+            order.order_creation.sell_token_balance,
+        );
         orders_map.entry(key).or_default().push(order);
     }
 
@@ -422,6 +452,7 @@ mod tests {
             Order {
                 order_creation: OrderCreation {
                     sell_token: another_sell_token,
+                    sell_token_balance: SellTokenSource::External,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -431,21 +462,29 @@ mod tests {
 
         balance_fetcher
             .expect_get_balance()
-            .with(eq(owner), eq(a_sell_token))
+            .with(eq(owner), eq(a_sell_token), eq(SellTokenSource::Erc20))
             .return_const(Some(a_balance));
 
         // Not having a balance for the second order, should trigger a register_many only for this token
         let mut seq = Sequence::new();
         balance_fetcher
             .expect_get_balance()
-            .with(eq(owner), eq(another_sell_token))
+            .with(
+                eq(owner),
+                eq(another_sell_token),
+                eq(SellTokenSource::External),
+            )
             .times(1)
             .in_sequence(&mut seq)
             .return_const(None);
 
         balance_fetcher
             .expect_register_many()
-            .with(eq(vec![(owner, another_sell_token)]))
+            .with(eq(vec![(
+                owner,
+                another_sell_token,
+                SellTokenSource::External,
+            )]))
             .times(1)
             .in_sequence(&mut seq)
             .returning(|_| ());
@@ -453,7 +492,11 @@ mod tests {
         // Once registered, we can return the balance
         balance_fetcher
             .expect_get_balance()
-            .with(eq(owner), eq(another_sell_token))
+            .with(
+                eq(owner),
+                eq(another_sell_token),
+                eq(SellTokenSource::External),
+            )
             .times(1)
             .in_sequence(&mut seq)
             .return_const(Some(another_balance));
@@ -462,8 +505,8 @@ mod tests {
         assert_eq!(
             balances,
             hashmap! {
-                (owner, a_sell_token) => a_balance,
-                (owner, another_sell_token) => another_balance
+                (owner, a_sell_token, SellTokenSource::Erc20) => a_balance,
+                (owner, another_sell_token, SellTokenSource::External) => another_balance
             }
         );
     }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -34,8 +34,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-pub type Web3 =
-    web3::Web3<transport::instrumented::MetricTransport<transport::http::HttpTransport>>;
+pub type Web3Transport = transport::instrumented::MetricTransport<transport::http::HttpTransport>;
+pub type Web3 = web3::Web3<Web3Transport>;
 
 /// Wraps H160 with FromStr and Deserialize that can handle a `0x` prefix.
 #[derive(Deserialize)]


### PR DESCRIPTION
Partial #901

This PR adds support in the account balance module for Vault external balances. This allows the orderbook to accept orders that use Vault ERC20 allowances. This mostly involved a lot of plumbing.

This PR is still in draft as I haven't had time to make the test run.

### Test Plan

Added new tests. Run the new tests manually connected to a Ganache instance with:
```
$ NODE_URL=http://127.0.0.1:8545 cargo test -p orderbook -- --ignored --nocapture testnet_vault_external_balance 
    Finished test [unoptimized + debuginfo] target(s) in 0.14s
     Running unittests (target/debug/deps/orderbook-b56b14be77745f86)

running 2 tests
test account_balances::tests::can_transfer_testnet_vault_external_balance ... ok
test account_balances::tests::watch_testnet_vault_external_balance ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 57 filtered out; finished in 1.58s

     Running unittests (target/debug/deps/orderbook-a86dfc4ff750ba67)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests orderbook

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
