### PR TITLE
Use enum for signature

### DIFF
--- a/e2e/tests/eth_integration.rs
+++ b/e2e/tests/eth_integration.rs
@@ -2,7 +2,7 @@ use contracts::IUniswapLikeRouter;
 use ethcontract::prelude::{Account, Address, PrivateKey, U256};
 use model::{
     order::{OrderBuilder, OrderKind, BUY_ETH_ADDRESS},
-    signature::SigningScheme,
+    signature::EcdsaSigningScheme,
 };
 use secp256k1::SecretKey;
 use serde_json::json;
@@ -149,8 +149,8 @@ async fn eth_integration(web3: Web3) {
         .with_buy_token(BUY_ETH_ADDRESS)
         .with_buy_amount(to_wei(49))
         .with_valid_to(shared::time::now_in_epoch_seconds() + 300)
-        .with_signing_scheme(SigningScheme::Eip712)
         .sign_with(
+            EcdsaSigningScheme::Eip712,
             &gpv2.domain_separator,
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_BUY_ETH_A_PK).unwrap()),
         )
@@ -171,8 +171,8 @@ async fn eth_integration(web3: Web3) {
         .with_buy_token(BUY_ETH_ADDRESS)
         .with_buy_amount(to_wei(49))
         .with_valid_to(shared::time::now_in_epoch_seconds() + 300)
-        .with_signing_scheme(SigningScheme::Eip712)
         .sign_with(
+            EcdsaSigningScheme::Eip712,
             &gpv2.domain_separator,
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_BUY_ETH_B_PK).unwrap()),
         )

--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -3,7 +3,7 @@ use ethcontract::prelude::{Account, Address, PrivateKey, U256};
 use hex_literal::hex;
 use model::{
     order::{OrderBuilder, OrderKind},
-    signature::SigningScheme,
+    signature::EcdsaSigningScheme,
 };
 use secp256k1::SecretKey;
 use serde_json::json;
@@ -157,8 +157,8 @@ async fn onchain_settlement(web3: Web3) {
         .with_buy_amount(to_wei(80))
         .with_valid_to(shared::time::now_in_epoch_seconds() + 300)
         .with_kind(OrderKind::Sell)
-        .with_signing_scheme(SigningScheme::Eip712)
         .sign_with(
+            EcdsaSigningScheme::Eip712,
             &gpv2.domain_separator,
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_A_PK).unwrap()),
         )
@@ -180,8 +180,8 @@ async fn onchain_settlement(web3: Web3) {
         .with_buy_amount(to_wei(40))
         .with_valid_to(shared::time::now_in_epoch_seconds() + 300)
         .with_kind(OrderKind::Sell)
-        .with_signing_scheme(SigningScheme::EthSign)
         .sign_with(
+            EcdsaSigningScheme::EthSign,
             &gpv2.domain_separator,
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_B_PK).unwrap()),
         )

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -3,7 +3,7 @@ use ethcontract::prelude::{Account, Address, PrivateKey, U256};
 use hex_literal::hex;
 use model::{
     order::{OrderBuilder, OrderKind},
-    signature::SigningScheme,
+    signature::EcdsaSigningScheme,
 };
 use secp256k1::SecretKey;
 use serde_json::json;
@@ -156,8 +156,8 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         .with_buy_amount(to_wei(90))
         .with_valid_to(shared::time::now_in_epoch_seconds() + 300)
         .with_kind(OrderKind::Sell)
-        .with_signing_scheme(SigningScheme::Eip712)
         .sign_with(
+            EcdsaSigningScheme::Eip712,
             &gpv2.domain_separator,
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_A_PK).unwrap()),
         )

--- a/e2e/tests/vault_balances.rs
+++ b/e2e/tests/vault_balances.rs
@@ -2,7 +2,7 @@ use contracts::IUniswapLikeRouter;
 use ethcontract::prelude::{Account, Address, PrivateKey, U256};
 use model::{
     order::{OrderBuilder, OrderKind, SellTokenSource},
-    signature::SigningScheme,
+    signature::EcdsaSigningScheme,
 };
 use secp256k1::SecretKey;
 use serde_json::json;
@@ -117,8 +117,8 @@ async fn vault_balances(web3: Web3) {
         .with_buy_token(gpv2.native_token.address())
         .with_buy_amount(to_wei(8))
         .with_valid_to(shared::time::now_in_epoch_seconds() + 300)
-        .with_signing_scheme(SigningScheme::Eip712)
         .sign_with(
+            EcdsaSigningScheme::Eip712,
             &gpv2.domain_separator,
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER).unwrap()),
         )

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -7,7 +7,7 @@ use futures::stream::TryStreamExt;
 use model::order::{BuyTokenDestination, SellTokenSource};
 use model::{
     order::{Order, OrderCreation, OrderKind, OrderMetaData, OrderStatus, OrderUid},
-    signature::{EcdsaSignature, SigningScheme},
+    signature::{Signature, SigningScheme},
 };
 use primitive_types::H160;
 use std::{borrow::Cow, convert::TryInto};
