### PR TITLE
*Rename Matcha to 0x

### DIFF
--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -4,7 +4,6 @@ use baseline_solver::BaselineSolver;
 use contracts::GPv2Settlement;
 use ethcontract::{Account, H160, U256};
 use http_solver::{buffers::BufferRetriever, HttpSolver, SolverConfig};
-use matcha_solver::MatchaSolver;
 use naive_solver::NaiveSolver;
 use oneinch_solver::OneInchSolver;
 use paraswap_solver::ParaswapSolver;
@@ -19,15 +18,16 @@ use std::{
     time::Instant,
 };
 use structopt::clap::arg_enum;
+use zeroex_solver::ZeroExSolver;
 
 mod baseline_solver;
 mod http_solver;
-mod matcha_solver;
 mod naive_solver;
 mod oneinch_solver;
 mod paraswap_solver;
 mod single_order_solver;
 mod solver_utils;
+mod zeroex_solver;
 
 /// Interface that all solvers must implement.
 ///
@@ -73,7 +73,7 @@ arg_enum! {
         Mip,
         OneInch,
         Paraswap,
-        Matcha,
+        ZeroEx,
         Quasimodo,
     }
 }
@@ -161,8 +161,8 @@ pub fn create(
                     min_order_size_one_inch,
                 ))
             }
