### PR TITLE
Fix gas estimation

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -333,6 +333,7 @@ impl Driver {
                 let gas_estimate = settlement_submission::estimate_gas(
                     &self.settlement_contract,
                     &settlement.clone().into(),
+                    solver.account().clone(),
                 )
                 .await
                 .ok()?;

--- a/solver/src/settlement_simulation.rs
+++ b/solver/src/settlement_simulation.rs
@@ -61,9 +61,9 @@ pub async fn simulate_settlements(
             let method = crate::settlement_submission::retry::settle_method_builder(
                 contract,
                 settlement.clone().into(),
+                solver.account().clone(),
             )
-            .gas_price(gas_price)
-            .from(solver.account().clone());
+            .gas_price(gas_price);
             let transaction_builder = method.tx.clone();
             let view = method
                 .view()

--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -25,8 +25,9 @@ const GAS_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
 pub async fn estimate_gas(
     contract: &GPv2Settlement,
     settlement: &EncodedSettlement,
+    from: Account,
 ) -> Result<U256, ExecutionError> {
-    retry::settle_method_builder(contract, settlement.clone())
+    retry::settle_method_builder(contract, settlement.clone(), from)
         .tx
         .estimate_gas()
         .await

--- a/solver/src/settlement_submission/archer_settlement.rs
+++ b/solver/src/settlement_submission/archer_settlement.rs
@@ -211,12 +211,16 @@ impl<'a> ArcherSolutionSubmitter<'a> {
                 .append_to_execution_plan(block_coinbase::PayBlockCoinbase {
                     amount: tx_gas_cost_in_ether_wei,
                 });
-            let method = super::retry::settle_method_builder(self.contract, settlement.into(), self.account.clone())
-                .nonce(nonce)
-                // Wouldn't work because the function isn't payable.
-                // .value(tx_gas_cost_in_ether_wei)
-                .gas(U256::from_f64_lossy(gas_limit))
-                .gas_price(GasPrice::Value(U256::zero()));
+            let method = super::retry::settle_method_builder(
+                self.contract,
+                settlement.into(),
+                self.account.clone(),
+            )
+            .nonce(nonce)
+            // Wouldn't work because the function isn't payable.
+            // .value(tx_gas_cost_in_ether_wei)
+            .gas(U256::from_f64_lossy(gas_limit))
+            .gas_price(GasPrice::Value(U256::zero()));
 
             // simulate transaction
 

--- a/solver/src/settlement_submission/archer_settlement.rs
+++ b/solver/src/settlement_submission/archer_settlement.rs
@@ -211,8 +211,7 @@ impl<'a> ArcherSolutionSubmitter<'a> {
                 .append_to_execution_plan(block_coinbase::PayBlockCoinbase {
                     amount: tx_gas_cost_in_ether_wei,
                 });
-            let method = super::retry::settle_method_builder(self.contract, settlement.into())
-                .from(self.account.clone())
+            let method = super::retry::settle_method_builder(self.contract, settlement.into(), self.account.clone())
                 .nonce(nonce)
                 // Wouldn't work because the function isn't payable.
                 // .value(tx_gas_cost_in_ether_wei)
@@ -349,10 +348,13 @@ mod tests {
         let gas_price_cap = 100e9;
 
         let settlement = Settlement::new(Default::default());
-        let gas_estimate =
-            crate::settlement_submission::estimate_gas(&contract, &settlement.clone().into())
-                .await
-                .unwrap();
+        let gas_estimate = crate::settlement_submission::estimate_gas(
+            &contract,
+            &settlement.clone().into(),
+            account.clone(),
+        )
+        .await
+        .unwrap();
 
         let submitter = ArcherSolutionSubmitter {
             web3: &web3,

--- a/solver/src/settlement_submission/retry.rs
+++ b/solver/src/settlement_submission/retry.rs
@@ -67,10 +67,11 @@ impl<'a> TransactionSending for SettlementSender<'a> {
 
     async fn send(&self, gas_price: f64) -> Self::Output {
         tracing::info!("submitting solution transaction at gas price {}", gas_price);
-        let mut method = settle_method_builder(self.contract, self.settlement.clone(), self.account.clone())
-            .nonce(self.nonce)
-            .gas_price(GasPrice::Value(U256::from_f64_lossy(gas_price)))
-            .gas(U256::from_f64_lossy(self.gas_limit));
+        let mut method =
+            settle_method_builder(self.contract, self.settlement.clone(), self.account.clone())
+                .nonce(self.nonce)
+                .gas_price(GasPrice::Value(U256::from_f64_lossy(gas_price)))
+                .gas(U256::from_f64_lossy(self.gas_limit));
         method.tx.resolve = Some(ResolveCondition::Confirmed(ConfirmParams::mined()));
         let result = method.send().await.map(|tx| tx.hash());
         SettleResult(result)

--- a/solver/src/settlement_submission/retry.rs
+++ b/solver/src/settlement_submission/retry.rs
@@ -67,11 +67,10 @@ impl<'a> TransactionSending for SettlementSender<'a> {
 
     async fn send(&self, gas_price: f64) -> Self::Output {
         tracing::info!("submitting solution transaction at gas price {}", gas_price);
-        let mut method = settle_method_builder(self.contract, self.settlement.clone())
+        let mut method = settle_method_builder(self.contract, self.settlement.clone(), self.account.clone())
             .nonce(self.nonce)
             .gas_price(GasPrice::Value(U256::from_f64_lossy(gas_price)))
-            .gas(U256::from_f64_lossy(self.gas_limit))
-            .from(self.account.clone());
+            .gas(U256::from_f64_lossy(self.gas_limit));
         method.tx.resolve = Some(ResolveCondition::Confirmed(ConfirmParams::mined()));
         let result = method.send().await.map(|tx| tx.hash());
         SettleResult(result)
@@ -81,13 +80,16 @@ impl<'a> TransactionSending for SettlementSender<'a> {
 pub fn settle_method_builder(
     contract: &GPv2Settlement,
     settlement: EncodedSettlement,
+    from: Account,
 ) -> DynMethodBuilder<()> {
-    contract.settle(
-        settlement.tokens,
-        settlement.clearing_prices,
-        settlement.trades,
-        settlement.interactions,
-    )
+    contract
+        .settle(
+            settlement.tokens,
+            settlement.clearing_prices,
+            settlement.trades,
+            settlement.interactions,
+        )
+        .from(from)
 }
 
 // We never send cancellations but we still need to have types that implement the traits.


### PR DESCRIPTION
This fixes a bug introduced in #1010: we didn't set the `from` account for calls to `estimate_gas`.

### Test Plan
Given that CI didn't catch the bug in #1010, I'm highly skeptical of it. My local cowswap installation is broken at the moment, perhaps someone else could test it? Or we could deploy to prestable and check it there.
