### PR TITLE
[Trivial] Remove error log on unsupported pool factory

### DIFF
--- a/shared/src/sources/balancer/pool_init.rs
+++ b/shared/src/sources/balancer/pool_init.rs
@@ -20,6 +20,8 @@ use futures::stream::{self, StreamExt as _, TryStreamExt as _};
 use reqwest::Client;
 use std::sync::Arc;
 
+const STABLE_POOL_FACTORY_ADDRESS: H160 = addr!("c66ba2b6595d3613ccab350c886ace23866ede24");
+
 #[derive(Debug, Default, PartialEq)]
 pub struct BalancerRegisteredPools {
     pub weighted_pools: Vec<RegisteredWeightedPool>,
@@ -148,8 +150,14 @@ where
             fetched_block_number: pools.fetched_block_number,
         };
 
+        //TODO: remove when we support the stable pool factoru
+        pools.pools_by_factory.remove(&STABLE_POOL_FACTORY_ADDRESS);
+
+        // Log an error in order to trigger an alert. This will allow us to make
+        // sure we get notified if new pool factories are added that we don't
+        // index for.
         for factory in pools.pools_by_factory.keys() {
-            tracing::warn!("unsupported pool factory {:?}", factory);
+            tracing::error!("unsupported pool factory {:?}", factory);
         }
 
         Ok(result)
@@ -238,8 +246,12 @@ where
             fetched_block_number: pools.fetched_block_number,
         };
 
+        pools.pools_by_factory.remove(&STABLE_POOL_FACTORY_ADDRESS);
+        // Log an error in order to trigger an alert. This will allow us to make
+        // sure we get notified if new pool factories are added that we don't
+        // index for.
         for factory in pools.pools_by_factory.keys() {
-            tracing::warn!("unsupported pool factory {:?}", factory);
+            tracing::error!("unsupported pool factory {:?}", factory);
         }
 
         Ok(result)

--- a/shared/src/sources/balancer/pool_init.rs
+++ b/shared/src/sources/balancer/pool_init.rs
@@ -148,11 +148,8 @@ where
             fetched_block_number: pools.fetched_block_number,
         };
 
-        // Log an error in order to trigger an alert. This will allow us to make
-        // sure we get notified if new pool factories are added that we don't
-        // index for.
         for factory in pools.pools_by_factory.keys() {
-            tracing::error!("unsupported pool factory {:?}", factory);
+            tracing::warn!("unsupported pool factory {:?}", factory);
         }
 
         Ok(result)
@@ -241,11 +238,8 @@ where
             fetched_block_number: pools.fetched_block_number,
         };
 
-        // Log an error in order to trigger an alert. This will allow us to make
-        // sure we get notified if new pool factories are added that we don't
-        // index for.
         for factory in pools.pools_by_factory.keys() {
-            tracing::error!("unsupported pool factory {:?}", factory);
+            tracing::warn!("unsupported pool factory {:?}", factory);
         }
 
         Ok(result)


### PR DESCRIPTION
The [StablePoolFactory](https://etherscan.io/address/0xc66ba2b6595d3613ccab350c886ace23866ede24#code) is not yet indexed, therefore we are logging this error on every restart causing a noisy alert.

Downgrading to WARN which will still allow us to see this when we check logs periodically

### Test Plan
CI