-            SolverType::Matcha => {
-                let matcha_solver = MatchaSolver::new(
+            SolverType::ZeroEx => {
+                let zeroex_solver = ZeroExSolver::new(
                     account,
                     web3.clone(),
                     settlement_contract.clone(),
@@ -170,7 +170,7 @@ pub fn create(
                     client.clone(),
                 )
                 .unwrap();
-                shared(SingleOrderSolver::from(matcha_solver))
+                shared(SingleOrderSolver::from(zeroex_solver))
             }
             SolverType::Paraswap => shared(SingleOrderSolver::from(ParaswapSolver::new(
                 account,

--- a/solver/src/solver/zeroex_solver.rs
+++ b/solver/src/solver/zeroex_solver.rs
@@ -1,7 +1,7 @@
-//! Module containing implementation of the Matcha solver.
+//! Module containing implementation of the 0x solver.
 //!
-//! This solver will simply use the Matcha API to get a quote for a
-//! single GPv2 order and produce a settlement directly against Matcha.
+//! This solver will simply use the 0x API to get a quote for a
+//! single GPv2 order and produce a settlement directly against 0x.
 //!
 //! Please be aware of the following subtlety for buy orders:
 //! 0x's API is adding the defined slippage on the sellAmount of a buy order
@@ -15,13 +15,13 @@
 //! fees also in the sell token, though, the fee's might not always be sufficient.
 //! This risk should be covered in a future PR.
 //!
-//! Sell orders are unproblematic, especially, since the positive slippage is handed back from matcha
+//! Sell orders are unproblematic, especially, since the positive slippage is handed back from 0x
 
 pub mod api;
 
 use super::solver_utils::Slippage;
 use crate::interactions::allowances::{AllowanceManager, AllowanceManaging};
-use crate::solver::matcha_solver::api::{MatchaApi, MatchaResponseError};
+use crate::solver::zeroex_solver::api::{ZeroExApi, ZeroExResponseError};
 use anyhow::{anyhow, ensure, Result};
 use contracts::GPv2Settlement;
 use ethcontract::{Account, Bytes};
@@ -30,7 +30,7 @@ use reqwest::Client;
 
 use super::single_order_solver::{SettlementError, SingleOrderSolving};
 
-use self::api::{DefaultMatchaApi, SwapQuery, SwapResponse};
+use self::api::{DefaultZeroExApi, SwapQuery, SwapResponse};
 use crate::{
     encoding::EncodedInteraction,
     liquidity::LimitOrder,
@@ -41,19 +41,19 @@ use shared::Web3;
 use std::fmt::{self, Display, Formatter};
 
 /// Constant maximum slippage of 5 BPS (0.05%) to use for on-chain liquidity.
-pub const STANDARD_MATCHA_SLIPPAGE_BPS: u16 = 5;
+pub const STANDARD_ZEROEX_SLIPPAGE_BPS: u16 = 5;
 
-/// A GPv2 solver that matches GP orders to direct Matcha swaps.
-pub struct MatchaSolver {
+/// A GPv2 solver that matches GP orders to direct 0x swaps.
+pub struct ZeroExSolver {
     account: Account,
-    client: Box<dyn MatchaApi + Send + Sync>,
+    client: Box<dyn ZeroExApi + Send + Sync>,
     allowance_fetcher: Box<dyn AllowanceManaging>,
 }
 
 /// Chain ID for Mainnet.
 const MAINNET_CHAIN_ID: u64 = 1;
 
-impl MatchaSolver {
+impl ZeroExSolver {
     pub fn new(
         account: Account,
         web3: Web3,
@@ -63,14 +63,14 @@ impl MatchaSolver {
     ) -> Result<Self> {
         ensure!(
             chain_id == MAINNET_CHAIN_ID,
-            "Matcha solver only supported on Mainnet",
+            "0x solver only supported on Mainnet",
         );
         let allowance_fetcher = AllowanceManager::new(web3, settlement_contract.address());
         Ok(Self {
             account,
             allowance_fetcher: Box::new(allowance_fetcher),
-            client: Box::new(DefaultMatchaApi::new(
-                DefaultMatchaApi::DEFAULT_URL,
+            client: Box::new(DefaultZeroExApi::new(
+                DefaultZeroExApi::DEFAULT_URL,
                 client,
             )?),
         })
@@ -78,7 +78,7 @@ impl MatchaSolver {
 }
 
 #[async_trait::async_trait]
-impl SingleOrderSolving for MatchaSolver {
+impl SingleOrderSolving for ZeroExSolver {
     async fn try_settle_order(
         &self,
         order: LimitOrder,
@@ -92,14 +92,14 @@ impl SingleOrderSolving for MatchaSolver {
             buy_token: order.buy_token,
             sell_amount,
             buy_amount,
-            slippage_percentage: Slippage::number_from_basis_points(STANDARD_MATCHA_SLIPPAGE_BPS)
+            slippage_percentage: Slippage::number_from_basis_points(STANDARD_ZEROEX_SLIPPAGE_BPS)
                 .unwrap(),
             skip_validation: Some(true),
         };
 
-        tracing::debug!("querying Matcha swap api with {:?}", query);
+        tracing::debug!("querying 0x swap api with {:?}", query);
         let swap = self.client.get_swap(query).await?;
-        tracing::debug!("proposed Matcha swap is {:?}", swap);
+        tracing::debug!("proposed 0x swap is {:?}", swap);
 
         if !swap_respects_limit_price(&swap, &order) {
             tracing::debug!("Order limit price not respected");
@@ -128,15 +128,15 @@ impl SingleOrderSolving for MatchaSolver {
     }
 
     fn name(&self) -> &'static str {
-        "Matcha"
+        "0x"
     }
 }
 
-impl From<MatchaResponseError> for SettlementError {
-    fn from(err: MatchaResponseError) -> Self {
+impl From<ZeroExResponseError> for SettlementError {
+    fn from(err: ZeroExResponseError) -> Self {
         SettlementError {
-            inner: anyhow!("Matcha Response Error {:?}", err),
-            retryable: matches!(err, MatchaResponseError::ServerError(_)),
+            inner: anyhow!("0x Response Error {:?}", err),
+            retryable: matches!(err, ZeroExResponseError::ServerError(_)),
         }
     }
 }
@@ -154,9 +154,9 @@ impl Interaction for SwapResponse {
     }
 }
 
-impl Display for MatchaSolver {
+impl Display for ZeroExSolver {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "MatchaSolver")
+        write!(f, "ZeroExSolver")
     }
 }
 
@@ -166,7 +166,7 @@ mod tests {
     use crate::interactions::allowances::{Approval, MockAllowanceManaging};
     use crate::liquidity::tests::CapturingSettlementHandler;
     use crate::liquidity::LimitOrder;
-    use crate::solver::matcha_solver::api::MockMatchaApi;
+    use crate::solver::zeroex_solver::api::MockZeroExApi;
     use crate::test::account;
     use contracts::{GPv2Settlement, WETH9};
     use ethcontract::{Web3, H160, U256};
@@ -177,7 +177,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn solve_sell_order_on_matcha() {
+    async fn solve_sell_order_on_zeroex() {
         let web3 = Web3::new(create_env_test_transport());
         let chain_id = web3.eth().chain_id().await.unwrap().as_u64();
         let settlement = GPv2Settlement::deployed(&web3).await.unwrap();
@@ -186,7 +186,7 @@ mod tests {
         let gno = shared::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
 
         let solver =
-            MatchaSolver::new(account(), web3, settlement, chain_id, Client::new()).unwrap();
+            ZeroExSolver::new(account(), web3, settlement, chain_id, Client::new()).unwrap();
         let settlement = solver
             .try_settle_order(
                 Order {
@@ -210,7 +210,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn solve_buy_order_on_matcha() {
+    async fn solve_buy_order_on_zeroex() {
         let web3 = Web3::new(create_env_test_transport());
         let chain_id = web3.eth().chain_id().await.unwrap().as_u64();
         let settlement = GPv2Settlement::deployed(&web3).await.unwrap();
@@ -219,7 +219,7 @@ mod tests {
         let gno = shared::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
 
         let solver =
-            MatchaSolver::new(account(), web3, settlement, chain_id, Client::new()).unwrap();
+            ZeroExSolver::new(account(), web3, settlement, chain_id, Client::new()).unwrap();
         let settlement = solver
             .try_settle_order(
                 Order {
@@ -243,7 +243,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_satisfies_limit_price_for_orders() {
-        let mut client = Box::new(MockMatchaApi::new());
+        let mut client = Box::new(MockZeroExApi::new());
         let mut allowance_fetcher = Box::new(MockAllowanceManaging::new());
 
         let sell_token = H160::from_low_u64_be(1);
@@ -273,7 +273,7 @@ mod tests {
                 })
             });
 
-        let solver = MatchaSolver {
+        let solver = ZeroExSolver {
             account: account(),
             client,
             allowance_fetcher,
@@ -360,12 +360,12 @@ mod tests {
         let chain_id = web3.eth().chain_id().await.unwrap().as_u64();
         let settlement = GPv2Settlement::deployed(&web3).await.unwrap();
 
-        assert!(MatchaSolver::new(account(), web3, settlement, chain_id, Client::new()).is_err())
+        assert!(ZeroExSolver::new(account(), web3, settlement, chain_id, Client::new()).is_err())
     }
 
     #[tokio::test]
     async fn test_sets_allowance_if_necessary() {
-        let mut client = Box::new(MockMatchaApi::new());
+        let mut client = Box::new(MockZeroExApi::new());
         let mut allowance_fetcher = Box::new(MockAllowanceManaging::new());
 
         let sell_token = H160::from_low_u64_be(1);
@@ -403,7 +403,7 @@ mod tests {
             .returning(|_, _, _| Ok(Approval::AllowanceSufficient))
             .in_sequence(&mut seq);
 
-        let solver = MatchaSolver {
+        let solver = ZeroExSolver {
             account: account(),
             client,
             allowance_fetcher,
@@ -435,7 +435,7 @@ mod tests {
         let sell_token = H160::from_low_u64_be(1);
         let buy_token = H160::from_low_u64_be(2);
 
-        let mut client = Box::new(MockMatchaApi::new());
+        let mut client = Box::new(MockZeroExApi::new());
         client.expect_get_swap().returning(move |_| {
             Ok(SwapResponse {
                 sell_amount: 1000.into(),
@@ -453,7 +453,7 @@ mod tests {
             .expect_get_approval()
             .returning(|_, _, _| Ok(Approval::AllowanceSufficient));
 
-        let solver = MatchaSolver {
+        let solver = ZeroExSolver {
             account: account(),
             client,
             allowance_fetcher,


### PR DESCRIPTION
This renames Matcha to 0x at the behest of the team.

While this is not strictly needed, it makes it so our metrics show up as `ZeroExSolver` instead of `MatchaSolver`, making it easier to share screenshots of our metrics.

**Note that this requires a configuration change because of the solver type name change, so please don't merge without making the appropriate changes to the staging configuration**.

### Test Plan

CI - no logic changes.
