### PR TITLE
[Easy] Balancer Stable Pool part 3: Info Fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e5519229db8380ff4c85c07eeaa2461278cdf792f5302a59c8fac0c048cf75"
+checksum = "2267d015c10e2df6bb5a24cdfdbfb037b2cec9b24132b83910ee77701a51a0c5"
 dependencies = [
  "arrayvec 0.7.1",
  "ethcontract-common",
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-common"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739903cf0e5c78f4f7622712f6da63ac66b61ce12944a714af2d78285a5085bd"
+checksum = "5b7af54e00ba011a694c8fcb4a00bbdd81994874c0203b7887a230e547550a50"
 dependencies = [
  "ethabi",
  "hex",
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-derive"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edc91217d6fc4d87f947836bea47f9dcdba00f3a877699c1ac77df266452dec"
+checksum = "802f4b47a4fea9182d0746bb121c03b45ddceee600e33a5eb90167eb64802547"
 dependencies = [
  "anyhow",
  "ethcontract-common",
@@ -820,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-generate"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae76f6ac380f7fe6d18c164155cd35a37fd1f5c9b13e87b6d5960f97045ac348"
+checksum = "3fd1a1ad98206db73dbb8e95849a737ff24e5b58bfe8abceb6ba33259c81b572"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -836,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-mock"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9528ed203744e1c001fb3808071dd1cc90fbc812f60b46435570dbaf5db9cf45"
+checksum = "8c925e885492448a4e3910d18d26823352a6a1e5f198866bcd3d1b77b6140c9d"
 dependencies = [
  "ethcontract",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ checksum = "5ea4f8a3e0a51e6745974d16076eb8f56b1abe12c642b5e9068adb5915ed991b"
 dependencies = [
  "arrayvec 0.7.1",
  "ethcontract-common",
+ "ethcontract-derive",
  "futures",
  "futures-timer",
  "hex",
@@ -773,6 +774,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethcontract-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a08621590a64c4d3cf0a120c2110a7ca466f8795d09b37839ab08c2090205458"
+dependencies = [
+ "anyhow",
+ "ethcontract-common",
+ "ethcontract-generate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ethcontract-generate"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +801,19 @@ dependencies = [
  "quote",
  "syn",
  "url",
+]
+
+[[package]]
+name = "ethcontract-mock"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97fdeb07be4374cbea23685c00565deb536c3415c1dfe4f19d89c906ad3e1c7"
+dependencies = [
+ "ethcontract",
+ "hex",
+ "mockall",
+ "predicates",
+ "rlp",
 ]
 
 [[package]]
@@ -2558,6 +2586,7 @@ dependencies = [
  "contracts",
  "derivative",
  "ethcontract",
+ "ethcontract-mock",
  "futures",
  "gas-estimation",
  "hex",
@@ -2589,6 +2618,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,6 +2646,21 @@ checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "soketto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4919971d141dbadaa0e82b5d369e2d7666c98e4625046140615ca363e50d4daa"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "httparse",
+ "log",
+ "rand",
+ "sha-1",
 ]
 
 [[package]]
@@ -2965,7 +3018,10 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
  "winapi",
 ]
@@ -3039,6 +3095,7 @@ checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "log",
  "pin-project-lite",
@@ -3475,7 +3532,23 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
+ "soketto",
  "tiny-keccak",
+ "tokio",
+ "tokio-util",
+ "url",
+ "web3-async-native-tls",
+]
+
+[[package]]
+name = "web3-async-native-tls"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6d8d1636b2627fe63518d5a9b38a569405d9c9bc665c43c9c341de57227ebb"
+dependencies = [
+ "native-tls",
+ "thiserror",
+ "tokio",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea4f8a3e0a51e6745974d16076eb8f56b1abe12c642b5e9068adb5915ed991b"
+checksum = "71e5519229db8380ff4c85c07eeaa2461278cdf792f5302a59c8fac0c048cf75"
 dependencies = [
  "arrayvec 0.7.1",
  "ethcontract-common",
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-common"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b475a483d1d874cbf3b757b6f87b1c90883c62c35542a0a5fc270a5f672546a8"
+checksum = "739903cf0e5c78f4f7622712f6da63ac66b61ce12944a714af2d78285a5085bd"
 dependencies = [
  "ethabi",
  "hex",
@@ -775,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-derive"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08621590a64c4d3cf0a120c2110a7ca466f8795d09b37839ab08c2090205458"
+checksum = "0edc91217d6fc4d87f947836bea47f9dcdba00f3a877699c1ac77df266452dec"
 dependencies = [
  "anyhow",
  "ethcontract-common",
@@ -789,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-generate"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0fa5f7c25b5bc82dd6bd452daebd3e4c7886d838f1079cbddb782add2151c3d"
+checksum = "ae76f6ac380f7fe6d18c164155cd35a37fd1f5c9b13e87b6d5960f97045ac348"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -805,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-mock"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97fdeb07be4374cbea23685c00565deb536c3415c1dfe4f19d89c906ad3e1c7"
+checksum = "9528ed203744e1c001fb3808071dd1cc90fbc812f60b46435570dbaf5db9cf45"
 dependencies = [
  "ethcontract",
  "hex",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -14,7 +14,7 @@ atty = "0.2"
 contracts = { path = "../contracts" }
 derivative = "2.2"
 ethcontract = { version = "0.15.1", default-features = false }
-ethcontract-mock = "0.15.2"
+ethcontract-mock = "0.15.3"
 futures = "0.3"
 gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.3.1", features = ["web3_", "tokio_"] }
 hex = { version = "0.4", default-features = false }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -13,7 +13,7 @@ atty = "0.2"
 contracts = { path = "../contracts" }
 derivative = "2.2"
 ethcontract = { version = "0.15.1", default-features = false }
-ethcontract-mock = "0.15.1"
+ethcontract-mock = "0.15.2"
 futures = "0.3"
 gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.3.1", features = ["web3_", "tokio_"] }
 hex = { version = "0.4", default-features = false }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -13,6 +13,7 @@ atty = "0.2"
 contracts = { path = "../contracts" }
 derivative = "2.2"
 ethcontract = { version = "0.15.1", default-features = false }
+ethcontract-mock = "0.15.1"
 futures = "0.3"
 gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.3.1", features = ["web3_", "tokio_"] }
 hex = { version = "0.4", default-features = false }

--- a/shared/src/sources/balancer/info_fetching.rs
+++ b/shared/src/sources/balancer/info_fetching.rs
@@ -5,17 +5,28 @@ use crate::{
     token_info::TokenInfoFetching, Web3,
 };
 use anyhow::{anyhow, Result};
-use contracts::{BalancerV2Vault, BalancerV2WeightedPool};
-use ethcontract::{batch::CallBatch, Bytes, H160, H256};
+use contracts::{BalancerV2StablePool, BalancerV2Vault, BalancerV2WeightedPool};
+use ethcontract::{batch::CallBatch, Bytes, H160, H256, U256};
 use mockall::*;
 use std::sync::Arc;
 
 #[derive(Clone)]
-pub struct WeightedPoolInfo {
+pub struct CommonPoolInfo {
     pub pool_id: H256,
     pub tokens: Vec<H160>,
-    pub weights: Vec<Bfp>,
     pub scaling_exponents: Vec<u8>,
+}
+
+#[derive(Clone)]
+pub struct WeightedPoolInfo {
+    pub common: CommonPoolInfo,
+    pub weights: Vec<Bfp>,
+}
+
+#[derive(Clone)]
+pub struct StablePoolInfo {
+    pub common: CommonPoolInfo,
+    pub amplification_parameter: U256,
 }
 
 /// Via `PoolInfoFetcher` (leverages a combination of `Web3` and `TokenInfoFetching`)
@@ -37,13 +48,14 @@ pub struct PoolInfoFetcher {
 #[automock]
 #[async_trait::async_trait]
 pub trait PoolInfoFetching: Send + Sync {
-    async fn get_pool_data(&self, pool_address: H160) -> Result<WeightedPoolInfo>;
+    async fn get_weighted_pool_data(&self, pool_address: H160) -> Result<WeightedPoolInfo>;
+    async fn get_stable_pool_data(&self, pool_address: H160) -> Result<StablePoolInfo>;
 }
 
 #[async_trait::async_trait]
 impl PoolInfoFetching for PoolInfoFetcher {
     /// Could result in ethcontract::{NodeError, MethodError or ContractError}
-    async fn get_pool_data(&self, pool_address: H160) -> Result<WeightedPoolInfo> {
+    async fn get_weighted_pool_data(&self, pool_address: H160) -> Result<WeightedPoolInfo> {
         let mut batch = CallBatch::new(self.web3.transport());
         let pool_contract = BalancerV2WeightedPool::at(&self.web3, pool_address);
         // Need vault and pool_id before we can fetch tokens.
@@ -83,10 +95,56 @@ impl PoolInfoFetching for PoolInfoFetcher {
             .map(Bfp::from_wei)
             .collect();
         Ok(WeightedPoolInfo {
-            pool_id,
-            tokens,
+            common: CommonPoolInfo {
+                pool_id,
+                tokens,
+                scaling_exponents,
+            },
             weights,
-            scaling_exponents,
+        })
+    }
+
+    async fn get_stable_pool_data(&self, pool_address: H160) -> Result<StablePoolInfo> {
+        let mut batch = CallBatch::new(self.web3.transport());
+        let pool_contract = BalancerV2StablePool::at(&self.web3, pool_address);
+        // Need vault and pool_id before we can fetch tokens.
+        let vault = BalancerV2Vault::deployed(&self.web3).await?;
+        let pool_id = H256::from(pool_contract.methods().get_pool_id().call().await?.0);
+
+        // token_data and weight calls can be batched
+        let token_data = vault
+            .methods()
+            .get_pool_tokens(Bytes(pool_id.0))
+            .batch_call(&mut batch);
+        let amplification_parameter = pool_contract
+            .methods()
+            .get_amplification_parameter()
+            .batch_call(&mut batch);
+        batch.execute_all(MAX_BATCH_SIZE).await;
+
+        let tokens = token_data.await?.0;
+
+        let token_decimals = self.token_info_fetcher.get_token_infos(&tokens).await;
+        let ordered_decimals = tokens
+            .iter()
+            .map(|token| token_decimals.get(token).and_then(|t| t.decimals))
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| anyhow!("all token decimals required to build scaling factors"))?;
+        // Note that balancer does not support tokens with more than 18 decimals
+        // https://github.com/balancer-labs/balancer-v2-monorepo/blob/ce70f7663e0ac94b25ed60cb86faaa8199fd9e13/pkg/pool-utils/contracts/BasePool.sol#L497-L508
+        let scaling_exponents = ordered_decimals
+            .iter()
+            .map(|decimals| 18u8.checked_sub(*decimals))
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| anyhow!("token with more than 18 decimals"))?;
+
+        Ok(StablePoolInfo {
+            common: CommonPoolInfo {
+                pool_id,
+                tokens,
+                scaling_exponents,
+            },
+            amplification_parameter: amplification_parameter.await?.0,
         })
     }
 }

--- a/shared/src/sources/balancer/info_fetching.rs
+++ b/shared/src/sources/balancer/info_fetching.rs
@@ -167,14 +167,14 @@ mod tests {
         let pool_id = H256::from_low_u64_be(1);
         let token = H160::from_low_u64_be(1);
         stable_pool
-            .expect(BalancerV2StablePool::signatures().get_pool_id())
+            .expect_call(BalancerV2StablePool::signatures().get_pool_id())
             .returns(Bytes(pool_id.0));
         vault_contract
-            .expect(BalancerV2Vault::signatures().get_pool_tokens())
+            .expect_call(BalancerV2Vault::signatures().get_pool_tokens())
             .predicate((predicate::eq(Bytes(pool_id.0)),))
             .returns((vec![token], vec![], U256::zero()));
         stable_pool
-            .expect(BalancerV2StablePool::signatures().get_amplification_parameter())
+            .expect_call(BalancerV2StablePool::signatures().get_amplification_parameter())
             .returns((U256::one(), false, U256::zero()));
 
         let mut mock_token_info_fetcher = MockTokenInfoFetching::new();
@@ -232,14 +232,14 @@ mod tests {
         let tokens = vec![H160::from_low_u64_be(1), H160::from_low_u64_be(2)];
 
         stable_pool
-            .expect(BalancerV2StablePool::signatures().get_pool_id())
+            .expect_call(BalancerV2StablePool::signatures().get_pool_id())
             .returns(Bytes(pool_id.0));
         vault_contract
-            .expect(BalancerV2Vault::signatures().get_pool_tokens())
+            .expect_call(BalancerV2Vault::signatures().get_pool_tokens())
             .predicate((predicate::eq(Bytes(pool_id.0)),))
             .returns((tokens.clone(), vec![], U256::zero()));
         stable_pool
-            .expect(BalancerV2StablePool::signatures().get_amplification_parameter())
+            .expect_call(BalancerV2StablePool::signatures().get_amplification_parameter())
             .returns((U256::one(), false, U256::zero()));
 
         let mut token_info_fetcher = MockTokenInfoFetching::new();

--- a/shared/src/sources/balancer/info_fetching.rs
+++ b/shared/src/sources/balancer/info_fetching.rs
@@ -120,7 +120,7 @@ impl PoolInfoFetching for PoolInfoFetcher {
     }
 
     async fn get_scaling_exponents(&self, tokens: &[H160]) -> Result<Vec<u8>> {
-        let token_decimals = self.token_info_fetcher.get_token_infos(&tokens).await;
+        let token_decimals = self.token_info_fetcher.get_token_infos(tokens).await;
         let ordered_decimals = tokens
             .iter()
             .map(|token| token_decimals.get(token).and_then(|t| t.decimals))

--- a/shared/src/sources/balancer/info_fetching.rs
+++ b/shared/src/sources/balancer/info_fetching.rs
@@ -261,7 +261,6 @@ mod tests {
         let pool_info_result = pool_info_fetcher
             .get_stable_pool_data(stable_pool.address())
             .await;
-        println!("{:?}", pool_info_result);
         assert!(pool_info_result.is_ok());
 
         let pool_info = pool_info_result.unwrap();

--- a/shared/src/sources/balancer/info_fetching.rs
+++ b/shared/src/sources/balancer/info_fetching.rs
@@ -156,6 +156,130 @@ mod tests {
     use maplit::hashmap;
 
     #[tokio::test]
+    async fn get_weighted_pool_data_err() {
+        let mock = Mock::new(49);
+        let web3 = mock.web3();
+
+        let vault_contract = mock.deploy(BalancerV2Vault::raw_contract().abi.clone());
+        let vault = BalancerV2Vault::at(&web3.clone(), vault_contract.address());
+        let weighted_pool_contract =
+            mock.deploy(BalancerV2WeightedPool::raw_contract().abi.clone());
+
+        let pool_id = H256::from_low_u64_be(1);
+        let token = H160::from_low_u64_be(1);
+        weighted_pool_contract
+            .expect_call(BalancerV2WeightedPool::signatures().get_pool_id())
+            .returns(Bytes(pool_id.0));
+        vault_contract
+            .expect_call(BalancerV2Vault::signatures().get_pool_tokens())
+            .predicate((predicate::eq(Bytes(pool_id.0)),))
+            .returns((vec![token], vec![], U256::zero()));
+        weighted_pool_contract
+            .expect_call(BalancerV2WeightedPool::signatures().get_normalized_weights())
+            .returns(vec![U256::from(1)]);
+
+        let mut mock_token_info_fetcher = MockTokenInfoFetching::new();
+        mock_token_info_fetcher
+            .expect_get_token_infos()
+            .return_once(move |_| {
+                hashmap! {
+                    token => TokenInfo { decimals: None },
+                }
+            });
+
+        let pool_info_fetcher = PoolInfoFetcher {
+            web3: web3.clone(),
+            token_info_fetcher: Arc::new(mock_token_info_fetcher),
+            vault: vault.clone(),
+        };
+
+        let result = pool_info_fetcher
+            .get_weighted_pool_data(weighted_pool_contract.address())
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            result.to_string(),
+            "all token decimals required to build scaling factors"
+        );
+
+        let mut mock_token_info_fetcher = MockTokenInfoFetching::new();
+        mock_token_info_fetcher
+            .expect_get_token_infos()
+            .return_once(move |_| {
+                hashmap! {
+                    token => TokenInfo { decimals: Some(19) },
+                }
+            });
+        let pool_info_fetcher = PoolInfoFetcher {
+            web3,
+            token_info_fetcher: Arc::new(mock_token_info_fetcher),
+            vault,
+        };
+
+        let result = pool_info_fetcher
+            .get_weighted_pool_data(weighted_pool_contract.address())
+            .await
+            .unwrap_err();
+
+        assert_eq!(result.to_string(), "token with more than 18 decimals");
+    }
+
+    #[tokio::test]
+    async fn get_weighted_pool_data_ok() {
+        let mock = Mock::new(49);
+        let web3 = mock.web3();
+
+        let vault_contract = mock.deploy(BalancerV2Vault::raw_contract().abi.clone());
+        let vault = BalancerV2Vault::at(&web3.clone(), vault_contract.address());
+        let weighted_pool_contract =
+            mock.deploy(BalancerV2WeightedPool::raw_contract().abi.clone());
+        let weight = U256::from(1);
+
+        let pool_id = H256::from_low_u64_be(1);
+        let tokens = vec![H160::from_low_u64_be(1), H160::from_low_u64_be(2)];
+        weighted_pool_contract
+            .expect_call(BalancerV2WeightedPool::signatures().get_pool_id())
+            .returns(Bytes(pool_id.0));
+        vault_contract
+            .expect_call(BalancerV2Vault::signatures().get_pool_tokens())
+            .predicate((predicate::eq(Bytes(pool_id.0)),))
+            .returns((vec![tokens[0], tokens[1]], vec![], U256::zero()));
+        weighted_pool_contract
+            .expect_call(BalancerV2WeightedPool::signatures().get_normalized_weights())
+            .returns(vec![weight]);
+
+        let mut token_info_fetcher = MockTokenInfoFetching::new();
+        token_info_fetcher
+            .expect_get_token_infos()
+            .return_once(move |_| {
+                hashmap! {
+                    tokens[0] => TokenInfo { decimals: Some(18) },
+                    tokens[1] => TokenInfo { decimals: Some(17) },
+                }
+            });
+
+        let pool_info_fetcher = PoolInfoFetcher {
+            web3,
+            token_info_fetcher: Arc::new(token_info_fetcher),
+            vault,
+        };
+
+        let pool_info = pool_info_fetcher
+            .get_weighted_pool_data(weighted_pool_contract.address())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            pool_info.common.tokens,
+            vec![H160::from_low_u64_be(1), H160::from_low_u64_be(2)]
+        );
+        assert_eq!(pool_info.common.pool_id, pool_id);
+        assert_eq!(pool_info.common.scaling_exponents, vec![0u8, 1u8]);
+        assert_eq!(pool_info.weights, vec![Bfp::from_wei(weight)]);
+    }
+
+    #[tokio::test]
     async fn get_stable_pool_data_err() {
         let mock = Mock::new(49);
         let web3 = mock.web3();
@@ -192,11 +316,15 @@ mod tests {
             vault: vault.clone(),
         };
 
-        let pool_info = pool_info_fetcher
+        let result = pool_info_fetcher
             .get_stable_pool_data(stable_pool.address())
-            .await;
+            .await
+            .unwrap_err();
 
-        assert!(pool_info.is_err());
+        assert_eq!(
+            result.to_string(),
+            "all token decimals required to build scaling factors"
+        );
 
         let mut mock_token_info_fetcher = MockTokenInfoFetching::new();
         mock_token_info_fetcher
@@ -212,11 +340,12 @@ mod tests {
             vault,
         };
 
-        let pool_info = pool_info_fetcher
+        let result = pool_info_fetcher
             .get_stable_pool_data(stable_pool.address())
-            .await;
+            .await
+            .unwrap_err();
 
-        assert!(pool_info.is_err());
+        assert_eq!(result.to_string(), "token with more than 18 decimals");
     }
 
     #[tokio::test]

--- a/shared/src/sources/balancer/pool_fetching.rs
+++ b/shared/src/sources/balancer/pool_fetching.rs
@@ -18,6 +18,7 @@ use crate::{
     Web3,
 };
 use anyhow::Result;
+use contracts::BalancerV2Vault;
 use ethcontract::{H160, H256, U256};
 use model::TokenPair;
 use reqwest::Client;
@@ -101,6 +102,7 @@ impl BalancerPoolFetcher {
         let pool_info = Arc::new(PoolInfoFetcher {
             web3: web3.clone(),
             token_info_fetcher: token_info_fetcher.clone(),
+            vault: BalancerV2Vault::deployed(&web3).await?,
         });
         let pool_initializer = DefaultPoolInitializer::new(chain_id, pool_info.clone(), client)?;
         let pool_registry =

--- a/shared/src/sources/balancer/pool_init.rs
+++ b/shared/src/sources/balancer/pool_init.rs
@@ -311,6 +311,7 @@ async fn deployment_block(contract: &Contract, chain_id: u64) -> Result<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sources::balancer::info_fetching::CommonPoolInfo;
     use crate::sources::balancer::pool_storage::RegisteredStablePool;
     use crate::sources::balancer::{
         info_fetching::{MockPoolInfoFetching, WeightedPoolInfo},
@@ -527,15 +528,17 @@ mod tests {
         let mut pool_info = MockPoolInfoFetching::new();
         let mut seq = Sequence::new();
         pool_info
-            .expect_get_pool_data()
+            .expect_get_weighted_pool_data()
             .times(1)
             .in_sequence(&mut seq)
             .with(eq(H160([1; 20])))
             .returning(|_| {
                 Ok(WeightedPoolInfo {
-                    pool_id: H256([1; 32]),
-                    tokens: vec![H160([0x11; 20]), H160([0x22; 20])],
-                    scaling_exponents: vec![0, 0],
+                    common: CommonPoolInfo {
+                        pool_id: H256([1; 32]),
+                        tokens: vec![H160([0x11; 20]), H160([0x22; 20])],
+                        scaling_exponents: vec![0, 0],
+                    },
                     weights: vec![
                         Bfp::from_wei(500_000_000_000_000_000u128.into()),
                         Bfp::from_wei(500_000_000_000_000_000u128.into()),
@@ -543,15 +546,17 @@ mod tests {
                 })
             });
         pool_info
-            .expect_get_pool_data()
+            .expect_get_weighted_pool_data()
             .times(1)
             .in_sequence(&mut seq)
             .with(eq(H160([2; 20])))
             .returning(|_| {
                 Ok(WeightedPoolInfo {
-                    pool_id: H256([2; 32]),
-                    tokens: vec![H160([0x11; 20]), H160([0x33; 20]), H160([0x44; 20])],
-                    scaling_exponents: vec![0, 0, 0],
+                    common: CommonPoolInfo {
+                        pool_id: H256([2; 32]),
+                        tokens: vec![H160([0x11; 20]), H160([0x33; 20]), H160([0x44; 20])],
+                        scaling_exponents: vec![0, 0, 0],
+                    },
                     weights: vec![
                         Bfp::from_wei(500_000_000_000_000_000u128.into()),
                         Bfp::from_wei(250_000_000_000_000_000u128.into()),


### PR DESCRIPTION
Follows #1003 and part of #733

This simple change renames `get_pool_info` to `get_weighted_pool_info` to make room for its analogous `get_stable_pool_info` which will be used in a following PR. The `PoolInfo`struct is extended to include the `amplification_parameter` and  also has `weights`. We note that these are only relevant to specific pools as a comment and set the values to `nullish` when irrelevant.

Note that it may appear like the two methods have some overlap, but there is actually quite distinguished order of operations here when fetching info. 

### Test Plan
Could write an ignored test here, but would require and infura key. Happy to do so if recommended, but we didn't have one before.
