### PR TITLE
Make it clear when price estimator fails because of missing liquidity

### DIFF
--- a/orderbook/src/api/get_fee_and_quote.rs
+++ b/orderbook/src/api/get_fee_and_quote.rs
@@ -78,7 +78,7 @@ enum Error {
 impl From<MinFeeCalculationError> for Error {
     fn from(other: MinFeeCalculationError) -> Self {
         match other {
-            MinFeeCalculationError::NotFound => Error::NoLiquidity,
+            MinFeeCalculationError::NoLiquidity => Error::NoLiquidity,
             MinFeeCalculationError::UnsupportedToken(token) => Error::UnsupportedToken(token),
             MinFeeCalculationError::Other(error) => Error::Other(error),
         }
@@ -88,6 +88,7 @@ impl From<MinFeeCalculationError> for Error {
 impl From<PriceEstimationError> for Error {
     fn from(other: PriceEstimationError) -> Self {
         match other {
+            PriceEstimationError::NoLiquidity => Error::NoLiquidity,
             PriceEstimationError::UnsupportedToken(token) => Error::UnsupportedToken(token),
             PriceEstimationError::Other(error) => Error::Other(error),
         }
@@ -197,7 +198,7 @@ fn response<T: Serialize>(result: Result<T, Error>) -> impl Reply {
     match result {
         Ok(response) => reply::with_status(reply::json(&response), StatusCode::OK),
         Err(Error::NoLiquidity) => reply::with_status(
-            super::error("NoLiquidity", "Token does not have enough liquidity."),
+            super::error("NoLiquidity", "not enough liquidity"),
             StatusCode::NOT_FOUND,
         ),
         Err(Error::UnsupportedToken(token)) => reply::with_status(

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -45,8 +45,8 @@ pub fn get_fee_info_response(
             };
             Ok(reply::with_status(reply::json(&fee_info), StatusCode::OK))
         }
-        Err(MinFeeCalculationError::NotFound) => Ok(reply::with_status(
-            super::error("NotFound", "Token was not found"),
+        Err(MinFeeCalculationError::NoLiquidity) => Ok(reply::with_status(
+            super::error("NoLiquidity", "not enough liquidity"),
             StatusCode::NOT_FOUND,
         )),
         Err(MinFeeCalculationError::UnsupportedToken(token)) => Ok(reply::with_status(
@@ -112,8 +112,8 @@ pub fn legacy_get_fee_info_response(
             };
             Ok(reply::with_status(reply::json(&fee_info), StatusCode::OK))
         }
-        Err(MinFeeCalculationError::NotFound) => Ok(reply::with_status(
-            super::error("NotFound", "Token was not found"),
+        Err(MinFeeCalculationError::NoLiquidity) => Ok(reply::with_status(
+            super::error("NoLiquidity", "not enough liquidity"),
             StatusCode::NOT_FOUND,
         )),
         Err(MinFeeCalculationError::UnsupportedToken(token)) => Ok(reply::with_status(

--- a/orderbook/src/api/get_markets.rs
+++ b/orderbook/src/api/get_markets.rs
@@ -92,10 +92,14 @@ fn get_amount_estimate_response(
             super::error("UnsupportedToken", format!("Token address {:?}", token)),
             StatusCode::BAD_REQUEST,
         ),
-        Err(PriceEstimationError::Other(_)) => reply::with_status(
-            super::error("NotFound", "No price estimate found"),
+        Err(PriceEstimationError::NoLiquidity) => reply::with_status(
+            super::error("NoLiquidity", "not enough liquidity"),
             StatusCode::NOT_FOUND,
         ),
+        Err(PriceEstimationError::Other(err)) => {
+            tracing::error!(?err, "get_market error");
+            reply::with_status(super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR)
+        }
     }
 }
 

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -80,11 +80,9 @@ const PERSISTED_VALIDITY_FOR_FEE_IN_SEC: i64 = 120;
 
 #[derive(Error, Debug)]
 pub enum MinFeeCalculationError {
-    // Represents a failure when no liquidity between sell and buy token via the native token can be found
-    #[error("Token not found")]
-    NotFound,
+    #[error("No liquidity")]
+    NoLiquidity,
 
-    // Represents a failure when one of the tokens involved is not supported by the system
     #[error("Token {0:?} not supported")]
     UnsupportedToken(H160),
 
@@ -266,7 +264,7 @@ impl MinFeeCalculating for MinFeeCalculator {
             .await?
         {
             Some(fee) => fee,
-            None => return Err(MinFeeCalculationError::NotFound),
+            None => return Err(MinFeeCalculationError::NoLiquidity),
         };
 
         let _ = self


### PR DESCRIPTION
Previously we only had a more generic NotFound error which conflates
unsupported tokens and missing liquidity. This commit clears that up and
changes some upstream api responses to follow along.

I also removed some comments and descriptions where I felt they were just echoing already obvious information.

### Test Plan
tested querying price with a very large amount and saw the no liquidity error