### PR TITLE
[HotFix] Fix Balancer v2 Graph Query

### DIFF
--- a/model/src/signature.rs
+++ b/model/src/signature.rs
@@ -68,6 +68,7 @@ impl Signature {
         }
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_bytes(&self) -> [u8; 65] {
         match self {
             Signature::Eip712(sig) | Signature::EthSign(sig) => sig.to_bytes(),

--- a/shared/src/sources/balancer/graph_api.rs
+++ b/shared/src/sources/balancer/graph_api.rs
@@ -170,7 +170,7 @@ mod pools_query {
                 first: $pageSize
                 where: {
                     id_gt: $lastId
-                    poolType: Weighted
+                    poolType: "Weighted"
                 }
             ) {
                 id
@@ -192,7 +192,7 @@ mod pools_query {
                 first: $pageSize
                 where: {
                     id_gt: $lastId
-                    poolType: Stable
+                    poolType: "Stable"
                 }
             ) {
                 id


### PR DESCRIPTION
The Balance rinkeby subgraph updated last night (mainnet stayed the same) with a change that makes our query fail. `Pool.poolType` is no longer an enum but a string now.

Luckily strings get coerced into enum values so changing our poolType to strings will still work on mainnet where the actual type is an enum.

### Test Plan
Tested that this query allows fetching Balancer pools on both Rinkeby and xDAI
