### PR TITLE
Share per solve invocation data between http solver instances

### DIFF
--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -35,6 +35,7 @@ pub struct BaselineSolver {
 impl Solver for BaselineSolver {
     async fn solve(
         &self,
+        _id: u64,
         liquidity: Vec<Liquidity>,
         _gas_price: f64,
         _deadline: Instant,

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::collections::HashMap;
 
-#[derive(Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct BatchAuctionModel {
     pub tokens: HashMap<H160, TokenInfoModel>,
     pub orders: HashMap<usize, OrderModel>,
@@ -17,7 +17,7 @@ pub struct BatchAuctionModel {
     pub metadata: Option<MetadataModel>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct OrderModel {
     pub sell_token: H160,
     pub buy_token: H160,
@@ -31,7 +31,7 @@ pub struct OrderModel {
     pub cost: CostModel,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AmmModel {
     #[serde(flatten)]
     pub parameters: AmmParameters,
@@ -60,7 +60,7 @@ impl AmmModel {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum AmmParameters {
     ConstantProduct(ConstantProductPoolParameters),
@@ -68,13 +68,13 @@ pub enum AmmParameters {
 }
 
 #[serde_as]
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ConstantProductPoolParameters {
     #[serde_as(as = "HashMap<_, DecimalU256>")]
     pub reserves: HashMap<H160, U256>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PoolTokenData {
     #[serde(with = "u256_decimal")]
     pub balance: U256,
@@ -82,13 +82,13 @@ pub struct PoolTokenData {
     pub weight: BigRational,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WeightedProductPoolParameters {
     pub reserves: HashMap<H160, PoolTokenData>,
 }
 
 #[serde_as]
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct TokenInfoModel {
     pub decimals: Option<u8>,
     pub external_price: Option<f64>,
@@ -97,14 +97,14 @@ pub struct TokenInfoModel {
     pub internal_buffer: Option<U256>,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct CostModel {
     #[serde(with = "u256_decimal")]
     pub amount: U256,
     pub token: H160,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct FeeModel {
     #[serde(with = "u256_decimal")]
     pub amount: U256,
@@ -133,7 +133,7 @@ impl SettledBatchAuctionModel {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct MetadataModel {
     pub environment: Option<String>,
 }

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -12,7 +12,7 @@ use std::collections::{hash_map::Entry, HashMap};
 
 // To send an instance to the solver we need to identify tokens and orders through strings. This
 // struct combines the created model and a mapping of those identifiers to their original value.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SettlementContext {
     pub limit_orders: HashMap<usize, LimitOrder>,
     pub constant_product_orders: HashMap<usize, ConstantProductOrder>,

--- a/solver/src/solver/naive_solver.rs
+++ b/solver/src/solver/naive_solver.rs
@@ -24,6 +24,7 @@ impl NaiveSolver {
 impl Solver for NaiveSolver {
     async fn solve(
         &self,
+        _id: u64,
         liquidity: Vec<Liquidity>,
         _gas_price: f64,
         _deadline: Instant,

--- a/solver/src/solver/single_order_solver.rs
+++ b/solver/src/solver/single_order_solver.rs
@@ -43,6 +43,7 @@ impl<I: SingleOrderSolving> From<I> for SingleOrderSolver<I> {
 impl<I: SingleOrderSolving + Send + Sync + 'static> Solver for SingleOrderSolver<I> {
     async fn solve(
         &self,
+        _id: u64,
         liquidity: Vec<Liquidity>,
         _gas_price: f64,
         deadline: Instant,
@@ -144,7 +145,7 @@ mod tests {
         ];
 
         let settlements = solver
-            .solve(orders, 0., Instant::now() + Duration::from_secs(10))
+            .solve(0, orders, 0., Instant::now() + Duration::from_secs(10))
             .await
             .unwrap();
         assert_eq!(settlements.len(), 2);
@@ -186,7 +187,7 @@ mod tests {
             settlement_handling: handler.clone(),
         });
         solver
-            .solve(vec![order], 0., Instant::now() + Duration::from_secs(10))
+            .solve(0, vec![order], 0., Instant::now() + Duration::from_secs(10))
             .await
             .unwrap();
     }
@@ -216,7 +217,7 @@ mod tests {
             settlement_handling: handler.clone(),
         });
         solver
-            .solve(vec![order], 0., Instant::now() + Duration::from_secs(10))
+            .solve(0, vec![order], 0., Instant::now() + Duration::from_secs(10))
             .await
             .unwrap();
     }


### PR DESCRIPTION
Without this we make a lot of duplicate requests to the node as every
http solver instance individually fetches the same data.
In order for us to know what counts as the same solve invocation a new
parameter solve_id is added to the trait which is incremented for
every driver run loop.

### Test Plan
Ran locally and added logging statements to the mutex code to see that multiple instances correctly only fetch data once while the other instances wait.
