### PR TITLE
Log settlement transaction hash

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -144,7 +144,8 @@ impl Driver {
             .settle(settlement, rated_settlement.gas_estimate)
             .await
         {
-            Ok(_) => {
+            Ok(hash) => {
+                tracing::info!("Successfully submitted {} settlement: {:?}", name, hash);
                 trades
                     .iter()
                     .for_each(|trade| self.metrics.order_settled(&trade.order, name));
@@ -159,9 +160,9 @@ impl Driver {
                     .map(|e| is_transaction_failure(&e.inner))
                     .unwrap_or(false)
                 {
-                    tracing::warn!("Failed to submit settlement: {:?}", err)
+                    tracing::warn!("Failed to submit {} settlement: {:?}", name, err)
                 } else {
-                    tracing::error!("Failed to submit settlement: {:?}", err)
+                    tracing::error!("Failed to submit {} settlement: {:?}", name, err)
                 };
                 self.metrics.settlement_submitted(false, name);
                 Err(err)

--- a/solver/src/settlement_submission/public_mempool.rs
+++ b/solver/src/settlement_submission/public_mempool.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::{encoding::EncodedSettlement, pending_transactions::Fee, settlement::Settlement};
 use anyhow::{Context, Result};
 use contracts::GPv2Settlement;
-use ethcontract::{dyns::DynTransport, Account, Web3};
+use ethcontract::{dyns::DynTransport, Account, TransactionHash, Web3};
 use futures::stream::StreamExt;
 use gas_estimation::GasPriceEstimating;
 use primitive_types::{H160, U256};
@@ -22,7 +22,7 @@ pub async fn submit(
     gas_price_cap: f64,
     settlement: Settlement,
     gas_estimate: U256,
-) -> Result<()> {
+) -> Result<TransactionHash> {
     let address = account.address();
     let settlement: EncodedSettlement = settlement.into();
 


### PR DESCRIPTION
This PR just logs the settlement transaction hash. This will hopefully make it easier to match settlement transactions to driver run loops in the logs.

### Test Plan

CI.
