### PR TITLE
Reduce some rebuilding on CI

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -38,21 +38,21 @@ jobs:
           path: flyway-${{ env.FLYWAY_VERSION }}
           key: ${{ runner.os }}-build-flyway-${{ env.FLYWAY_VERSION }}
       - run: "[[ -d flyway-${FLYWAY_VERSION} ]] || (curl -L https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz -o flyway-commandline-${FLYWAY_VERSION}.tar.gz && tar -xzf flyway-commandline-${FLYWAY_VERSION}.tar.gz && rm flyway-commandline-${FLYWAY_VERSION}.tar.gz)"
+      - run: cargo build --locked --all-features --tests
       - run: cargo test --locked --all-features
       - run: |
           sudo systemctl start postgresql.service
           sudo -u postgres createuser $USER
           sudo -u postgres createdb $USER
           psql -c "ALTER USER $USER PASSWORD '$FLYWAY_PASSWORD';"
-          flyway-${FLYWAY_VERSION}/flyway -url="jdbc:postgresql:///" -user=$USER -locations="filesystem:database/sql/" migrate 
-          # Postgres tests should not run in parallel because they use the same database.
-          cargo test --locked --workspace --all-features --jobs 1 postgres -- --ignored --test-threads 1
+          flyway-${FLYWAY_VERSION}/flyway -url="jdbc:postgresql:///" -user=$USER -locations="filesystem:database/sql/" migrate
+        # Postgres tests should not run in parallel because they use the same database.
+      - run: cargo test --locked --all-features --jobs 1 postgres -- --ignored --test-threads 1
       - run: |
           npm install ganache-cli
           node_modules/.bin/ganache-cli --networkId 5777 --gasLimit 10000000 --gasPrice 0  --defaultBalanceEther 1000000 &
-      - run: cargo run --bin deploy --features bin
-        working-directory: contracts
-      - run: cargo test --locked --package e2e
+      - run: cargo run --locked --all-features --bin deploy
+      - run: cargo test --locked --all-features --package e2e
   openapi:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -47,7 +47,7 @@ jobs:
           psql -c "ALTER USER $USER PASSWORD '$FLYWAY_PASSWORD';"
           flyway-${FLYWAY_VERSION}/flyway -url="jdbc:postgresql:///" -user=$USER -locations="filesystem:database/sql/" migrate
         # Postgres tests should not run in parallel because they use the same database.
-      - run: cargo test --locked --all-features --jobs 1 postgres -- --ignored --test-threads 1
+      - run: cargo test --locked --all-features postgres -- --ignored --test-threads 1
       - run: |
           npm install ganache-cli
           node_modules/.bin/ganache-cli --networkId 5777 --gasLimit 10000000 --gasPrice 0  --defaultBalanceEther 1000000 &


### PR DESCRIPTION
The different crates in our workspace activate different features in dependencies. This means that some dependencies have to be recompiled based on which crate (--package) is being compiled.
This commit avoids this by introducing one global build step first.
Sadly we still recompilations for the e2e tests because the only way to run them is through --package .
Also moved some commands into their own step so they are easier to keep track of in the github actions page output.

### Test Plan
ci still works
