### PR TITLE
Add code coverage to CI

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -53,6 +53,21 @@ jobs:
       - run: cargo run --bin deploy --features bin
         working-directory: contracts
       - run: cargo test --locked --package e2e
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        run: rustup toolchain install nightly --component llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        run: curl -LsSf https://github.com/taiki-e/cargo-llvm-cov/releases/latest/download/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
   openapi:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -53,6 +53,12 @@ jobs:
       - run: cargo run --bin deploy --features bin
         working-directory: contracts
       - run: cargo test --locked --package e2e
+  openapi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm install @apidevtools/swagger-cli
+      - run: node_modules/.bin/swagger-cli validate orderbook/openapi.yml
   coverage:
     runs-on: ubuntu-latest
     steps:
@@ -68,9 +74,3 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: true
-  openapi:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: npm install @apidevtools/swagger-cli
-      - run: node_modules/.bin/swagger-cli validate orderbook/openapi.yml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+comment:
+  layout: diff


### PR DESCRIPTION
This PR adds code coverage using `cargo-llvm-cov`. I chose this coverage tool because:
- It leverages the built-in LLVM coverage instrumentation from the nightly compiler
- Has incredibly easy setup :tada:

### Test Plan

See code coverage in CI :point_down: 
