### PR TITLE
Create index for order creation timestamp

### DIFF
--- a/database/sql/V013__index_order_creation_date.sql
+++ b/database/sql/V013__index_order_creation_date.sql
@@ -1,0 +1,1 @@
+CREATE INDEX order_creation_timestamp ON orders USING BTREE (creation_timestamp);


### PR DESCRIPTION
Part of #969

Note that a btree index can be used for sorting in either direction.

### Test Plan
Tested that it applies with local postgres instance.
