### PR TITLE
Query order presignature status

### DIFF
--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -48,9 +48,10 @@ impl Default for Order {
     }
 }
 
-#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash)]
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Deserialize, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub enum OrderStatus {
+    SignaturePending,
     Open,
     Fulfilled,
     Cancelled,

--- a/model/src/signature.rs
+++ b/model/src/signature.rs
@@ -117,6 +117,10 @@ impl From<EcdsaSigningScheme> for SigningScheme {
 }
 
 impl SigningScheme {
+    pub fn is_ecdsa_scheme(&self) -> bool {
+        self.try_to_ecdsa_scheme().is_some()
+    }
+
     pub fn try_to_ecdsa_scheme(&self) -> Option<EcdsaSigningScheme> {
         match self {
             Self::Eip712 => Some(EcdsaSigningScheme::Eip712),

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -447,7 +447,7 @@ components:
     OrderStatus:
       description: The current order status
       type: string
-      enum: [open, fulfilled, cancelled, expired]
+      enum: [signaturePending, open, fulfilled, cancelled, expired]
     OrderCreation:
       description: Data a user provides when creating a new order.
       type: object
@@ -681,7 +681,16 @@ components:
       properties:
         errorType:
           type: string
-          enum: [InvalidSignature, WrongOwner, OrderNotFound, AlreadyCancelled, OrderFullyExecuted, OrderExpired]
+          enum:
+            [
+              InvalidSignature,
+              WrongOwner,
+              OrderNotFound,
+              AlreadyCancelled,
+              OrderFullyExecuted,
+              OrderExpired,
+              OnChainOrder,
+            ]
         description:
           type: string
       required:

--- a/orderbook/src/api/cancel_order.rs
+++ b/orderbook/src/api/cancel_order.rs
@@ -49,7 +49,7 @@ pub fn cancel_order_response(result: Result<OrderCancellationResult>) -> impl Re
             StatusCode::BAD_REQUEST,
         ),
         Ok(OrderCancellationResult::OrderNotFound) => (
-            super::error("OrderNotFound", "order not located in database"),
+            super::error("OrderNotFound", "Order not located in database"),
             StatusCode::NOT_FOUND,
         ),
         Ok(OrderCancellationResult::WrongOwner) => (
@@ -58,6 +58,10 @@ pub fn cancel_order_response(result: Result<OrderCancellationResult>) -> impl Re
                 "Signature recovery's owner doesn't match order's",
             ),
             StatusCode::UNAUTHORIZED,
+        ),
+        Ok(OrderCancellationResult::OnChainOrder) => (
+            super::error("OnChainOrder", "On-chain orders must be cancelled on-chain"),
+            StatusCode::BAD_REQUEST,
         ),
         Err(_) => (super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR),
     };

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -169,13 +169,13 @@ const ORDERS_SELECT: &str = "\
     COALESCE(SUM(t.sell_amount), 0) AS sum_sell, \
     COALESCE(SUM(t.fee_amount), 0) AS sum_fee, \
     (COUNT(invalidations.*) > 0 OR o.cancellation_timestamp IS NOT NULL) AS invalidated, \
-    COALESCE((o.signing_scheme = 'presign' AND ( \
+    (o.signing_scheme = 'presign' AND COALESCE(( \
         SELECT (NOT p.signed) as unsigned \
         FROM presignature_events p \
         WHERE o.uid = p.order_uid \
         ORDER BY p.block_number DESC, p.log_index DESC \
         LIMIT 1 \
-    )), true) AS presignature_pending \
+    ), true)) AS presignature_pending \
 ";
 
 const ORDERS_FROM: &str = "\


### PR DESCRIPTION
This PR adds a `SignaturePending` status to order for pre-sign orders in the `OrderMetadata` for signalling that a pre-sign order is waiting for a pre-signature in the GPv2 settlement contract.

Please note that my SQL skillz are :-1:. So please scrutinize the query modification that was made.

### Test Plan

Added new unit tests for the added order status computation. Added an ignored test for the Postgres query for presignature status that can be manually run:
```
$ cargo test -p orderbook -- --ignored postgres_presignature_status --test-threads 1
    Finished test [unoptimized + debuginfo] target(s) in 0.14s
     Running unittests (target/debug/deps/orderbook-68be6fafd7ab0abc)

running 1 test
test database::orders::tests::postgres_presignature_status ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 59 filtered out; finished in 0.06s
```

### Query Rational

We use a subquery in order to get the latest presignature.

```
nlordell=# explain SELECT
  (o.signing_scheme = 'presign' AND COALESCE((
    SELECT (NOT p.signed) as unsigned
    FROM presignature_events p
    WHERE o.uid = p.order_uid
    ORDER BY p.block_number DESC, p.log_index DESC
    LIMIT 1
  ), true)) as presignature_pending
FROM orders o
GROUP BY o.uid;
                                        QUERY PLAN                                        
------------------------------------------------------------------------------------------
 HashAggregate  (cost=12.88..260.70 rows=230 width=58)
   Group Key: o.uid
   ->  Seq Scan on orders o  (cost=0.00..12.30 rows=230 width=61)
   SubPlan 1
     ->  Limit  (cost=1.06..1.06 rows=1 width=17)
           ->  Sort  (cost=1.06..1.06 rows=1 width=17)
                 Sort Key: p.block_number DESC, p.log_index DESC
                 ->  Seq Scan on presignature_events p  (cost=0.00..1.05 rows=1 width=17)
                       Filter: (o.uid = order_uid)
(9 rows)
```

This seems to be more performant than a `JOIN LEFT LATERAL`.