### PR TITLE
Split orders sql statement into several use cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c7d3aa11be45d56befebb10f4a8785fcb62aabddf5f33638efef922e505ec9"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c36c619c422113552db4eb28cddba8faa757e33f758cc3415bd2885977b591"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "contracts"
 version = "0.1.0"
 dependencies = [
@@ -1792,6 +1812,7 @@ dependencies = [
  "async-trait",
  "bigdecimal",
  "chrono",
+ "const_format",
  "contracts",
  "either",
  "ethcontract",

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -19,6 +19,7 @@ assert_approx_eq = "1.1"
 async-trait = "0.1"
 bigdecimal = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+const_format = "0.2"
 contracts = { path = "../contracts" }
 either = "1.0"
 ethcontract = { version = "0.15.1", default-features = false }

--- a/orderbook/src/database/instrumented.rs
+++ b/orderbook/src/database/instrumented.rs
@@ -128,6 +128,25 @@ impl OrderStoring for Instrumented {
             .start_timer();
         self.inner.orders(filter).await
     }
+
+    async fn single_order(
+        &self,
+        uid: &model::order::OrderUid,
+    ) -> anyhow::Result<model::order::Order> {
+        let _timer = self
+            .metrics
+            .database_query_histogram("single_order")
+            .start_timer();
+        self.inner.single_order(uid).await
+    }
+
+    async fn solvable_orders(&self, min_valid_to: u32) -> anyhow::Result<Vec<model::order::Order>> {
+        let _timer = self
+            .metrics
+            .database_query_histogram("solvable_orders")
+            .start_timer();
+        self.inner.solvable_orders(min_valid_to).await
+    }
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
We initially decided on having one big statement for all uses that was
customized by several filtering criteria (see OrderFilter). Now we see
that the number of use cases has grown:
- single order: no ordering, filtered by id
- solvable orders: no ordering, filtered by valid_to, executed amounts,
  invalidations
- user orders: ordered by creation date. many filters.
- orders with presignatures: i am not sure how the query will look

Cramming these all into the same query is in some cases impossible
(different orderings) and in other cases inefficient. The query ends up
very complex because it has to accommodate all use cases. We see this in
the `$N IS NULL o.x = $N` statements that are only needed for some type
of queries but not orders.
This is harder to understand for the programmer and more importantly
makes the query hard to optimize for Postgres and harder to reason about
its performance characteristics as the optimal query plan depends on the
value of the parameters [0] .

For these reasons we factor out the common part of the big query and
reassemble it in several smaller queries.

[0] https://www.postgresql.org/docs/13/sql-prepare.html

---

Before writing tests and integrating the new specialized functions I want to hear feedback on the PR. If we like it then I will do so in a follow up PR.

`concatcp!` is a macro for concatenating strings at compile time.

### Test Plan
existing tests