@@ -177,7 +177,9 @@ impl OrderStoring for Postgres {
             .bind(DbOrderKind::from(order.order_creation.kind))
             .bind(order.order_creation.partially_fillable)
             .bind(order.order_creation.signature.to_bytes().as_ref())
-            .bind(DbSigningScheme::from(order.order_creation.signing_scheme))
+            .bind(DbSigningScheme::from(
+                order.order_creation.signature.scheme(),
+            ))
             .bind(order.order_meta_data.settlement_contract.as_bytes())
             .bind(DbSellTokenSource::from(
                 order.order_creation.sell_token_balance,
@@ -342,6 +344,7 @@ impl OrdersQueryRow {
             status,
             settlement_contract: h160_from_vec(self.settlement_contract)?,
         };
+        let signing_scheme = self.signing_scheme.into();
         let order_creation = OrderCreation {
             sell_token: h160_from_vec(self.sell_token)?,
             buy_token: h160_from_vec(self.buy_token)?,
@@ -359,14 +362,13 @@ impl OrdersQueryRow {
                 .ok_or_else(|| anyhow!("buy_amount is not U256"))?,
             kind: self.kind.into(),
             partially_fillable: self.partially_fillable,
-            signature: EcdsaSignature::from_bytes(
+            signature: Signature::from_bytes(
+                signing_scheme,
                 &self
                     .signature
                     .try_into()
-                    .map_err(|_| anyhow!("signature has wrong length"))?,
-            )
-            .into(),
-            signing_scheme: self.signing_scheme.into(),
+                    .map_err(|_| anyhow!("invalid signature"))?,
+            ),
             sell_token_balance: self.sell_token_balance.into(),
             buy_token_balance: self.buy_token_balance.into(),
         };
@@ -598,8 +600,7 @@ mod tests {
                     fee_amount: 5.into(),
                     kind: OrderKind::Sell,
                     partially_fillable: true,
-                    signature: Default::default(),
-                    signing_scheme: *signing_scheme,
+                    signature: Signature::default_with(*signing_scheme),
                     sell_token_balance: SellTokenSource::Erc20,
                     buy_token_balance: BuyTokenDestination::Internal,
                 },

--- a/solver/src/encoding.rs
+++ b/solver/src/encoding.rs
@@ -62,7 +62,7 @@ fn order_flags(order: &OrderCreation) -> U256 {
         BuyTokenDestination::Internal => 0b1,
     } << 4;
     // The signing scheme is encoded as a 2 bits in position 5.
-    result |= match order.signing_scheme {
+    result |= match order.signature.scheme() {
         SigningScheme::Eip712 => 0b00,
         SigningScheme::EthSign => 0b01,
     } << 5;
@@ -86,6 +86,7 @@ pub struct EncodedSettlement {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use model::signature::Signature;
 
     #[test]
     fn order_flag_permutations() {
@@ -96,7 +97,7 @@ mod tests {
                     partially_fillable: false,
                     sell_token_balance: SellTokenSource::Erc20,
                     buy_token_balance: BuyTokenDestination::Erc20,
-                    signing_scheme: SigningScheme::Eip712,
+                    signature: Signature::default_with(SigningScheme::Eip712),
                     ..Default::default()
                 },
                 // ......0 - sell order
@@ -112,7 +113,7 @@ mod tests {
                     partially_fillable: true,
                     sell_token_balance: SellTokenSource::Erc20,
                     buy_token_balance: BuyTokenDestination::Internal,
-                    signing_scheme: SigningScheme::Eip712,
+                    signature: Signature::default_with(SigningScheme::Eip712),
                     ..Default::default()
                 },
                 // ......0 - sell order
@@ -128,7 +129,7 @@ mod tests {
                     partially_fillable: false,
                     sell_token_balance: SellTokenSource::External,
                     buy_token_balance: BuyTokenDestination::Erc20,
-                    signing_scheme: SigningScheme::Eip712,
+                    signature: Signature::default_with(SigningScheme::Eip712),
                     ..Default::default()
                 },
                 // ......1 - buy order
@@ -144,7 +145,7 @@ mod tests {
                     partially_fillable: false,
                     sell_token_balance: SellTokenSource::Internal,
                     buy_token_balance: BuyTokenDestination::Erc20,
-                    signing_scheme: SigningScheme::EthSign,
+                    signature: Signature::default_with(SigningScheme::EthSign),
                     ..Default::default()
                 },
                 // ......0 - sell order
@@ -160,7 +161,7 @@ mod tests {
                     partially_fillable: true,
                     sell_token_balance: SellTokenSource::Internal,
                     buy_token_balance: BuyTokenDestination::Internal,
-                    signing_scheme: SigningScheme::EthSign,
+                    signature: Signature::default_with(SigningScheme::EthSign),
                     ..Default::default()
                 },
                 // ......1 - buy order


### PR DESCRIPTION
Implements suggestions in https://github.com/gnosis/gp-v2-services/pull/999#discussion_r693711292.

This replace the `Signature` struct with a `Signature` enum, and takes care of the surrounding logic.

Notable mention to the Serde magic, suggesteb by Nick, that makes it so that the field `signature_scheme` is used by Serde to derive the enum variant for `Signature` when deserializing.

### Test Plan
Existing unit tests.