### PR TITLE
Proper parsing for 1Inch swap errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,6 +2643,7 @@ dependencies = [
  "chrono",
  "contracts",
  "derivative",
+ "derive_more",
  "ethcontract",
  "futures",
  "gas-estimation",

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -20,6 +20,7 @@ bigdecimal = { version = "0.2", features = ["serde"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 contracts = { path = "../contracts" }
 derivative = "2.2"
+derive_more = "0.99"
 ethcontract = { version = "0.15.1", default-features = false }
 futures = "0.3"
 gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.3.1", features = ["web3_"] }


### PR DESCRIPTION
Paraswap and Matcha have proper result/error parsing to determine retryable errors. For 1Inch we have gotten some uncategorised errors like [this one](https://gnosisinc.slack.com/archives/CUD4MUCUF/p1630207065000100):

> ERROR solver::solver::single_order_solver: 1Inch inner solver error: 1inch result parsing failed
Caused by:
   missing field fromToken at line 1 column 52
   
I checked the logs for what type of response it returned in these cases: https://logs.gnosis.io/goto/2be95eb46e896ebea6db424f9679b773

This PR makes it so that we parse those responses and classify them as structure errors which allows deciding whether or not they should be retryable. For now 500 errors are classified as retryable (I checked the failing swap requests are now passing on their API)

### Test Plan
Adjusted unit test for response parsing with sample response
