### PR TITLE
Return orders and trades as Vec instead of Stream from db

### DIFF
--- a/orderbook/src/api/get_trades.rs
+++ b/orderbook/src/api/get_trades.rs
@@ -2,7 +2,6 @@ use crate::api::convert_get_trades_error_to_reply;
 use crate::database::trades::TradeFilter;
 use crate::database::trades::TradeRetrieving;
 use anyhow::Result;
-use futures::TryStreamExt;
 use model::order::OrderUid;
 use model::trade::Trade;
 use serde::Deserialize;
@@ -66,7 +65,7 @@ pub fn get_trades(
         async move {
             match request_result {
                 Ok(trade_filter) => {
-                    let result = database.trades(&trade_filter).try_collect::<Vec<_>>().await;
+                    let result = database.trades(&trade_filter).await;
                     Result::<_, Infallible>::Ok(get_trades_response(result))
                 }
                 Err(TradeFilterError::InvalidFilter(msg)) => {

--- a/orderbook/src/database.rs
+++ b/orderbook/src/database.rs
@@ -5,7 +5,6 @@ pub mod orders;
 pub mod trades;
 
 use anyhow::Result;
-use futures::stream::BoxStream;
 use sqlx::{Executor, PgPool, Row};
 use std::collections::HashMap;
 

--- a/orderbook/src/database/instrumented.rs
+++ b/orderbook/src/database/instrumented.rs
@@ -118,20 +118,29 @@ impl OrderStoring for Instrumented {
         self.inner.cancel_order(order_uid, now).await
     }
 
-    fn orders<'a>(
-        &'a self,
-        filter: &'a super::orders::OrderFilter,
-    ) -> futures::stream::BoxStream<'a, anyhow::Result<model::order::Order>> {
-        self.inner.orders(filter)
+    async fn orders(
+        &self,
+        filter: &super::orders::OrderFilter,
+    ) -> anyhow::Result<Vec<model::order::Order>> {
+        let _timer = self
+            .metrics
+            .database_query_histogram("orders")
+            .start_timer();
+        self.inner.orders(filter).await
     }
 }
 
+#[async_trait::async_trait]
 impl TradeRetrieving for Instrumented {
-    fn trades<'a>(
-        &'a self,
-        filter: &'a super::trades::TradeFilter,
-    ) -> futures::stream::BoxStream<'a, anyhow::Result<model::trade::Trade>> {
-        self.inner.trades(filter)
+    async fn trades(
+        &self,
+        filter: &super::trades::TradeFilter,
+    ) -> anyhow::Result<Vec<model::trade::Trade>> {
+        let _timer = self
+            .metrics
+            .database_query_histogram("trades")
+            .start_timer();
+        self.inner.trades(filter).await
     }
 }
 

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -6,7 +6,6 @@ use crate::{
 use anyhow::Result;
 use chrono::Utc;
 use contracts::WETH9;
-use futures::TryStreamExt;
 use model::order::{
     BuyTokenDestination, OrderCancellation, OrderCreation, OrderCreationPayload, SellTokenSource,
 };
@@ -236,7 +235,7 @@ impl Orderbook {
     }
 
     pub async fn get_orders(&self, filter: &OrderFilter) -> Result<Vec<Order>> {
-        let mut orders = self.database.orders(filter).try_collect::<Vec<_>>().await?;
+        let mut orders = self.database.orders(filter).await?;
         let balances =
             track_and_get_balances(self.balance_fetcher.as_ref(), orders.as_slice()).await;
         // The meaning of the available balance field is different depending on whether we return


### PR DESCRIPTION
While a stream is more powerful we were already always collecting into a
Vec anyway. Doing this inside of the trait allows us to collect metrics
for this queries when it didn't before.

### Test Plan
existing tests
