### PR TITLE
Balancer Stable Pool part 4: Event Handling and Pool Registry

### DIFF
--- a/shared/src/sources/balancer/pool_cache.rs
+++ b/shared/src/sources/balancer/pool_cache.rs
@@ -59,7 +59,7 @@ impl CacheFetching<H256, WeightedPool> for PoolReserveFetcher {
         let block = BlockId::Number(at_block.into());
         let futures = self
             .pool_registry
-            .get_pools(&pool_ids)
+            .get_weighted_pools(&pool_ids)
             .await
             .into_iter()
             .map(|registered_pool| {

--- a/shared/src/sources/balancer/pool_init.rs
+++ b/shared/src/sources/balancer/pool_init.rs
@@ -346,10 +346,9 @@ async fn deployment_block(contract: &Contract, chain_id: u64) -> Result<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sources::balancer::pool_storage::common_pool;
     use crate::sources::balancer::{
         info_fetching::{CommonPoolInfo, MockPoolInfoFetching, StablePoolInfo, WeightedPoolInfo},
-        pool_storage::{CommonPoolData, RegisteredStablePool},
+        pool_storage::{common_pool, CommonPoolData, RegisteredStablePool},
         swap::fixed_point::Bfp,
     };
     use anyhow::bail;


### PR DESCRIPTION
Following #1006 and part of #733

We introduce the stable pool creation event listener and adapt the event handling and PoolRegistry to store stable pools along side weighted in the previously introduced enum `RegisteredPool`.

### Test Plan
TBD...
