### PR TITLE
Implement transport metrics using the new global metrics interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2575,6 +2575,7 @@ dependencies = [
  "prometheus",
  "regex",
  "reqwest",
+ "scopeguard",
  "serde",
  "serde_json",
  "serde_with",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -29,6 +29,7 @@ once_cell = "1.8.0"
 primitive-types = "0.9"
 prometheus = "0.12"
 reqwest = { version = "0.11", features = ["json"] }
+scopeguard = "1.1.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_with = { version = "1.9", default-features = false }

--- a/shared/src/transport.rs
+++ b/shared/src/transport.rs
@@ -12,7 +12,7 @@ use reqwest::Client;
 use std::{convert::TryInto as _, sync::Arc};
 use web3::BatchTransport;
 
-/// Convenience method to create our standard instrumented transport
+/// Convenience method to create our standard instrumented transport.
 pub fn create_instrumented_transport<T>(
     transport: T,
     metrics: Arc<dyn TransportMetrics>,


### PR DESCRIPTION
Note: I want to follow prometheus guidelines for metric names (I'll make a slack thread about it), thus some names were changed. I haven't removed previous metrics implementation so that we can compare old and new metrics after release, and switch our dashboards to new metrics later.

### Test Plan
Manual testing.
