### PR TITLE
Allow buy token to be pain in internal Vault balances

### DIFF
--- a/e2e/tests/vault_balances.rs
+++ b/e2e/tests/vault_balances.rs
@@ -1,7 +1,7 @@
 use contracts::IUniswapLikeRouter;
 use ethcontract::prelude::{Account, Address, PrivateKey, U256};
 use model::{
-    order::{OrderBuilder, OrderKind, SellTokenSource},
+    order::{BuyTokenDestination, OrderBuilder, OrderKind, SellTokenSource},
     SigningScheme,
 };
 use secp256k1::SecretKey;
@@ -116,6 +116,7 @@ async fn vault_balances(web3: Web3) {
         .with_fee_amount(to_wei(1))
         .with_buy_token(gpv2.native_token.address())
         .with_buy_amount(to_wei(8))
+        .with_buy_token_balance(BuyTokenDestination::Internal)
         .with_valid_to(shared::time::now_in_epoch_seconds() + 300)
         .with_signing_scheme(SigningScheme::Eip712)
         .sign_with(
@@ -192,10 +193,10 @@ async fn vault_balances(web3: Web3) {
     assert_eq!(balance, U256::zero());
 
     let balance = gpv2
-        .native_token
-        .balance_of(trader.address())
+        .vault
+        .get_internal_balance(trader.address(), vec![gpv2.native_token.address()])
         .call()
         .await
         .expect("Couldn't fetch native token balance");
-    assert_eq!(balance, U256::from(8_972_194_924_949_384_291_u128));
+    assert_eq!(balance, [U256::from(8_972_194_924_949_384_291_u128)]);
 }

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -670,7 +670,6 @@ components:
               UnsupportedToken,
               WrongOwner,
               SameBuyAndSellToken,
-              UnsupportedBuyTokenDestination,
               UnsupportedSellTokenSource,
             ]
         description:

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -15,10 +15,6 @@ pub fn create_order_request(
 pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
     let (body, status_code) = match result {
         Ok(AddOrderResult::Added(uid)) => (warp::reply::json(&uid), StatusCode::CREATED),
-        Ok(AddOrderResult::UnsupportedBuyTokenDestination(dest)) => (
-            super::error("UnsupportedBuyTokenDestination", format!("Type {:?}", dest)),
-            StatusCode::BAD_REQUEST,
-        ),
         Ok(AddOrderResult::UnsupportedSellTokenSource(source)) => (
             super::error("UnsupportedSellTokenSource", format!("Type {:?}", source)),
             StatusCode::BAD_REQUEST,

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use chrono::Utc;
 use contracts::WETH9;
 use model::order::{
-    BuyTokenDestination, OrderCancellation, OrderCreation, OrderCreationPayload, SellTokenSource,
+    OrderCancellation, OrderCreation, OrderCreationPayload, SellTokenSource,
 };
 use model::{
     order::{Order, OrderStatus, OrderUid, BUY_ETH_ADDRESS},
@@ -38,7 +38,6 @@ pub enum AddOrderResult {
     UnsupportedToken(H160),
     TransferEthToContract,
     SameBuyAndSellToken,
-    UnsupportedBuyTokenDestination(BuyTokenDestination),
     UnsupportedSellTokenSource(SellTokenSource),
 }
 
@@ -97,12 +96,6 @@ impl Orderbook {
     pub async fn add_order(&self, payload: OrderCreationPayload) -> Result<AddOrderResult> {
         let order = payload.order_creation;
 
-        // Temporary - reject new order types until last stage of balancer integration
-        if order.buy_token_balance != BuyTokenDestination::Erc20 {
-            return Ok(AddOrderResult::UnsupportedBuyTokenDestination(
-                order.buy_token_balance,
-            ));
-        }
         if !matches!(
             order.sell_token_balance,
             SellTokenSource::Erc20 | SellTokenSource::External

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -6,9 +6,7 @@ use crate::{
 use anyhow::Result;
 use chrono::Utc;
 use contracts::WETH9;
-use model::order::{
-    OrderCancellation, OrderCreation, OrderCreationPayload, SellTokenSource,
-};
+use model::order::{OrderCancellation, OrderCreation, OrderCreationPayload, SellTokenSource};
 use model::{
     order::{Order, OrderStatus, OrderUid, BUY_ETH_ADDRESS},
     DomainSeparator,


### PR DESCRIPTION
This PR enables an order's `buyTokenBalance` field to be `internal` (i.e. Balancer V2 Vault internal balance). While I don't suspect it will really be used anytime soon it:
- Removes a code branch! (passively increase coverage :heavy_check_mark:)
- There is no technical reason to not allow it (besides the additional gas cost, however this is an larger general issue we face and IMO is a bigger problem with some of the tokens we allow).

### Test Plan

Modified E2E test to pay out in internal balances.
