### PR TITLE
[Easy] rework RegisteredPool for maintainability

### DIFF
--- a/shared/src/sources/balancer/pool_cache.rs
+++ b/shared/src/sources/balancer/pool_cache.rs
@@ -64,14 +64,14 @@ impl CacheFetching<H256, WeightedPool> for PoolReserveFetcher {
             .into_iter()
             .map(|registered_pool| {
                 let pool_contract =
-                    BalancerV2WeightedPool::at(&self.web3, registered_pool.pool_address);
+                    BalancerV2WeightedPool::at(&self.web3, registered_pool.common.pool_address);
                 let swap_fee = pool_contract
                     .get_swap_fee_percentage()
                     .block(block)
                     .batch_call(&mut batch);
                 let reserves = self
                     .vault
-                    .get_pool_tokens(Bytes(registered_pool.pool_id.0))
+                    .get_pool_tokens(Bytes(registered_pool.common.pool_id.0))
                     .block(block)
                     .batch_call(&mut batch);
                 let paused_state = pool_contract

--- a/shared/src/sources/balancer/pool_fetching.rs
+++ b/shared/src/sources/balancer/pool_fetching.rs
@@ -56,17 +56,17 @@ impl WeightedPool {
         // use them and fetch the weights from the registry by token address.
         for (i, balance) in balances.into_iter().enumerate() {
             reserves.insert(
-                pool_data.tokens[i],
+                pool_data.common.tokens[i],
                 PoolTokenState {
                     balance,
                     weight: pool_data.normalized_weights[i],
-                    scaling_exponent: pool_data.scaling_exponents[i],
+                    scaling_exponent: pool_data.common.scaling_exponents[i],
                 },
             );
         }
         WeightedPool {
-            pool_id: pool_data.pool_id,
-            pool_address: pool_data.pool_address,
+            pool_id: pool_data.common.pool_id,
+            pool_address: pool_data.common.pool_address,
             swap_fee_percentage,
             reserves,
             paused,

--- a/shared/src/sources/balancer/pool_init.rs
+++ b/shared/src/sources/balancer/pool_init.rs
@@ -537,7 +537,13 @@ mod tests {
             Ok(RegisteredPools {
                 weighted_pools_by_factory: hashmap! {
                     weighted_factory => vec![RegisteredWeightedPool {
-                        common: common_pool(1),
+                        common: CommonPoolData {
+                            pool_id: H256([1; 32]),
+                            pool_address: H160([1; 20]),
+                            tokens: vec![],
+                            scaling_exponents: vec![],
+                            block_created: 42,
+                        },
                         normalized_weights: vec![],
                     }],
                     weighted_2token_factory => vec![RegisteredWeightedPool {

--- a/shared/src/sources/balancer/pool_init.rs
+++ b/shared/src/sources/balancer/pool_init.rs
@@ -6,11 +6,12 @@
 use crate::sources::balancer::{
     graph_api::{BalancerSubgraphClient, RegisteredPools},
     info_fetching::PoolInfoFetching,
-    pool_storage::RegisteredWeightedPool,
+    pool_storage::{RegisteredStablePool, RegisteredWeightedPool},
 };
 use anyhow::{anyhow, bail, Result};
 use contracts::{
-    BalancerV2Vault, BalancerV2WeightedPool2TokensFactory, BalancerV2WeightedPoolFactory,
+    BalancerV2StablePoolFactory, BalancerV2Vault, BalancerV2WeightedPool2TokensFactory,
+    BalancerV2WeightedPoolFactory,
 };
 use ethcontract::{
     common::{contract::Network, DeploymentInformation},
@@ -20,12 +21,11 @@ use futures::stream::{self, StreamExt as _, TryStreamExt as _};
 use reqwest::Client;
 use std::sync::Arc;
 
-const STABLE_POOL_FACTORY_ADDRESS: H160 = addr!("c66ba2b6595d3613ccab350c886ace23866ede24");
-
 #[derive(Debug, Default, PartialEq)]
 pub struct BalancerRegisteredPools {
     pub weighted_pools: Vec<RegisteredWeightedPool>,
     pub weighted_2token_pools: Vec<RegisteredWeightedPool>,
+    pub stable_pools: Vec<RegisteredStablePool>,
     pub fetched_block_number: u64,
 }
 
@@ -128,36 +128,38 @@ where
         let mut pools = self.client.registered_pools().await?;
         let result = BalancerRegisteredPools {
             weighted_pools: pools
-                .pools_by_factory
+                .weighted_pools_by_factory
                 .remove(&deployment_address(
                     BalancerV2WeightedPoolFactory::raw_contract(),
                     self.chain_id,
                 )?)
-                .unwrap_or_default()
-                .into_iter()
-                .filter_map(|pool| pool.try_into_weighted().ok())
-                .collect(),
+                .unwrap_or_default(),
             weighted_2token_pools: pools
-                .pools_by_factory
+                .weighted_pools_by_factory
                 .remove(&deployment_address(
                     BalancerV2WeightedPool2TokensFactory::raw_contract(),
                     self.chain_id,
                 )?)
-                .unwrap_or_default()
-                .into_iter()
-                .filter_map(|pool| pool.try_into_weighted().ok())
-                .collect(),
+                .unwrap_or_default(),
+            stable_pools: pools
+                .stable_pools_by_factory
+                .remove(&deployment_address(
+                    BalancerV2StablePoolFactory::raw_contract(),
+                    self.chain_id,
+                )?)
+                .unwrap_or_default(),
             fetched_block_number: pools.fetched_block_number,
         };
-
-        //TODO: remove when we support the stable pool factoru
-        pools.pools_by_factory.remove(&STABLE_POOL_FACTORY_ADDRESS);
 
         // Log an error in order to trigger an alert. This will allow us to make
         // sure we get notified if new pool factories are added that we don't
         // index for.
-        for factory in pools.pools_by_factory.keys() {
-            tracing::error!("unsupported pool factory {:?}", factory);
+        for factory in pools.weighted_pools_by_factory.keys() {
+            tracing::error!("unsupported weighted pool factory {:?}", factory);
+        }
+
+        for factory in pools.stable_pools_by_factory.keys() {
+            tracing::error!("unsupported stable pool factory {:?}", factory);
         }
 
         Ok(result)
@@ -205,7 +207,7 @@ where
     S: BalancerSubgraph,
 {
     async fn initialize_pools_inner(&self) -> Result<BalancerRegisteredPools> {
-        let mut pools = self.client.registered_pools().await?;
+        let mut registered_pools = self.client.registered_pools().await?;
 
         // For subgraphs on networks without an archive node (all the testnets)
         // the results from the query will all have missing token data, so fetch
@@ -214,50 +216,59 @@ where
         #[allow(clippy::eval_order_dependence)]
         let result = BalancerRegisteredPools {
             weighted_pools: self
-                .fetch_pool_info(
-                    pools
-                        .pools_by_factory
+                .fetch_weighted_pool_info(
+                    registered_pools
+                        .weighted_pools_by_factory
                         .remove(&deployment_address(
                             BalancerV2WeightedPoolFactory::raw_contract(),
                             self.chain_id,
                         )?)
-                        .unwrap_or_default()
-                        .into_iter()
-                        .filter_map(|pool| pool.try_into_weighted().ok())
-                        .collect(),
-                    pools.fetched_block_number,
+                        .unwrap_or_default(),
+                    registered_pools.fetched_block_number,
                 )
                 .await?,
             weighted_2token_pools: self
-                .fetch_pool_info(
-                    pools
-                        .pools_by_factory
+                .fetch_weighted_pool_info(
+                    registered_pools
+                        .weighted_pools_by_factory
                         .remove(&deployment_address(
                             BalancerV2WeightedPool2TokensFactory::raw_contract(),
                             self.chain_id,
                         )?)
-                        .unwrap_or_default()
-                        .into_iter()
-                        .filter_map(|pool| pool.try_into_weighted().ok())
-                        .collect(),
-                    pools.fetched_block_number,
+                        .unwrap_or_default(),
+                    registered_pools.fetched_block_number,
                 )
                 .await?,
-            fetched_block_number: pools.fetched_block_number,
+            stable_pools: self
+                .fetch_stable_pool_info(
+                    registered_pools
+                        .stable_pools_by_factory
+                        .remove(&deployment_address(
+                            BalancerV2StablePoolFactory::raw_contract(),
+                            self.chain_id,
+                        )?)
+                        .unwrap_or_default(),
+                    registered_pools.fetched_block_number,
+                )
+                .await?,
+            fetched_block_number: registered_pools.fetched_block_number,
         };
 
-        pools.pools_by_factory.remove(&STABLE_POOL_FACTORY_ADDRESS);
         // Log an error in order to trigger an alert. This will allow us to make
         // sure we get notified if new pool factories are added that we don't
         // index for.
-        for factory in pools.pools_by_factory.keys() {
-            tracing::error!("unsupported pool factory {:?}", factory);
+        for factory in registered_pools.weighted_pools_by_factory.keys() {
+            tracing::error!("unsupported weighted pool factory {:?}", factory);
+        }
+
+        for factory in registered_pools.stable_pools_by_factory.keys() {
+            tracing::error!("unsupported stable pool factory {:?}", factory);
         }
 
         Ok(result)
     }
 
-    async fn fetch_pool_info(
+    async fn fetch_weighted_pool_info(
         &self,
         pools: Vec<RegisteredWeightedPool>,
         block_number: u64,
@@ -266,7 +277,25 @@ where
             .then(|pool| {
                 let pool_info = self.pool_info.clone();
                 async move {
-                    RegisteredWeightedPool::new(block_number, pool.pool_address, &*pool_info).await
+                    RegisteredWeightedPool::new(block_number, pool.common.pool_address, &*pool_info)
+                        .await
+                }
+            })
+            .try_collect()
+            .await
+    }
+
+    async fn fetch_stable_pool_info(
+        &self,
+        pools: Vec<RegisteredStablePool>,
+        block_number: u64,
+    ) -> Result<Vec<RegisteredStablePool>> {
+        stream::iter(pools)
+            .then(|pool| {
+                let pool_info = self.pool_info.clone();
+                async move {
+                    RegisteredStablePool::new(block_number, pool.common.pool_address, &*pool_info)
+                        .await
                 }
             })
             .try_collect()
@@ -317,15 +346,14 @@ async fn deployment_block(contract: &Contract, chain_id: u64) -> Result<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sources::balancer::info_fetching::CommonPoolInfo;
-    use crate::sources::balancer::pool_storage::RegisteredStablePool;
+    use crate::sources::balancer::pool_storage::common_pool;
     use crate::sources::balancer::{
-        info_fetching::{MockPoolInfoFetching, WeightedPoolInfo},
-        pool_storage::RegisteredPool,
+        info_fetching::{CommonPoolInfo, MockPoolInfoFetching, StablePoolInfo, WeightedPoolInfo},
+        pool_storage::{CommonPoolData, RegisteredStablePool},
         swap::fixed_point::Bfp,
     };
     use anyhow::bail;
-    use ethcontract::H256;
+    use ethcontract::{H256, U256};
     use maplit::hashmap;
     use mockall::{predicate::*, Sequence};
 
@@ -358,46 +386,47 @@ mod tests {
             chain_id,
         )
         .unwrap();
+        let stable_factory =
+            deployment_address(BalancerV2StablePoolFactory::raw_contract(), chain_id).unwrap();
 
         fn weighted_pool(seed: u8) -> RegisteredWeightedPool {
             RegisteredWeightedPool {
-                pool_id: H256([seed; 32]),
-                pool_address: H160([seed; 20]),
-                tokens: vec![H160([seed; 20]), H160([seed + 1; 20])],
-                scaling_exponents: vec![0, 0],
+                common: common_pool(seed),
                 normalized_weights: vec![
                     Bfp::from_wei(500_000_000_000_000_000u128.into()),
                     Bfp::from_wei(500_000_000_000_000_000u128.into()),
                 ],
-                block_created: seed as _,
             }
         }
 
         fn stable_pool(seed: u8) -> RegisteredStablePool {
             RegisteredStablePool {
-                pool_id: H256([seed; 32]),
-                pool_address: H160([seed; 20]),
-                tokens: vec![H160([seed; 20]), H160([seed + 1; 20])],
-                scaling_exponents: vec![0, 0],
-                block_created: seed as _,
+                common: common_pool(seed),
             }
         }
 
         let mut subgraph = MockBalancerSubgraph::new();
         subgraph.expect_registered_pools().returning(move || {
             Ok(RegisteredPools {
-                pools_by_factory: hashmap! {
+                weighted_pools_by_factory: hashmap! {
                     weighted_factory => vec![
-                        RegisteredPool::Weighted(weighted_pool(1)),
-                        RegisteredPool::Weighted(weighted_pool(2)),
+                        weighted_pool(1),
+                        weighted_pool(2),
                     ],
                     weighted_2token_factory => vec![
-                        RegisteredPool::Weighted(weighted_pool(3)),
+                        weighted_pool(3),
                     ],
                     addr!("0102030405060708091011121314151617181920") => vec![
-                        RegisteredPool::Weighted(weighted_pool(4)),
-                        RegisteredPool::Stable(stable_pool(5)),
+                        weighted_pool(4),
                     ],
+                },
+                stable_pools_by_factory: hashmap! {
+                    stable_factory => vec![
+                        stable_pool(6),
+                    ],
+                    addr!("1102030405060708008011121314151617181920") => vec![
+                        stable_pool(5),
+                    ]
                 },
                 fetched_block_number: 42,
             })
@@ -413,6 +442,7 @@ mod tests {
             BalancerRegisteredPools {
                 weighted_pools: vec![weighted_pool(1), weighted_pool(2)],
                 weighted_2token_pools: vec![weighted_pool(3)],
+                stable_pools: vec![stable_pool(6)],
                 fetched_block_number: 42,
             },
         );
@@ -431,9 +461,10 @@ mod tests {
         let mut subgraph = MockBalancerSubgraph::new();
         subgraph.expect_registered_pools().returning(move || {
             Ok(RegisteredPools {
-                pools_by_factory: hashmap! {
+                weighted_pools_by_factory: hashmap! {
                     weighted_2token_factory => vec![],
                 },
+                stable_pools_by_factory: hashmap! {},
                 fetched_block_number: 0,
             })
         });
@@ -473,7 +504,8 @@ mod tests {
         let mut subgraph = MockBalancerSubgraph::new();
         subgraph.expect_registered_pools().returning(|| {
             Ok(RegisteredPools {
-                pools_by_factory: hashmap! {},
+                weighted_pools_by_factory: hashmap! {},
+                stable_pools_by_factory: hashmap! {},
                 fetched_block_number: 0,
             })
         });
@@ -497,35 +529,61 @@ mod tests {
             chain_id,
         )
         .unwrap();
+        let stable_factory =
+            deployment_address(BalancerV2StablePoolFactory::raw_contract(), chain_id).unwrap();
 
         let mut subgraph = MockBalancerSubgraph::new();
         subgraph.expect_registered_pools().returning(move || {
             Ok(RegisteredPools {
-                pools_by_factory: hashmap! {
-                    weighted_factory => vec![RegisteredPool::Weighted(RegisteredWeightedPool {
-                        pool_id: H256([1; 32]),
-                        pool_address: H160([1; 20]),
-                        tokens: vec![],
-                        scaling_exponents: vec![],
+                weighted_pools_by_factory: hashmap! {
+                    weighted_factory => vec![RegisteredWeightedPool {
+                        common: common_pool(1),
                         normalized_weights: vec![],
-                        block_created: 42,
-                    })],
-                    weighted_2token_factory => vec![RegisteredPool::Weighted(RegisteredWeightedPool {
-                        pool_id: H256([2; 32]),
-                        pool_address: H160([2; 20]),
-                        tokens: vec![],
-                        scaling_exponents: vec![],
+                    }],
+                    weighted_2token_factory => vec![RegisteredWeightedPool {
+                        common: CommonPoolData {
+                            pool_id: H256([2; 32]),
+                            pool_address: H160([2; 20]),
+                            tokens: vec![],
+                            scaling_exponents: vec![],
+                            block_created: 42,
+                        },
                         normalized_weights: vec![],
-                        block_created: 42,
-                    })],
-                    addr!("0102030405060708091011121314151617181920") => vec![RegisteredPool::Weighted(RegisteredWeightedPool {
-                        pool_id: H256([3; 32]),
-                        pool_address: H160([3; 20]),
-                        tokens: vec![],
-                        scaling_exponents: vec![],
-                        normalized_weights: vec![],
-                        block_created: 42,
-                    })],
+                    }],
+                    addr!("0102030405060708091011121314151617181920") => vec![
+                        RegisteredWeightedPool {
+                            common: CommonPoolData {
+                                pool_id: H256([4; 32]),
+                                pool_address: H160([4; 20]),
+                                tokens: vec![],
+                                scaling_exponents: vec![],
+                                block_created: 42,
+                            },
+                            normalized_weights: vec![],
+                        },
+                    ],
+                },
+                stable_pools_by_factory: hashmap! {
+                    stable_factory => vec![RegisteredStablePool {
+                        common: CommonPoolData {
+                            pool_id: H256([3; 32]),
+                            pool_address: H160([3; 20]),
+                            tokens: vec![],
+                            scaling_exponents: vec![],
+                            block_created: 42,
+                        }
+                    }],
+                    addr!("0102030405060708091011121314151617181920") => vec![
+                        RegisteredStablePool {
+                            common: CommonPoolData {
+                                pool_id: H256([5; 32]),
+                                pool_address: H160([5; 20]),
+                                tokens: vec![],
+                                scaling_exponents: vec![],
+                                block_created: 42,
+                            }
+                        }
+                    ],
                 },
                 fetched_block_number: 42,
             })
@@ -570,6 +628,21 @@ mod tests {
                     ],
                 })
             });
+        pool_info
+            .expect_get_stable_pool_data()
+            .times(1)
+            .in_sequence(&mut seq)
+            .with(eq(H160([3; 20])))
+            .returning(|_| {
+                Ok(StablePoolInfo {
+                    common: CommonPoolInfo {
+                        pool_id: H256([3; 32]),
+                        tokens: vec![],
+                        scaling_exponents: vec![],
+                    },
+                    amplification_parameter: U256::one(),
+                })
+            });
 
         let initializer = FetchedPoolInitializerInner {
             chain_id,
@@ -581,27 +654,40 @@ mod tests {
             initializer.initialize_pools_inner().await.unwrap(),
             BalancerRegisteredPools {
                 weighted_pools: vec![RegisteredWeightedPool {
-                    pool_id: H256([1; 32]),
-                    pool_address: H160([1; 20]),
-                    tokens: vec![H160([0x11; 20]), H160([0x22; 20])],
-                    scaling_exponents: vec![0, 0],
+                    common: CommonPoolData {
+                        pool_id: H256([1; 32]),
+                        pool_address: H160([1; 20]),
+                        tokens: vec![H160([0x11; 20]), H160([0x22; 20])],
+                        scaling_exponents: vec![0, 0],
+                        block_created: 42,
+                    },
                     normalized_weights: vec![
                         Bfp::from_wei(500_000_000_000_000_000u128.into()),
                         Bfp::from_wei(500_000_000_000_000_000u128.into()),
                     ],
-                    block_created: 42,
                 }],
                 weighted_2token_pools: vec![RegisteredWeightedPool {
-                    pool_id: H256([2; 32]),
-                    pool_address: H160([2; 20]),
-                    tokens: vec![H160([0x11; 20]), H160([0x33; 20]), H160([0x44; 20])],
-                    scaling_exponents: vec![0, 0, 0],
+                    common: CommonPoolData {
+                        pool_id: H256([2; 32]),
+                        pool_address: H160([2; 20]),
+                        tokens: vec![H160([0x11; 20]), H160([0x33; 20]), H160([0x44; 20])],
+                        scaling_exponents: vec![0, 0, 0],
+                        block_created: 42,
+                    },
                     normalized_weights: vec![
                         Bfp::from_wei(500_000_000_000_000_000u128.into()),
                         Bfp::from_wei(250_000_000_000_000_000u128.into()),
                         Bfp::from_wei(250_000_000_000_000_000u128.into()),
                     ],
-                    block_created: 42,
+                }],
+                stable_pools: vec![RegisteredStablePool {
+                    common: CommonPoolData {
+                        pool_id: H256([3; 32]),
+                        pool_address: H160([3; 20]),
+                        tokens: vec![],
+                        scaling_exponents: vec![],
+                        block_created: 42,
+                    }
                 }],
                 fetched_block_number: 42,
             },

--- a/shared/src/sources/balancer/pool_storage.rs
+++ b/shared/src/sources/balancer/pool_storage.rs
@@ -41,11 +41,6 @@ use std::{
     sync::Arc,
 };
 
-pub trait PoolEvaluating {
-    fn pool_id(&self) -> H256;
-    fn tokens(&self) -> Vec<H160>;
-}
-
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct CommonPoolData {
     pub pool_id: H256,
@@ -72,29 +67,9 @@ pub struct RegisteredWeightedPool {
     pub normalized_weights: Vec<Bfp>,
 }
 
-impl PoolEvaluating for RegisteredWeightedPool {
-    fn pool_id(&self) -> H256 {
-        self.common.pool_id
-    }
-
-    fn tokens(&self) -> Vec<H160> {
-        self.common.tokens.clone()
-    }
-}
-
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct RegisteredStablePool {
     pub common: CommonPoolData,
-}
-
-impl PoolEvaluating for RegisteredStablePool {
-    fn pool_id(&self) -> H256 {
-        self.common.pool_id
-    }
-
-    fn tokens(&self) -> Vec<H160> {
-        self.common.tokens.clone()
-    }
 }
 
 #[derive(Copy, Debug, Clone, Eq, PartialEq)]

--- a/shared/src/sources/balancer/pool_storage.rs
+++ b/shared/src/sources/balancer/pool_storage.rs
@@ -32,7 +32,7 @@ use crate::{
     event_handling::EventIndex,
     sources::balancer::{info_fetching::PoolInfoFetching, swap::fixed_point::Bfp},
 };
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use derivative::Derivative;
 use ethcontract::{H160, H256};
 use model::TokenPair;
@@ -41,17 +41,63 @@ use std::{
     sync::Arc,
 };
 
+pub trait PoolEvaluating {
+    fn pool_id(&self) -> H256;
+    fn tokens(&self) -> Vec<H160>;
+}
+
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct RegisteredWeightedPool {
+pub struct CommonPoolData {
     pub pool_id: H256,
     pub pool_address: H160,
     pub tokens: Vec<H160>,
-    pub normalized_weights: Vec<Bfp>,
     pub scaling_exponents: Vec<u8>,
     pub block_created: u64,
 }
 
-#[derive(Copy, Debug, Default, Clone, Eq, PartialEq)]
+#[cfg(test)]
+pub fn common_pool(seed: u8) -> CommonPoolData {
+    CommonPoolData {
+        pool_id: H256([seed; 32]),
+        pool_address: H160([seed; 20]),
+        tokens: vec![H160([seed; 20]), H160([seed + 1; 20])],
+        scaling_exponents: vec![0, 0],
+        block_created: seed as _,
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RegisteredWeightedPool {
+    pub common: CommonPoolData,
+    pub normalized_weights: Vec<Bfp>,
+}
+
+impl PoolEvaluating for RegisteredWeightedPool {
+    fn pool_id(&self) -> H256 {
+        self.common.pool_id
+    }
+
+    fn tokens(&self) -> Vec<H160> {
+        self.common.tokens.clone()
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RegisteredStablePool {
+    pub common: CommonPoolData,
+}
+
+impl PoolEvaluating for RegisteredStablePool {
+    fn pool_id(&self) -> H256 {
+        self.common.pool_id
+    }
+
+    fn tokens(&self) -> Vec<H160> {
+        self.common.tokens.clone()
+    }
+}
+
+#[derive(Copy, Debug, Clone, Eq, PartialEq)]
 pub struct PoolCreated {
     pub pool_address: H160,
 }
@@ -64,12 +110,14 @@ impl RegisteredWeightedPool {
     ) -> Result<RegisteredWeightedPool> {
         let pool_data = data_fetcher.get_weighted_pool_data(pool_address).await?;
         Ok(RegisteredWeightedPool {
-            pool_id: pool_data.common.pool_id,
-            pool_address,
-            tokens: pool_data.common.tokens,
+            common: CommonPoolData {
+                pool_id: pool_data.common.pool_id,
+                pool_address,
+                tokens: pool_data.common.tokens,
+                scaling_exponents: pool_data.common.scaling_exponents,
+                block_created,
+            },
             normalized_weights: pool_data.weights,
-            scaling_exponents: pool_data.common.scaling_exponents,
-            block_created,
         })
     }
 
@@ -83,43 +131,31 @@ impl RegisteredWeightedPool {
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct RegisteredStablePool {
-    pub pool_id: H256,
-    pub pool_address: H160,
-    pub tokens: Vec<H160>,
-    pub scaling_exponents: Vec<u8>,
-    pub block_created: u64,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum RegisteredPool {
-    Weighted(RegisteredWeightedPool),
-    Stable(RegisteredStablePool),
-}
-
-impl RegisteredPool {
-    pub fn block_created(&self) -> u64 {
-        match self {
-            RegisteredPool::Weighted(pool) => pool.block_created,
-            RegisteredPool::Stable(pool) => pool.block_created,
-        }
+impl RegisteredStablePool {
+    pub async fn new(
+        block_created: u64,
+        pool_address: H160,
+        data_fetcher: &dyn PoolInfoFetching,
+    ) -> Result<RegisteredStablePool> {
+        let pool_data = data_fetcher.get_stable_pool_data(pool_address).await?;
+        Ok(RegisteredStablePool {
+            common: CommonPoolData {
+                pool_id: pool_data.common.pool_id,
+                pool_address,
+                tokens: pool_data.common.tokens,
+                scaling_exponents: pool_data.common.scaling_exponents,
+                block_created,
+            },
+        })
     }
 
-    pub fn try_into_weighted(self) -> Result<RegisteredWeightedPool> {
-        if let RegisteredPool::Weighted(pool) = self {
-            Ok(pool)
-        } else {
-            Err(anyhow!("Not a weighted pool!"))
-        }
-    }
-
-    pub fn try_into_stable(self) -> Result<RegisteredStablePool> {
-        if let RegisteredPool::Stable(pool) = self {
-            Ok(pool)
-        } else {
-            Err(anyhow!("Not a stable pool!"))
-        }
+    /// Errors expected here are propagated from `get_pool_data`.
+    pub async fn from_event(
+        block_created: u64,
+        creation: PoolCreated,
+        data_fetcher: &dyn PoolInfoFetching,
+    ) -> Result<RegisteredStablePool> {
+        Self::new(block_created, creation.pool_address, data_fetcher).await
     }
 }
 
@@ -143,13 +179,13 @@ impl PoolStorage {
         let mut pools_by_token = HashMap::<_, HashSet<_>>::new();
         let mut pools = HashMap::new();
         for pool in initial_pools {
-            for token in &pool.tokens {
+            for token in &pool.common.tokens {
                 pools_by_token
                     .entry(*token)
                     .or_default()
-                    .insert(pool.pool_id);
+                    .insert(pool.common.pool_id);
             }
-            pools.insert(pool.pool_id, pool);
+            pools.insert(pool.common.pool_id, pool);
         }
 
         PoolStorage {
@@ -211,9 +247,9 @@ impl PoolStorage {
                 &*self.data_fetcher,
             )
             .await?;
-            let pool_id = weighted_pool.pool_id;
+            let pool_id = weighted_pool.common.pool_id;
             self.pools.insert(pool_id, weighted_pool.clone());
-            for token in weighted_pool.tokens {
+            for token in weighted_pool.common.tokens {
                 self.pools_by_token
                     .entry(token)
                     .or_default()
@@ -240,7 +276,7 @@ impl PoolStorage {
 
     fn delete_pools(&mut self, delete_from_block_number: u64) {
         self.pools
-            .retain(|_, pool| pool.block_created < delete_from_block_number);
+            .retain(|_, pool| pool.common.block_created < delete_from_block_number);
         // Note that this could result in an empty set for some tokens.
         let retained_pool_ids: HashSet<H256> = self.pools.keys().copied().collect();
         for (_, pool_set) in self.pools_by_token.iter_mut() {
@@ -256,7 +292,7 @@ impl PoolStorage {
         // but the maintenance seems like more overhead that needs to be tested.
         self.pools
             .iter()
-            .map(|(_, pool)| pool.block_created)
+            .map(|(_, pool)| pool.common.block_created)
             .max()
             .unwrap_or(0)
     }
@@ -293,79 +329,34 @@ mod tests {
     }
 
     #[test]
-    fn registered_pool_block_created() {
-        let registered_weighted_pool = RegisteredPool::Weighted(RegisteredWeightedPool {
-            pool_id: Default::default(),
-            pool_address: Default::default(),
-            tokens: vec![],
-            normalized_weights: vec![],
-            scaling_exponents: vec![],
-            block_created: 6,
-        });
-
-        let registered_stable_pool = RegisteredPool::Stable(RegisteredStablePool {
-            pool_id: Default::default(),
-            pool_address: Default::default(),
-            tokens: vec![],
-            scaling_exponents: vec![],
-            block_created: 4,
-        });
-
-        assert_eq!(registered_weighted_pool.block_created(), 6);
-        assert_eq!(registered_stable_pool.block_created(), 4);
-    }
-
-    #[test]
-    fn registered_pool_try_into() {
-        let registered_weighted_pool = RegisteredPool::Weighted(RegisteredWeightedPool {
-            pool_id: Default::default(),
-            pool_address: Default::default(),
-            tokens: vec![],
-            normalized_weights: vec![],
-            scaling_exponents: vec![],
-            block_created: 0,
-        });
-
-        assert!(registered_weighted_pool.clone().try_into_weighted().is_ok());
-        assert!(registered_weighted_pool.try_into_stable().is_err());
-
-        let registered_stable_pool = RegisteredPool::Stable(RegisteredStablePool {
-            pool_id: Default::default(),
-            pool_address: Default::default(),
-            tokens: vec![],
-            scaling_exponents: vec![],
-            block_created: 0,
-        });
-
-        assert!(registered_stable_pool.clone().try_into_stable().is_ok());
-        assert!(registered_stable_pool.try_into_weighted().is_err());
-    }
-
-    #[test]
     fn initialize_storage() {
         let storage = PoolStorage::new(
             vec![
                 RegisteredWeightedPool {
-                    pool_id: H256([1; 32]),
-                    pool_address: H160([1; 20]),
-                    tokens: vec![H160([0x11; 20]), H160([0x22; 20])],
-                    scaling_exponents: vec![0, 0],
+                    common: CommonPoolData {
+                        pool_id: H256([1; 32]),
+                        pool_address: H160([1; 20]),
+                        tokens: vec![H160([0x11; 20]), H160([0x22; 20])],
+                        scaling_exponents: vec![0, 0],
+                        block_created: 0,
+                    },
                     normalized_weights: vec![
                         Bfp::from_wei(500_000_000_000_000_000u128.into()),
                         Bfp::from_wei(500_000_000_000_000_000u128.into()),
                     ],
-                    block_created: 0,
                 },
                 RegisteredWeightedPool {
-                    pool_id: H256([2; 32]),
-                    pool_address: H160([2; 20]),
-                    tokens: vec![H160([0x11; 20]), H160([0x33; 20]), H160([0x77; 20])],
-                    scaling_exponents: vec![0, 0],
+                    common: CommonPoolData {
+                        pool_id: H256([2; 32]),
+                        pool_address: H160([2; 20]),
+                        tokens: vec![H160([0x11; 20]), H160([0x33; 20]), H160([0x77; 20])],
+                        scaling_exponents: vec![0, 0],
+                        block_created: 0,
+                    },
                     normalized_weights: vec![
                         Bfp::from_wei(500_000_000_000_000_000u128.into()),
                         Bfp::from_wei(500_000_000_000_000_000u128.into()),
                     ],
-                    block_created: 0,
                 },
             ],
             Arc::new(MockPoolInfoFetching::new()),
@@ -434,12 +425,14 @@ mod tests {
             assert_eq!(
                 pool_store.pools.get(&pool_ids[i]).unwrap(),
                 &RegisteredWeightedPool {
-                    pool_id: pool_ids[i],
-                    pool_address: pool_addresses[i],
-                    tokens: vec![tokens[i], tokens[i + 1]],
+                    common: CommonPoolData {
+                        pool_id: pool_ids[i],
+                        pool_address: pool_addresses[i],
+                        tokens: vec![tokens[i], tokens[i + 1]],
+                        scaling_exponents: vec![0, 0],
+                        block_created: i as u64 + 1,
+                    },
                     normalized_weights: vec![weights[i], weights[i + 1]],
-                    scaling_exponents: vec![0, 0],
-                    block_created: i as u64 + 1
                 },
                 "failed assertion at index {}",
                 i
@@ -511,12 +504,14 @@ mod tests {
             assert_eq!(
                 pool_store.pools.get(&pool_ids[i]).unwrap(),
                 &RegisteredWeightedPool {
-                    pool_id: pool_ids[i],
-                    pool_address: pool_addresses[i],
-                    tokens: vec![tokens[i], tokens[i + 1]],
+                    common: CommonPoolData {
+                        pool_id: pool_ids[i],
+                        pool_address: pool_addresses[i],
+                        tokens: vec![tokens[i], tokens[i + 1]],
+                        scaling_exponents: vec![0, 0],
+                        block_created: i as u64,
+                    },
                     normalized_weights: vec![weights[i], weights[i + 1]],
-                    scaling_exponents: vec![0, 0],
-                    block_created: i as u64
                 },
                 "assertion failed at index {}",
                 i
@@ -553,12 +548,14 @@ mod tests {
         assert_eq!(
             pool_store.pools.get(&new_pool_id).unwrap(),
             &RegisteredWeightedPool {
-                pool_id: new_pool_id,
-                pool_address: new_pool_address,
-                tokens: vec![new_token],
+                common: CommonPoolData {
+                    pool_id: new_pool_id,
+                    pool_address: new_pool_address,
+                    tokens: vec![new_token],
+                    scaling_exponents: vec![0],
+                    block_created: new_event_block,
+                },
                 normalized_weights: vec![new_weight],
-                scaling_exponents: vec![0],
-                block_created: new_event_block
             }
         );
 
@@ -608,12 +605,14 @@ mod tests {
             }
             // This is weighted_pools[i] has tokens [tokens[i], tokens[i+1], ... , tokens[n]]
             weighted_pools.push(RegisteredWeightedPool {
-                pool_id: pool_ids[i],
-                tokens: tokens[i..n].to_owned(),
+                common: CommonPoolData {
+                    pool_id: pool_ids[i],
+                    tokens: tokens[i..n].to_owned(),
+                    scaling_exponents: vec![],
+                    block_created: 0,
+                    pool_address: pool_addresses[i],
+                },
                 normalized_weights: vec![],
-                scaling_exponents: vec![],
-                block_created: 0,
-                pool_address: pool_addresses[i],
             });
             registry
                 .pools


### PR DESCRIPTION
As a precursor to #1007, we remove the enum `RegisteredPool` and keep both stable and weighted pools separated throughout the code.

Since this appears to be quite a large change I will summarize here:

- Introduce struct `CommonPoolData` and refactor `RegisteredWeighted` and `RegisteredStable` pools to contain a field `common: CommonPoolData`.
- eliminate all occurrences of `RegisteredPool` in favor of the more specific type.

### Test Plan

Existing CI.

