### PR TITLE
Use single order specialized query

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -125,9 +125,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Order"
+                $ref: "#/components/schemas/Order"
         404:
           description: Order was not found
     delete:

--- a/orderbook/src/database/instrumented.rs
+++ b/orderbook/src/database/instrumented.rs
@@ -132,7 +132,7 @@ impl OrderStoring for Instrumented {
     async fn single_order(
         &self,
         uid: &model::order::OrderUid,
-    ) -> anyhow::Result<model::order::Order> {
+    ) -> anyhow::Result<Option<model::order::Order>> {
         let _timer = self
             .metrics
             .database_query_histogram("single_order")


### PR DESCRIPTION
and fixes openapi documentation saying we return an array for this route
when we were already always returning a single order.

### Test Plan
new test for db
