### PR TITLE
Add specialized query for querying user orders paginated

### DIFF
--- a/database/sql/V016__update_order_indexes.sql
+++ b/database/sql/V016__update_order_indexes.sql
@@ -1,0 +1,6 @@
+-- The following index already allows indexing by owner.
+DROP INDEX order_owner;
+
+-- The index can be traversed in both directions anyway but we usually fetch user orders with this
+-- ordering so using it here too.
+CREATE INDEX user_order_creation_timestamp ON orders USING BTREE (owner, creation_timestamp DESC);

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -425,6 +425,15 @@ impl Default for OrderMetaData {
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct OrderUid(pub [u8; 56]);
 
+impl OrderUid {
+    /// Intended for easier uid creation in tests.
+    pub fn from_integer(i: u32) -> Self {
+        let mut uid = OrderUid::default();
+        uid.0[0..4].copy_from_slice(&i.to_le_bytes());
+        uid
+    }
+}
+
 impl FromStr for OrderUid {
     type Err = hex::FromHexError;
     fn from_str(s: &str) -> Result<OrderUid, hex::FromHexError> {

--- a/orderbook/src/database/instrumented.rs
+++ b/orderbook/src/database/instrumented.rs
@@ -147,6 +147,19 @@ impl OrderStoring for Instrumented {
             .start_timer();
         self.inner.solvable_orders(min_valid_to).await
     }
+
+    async fn user_orders(
+        &self,
+        owner: &ethcontract::H160,
+        offset: u64,
+        limit: Option<u64>,
+    ) -> anyhow::Result<Vec<model::order::Order>> {
+        let _timer = self
+            .metrics
+            .database_query_histogram("user_orders")
+            .start_timer();
+        self.inner.user_orders(owner, offset, limit).await
+    }
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
This is going to be used by a new route for the frontend.

related to https://github.com/gnosis/gp-v2-services/issues/969 .

I decided to keep the database level operations close to what happens under the hood. The http api can still provide a different interface.

I tried a lot of varations on the query but as I documented in the code this is what I found to work best taking postgres limitations into account.

### Test Plan
new unit test and looked at query analyzer