### PR TITLE
*Making discount factor intuitivly accurate

### DIFF
--- a/e2e/tests/eth_integration.rs
+++ b/e2e/tests/eth_integration.rs
@@ -227,7 +227,7 @@ async fn eth_integration(web3: Web3) {
         Duration::from_secs(30),
         None,
         block_stream,
-        1.0,
+        0.0,
         SolutionSubmitter {
             web3: web3.clone(),
             contract: gpv2.settlement.clone(),

--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -200,7 +200,7 @@ async fn onchain_settlement(web3: Web3) {
         Duration::from_secs(30),
         None,
         block_stream,
-        1.0,
+        0.0,
         SolutionSubmitter {
             web3: web3.clone(),
             contract: gpv2.settlement.clone(),

--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -178,7 +178,7 @@ impl OrderbookServices {
             gas_estimator,
             native_token,
             db.clone(),
-            1.0,
+            0.0,
             bad_token_detector.clone(),
         ));
         let orderbook = Arc::new(Orderbook::new(

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -187,7 +187,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         Duration::from_secs(10),
         Some(market_makable_token_list),
         block_stream,
-        1.0,
+        0.0,
         SolutionSubmitter {
             web3: web3.clone(),
             contract: gpv2.settlement.clone(),

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -23,7 +23,7 @@ pub struct MinFeeCalculator {
     native_token: H160,
     measurements: Arc<dyn MinFeeStoring>,
     now: Box<dyn Fn() -> DateTime<Utc> + Send + Sync>,
-    discount_factor: f64,
+    fee_subsidy_factor: f64,
     bad_token_detector: Arc<dyn BadTokenDetecting>,
 }
 
@@ -106,7 +106,7 @@ impl EthAwareMinFeeCalculator {
         gas_estimator: Arc<dyn GasPriceEstimating>,
         native_token: H160,
         measurements: Arc<dyn MinFeeStoring>,
-        discount_factor: f64,
+        fee_subsidy_factor: f64,
         bad_token_detector: Arc<dyn BadTokenDetecting>,
     ) -> Self {
         Self {
@@ -115,7 +115,7 @@ impl EthAwareMinFeeCalculator {
                 gas_estimator,
                 native_token,
                 measurements,
-                discount_factor,
+                fee_subsidy_factor,
                 bad_token_detector,
             ),
             weth: native_token,
@@ -156,7 +156,7 @@ impl MinFeeCalculator {
         gas_estimator: Arc<dyn GasPriceEstimating>,
         native_token: H160,
         measurements: Arc<dyn MinFeeStoring>,
-        discount_factor: f64,
+        fee_subsidy_factor: f64,
         bad_token_detector: Arc<dyn BadTokenDetecting>,
     ) -> Self {
         Self {
@@ -165,7 +165,7 @@ impl MinFeeCalculator {
             native_token,
             measurements,
             now: Box::new(Utc::now),
-            discount_factor,
+            fee_subsidy_factor,
             bad_token_detector,
         }
     }
@@ -186,7 +186,7 @@ impl MinFeeCalculator {
                     .estimate_gas(sell_token, buy_token, amount, kind)
                     .await
                 {
-                    Ok(amount) => amount.to_f64_lossy() * self.discount_factor,
+                    Ok(amount) => amount.to_f64_lossy() * (1f64 - self.fee_subsidy_factor),
                     Err(err) => {
                         tracing::warn!("Failed to estimate gas amount: {}", err);
                         return Ok(None);
@@ -436,7 +436,7 @@ mod tests {
                 native_token: Default::default(),
                 measurements: Arc::new(InMemoryFeeStore::default()),
                 now,
-                discount_factor: 1.0,
+                fee_subsidy_factor: 0.0,
                 bad_token_detector: Arc::new(ListBasedDetector::deny_list(Vec::new())),
             }
         }
@@ -516,7 +516,7 @@ mod tests {
             native_token: Default::default(),
             measurements: Arc::new(InMemoryFeeStore::default()),
             now: Box::new(Utc::now),
-            discount_factor: 1.0,
+            fee_subsidy_factor: 0.0,
             bad_token_detector: Arc::new(ListBasedDetector::deny_list(vec![unsupported_token])),
         };
 

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -97,7 +97,7 @@ struct Arguments {
     #[structopt(long, env = "BANNED_USERS", use_delimiter = true)]
     pub banned_users: Vec<H160>,
 
-    /// List of token addresses that shoud be allowed regardless of whether the bad token detector
+    /// List of token addresses that should be allowed regardless of whether the bad token detector
     /// thinks they are bad. Base tokens are automatically allowed.
     #[structopt(long, env = "ALLOWED_TOKENS", use_delimiter = true)]
     pub allowed_tokens: Vec<H160>,
@@ -125,7 +125,8 @@ pub async fn database_metrics(metrics: Arc<Metrics>, database: Postgres) -> ! {
 async fn main() {
     let args = Arguments::from_args();
     shared::tracing::initialize(args.shared.log_filter.as_str());
-    tracing::info!("running order book with {:#?}", args);
+    args.shared.validate();
+    tracing::info!("running order book with validated {:#?}", args);
 
     let registry = Registry::default();
     let metrics = Arc::new(Metrics::new(&registry).unwrap());
@@ -284,7 +285,7 @@ async fn main() {
         gas_price_estimator,
         native_token.address(),
         database.clone(),
-        args.shared.fee_discount_factor,
+        args.shared.fee_subsidy_factor,
         bad_token_detector.clone(),
     ));
 

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -49,9 +49,9 @@ pub struct Arguments {
     #[structopt(long, env = "BASE_TOKENS", use_delimiter = true)]
     pub base_tokens: Vec<H160>,
 
-    /// Fee discount factor: 1 means no discount, 0.9 means 10% discount.
-    #[structopt(long, env = "FEE_DISCOUNT_FACTOR", default_value = "1")]
-    pub fee_discount_factor: f64,
+    /// Gas Fee Subsidy: 0 means no subsidy, 0.9 means 90% subsidized.
+    #[structopt(long, env = "FEE_SUBSIDY_FACTOR", default_value = "0")]
+    pub fee_subsidy_factor: f64,
 
     /// Which Liquidity sources to be used by Price Estimator.
     #[structopt(
@@ -88,6 +88,15 @@ pub struct Arguments {
         parse(try_from_str = duration_from_seconds),
     )]
     pub block_stream_poll_interval_seconds: Duration,
+}
+
+impl Arguments {
+    pub fn validate(&self) {
+        assert!(
+            0f64 <= self.fee_subsidy_factor && self.fee_subsidy_factor <= 1f64,
+            "Fee subsidy must be in the range [0, 1]"
+        );
+    }
 }
 
 pub fn duration_from_seconds(s: &str) -> Result<Duration, ParseFloatError> {

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -50,7 +50,7 @@ pub struct Driver {
     market_makable_token_list: Option<TokenList>,
     inflight_trades: HashSet<OrderUid>,
     block_stream: CurrentBlockStream,
-    fee_discount_factor: f64,
+    fee_subsidy_factor: f64,
     solution_submitter: SolutionSubmitter,
 }
 impl Driver {
@@ -71,7 +71,7 @@ impl Driver {
         solver_time_limit: Duration,
         market_makable_token_list: Option<TokenList>,
         block_stream: CurrentBlockStream,
-        fee_discount_factor: f64,
+        fee_subsidy_factor: f64,
         solution_submitter: SolutionSubmitter,
     ) -> Self {
         Self {
@@ -91,7 +91,7 @@ impl Driver {
             market_makable_token_list,
             inflight_trades: HashSet::new(),
             block_stream,
-            fee_discount_factor,
+            fee_subsidy_factor,
             solution_submitter,
         }
     }
@@ -320,7 +320,7 @@ impl Driver {
                 let surplus = settlement.settlement.total_surplus(prices);
                 // Because of a potential fee discount, the solver fees may by themselves not be sufficient to make a solution economically viable (leading to a negative objective value)
                 // We therefore reverse apply the fee discount to simulate unsubsidized fees for ranking.
-                let unsubsidized_solver_fees = settlement.settlement.total_fees(prices) / BigRational::from_float(self.fee_discount_factor).expect("Discount factor is not a rational");
+                let unsubsidized_solver_fees = settlement.settlement.total_fees(prices) / BigRational::from_float(1f64 - self.fee_subsidy_factor).expect("Discount factor is not a rational");
                 let gas_estimate = settlement_submission::estimate_gas(
                     &self.settlement_contract,
                     &settlement.settlement.clone().into(),

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -197,7 +197,8 @@ arg_enum! {
 async fn main() {
     let args = Arguments::from_args();
     shared::tracing::initialize(args.shared.log_filter.as_str());
-    tracing::info!("running solver with {:#?}", args);
+    args.shared.validate();
+    tracing::info!("running solver with validated {:#?}", args);
 
     let registry = Registry::default();
     let metrics = Arc::new(Metrics::new(&registry).expect("Couldn't register metrics"));
@@ -349,7 +350,7 @@ async fn main() {
         price_estimator.clone(),
         network_name.to_string(),
         chain_id,
-        args.shared.fee_discount_factor,
+        args.shared.fee_subsidy_factor,
         args.min_order_size_one_inch,
         args.disabled_one_inch_protocols,
         args.paraswap_slippage_bps,
@@ -402,7 +403,7 @@ async fn main() {
         args.solver_time_limit,
         market_makable_token_list,
         current_block_stream.clone(),
-        args.shared.fee_discount_factor,
+        args.shared.fee_subsidy_factor,
         solution_submitter,
     );
 

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -81,7 +81,7 @@ pub fn create(
     price_estimator: Arc<dyn PriceEstimating>,
     network_id: String,
     chain_id: u64,
-    fee_discount_factor: f64,
+    fee_subsidy_factor: f64,
     min_order_size_one_inch: U256,
     disabled_one_inch_protocols: Vec<String>,
     paraswap_slippage_bps: usize,
@@ -115,7 +115,7 @@ pub fn create(
             buffer_retriever.clone(),
             network_id.clone(),
             chain_id,
-            fee_discount_factor,
+            fee_subsidy_factor,
             client.clone(),
         )
     };

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -72,7 +72,7 @@ pub struct HttpSolver {
     buffer_retriever: Arc<dyn BufferRetrieving>,
     network_id: String,
     chain_id: u64,
-    fee_discount_factor: f64,
+    fee_subsidy_factor: f64,
 }
 
 impl HttpSolver {
@@ -89,7 +89,7 @@ impl HttpSolver {
         buffer_retriever: Arc<dyn BufferRetrieving>,
         network_id: String,
         chain_id: u64,
-        fee_discount_factor: f64,
+        fee_subsidy_factor: f64,
         client: Client,
     ) -> Self {
         Self {
@@ -105,7 +105,7 @@ impl HttpSolver {
             buffer_retriever,
             network_id,
             chain_id,
-            fee_discount_factor,
+            fee_subsidy_factor,
         }
     }
 
@@ -418,7 +418,8 @@ impl HttpSolver {
     }
 
     fn order_fee(&self, order: &LimitOrder) -> U256 {
-        let ceiled_div = (order.fee_amount.to_f64_lossy() / self.fee_discount_factor).ceil();
+        let ceiled_div =
+            (order.fee_amount.to_f64_lossy() / (1f64 - self.fee_subsidy_factor)).ceil();
         U256::from_f64_lossy(ceiled_div)
     }
 


### PR DESCRIPTION
Rename fee discount factor to fee subsidy factor (synonomous, but encourages the necessary configuration change).

We make all calculations based on (1 - old_value) so that the term itself makes sense.

Now we have "Fee subsidy - 0 means no subsidy" 

Renamed a few variables and included validation at runtime.
