### PR TITLE
Add flag for enabling presign orders 

### DIFF
--- a/e2e/tests/eth_integration.rs
+++ b/e2e/tests/eth_integration.rs
@@ -154,7 +154,6 @@ async fn eth_integration(web3: Web3) {
             &gpv2.domain_separator,
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_BUY_ETH_A_PK).unwrap()),
         )
-        .unwrap()
         .build()
         .order_creation;
     let placement = client
@@ -176,7 +175,6 @@ async fn eth_integration(web3: Web3) {
             &gpv2.domain_separator,
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_BUY_ETH_B_PK).unwrap()),
         )
-        .unwrap()
         .build()
         .order_creation;
     let placement = client

--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -162,7 +162,6 @@ async fn onchain_settlement(web3: Web3) {
             &gpv2.domain_separator,
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_A_PK).unwrap()),
         )
-        .unwrap()
         .build()
         .order_creation;
     let placement = client
@@ -185,7 +184,6 @@ async fn onchain_settlement(web3: Web3) {
             &gpv2.domain_separator,
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_B_PK).unwrap()),
         )
-        .unwrap()
         .build()
         .order_creation;
     let placement = client

--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -204,6 +204,7 @@ impl OrderbookServices {
             Box::new(web3.clone()),
             gpv2.native_token.clone(),
             vec![],
+            true,
         ));
         let maintenance = ServiceMaintenance {
             maintainers: vec![orderbook.clone(), db.clone(), event_updater],

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -161,7 +161,6 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             &gpv2.domain_separator,
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_A_PK).unwrap()),
         )
-        .unwrap()
         .build()
         .order_creation;
     let placement = client

--- a/e2e/tests/smart_contract_orders.rs
+++ b/e2e/tests/smart_contract_orders.rs
@@ -141,7 +141,7 @@ async fn smart_contract_orders(web3: Web3) {
     };
 
     // Execute pre-sign transaction.
