### PR TITLE
[Temp] To see the various response texts

### DIFF
--- a/solver/src/solver/matcha_solver/api.rs
+++ b/solver/src/solver/matcha_solver/api.rs
@@ -135,8 +135,8 @@ pub enum MatchaResponseError {
     #[error("uncatalogued error message: {0}")]
     UnknownMatchaError(String),
 
-    #[error(transparent)]
-    DeserializeError(#[from] serde_json::Error),
+    #[error("Error({0}) for response {1}")]
+    DeserializeError(serde_json::Error, String),
 
     // Recovered Response but failed on async call of response.text()
     #[error(transparent)]
@@ -175,7 +175,7 @@ fn parse_matcha_response_text(
             "Server Error" => Err(MatchaResponseError::ServerError(format!("{:?}", query))),
             _ => Err(MatchaResponseError::UnknownMatchaError(message)),
         },
-        Err(err) => Err(MatchaResponseError::DeserializeError(err)),
+        Err(err) => Err(MatchaResponseError::DeserializeError(err, response_text.parse().unwrap())),
     }
 }
 

--- a/solver/src/solver/matcha_solver/api.rs
+++ b/solver/src/solver/matcha_solver/api.rs
@@ -175,7 +175,10 @@ fn parse_matcha_response_text(
             "Server Error" => Err(MatchaResponseError::ServerError(format!("{:?}", query))),
             _ => Err(MatchaResponseError::UnknownMatchaError(message)),
         },
-        Err(err) => Err(MatchaResponseError::DeserializeError(err, response_text.parse().unwrap())),
+        Err(err) => Err(MatchaResponseError::DeserializeError(
+            err,
+            response_text.parse().unwrap(),
+        )),
     }
 }
 


### PR DESCRIPTION

Lately we have been seeing DeserializeError in the form

```
solver error: Matcha Response Error DeserializeError(Error("data did not match any variant of untagged enum RawResponse", line: 0, column: 0))
```

However, it is challenging to debug since I haven't been able to dig up the response (or at least link the many responses we get to this particular error). 

I suspect that the response in this case is actually empty, but this temporary fix should confirm that theory.