### PR TITLE
[Easy] Balancer Stable Pool part 5: Structural Refactoring

### DIFF
--- a/shared/src/sources/balancer/pool_fetching.rs
+++ b/shared/src/sources/balancer/pool_fetching.rs
@@ -9,7 +9,7 @@ use crate::{
     sources::balancer::{
         event_handler::BalancerPoolRegistry,
         info_fetching::PoolInfoFetcher,
-        pool_cache::{BalancerPoolReserveCache, PoolReserveFetcher, WeightedPoolCacheMetrics},
+        pool_cache::{BalancerPoolCacheMetrics, BalancerPoolReserveCache, PoolReserveFetcher},
         pool_init::DefaultPoolInitializer,
         pool_storage::RegisteredWeightedPool,
         swap::fixed_point::Bfp,
@@ -28,10 +28,15 @@ use std::{
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PoolTokenState {
+pub struct TokenState {
     pub balance: U256,
-    pub weight: Bfp,
     pub scaling_exponent: u8,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WeightedTokenState {
+    pub token_state: TokenState,
+    pub weight: Bfp,
 }
 
 #[derive(Clone, Debug)]
@@ -39,7 +44,7 @@ pub struct WeightedPool {
     pub pool_id: H256,
     pub pool_address: H160,
     pub swap_fee_percentage: Bfp,
-    pub reserves: HashMap<H160, PoolTokenState>,
+    pub reserves: HashMap<H160, WeightedTokenState>,
     pub paused: bool,
 }
 
@@ -57,10 +62,12 @@ impl WeightedPool {
         for (i, balance) in balances.into_iter().enumerate() {
             reserves.insert(
                 pool_data.common.tokens[i],
-                PoolTokenState {
-                    balance,
+                WeightedTokenState {
+                    token_state: TokenState {
+                        balance,
+                        scaling_exponent: pool_data.common.scaling_exponents[i],
+                    },
                     weight: pool_data.normalized_weights[i],
-                    scaling_exponent: pool_data.common.scaling_exponents[i],
                 },
             );
         }
@@ -96,7 +103,7 @@ impl BalancerPoolFetcher {
         token_info_fetcher: Arc<dyn TokenInfoFetching>,
         config: CacheConfig,
         block_stream: CurrentBlockStream,
-        metrics: Arc<dyn WeightedPoolCacheMetrics>,
+        metrics: Arc<dyn BalancerPoolCacheMetrics>,
         client: Client,
     ) -> Result<Self> {
         let pool_info = Arc::new(PoolInfoFetcher {

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -10,7 +10,7 @@ use model::order::Order;
 use model::{order::OrderKind, TokenPair};
 use num::{rational::Ratio, BigRational};
 use primitive_types::{H160, U256};
-use shared::sources::balancer::pool_fetching::PoolTokenState;
+use shared::sources::balancer::pool_fetching::WeightedTokenState;
 #[cfg(test)]
 use shared::sources::uniswap::pool_fetching::Pool;
 use std::collections::HashMap;
@@ -140,7 +140,7 @@ impl From<Pool> for ConstantProductOrder {
 /// 2 sided weighted product automated market maker with weighted reserves and a trading fee (e.g. BalancerV2)
 #[derive(Clone)]
 pub struct WeightedProductOrder {
-    pub reserves: HashMap<H160, PoolTokenState>,
+    pub reserves: HashMap<H160, WeightedTokenState>,
     pub fee: BigRational,
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
 }
@@ -226,6 +226,7 @@ impl Default for WeightedProductOrder {
 pub mod tests {
     use super::*;
     use maplit::hashmap;
+    use shared::sources::balancer::pool_fetching::TokenState;
     use std::sync::Mutex;
 
     pub struct CapturingSettlementHandler<L>
@@ -305,10 +306,12 @@ pub mod tests {
 
     #[test]
     fn weighted_pool_enumerate_token_pairs() {
-        let token_state = PoolTokenState {
-            balance: 0.into(),
+        let token_state = WeightedTokenState {
+            token_state: TokenState {
+                balance: 0.into(),
+                scaling_exponent: 0,
+            },
             weight: "0.25".parse().unwrap(),
-            scaling_exponent: 0,
         };
         let pool = WeightedProductOrder {
             reserves: hashmap! {

--- a/solver/src/liquidity/balancer.rs
+++ b/solver/src/liquidity/balancer.rs
@@ -153,7 +153,7 @@ mod tests {
     use shared::{
         dummy_contract,
         sources::balancer::pool_fetching::{
-            MockWeightedPoolFetching, PoolTokenState, WeightedPool,
+            MockWeightedPoolFetching, TokenState, WeightedPool, WeightedTokenState,
         },
     };
 
@@ -179,20 +179,26 @@ mod tests {
                 pool_address: H160([0x90; 20]),
                 swap_fee_percentage: "0.002".parse().unwrap(),
                 reserves: hashmap! {
-                    H160([0x70; 20]) => PoolTokenState {
-                        balance: 100.into(),
+                    H160([0x70; 20]) => WeightedTokenState {
+                        token_state: TokenState {
+                            balance: 100.into(),
+                            scaling_exponent: 16,
+                        },
                         weight: "0.25".parse().unwrap(),
-                        scaling_exponent: 16,
                     },
-                    H160([0x71; 20]) => PoolTokenState {
-                        balance: 1_000_000.into(),
+                    H160([0x71; 20]) => WeightedTokenState {
+                        token_state: TokenState {
+                            balance: 1_000_000.into(),
+                            scaling_exponent: 12,
+                        },
                         weight: "0.25".parse().unwrap(),
-                        scaling_exponent: 12,
                     },
-                    H160([0xb0; 20]) => PoolTokenState {
-                        balance: 1_000_000_000_000_000_000u128.into(),
+                    H160([0xb0; 20]) => WeightedTokenState {
+                        token_state: TokenState {
+                            balance: 1_000_000_000_000_000_000u128.into(),
+                            scaling_exponent: 0,
+                        },
                         weight: "0.5".parse().unwrap(),
-                        scaling_exponent: 0,
                     },
                 },
                 paused: true,
@@ -202,15 +208,19 @@ mod tests {
                 pool_address: H160([0x91; 20]),
                 swap_fee_percentage: "0.001".parse().unwrap(),
                 reserves: hashmap! {
-                    H160([0x73; 20]) => PoolTokenState {
-                        balance: 1_000_000_000_000_000_000u128.into(),
+                    H160([0x73; 20]) => WeightedTokenState {
+                        token_state: TokenState {
+                            balance: 1_000_000_000_000_000_000u128.into(),
+                            scaling_exponent: 0,
+                        },
                         weight: "0.5".parse().unwrap(),
-                        scaling_exponent: 0,
                     },
-                    H160([0xb0; 20]) => PoolTokenState {
-                        balance: 1_000_000_000_000_000_000u128.into(),
+                    H160([0xb0; 20]) => WeightedTokenState {
+                        token_state: TokenState {
+                            balance: 1_000_000_000_000_000_000u128.into(),
+                            scaling_exponent: 0,
+                        },
                         weight: "0.5".parse().unwrap(),
-                        scaling_exponent: 0,
                     },
                 },
                 paused: true,

--- a/solver/src/metrics.rs
+++ b/solver/src/metrics.rs
@@ -10,7 +10,7 @@ use prometheus::{HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGaug
 use shared::{
     metrics::LivenessChecking,
     sources::{
-        balancer::pool_cache::WeightedPoolCacheMetrics, uniswap::pool_cache::PoolCacheMetrics,
+        balancer::pool_cache::BalancerPoolCacheMetrics, uniswap::pool_cache::PoolCacheMetrics,
     },
     transport::instrumented::TransportMetrics,
 };
@@ -224,7 +224,7 @@ impl PoolCacheMetrics for Metrics {
     }
 }
 
-impl WeightedPoolCacheMetrics for Metrics {
+impl BalancerPoolCacheMetrics for Metrics {
     fn pools_fetched(&self, cache_hits: usize, cache_misses: usize) {
         // We may want to distinguish cache metrics between the different
         // liquidity sources in the future, for now just use the same counters.

--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -303,7 +303,10 @@ mod tests {
     use maplit::hashset;
     use model::order::OrderKind;
     use num::rational::Ratio;
-    use shared::{addr, sources::balancer::pool_fetching::PoolTokenState};
+    use shared::{
+        addr,
+        sources::balancer::pool_fetching::{TokenState, WeightedTokenState},
+    };
 
     #[test]
     fn finds_best_route_sell_order() {
@@ -583,15 +586,19 @@ mod tests {
             }),
             Liquidity::WeightedProduct(WeightedProductOrder {
                 reserves: hashmap! {
-                    addr!("c778417e063141139fce010982780140aa0cd5ab") => PoolTokenState {
-                        balance: 799_086_982_149_629_058_u128.into(),
+                    addr!("c778417e063141139fce010982780140aa0cd5ab") => WeightedTokenState {
+                        token_state: TokenState {
+                            balance: 799_086_982_149_629_058_u128.into(),
+                            scaling_exponent: 0,
+                        },
                         weight: "0.5".parse().unwrap(),
-                        scaling_exponent: 0,
                     },
-                    addr!("e4b9895e638f54c3bee2a3a78d6a297cc03e0353") => PoolTokenState {
-                        balance: 1_251_682_293_173_877_359_u128.into(),
+                    addr!("e4b9895e638f54c3bee2a3a78d6a297cc03e0353") => WeightedTokenState {
+                        token_state: TokenState {
+                            balance: 1_251_682_293_173_877_359_u128.into(),
+                            scaling_exponent: 0,
+                        },
                         weight: "0.5".parse().unwrap(),
-                        scaling_exponent: 0,
                     },
                 },
                 fee: Ratio::new(1.into(), 1000.into()),

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -246,7 +246,7 @@ impl HttpSolver {
                         (
                             *token,
                             PoolTokenData {
-                                balance: state.balance,
+                                balance: state.token_state.balance,
                                 weight: BigRational::from(state.weight),
                             },
                         )

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -203,7 +203,10 @@ mod tests {
     use model::TokenPair;
     use num::rational::Ratio;
     use num::BigRational;
-    use shared::sources::balancer::{pool_fetching::PoolTokenState, swap::fixed_point::Bfp};
+    use shared::sources::balancer::{
+        pool_fetching::{TokenState, WeightedTokenState},
+        swap::fixed_point::Bfp,
+    };
 
     #[test]
     fn convert_settlement_() {
@@ -235,15 +238,19 @@ mod tests {
         let wp_amm_handler = CapturingSettlementHandler::arc();
         let weighted_product_order = WeightedProductOrder {
             reserves: hashmap! {
-                t0 => PoolTokenState {
-                    balance: U256::from(200),
+                t0 => WeightedTokenState {
+                    token_state: TokenState {
+                        balance: U256::from(200),
+                        scaling_exponent: 4,
+                    },
                     weight: Bfp::from(200_000_000_000_000_000),
-                    scaling_exponent: 4,
                 },
-                t1 => PoolTokenState {
-                    balance: U256::from(800),
+                t1 => WeightedTokenState {
+                    token_state: TokenState {
+                        balance: U256::from(800),
+                        scaling_exponent: 6,
+                    },
                     weight: Bfp::from(800_000_000_000_000_000),
-                    scaling_exponent: 6,
                 }
             },
             fee: BigRational::new(3.into(), 1.into()),
@@ -336,15 +343,19 @@ mod tests {
         let constant_product_orders = hashmap! { 0usize => cpo_0.clone(), 1usize => cpo_1 };
         let weighted_product_order = WeightedProductOrder {
             reserves: hashmap! {
-                token_c => PoolTokenState {
-                    balance: U256::from(1251682293173877359u128),
+                token_c => WeightedTokenState {
+                    token_state: TokenState {
+                        balance: U256::from(1251682293173877359u128),
+                        scaling_exponent: 0,
+                    },
                     weight: Bfp::from(500_000_000_000_000_000),
-                    scaling_exponent: 0,
                 },
-                token_b => PoolTokenState {
-                    balance: U256::from(799086982149629058u128),
+                token_b => WeightedTokenState {
+                    token_state: TokenState {
+                        balance: U256::from(799086982149629058u128),
+                        scaling_exponent: 0,
+                    },
                     weight: Bfp::from(500_000_000_000_000_000),
-                    scaling_exponent: 0,
                 }
             },
             fee: BigRational::new(1.into(), 1000.into()),


### PR DESCRIPTION
Following #1007 and part of #733

This is essentially a rename of a couple types and introducing a sub structure, `TokenState`, to the `WeightedTokenState` intended to make the diff of the following PR easier to read.

### Test Plan
Only refactored existing tests according to the structural refactoring.
