### PR TITLE
Set X-Partner header on Paraswap queries

### DIFF
--- a/solver/src/solver/paraswap_solver.rs
+++ b/solver/src/solver/paraswap_solver.rs
@@ -54,12 +54,16 @@ impl ParaswapSolver {
         client: Client,
     ) -> Self {
         let allowance_fetcher = AllowanceManager::new(web3, settlement_contract.address());
+
         Self {
             account,
             settlement_contract,
             token_info,
             allowance_fetcher: Box::new(allowance_fetcher),
-            client: Box::new(DefaultParaswapApi { client }),
+            client: Box::new(DefaultParaswapApi {
+                client,
+                partner_header_value: REFERRER,
+            }),
             slippage_bps,
             disabled_paraswap_dexs,
         }

--- a/solver/src/solver/paraswap_solver/api.rs
+++ b/solver/src/solver/paraswap_solver/api.rs
@@ -11,6 +11,7 @@ use model::u256_decimal;
 use web3::types::Bytes;
 
 const BASE_URL: &str = "https://apiv4.paraswap.io";
+const PARTNER_HEADER_KEY: &str = "X-Partner";
 
 /// Mockable implementation of the API for unit test
 #[cfg_attr(test, mockall::automock)]
@@ -25,6 +26,8 @@ pub trait ParaswapApi {
 
 pub struct DefaultParaswapApi {
     pub client: Client,
+    // X-Partner header to void rate limiting
+    pub partner_header_value: &'static str,
 }
 
 #[async_trait::async_trait]
@@ -33,7 +36,11 @@ impl ParaswapApi for DefaultParaswapApi {
         let query_str = format!("{:?}", &query);
         let url = query.into_url();
         tracing::debug!("Querying Paraswap API (price) for url {}", url);
-        let response_text = reqwest::get(url)
+        let response_text = self
+            .client
+            .get(url)
+            .header(PARTNER_HEADER_KEY, self.partner_header_value)
+            .send()
             .await
             .map_err(ParaswapResponseError::Send)?
             .text()
@@ -65,6 +72,7 @@ impl ParaswapApi for DefaultParaswapApi {
         let query_str = serde_json::to_string(&query).unwrap();
         let response_text = query
             .into_request(&self.client)
+            .header(PARTNER_HEADER_KEY, self.partner_header_value)
             .send()
             .await
             .map_err(ParaswapResponseError::Send)?
@@ -625,6 +633,7 @@ mod tests {
 
         let api = DefaultParaswapApi {
             client: Client::new(),
+            partner_header_value: "Test",
         };
 
         let good_query = TransactionBuilderQuery {


### PR DESCRIPTION
Context: https://gnosisinc.slack.com/archives/C0203Q9R4JJ/p1630337209009700

### Test Plan
- Install proxyman and add certificate to local keychain to intercept HTTPs requests
- export `https_proxy=<proxyman listening port>`
- run solver on mainnet, watch paraswap API requests, see header being set.
