### PR TITLE
Do not allow 100% fee subsidy

### DIFF
--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -93,8 +93,8 @@ pub struct Arguments {
 impl Arguments {
     pub fn validate(&self) {
         assert!(
-            0f64 <= self.fee_subsidy_factor && self.fee_subsidy_factor <= 1f64,
-            "Fee subsidy must be in the range [0, 1]"
+            0f64 <= self.fee_subsidy_factor && self.fee_subsidy_factor < 1f64,
+            "Fee subsidy must be in the range [0, 1)"
         );
     }
 }


### PR DESCRIPTION

Closes #981

On second thought, I realized that subsidizing fees by more than 100% does not make sense because we can't just pay people on top of not charging fees. Thus, we avoid the zero division error by not allowing fee_subsidy_factor to equal 1.

### Test Plan
No changed tests.
