### PR TITLE
Add parameter to filter order query on pending presignature

### DIFF
--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -51,7 +51,7 @@ impl Default for Order {
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Deserialize, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub enum OrderStatus {
-    SignaturePending,
+    PresignaturePending,
     Open,
     Fulfilled,
     Cancelled,

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -88,6 +88,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: includePresignaturePending
+          in: query
+          description: Should pre-sign orders waiting for the on-chain presignature be included?
+          schema:
+            type: boolean
+            default: false
         - name: includeUnsupportedTokens
           in: query
           description: Should the orders containing unsupported tokens be included?
@@ -447,7 +453,7 @@ components:
     OrderStatus:
       description: The current order status
       type: string
-      enum: [signaturePending, open, fulfilled, cancelled, expired]
+      enum: [presignaturePending, open, fulfilled, cancelled, expired]
     OrderCreation:
       description: Data a user provides when creating a new order.
       type: object

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -29,6 +29,8 @@ struct Query {
     include_insufficient_balance: bool,
     #[serde(default)]
     include_unsupported_tokens: bool,
+    #[serde(default)]
+    include_signature_pending: bool,
 }
 
 impl Query {
@@ -46,6 +48,7 @@ impl Query {
             exclude_invalidated: !self.include_invalidated,
             exclude_insufficient_balance: !self.include_insufficient_balance,
             exclude_unsupported_tokens: !self.include_unsupported_tokens,
+            exclude_presignature_pending: !self.include_signature_pending,
             uid: None,
         })
     }
@@ -89,8 +92,7 @@ pub fn get_orders(
 mod tests {
     use super::*;
     use crate::api::response_body;
-    use hex_literal::hex;
-    use primitive_types::H160;
+    use shared::addr;
     use warp::test::{request, RequestBuilder};
 
     #[tokio::test]
@@ -100,11 +102,19 @@ mod tests {
             request.method("GET").filter(&filter).await
         };
 
-        let owner = H160::from_slice(&hex!("0000000000000000000000000000000000000001"));
-        let sell = H160::from_slice(&hex!("0000000000000000000000000000000000000002"));
-        let buy = H160::from_slice(&hex!("0000000000000000000000000000000000000003"));
+        let owner = addr!("0000000000000000000000000000000000000001");
+        let sell = addr!("0000000000000000000000000000000000000002");
+        let buy = addr!("0000000000000000000000000000000000000003");
         let path = format!(
-            "/orders?owner=0x{:x}&sellToken=0x{:x}&buyToken=0x{:x}&minValidTo=2&includeFullyExecuted=true&includeInvalidated=true&includeInsufficientBalance=true",
+            "/orders\
+                 ?owner=0x{:x}\
+                 &sellToken=0x{:x}\
+                 &buyToken=0x{:x}\
+                 &minValidTo=2\
+                 &includeFullyExecuted=true\
+                 &includeInvalidated=true\
+                 &includeInsufficientBalance=true\
+                 &includeSignaturePending=true",
             owner, sell, buy
         );
         let request = request().path(path.as_str());
@@ -116,6 +126,7 @@ mod tests {
         assert!(!result.exclude_fully_executed);
         assert!(!result.exclude_invalidated);
         assert!(!result.exclude_insufficient_balance);
+        assert!(!result.exclude_presignature_pending);
     }
 
     #[test]

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -30,7 +30,7 @@ struct Query {
     #[serde(default)]
     include_unsupported_tokens: bool,
     #[serde(default)]
-    include_signature_pending: bool,
+    include_presignature_pending: bool,
 }
 
 impl Query {
@@ -48,7 +48,7 @@ impl Query {
             exclude_invalidated: !self.include_invalidated,
             exclude_insufficient_balance: !self.include_insufficient_balance,
             exclude_unsupported_tokens: !self.include_unsupported_tokens,
-            exclude_presignature_pending: !self.include_signature_pending,
+            exclude_presignature_pending: !self.include_presignature_pending,
             uid: None,
         })
     }
@@ -114,7 +114,7 @@ mod tests {
                  &includeFullyExecuted=true\
                  &includeInvalidated=true\
                  &includeInsufficientBalance=true\
-                 &includeSignaturePending=true",
+                 &includePresignaturePending=true",
             owner, sell, buy
         );
         let request = request().path(path.as_str());

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -224,7 +224,7 @@ impl Orderbook {
         };
 
         match order.order_meta_data.status {
-            OrderStatus::SignaturePending => return Ok(OrderCancellationResult::OnChainOrder),
+            OrderStatus::PresignaturePending => return Ok(OrderCancellationResult::OnChainOrder),
             OrderStatus::Open if !order.order_creation.signature.scheme().is_ecdsa_scheme() => {
                 return Ok(OrderCancellationResult::OnChainOrder);
             }


### PR DESCRIPTION
This PR adds a new `OrderFilter` parameter to filter orders that are waiting on a presignature. This will be used when fetching the list of solvable orders from the orderbook.

### Test Plan

Adjusted some existing unit tests for the new filter parameter and added a new manual Postgres test for checking filtering logic.

<details><summary><code>cargo test -p orderbook -- --ignored postgres_filter_presignature_pending --test-threads 1</code></summary>

```
   Compiling orderbook v0.1.0 (/var/home/nlordell/Developer/gp-v2-services/orderbook)
    Finished test [unoptimized + debuginfo] target(s) in 14.25s
     Running unittests (target/debug/deps/orderbook-68be6fafd7ab0abc)

running 1 test
test database::orders::tests::postgres_filter_presignature_pending ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 60 filtered out; finished in 0.15s
```

</details>


**edit**: TIL that postgres tests run in CI. This is good, as the test :point_up: will also run in CI :smile: :tada: :rocket: :robot:.
