### PR TITLE
Refactor price estimation to avoid boxing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,17 +108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
 
 [[package]]
-name = "async-recursion"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2614,7 +2603,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_approx_eq",
- "async-recursion",
  "async-trait",
  "atty",
  "contracts",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT OR Apache-2.0"
 anyhow = "1.0"
 assert_approx_eq = "1.1"
 async-trait = "0.1"
-async-recursion = "0.3"
 atty = "0.2"
 contracts = { path = "../contracts" }
 derivative = "2.2"


### PR DESCRIPTION
fixes #1041

Note that the diff is pretty hard to read. I would open both versions side by side to understand what is going on.

Technically we could get rid of the estimate_gas_cost: bool parameter again but I think it might be useful in the future and is still useful in tests.

In order to take gas cost into account price estimation needs to perform
one extra estimate to get the price in the native of token of the sell
token for buy orders and the buy token for sell orders.

This order of function calls used to be (for a sell order):
```
price_helper(sell_token, buy_token gas = true)
    best_e_sell_order(sell_token, buy_token, gas = true)
        price_helper(native_token, buy_token, gas = false)
            best_e_sell_order(native_token, buy_token, gas = false)
```

Now it is:
```
price_helper(sell_token, buy_token gas = true)
    best_e_sell_order(native_token, buy_token)
    best_e_sell_order(sell_token, buy_token)
```

The extra estimate with the native token has moved directly into
price_helper.

This also got rid of boxing the path_comparison functions and I have
inlined the evalue_* functions because I found it easier to read this
way.


### Test Plan
existing tests, will also manually compare a few prices to what is running in staging
