### PR TITLE
Switch to dyn transport

### DIFF
--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -24,6 +24,7 @@ pub mod tracing;
 pub mod transport;
 pub mod web3_traits;
 
+use ethcontract::dyns::{DynTransport, DynWeb3};
 use ethcontract::H160;
 use hex::{FromHex, FromHexError};
 use model::h160_hexadecimal;
@@ -34,8 +35,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-pub type Web3Transport = transport::instrumented::MetricTransport<transport::http::HttpTransport>;
-pub type Web3 = web3::Web3<Web3Transport>;
+pub type Web3Transport = DynTransport;
+pub type Web3 = DynWeb3;
 
 /// Wraps H160 with FromStr and Deserialize that can handle a `0x` prefix.
 #[derive(Deserialize)]

--- a/shared/src/transport.rs
+++ b/shared/src/transport.rs
@@ -7,40 +7,30 @@ use self::{
     http::HttpTransport,
     instrumented::{MetricTransport, TransportMetrics},
 };
-use ethcontract::web3::Transport;
+use crate::Web3Transport;
 use reqwest::Client;
-use std::{convert::TryInto as _, sync::Arc, time::Duration};
+use std::{convert::TryInto as _, sync::Arc};
+use web3::BatchTransport;
 
 /// Convenience method to create our standard instrumented transport
 pub fn create_instrumented_transport<T>(
     transport: T,
     metrics: Arc<dyn TransportMetrics>,
-) -> MetricTransport<T>
+) -> Web3Transport
 where
-    T: Transport,
-    <T as Transport>::Out: Send + 'static,
+    T: BatchTransport + Send + Sync + 'static,
+    T::Out: Send + 'static,
+    T::Batch: Send + 'static,
 {
-    MetricTransport::new(transport, metrics)
+    Web3Transport::new(MetricTransport::new(transport, metrics))
 }
 
-struct NoopTransportMetrics;
-impl TransportMetrics for NoopTransportMetrics {
-    fn report_query(&self, _: &str, _: Duration) {}
-}
-
-/// Convenience method to create a compatible transport without metrics (noop)
-pub fn create_test_transport(url: &str) -> MetricTransport<HttpTransport>
-where
-{
-    let transport = HttpTransport::new(Client::new(), url.try_into().unwrap());
-    MetricTransport::new(transport, Arc::new(NoopTransportMetrics))
+/// Convenience method to create a transport from a URL.
+pub fn create_test_transport(url: &str) -> Web3Transport {
+    Web3Transport::new(HttpTransport::new(Client::new(), url.try_into().unwrap()))
 }
 
 /// Like above but takes url from the environment NODE_URL.
-pub fn create_env_test_transport() -> MetricTransport<HttpTransport>
-where
-{
-    let env = std::env::var("NODE_URL").unwrap();
-    let transport = HttpTransport::new(Client::new(), env.parse().unwrap());
-    MetricTransport::new(transport, Arc::new(NoopTransportMetrics))
+pub fn create_env_test_transport() -> Web3Transport {
+    create_test_transport(&std::env::var("NODE_URL").unwrap())
 }

--- a/shared/src/transport/instrumented.rs
+++ b/shared/src/transport/instrumented.rs
@@ -28,7 +28,7 @@ impl<T: Transport> MetricTransport<T> {
 impl<T> Transport for MetricTransport<T>
 where
     T: Transport,
-    <T as Transport>::Out: Send + 'static,
+    T::Out: Send + 'static,
 {
     type Out = BoxFuture<'static, error::Result<Value>>;
 
@@ -57,7 +57,7 @@ impl<T> BatchTransport for MetricTransport<T>
 where
     T: BatchTransport,
     T::Batch: Send + 'static,
-    <T as Transport>::Out: Send + 'static,
+    T::Out: Send + 'static,
 {
     type Batch = BoxFuture<'static, error::Result<Vec<error::Result<Value>>>>;
 


### PR DESCRIPTION
Make code abstract over transport type by switching to `DynTransport` from ethcontract. This change will allow us substituting transport in tests.

### Test Plan

This PR doesn't change any logic, so existing tests should be enough. The only side effect I can see is that we add additional overhead for every node call. I doubt this will affect production, but I'd still kept an eye on performance metrics after we release.