-    assert_eq!(order_status().await, OrderStatus::SignaturePending);
+    assert_eq!(order_status().await, OrderStatus::PresignaturePending);
     tx!(
         trader,
         gpv2.settlement
@@ -191,7 +191,7 @@ async fn smart_contract_orders(web3: Web3) {
         Duration::from_secs(30),
         None,
         block_stream,
-        0.0,
+        1.0,
         SolutionSubmitter {
             web3: web3.clone(),
             contract: gpv2.settlement.clone(),

--- a/e2e/tests/smart_contract_orders.rs
+++ b/e2e/tests/smart_contract_orders.rs
@@ -1,12 +1,12 @@
-use contracts::IUniswapLikeRouter;
-use ethcontract::prelude::{Account, Address, PrivateKey, U256};
-use model::{
-    order::{OrderBuilder, OrderKind, SellTokenSource},
-    signature::EcdsaSigningScheme,
+use crate::services::{
+    create_orderbook_api, deploy_mintable_token, to_wei, GPv2, OrderbookServices, UniswapContracts,
+    API_HOST,
 };
-use secp256k1::SecretKey;
-use serde_json::json;
+use contracts::IUniswapLikeRouter;
+use ethcontract::prelude::{Account, Address, Bytes, PrivateKey, U256};
+use model::order::{Order, OrderBuilder, OrderKind, OrderStatus, OrderUid};
 use shared::{
+    maintenance::Maintaining,
     sources::uniswap::{pair_provider::UniswapPairProvider, pool_fetching::PoolFetcher},
     Web3,
 };
@@ -15,26 +15,21 @@ use solver::{
     metrics::NoopMetrics, settlement_submission::SolutionSubmitter,
 };
 use std::{collections::HashSet, sync::Arc, time::Duration};
-use web3::signing::SecretKeyRef;
 
 mod ganache;
 #[macro_use]
 mod services;
-use crate::services::{
-    create_orderbook_api, deploy_mintable_token, to_wei, GPv2, OrderbookServices, UniswapContracts,
-    API_HOST,
-};
 
 const TRADER: [u8; 32] = [1; 32];
 
 const ORDER_PLACEMENT_ENDPOINT: &str = "/api/v1/orders/";
 
 #[tokio::test]
-async fn ganache_vault_balances() {
-    ganache::test(vault_balances).await;
+async fn ganache_smart_contract_orders() {
+    ganache::test(smart_contract_orders).await;
 }
 
-async fn vault_balances(web3: Web3) {
+async fn smart_contract_orders(web3: Web3) {
     shared::tracing::initialize("warn,orderbook=debug,solver=debug");
     let chain_id = web3
         .eth()
@@ -47,7 +42,7 @@ async fn vault_balances(web3: Web3) {
     let solver_account = Account::Local(accounts[0], None);
     let trader = Account::Offline(PrivateKey::from_raw(TRADER).unwrap(), None);
 
-    let gpv2 = GPv2::fetch(&web3).await;
+    let gpv2 = GPv2::fetch(&web3, &solver_account).await;
     let UniswapContracts {
         uniswap_factory,
         uniswap_router,
@@ -92,17 +87,12 @@ async fn vault_balances(web3: Web3) {
     );
 
     // Approve GPv2 for trading
-    tx!(trader, token.approve(gpv2.vault.address(), to_wei(10)));
-    tx!(
-        trader,
-        gpv2.vault
-            .set_relayer_approval(trader.address(), gpv2.allowance, true)
-    );
+    tx!(trader, token.approve(gpv2.allowance, to_wei(10)));
 
     let OrderbookServices {
         price_estimator,
         block_stream,
-        ..
+        maintenance,
     } = OrderbookServices::new(&web3, &gpv2, &uniswap_factory).await;
 
     let client = reqwest::Client::new();
@@ -112,24 +102,49 @@ async fn vault_balances(web3: Web3) {
         .with_kind(OrderKind::Sell)
         .with_sell_token(token.address())
         .with_sell_amount(to_wei(9))
-        .with_sell_token_balance(SellTokenSource::External)
         .with_fee_amount(to_wei(1))
         .with_buy_token(gpv2.native_token.address())
         .with_buy_amount(to_wei(8))
         .with_valid_to(shared::time::now_in_epoch_seconds() + 300)
-        .sign_with(
-            EcdsaSigningScheme::Eip712,
-            &gpv2.domain_separator,
-            SecretKeyRef::from(&SecretKey::from_slice(&TRADER).unwrap()),
-        )
+        .with_presign(trader.address())
         .build()
         .order_creation;
     let placement = client
         .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
-        .body(json!(order).to_string())
+        .json(&order)
         .send()
-        .await;
-    assert_eq!(placement.unwrap().status(), 201);
+        .await
+        .unwrap();
+    assert_eq!(placement.status(), 201);
+
+    let order_uid = placement.json::<OrderUid>().await.unwrap();
+    let order_status = || async {
+        client
+            .get(&format!(
+                "{}{}{}",
+                API_HOST, ORDER_PLACEMENT_ENDPOINT, &order_uid
+            ))
+            .send()
+            .await
+            .unwrap()
+            .json::<Order>()
+            .await
+            .unwrap()
+            .order_meta_data
+            .status
+    };
+
+    // Execute pre-sign transaction.
+    assert_eq!(order_status().await, OrderStatus::SignaturePending);
+    tx!(
+        trader,
+        gpv2.settlement
+            .set_pre_signature(Bytes(order_uid.0.to_vec()), true)
+    );
+
+    // Drive orderbook in order to check that the presignature event was received.
+    maintenance.run_maintenance().await.unwrap();
+    assert_eq!(order_status().await, OrderStatus::Open);
 
     // Drive solution
     let uniswap_pair_provider = Arc::new(UniswapPairProvider {
@@ -170,7 +185,7 @@ async fn vault_balances(web3: Web3) {
         Duration::from_secs(30),
         None,
         block_stream,
-        1.0,
+        0.0,
         SolutionSubmitter {
             web3: web3.clone(),
             contract: gpv2.settlement.clone(),

--- a/e2e/tests/smart_contract_orders.rs
+++ b/e2e/tests/smart_contract_orders.rs
@@ -40,9 +40,15 @@ async fn smart_contract_orders(web3: Web3) {
 
     let accounts: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");
     let solver_account = Account::Local(accounts[0], None);
+
+    // Note that this account is technically not a SC order. However, we allow
+    // presign orders from EOAs as well, and it is easier to setup an order
+    // for an EOA then SC wallet. In the future, once we add EIP-1271 support,
+    // where we would **need** an SC wallet, we can also change this trader to
+    // use one.
     let trader = Account::Offline(PrivateKey::from_raw(TRADER).unwrap(), None);
 
-    let gpv2 = GPv2::fetch(&web3, &solver_account).await;
+    let gpv2 = GPv2::fetch(&web3).await;
     let UniswapContracts {
         uniswap_factory,
         uniswap_router,

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -163,7 +163,7 @@ impl OrderBuilder {
         signing_scheme: EcdsaSigningScheme,
         domain: &DomainSeparator,
         key: SecretKeyRef,
-    ) -> Result<Self, Self> {
+    ) -> Self {
         self.0.order_meta_data.owner = key.address();
         self.0.order_meta_data.uid = self.0.order_creation.uid(domain, &key.address());
         self.0.order_creation.signature = EcdsaSignature::sign(
@@ -173,7 +173,13 @@ impl OrderBuilder {
             key,
         )
         .to_signature(signing_scheme);
-        Ok(self)
+        self
+    }
+
+    pub fn with_presign(mut self, owner: H160) -> Self {
+        self.0.order_meta_data.owner = owner;
+        self.0.order_creation.signature = Signature::PreSign(owner);
+        self
     }
 
     pub fn build(self) -> Order {
@@ -812,7 +818,6 @@ mod tests {
                 &DomainSeparator::default(),
                 SecretKeyRef::from(&sk),
             )
-            .unwrap()
             .build();
 
         let owner = order

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -105,6 +105,13 @@ struct Arguments {
     /// The number of pairs that are automatically updated in the pool cache.
     #[structopt(long, env, default_value = "200")]
     pub pool_cache_lru_size: usize,
+
+    /// Enable pre-sign orders. Pre-sign orders are accepted into the database without a valid
+    /// signature, so this flag allows this feature to be turned off if malicious users are
+    /// abusing the database by inserting a bunch of order rows that won't ever be valid.
+    /// This flag can be removed once DDoS protection is implemented.
+    #[structopt(long, env, parse(try_from_str), default_value = "false")]
+    pub enable_presign_orders: bool,
 }
 
 pub async fn database_metrics(metrics: Arc<Metrics>, database: Postgres) -> ! {
@@ -325,6 +332,7 @@ async fn main() {
         Box::new(web3.clone()),
         native_token.clone(),
         args.banned_users,
+        args.enable_presign_orders,
     ));
     let service_maintainer = ServiceMaintenance {
         maintainers: vec![

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -70,6 +70,7 @@ pub struct Orderbook {
     code_fetcher: Box<dyn CodeFetching>,
     native_token: WETH9,
     banned_users: Vec<H160>,
+    enable_presign_orders: bool,
 }
 
 impl Orderbook {
@@ -85,6 +86,7 @@ impl Orderbook {
         code_fetcher: Box<dyn CodeFetching>,
         native_token: WETH9,
         banned_users: Vec<H160>,
+        enable_presign_orders: bool,
     ) -> Self {
         Self {
             domain_separator,
@@ -97,6 +99,7 @@ impl Orderbook {
             code_fetcher,
             native_token,
             banned_users,
+            enable_presign_orders,
         }
     }
 
@@ -118,8 +121,8 @@ impl Orderbook {
             ));
         }
         if !matches!(
-            order.signature.scheme(),
-            SigningScheme::Eip712 | SigningScheme::EthSign,
+            (order.signature.scheme(), self.enable_presign_orders),
+            (SigningScheme::Eip712 | SigningScheme::EthSign, _) | (SigningScheme::PreSign, true)
         ) {
             return Ok(AddOrderResult::UnsupportedSignature);
         }


### PR DESCRIPTION
Fixes #924

This PR adds support for `presign` orders as a form of initial SC order support. SC orders are enabled behind a flag and can be quickly disabled in case we encounter issues with DDoS.

### Test Plan

Added an E2E test trading a `presign` order.

Ran services locally and solved with a pre-signed order! https://rinkeby.etherscan.io/tx/0x7917fa82e7f5e6a86b0c0b9ad3ca36e385599ffac42b14fc1b702423c0dbbfb5

Observe the [Tenderly trace](https://dashboard.tenderly.co/gp-v2/staging/tx/rinkeby/0x7917fa82e7f5e6a86b0c0b9ad3ca36e385599ffac42b14fc1b702423c0dbbfb5): the signature is recovered as a presigner:
![image](https://user-images.githubusercontent.com/4210206/131474252-e4439d3c-46fa-4c4a-8b9d-2652c2701597.png)

