### PR TITLE
remove limit order from liquidity

### DIFF
--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -20,7 +20,6 @@ use strum_macros::{AsStaticStr, EnumVariantNames};
 /// Defines the different types of liquidity our solvers support
 #[derive(Clone, AsStaticStr, EnumVariantNames, Debug)]
 pub enum Liquidity {
-    Limit(LimitOrder),
     ConstantProduct(ConstantProductOrder),
     WeightedProduct(WeightedProductOrder),
 }

--- a/solver/src/liquidity/uniswap.rs
+++ b/solver/src/liquidity/uniswap.rs
@@ -59,7 +59,7 @@ impl UniswapLikeLiquidity {
     /// Given a list of offchain orders returns the list of AMM liquidity to be considered
     pub async fn get_liquidity(
         &self,
-        offchain_orders: impl Iterator<Item = &LimitOrder> + Send + Sync,
+        offchain_orders: &[LimitOrder],
         at_block: Block,
     ) -> Result<Vec<ConstantProductOrder>> {
         let mut pools = HashSet::new();

--- a/solver/src/liquidity_collector.rs
+++ b/solver/src/liquidity_collector.rs
@@ -1,6 +1,6 @@
 use crate::{
     liquidity::Liquidity,
-    liquidity::{balancer::BalancerV2Liquidity, uniswap::UniswapLikeLiquidity},
+    liquidity::{balancer::BalancerV2Liquidity, uniswap::UniswapLikeLiquidity, LimitOrder},
     orderbook::OrderBookApi,
 };
 use anyhow::{Context, Result};
@@ -15,23 +15,26 @@ pub struct LiquidityCollector {
 }
 
 impl LiquidityCollector {
-    pub async fn get_liquidity(
-        &self,
-        at_block: Block,
-        inflight_trades: &HashSet<OrderUid>,
-    ) -> Result<Vec<Liquidity>> {
+    pub async fn get_orders(&self, inflight_trades: &HashSet<OrderUid>) -> Result<Vec<LimitOrder>> {
         let limit_orders = self
             .orderbook_api
             .get_liquidity(inflight_trades)
             .await
             .context("failed to get orderbook liquidity")?;
         tracing::info!("got {} orders: {:?}", limit_orders.len(), limit_orders);
+        Ok(limit_orders)
+    }
 
+    pub async fn get_liquidity_for_orders(
+        &self,
+        limit_orders: &[LimitOrder],
+        at_block: Block,
+    ) -> Result<Vec<Liquidity>> {
         let mut amms = vec![];
         for liquidity in &self.uniswap_like_liquidity {
             amms.extend(
                 liquidity
-                    .get_liquidity(limit_orders.iter(), at_block)
+                    .get_liquidity(limit_orders, at_block)
                     .await
                     .context("failed to get UniswapLike liquidity")?
                     .into_iter()
@@ -41,7 +44,7 @@ impl LiquidityCollector {
         if let Some(balancer_v2_liquidity) = self.balancer_v2_liquidity.as_ref() {
             amms.extend(
                 balancer_v2_liquidity
-                    .get_liquidity(&limit_orders, at_block)
+                    .get_liquidity(limit_orders, at_block)
                     .await
                     .context("failed to get Balancer liquidity")?
                     .into_iter()
@@ -50,10 +53,6 @@ impl LiquidityCollector {
         }
         tracing::debug!("got {} AMMs", amms.len());
 
-        Ok(limit_orders
-            .into_iter()
-            .map(Liquidity::Limit)
-            .chain(amms.into_iter())
-            .collect())
+        Ok(amms)
     }
 }

--- a/solver/src/metrics.rs
+++ b/solver/src/metrics.rs
@@ -1,28 +1,27 @@
-use std::{
-    convert::TryInto,
-    sync::Mutex,
-    time::{Duration, Instant},
-};
-
+use crate::liquidity::{LimitOrder, Liquidity};
 use anyhow::Result;
 use model::order::Order;
 use prometheus::{HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGaugeVec, Opts};
 use shared::{
+    metrics::get_metrics_registry,
     metrics::LivenessChecking,
     sources::{
         balancer::pool_cache::BalancerPoolCacheMetrics, uniswap::pool_cache::PoolCacheMetrics,
     },
     transport::instrumented::TransportMetrics,
 };
+use std::{
+    convert::TryInto,
+    sync::Mutex,
+    time::{Duration, Instant},
+};
 use strum::{AsStaticRef, VariantNames};
-
-use crate::liquidity::Liquidity;
-use shared::metrics::get_metrics_registry;
 
 /// The maximum time between the completion of two run loops. If exceeded the service will be considered unhealthy.
 const MAX_RUNLOOP_DURATION: Duration = Duration::from_secs(7 * 60);
 
 pub trait SolverMetrics {
+    fn orders_fetched(&self, orders: &[LimitOrder]);
     fn liquidity_fetched(&self, liquidity: &[Liquidity]);
     fn settlement_computed(&self, solver_type: &str, start: Instant);
     fn order_settled(&self, order: &Order, solver: &'static str);
@@ -137,6 +136,12 @@ impl Metrics {
 }
 
 impl SolverMetrics for Metrics {
+    fn orders_fetched(&self, orders: &[LimitOrder]) {
+        self.liquidity
+            .with_label_values(&["Limit"])
+            .set(orders.len() as _);
+    }
+
     fn liquidity_fetched(&self, liquidity: &[Liquidity]) {
         // Reset all gauges and start from scratch
         Liquidity::VARIANTS.iter().for_each(|label| {
@@ -249,6 +254,7 @@ impl LivenessChecking for Metrics {
 pub struct NoopMetrics {}
 
 impl SolverMetrics for NoopMetrics {
+    fn orders_fetched(&self, _liquidity: &[LimitOrder]) {}
     fn liquidity_fetched(&self, _liquidity: &[Liquidity]) {}
     fn settlement_computed(&self, _solver_type: &str, _start: Instant) {}
     fn order_settled(&self, _: &Order, _: &'static str) {}

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -1,4 +1,7 @@
-use crate::{liquidity::Liquidity, settlement::Settlement};
+use crate::{
+    liquidity::{LimitOrder, Liquidity},
+    settlement::Settlement,
+};
 use anyhow::Result;
 use baseline_solver::BaselineSolver;
 use contracts::GPv2Settlement;
@@ -63,7 +66,11 @@ pub struct Auction {
     /// service restarts.
     pub id: u64,
 
-    /// The collection of all liquidity that the solver can use.
+    /// The GPv2 orders to match.
+    pub orders: Vec<LimitOrder>,
+
+    /// The baseline on-chain liquidity that can be used by the solvers for
+    /// settling orders.
     pub liquidity: Vec<Liquidity>,
 
     /// The current gas price estimate.
@@ -86,6 +93,7 @@ impl Default for Auction {
         let never = Instant::now() + Duration::from_secs(SECONDS_IN_A_YEAR);
         Self {
             id: Default::default(),
+            orders: Default::default(),
             liquidity: Default::default(),
             gas_price: Default::default(),
             deadline: never,
@@ -264,17 +272,8 @@ impl SellVolumeFilteringSolver {
         }
     }
 
-    async fn filter_liquidity(&self, orders: Vec<Liquidity>) -> Vec<Liquidity> {
-        let sell_tokens: Vec<_> = orders
-            .iter()
-            .filter_map(|order| {
-                if let Liquidity::Limit(order) = order {
-                    Some(order.sell_token)
-                } else {
-                    None
-                }
-            })
-            .collect();
+    async fn filter_orders(&self, orders: Vec<LimitOrder>) -> Vec<LimitOrder> {
+        let sell_tokens: Vec<_> = orders.iter().map(|order| order.sell_token).collect();
         let prices: HashMap<_, _> = self
             .price_estimator
             .estimate_prices(&sell_tokens, self.denominator_token)
@@ -293,17 +292,13 @@ impl SellVolumeFilteringSolver {
         orders
             .into_iter()
             .filter(|order| {
-                if let Liquidity::Limit(order) = order {
-                    prices
-                        .get(&order.sell_token)
-                        .map(|price| {
-                            price * order.sell_amount.to_big_rational()
-                                > self.min_value.to_big_rational()
-                        })
-                        .unwrap_or(false)
-                } else {
-                    true
-                }
+                prices
+                    .get(&order.sell_token)
+                    .map(|price| {
+                        price * order.sell_amount.to_big_rational()
+                            > self.min_value.to_big_rational()
+                    })
+                    .unwrap_or(false)
             })
             .collect()
     }
@@ -312,11 +307,11 @@ impl SellVolumeFilteringSolver {
 #[async_trait::async_trait]
 impl Solver for SellVolumeFilteringSolver {
     async fn solve(&self, mut auction: Auction) -> Result<Vec<Settlement>> {
-        let original_length = auction.liquidity.len();
-        auction.liquidity = self.filter_liquidity(auction.liquidity).await;
+        let original_length = auction.orders.len();
+        auction.orders = self.filter_orders(auction.orders).await;
         tracing::info!(
             "Filtered {} orders because on insufficient volume",
-            original_length - auction.liquidity.len()
+            original_length - auction.orders.len()
         );
         self.inner.solve(auction).await
     }
@@ -359,26 +354,24 @@ mod tests {
     #[tokio::test]
     async fn test_filtering_solver_removes_limit_orders_with_too_little_volume() {
         let sell_token = H160::from_low_u64_be(1);
-        let liquidity = vec![
-            // Only filter limit orders
-            Liquidity::ConstantProduct(Default::default()),
+        let orders = vec![
             // Orders with high enough amount
-            Liquidity::Limit(LimitOrder {
+            LimitOrder {
                 sell_amount: 100_000.into(),
                 sell_token,
                 ..Default::default()
-            }),
-            Liquidity::Limit(LimitOrder {
+            },
+            LimitOrder {
                 sell_amount: 500_000.into(),
                 sell_token,
                 ..Default::default()
-            }),
+            },
             // Order with small amount
-            Liquidity::Limit(LimitOrder {
+            LimitOrder {
                 sell_amount: 100.into(),
                 sell_token,
                 ..Default::default()
-            }),
+            },
         ];
 
         let price_estimator = Arc::new(FakePriceEstimator(BigRational::from_integer(42.into())));
@@ -388,17 +381,17 @@ mod tests {
             denominator_token: H160::zero(),
             min_value: 400_000.into(),
         };
-        assert_eq!(solver.filter_liquidity(liquidity).await.len(), 3);
+        assert_eq!(solver.filter_orders(orders).await.len(), 2);
     }
 
     #[tokio::test]
     async fn test_filtering_solver_removes_orders_without_price_estimate() {
         let sell_token = H160::from_low_u64_be(1);
-        let liquidity = vec![Liquidity::Limit(LimitOrder {
+        let orders = vec![LimitOrder {
             sell_amount: 100_000.into(),
             sell_token,
             ..Default::default()
-        })];
+        }];
 
         let price_estimator = Arc::new(FailingPriceEstimator());
         let solver = SellVolumeFilteringSolver {
@@ -407,6 +400,6 @@ mod tests {
             denominator_token: H160::zero(),
             min_value: 0.into(),
         };
-        assert_eq!(solver.filter_liquidity(liquidity).await.len(), 0);
+        assert_eq!(solver.filter_orders(orders).await.len(), 0);
     }
 }

--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -32,8 +32,13 @@ pub struct BaselineSolver {
 
 #[async_trait::async_trait]
 impl Solver for BaselineSolver {
-    async fn solve(&self, Auction { liquidity, .. }: Auction) -> Result<Vec<Settlement>> {
-        Ok(self.solve(liquidity))
+    async fn solve(
+        &self,
+        Auction {
+            orders, liquidity, ..
+        }: Auction,
+    ) -> Result<Vec<Settlement>> {
+        Ok(self.solve(orders, liquidity))
     }
 
     fn account(&self) -> &Account {
@@ -141,30 +146,29 @@ impl BaselineSolver {
         }
     }
 
-    fn solve(&self, liquidity: Vec<Liquidity>) -> Vec<Settlement> {
-        let (user_orders, amm_map) = liquidity.into_iter().fold(
-            (Vec::new(), HashMap::<_, Vec<_>>::new()),
-            |(mut user_orders, mut amm_map), liquidity| {
-                match liquidity {
-                    Liquidity::Limit(order) => user_orders.push(order),
-                    Liquidity::ConstantProduct(order) => {
-                        amm_map.entry(order.tokens).or_default().push(Amm {
-                            tokens: order.tokens,
-                            order: AmmOrder::ConstantProduct(order),
-                        });
-                    }
-                    Liquidity::WeightedProduct(order) => {
-                        for tokens in order.token_pairs() {
-                            amm_map.entry(tokens).or_default().push(Amm {
-                                tokens,
-                                order: AmmOrder::WeightedProduct(order.clone()),
+    fn solve(&self, user_orders: Vec<LimitOrder>, liquidity: Vec<Liquidity>) -> Vec<Settlement> {
+        let amm_map =
+            liquidity
+                .into_iter()
+                .fold(HashMap::<_, Vec<_>>::new(), |mut amm_map, liquidity| {
+                    match liquidity {
+                        Liquidity::ConstantProduct(order) => {
+                            amm_map.entry(order.tokens).or_default().push(Amm {
+                                tokens: order.tokens,
+                                order: AmmOrder::ConstantProduct(order),
                             });
                         }
+                        Liquidity::WeightedProduct(order) => {
+                            for tokens in order.token_pairs() {
+                                amm_map.entry(tokens).or_default().push(Amm {
+                                    tokens,
+                                    order: AmmOrder::WeightedProduct(order.clone()),
+                                });
+                            }
+                        }
                     }
-                }
-                (user_orders, amm_map)
-            },
-        );
+                    amm_map
+                });
 
         // We assume that individual settlements do not move the amm pools significantly when
         // returning multiple settlements.
@@ -229,8 +233,8 @@ impl BaselineSolver {
     }
 
     #[cfg(test)]
-    fn must_solve(&self, liquidity: Vec<Liquidity>) -> Settlement {
-        self.solve(liquidity).into_iter().next().unwrap()
+    fn must_solve(&self, orders: Vec<LimitOrder>, liquidity: Vec<Liquidity>) -> Settlement {
+        self.solve(orders, liquidity).into_iter().next().unwrap()
     }
 }
 
@@ -370,12 +374,10 @@ mod tests {
                 settlement_handling: amm_handler[2].clone(),
             },
         ];
-
-        let mut liquidity: Vec<_> = orders.iter().cloned().map(Liquidity::Limit).collect();
-        liquidity.extend(amms.iter().cloned().map(Liquidity::ConstantProduct));
+        let liquidity = amms.into_iter().map(Liquidity::ConstantProduct).collect();
 
         let solver = BaselineSolver::new(account(), hashset! { native_token });
-        let result = solver.must_solve(liquidity);
+        let result = solver.must_solve(orders, liquidity);
         assert_eq!(
             result.clearing_prices(),
             &hashmap! {
@@ -475,12 +477,10 @@ mod tests {
                 settlement_handling: amm_handler[2].clone(),
             },
         ];
-
-        let mut liquidity: Vec<_> = orders.iter().cloned().map(Liquidity::Limit).collect();
-        liquidity.extend(amms.iter().cloned().map(Liquidity::ConstantProduct));
+        let liquidity = amms.into_iter().map(Liquidity::ConstantProduct).collect();
 
         let solver = BaselineSolver::new(account(), hashset! { native_token });
-        let result = solver.must_solve(liquidity);
+        let result = solver.must_solve(orders, liquidity);
         assert_eq!(
             result.clearing_prices(),
             &hashmap! {
@@ -544,29 +544,27 @@ mod tests {
                 settlement_handling: CapturingSettlementHandler::arc(),
             },
         ];
-
-        let mut liquidity: Vec<_> = orders.iter().cloned().map(Liquidity::Limit).collect();
-        liquidity.extend(amms.iter().cloned().map(Liquidity::ConstantProduct));
+        let liquidity = amms.into_iter().map(Liquidity::ConstantProduct).collect();
 
         let solver = BaselineSolver::new(account(), hashset! {});
-        assert_eq!(solver.solve(liquidity).len(), 1);
+        assert_eq!(solver.solve(orders, liquidity).len(), 1);
     }
 
     #[test]
     fn does_not_panic_when_building_solution() {
         // Regression test for https://github.com/gnosis/gp-v2-services/issues/838
+        let order = LimitOrder {
+            sell_token: addr!("e4b9895e638f54c3bee2a3a78d6a297cc03e0353"),
+            buy_token: addr!("a7d1c04faf998f9161fc9f800a99a809b84cfc9d"),
+            sell_amount: 1_741_103_528_769_588_955_u128.into(),
+            buy_amount: 500_000_000_000_000_000_000_u128.into(),
+            kind: OrderKind::Buy,
+            partially_fillable: false,
+            fee_amount: 3_429_706_374_800_940_u128.into(),
+            settlement_handling: CapturingSettlementHandler::arc(),
+            id: "Crash Bandicoot".to_string(),
+        };
         let liquidity = vec![
-            Liquidity::Limit(LimitOrder {
-                sell_token: addr!("e4b9895e638f54c3bee2a3a78d6a297cc03e0353"),
-                buy_token: addr!("a7d1c04faf998f9161fc9f800a99a809b84cfc9d"),
-                sell_amount: 1_741_103_528_769_588_955_u128.into(),
-                buy_amount: 500_000_000_000_000_000_000_u128.into(),
-                kind: OrderKind::Buy,
-                partially_fillable: false,
-                fee_amount: 3_429_706_374_800_940_u128.into(),
-                settlement_handling: CapturingSettlementHandler::arc(),
-                id: "Crash Bandicoot".to_string(),
-            }),
             Liquidity::ConstantProduct(ConstantProductOrder {
                 tokens: TokenPair::new(
                     addr!("a7d1c04faf998f9161fc9f800a99a809b84cfc9d"),
@@ -603,6 +601,6 @@ mod tests {
             account(),
             hashset![addr!("c778417e063141139fce010982780140aa0cd5ab")],
         );
-        assert_eq!(solver.solve(liquidity).len(), 0);
+        assert_eq!(solver.solve(vec![order], liquidity).len(), 0);
     }
 }

--- a/solver/src/solver/naive_solver.rs
+++ b/solver/src/solver/naive_solver.rs
@@ -22,15 +22,14 @@ impl NaiveSolver {
 
 #[async_trait::async_trait]
 impl Solver for NaiveSolver {
-    async fn solve(&self, Auction { liquidity, .. }: Auction) -> Result<Vec<Settlement>> {
+    async fn solve(
+        &self,
+        Auction {
+            orders, liquidity, ..
+        }: Auction,
+    ) -> Result<Vec<Settlement>> {
         let uniswaps = extract_deepest_amm_liquidity(&liquidity);
-        let limit_orders = liquidity
-            .into_iter()
-            .filter_map(|liquidity| match liquidity {
-                Liquidity::Limit(order) => Some(order),
-                _ => None,
-            });
-        Ok(settle(limit_orders, uniswaps).await)
+        Ok(settle(orders, uniswaps).await)
     }
 
     fn account(&self) -> &Account {
@@ -43,7 +42,7 @@ impl Solver for NaiveSolver {
 }
 
 async fn settle(
-    orders: impl Iterator<Item = LimitOrder>,
+    orders: Vec<LimitOrder>,
     uniswaps: HashMap<TokenPair, ConstantProductOrder>,
 ) -> Vec<Settlement> {
     // The multi order solver matches as many orders as possible together with one uniswap pool.
@@ -69,11 +68,9 @@ fn settle_pair(
     multi_order_solver::solve(orders.into_iter(), uniswap)
 }
 
-fn organize_orders_by_token_pair(
-    orders: impl Iterator<Item = LimitOrder>,
-) -> HashMap<TokenPair, Vec<LimitOrder>> {
+fn organize_orders_by_token_pair(orders: Vec<LimitOrder>) -> HashMap<TokenPair, Vec<LimitOrder>> {
     let mut result = HashMap::<_, Vec<LimitOrder>>::new();
-    for (order, token_pair) in orders.filter(usable_order).filter_map(|order| {
+    for (order, token_pair) in orders.into_iter().filter(usable_order).filter_map(|order| {
         let pair = TokenPair::new(order.buy_token, order.sell_token)?;
         Some((order, pair))
     }) {


### PR DESCRIPTION
This PR removes `LimitOrder` from the `Liquidity` enum. This was done as a first step towards refactoring to make it easier to add new liquidity such that:
- `Liquidity` type will eventually be all the baseline liquidity that we fetch. This will hopefully allow us to simplify the whole solver liquidity vs API liquidity issue and make it easier to compute baseline solutions in the orderbook API for bad token detection, etc.
- We were grouping limit orders and AMM liquidity only to split it back up again in _every_ solver: `([LimitOrder], [Amms]) -> Liquidity -> ([LimitOrder], [Amms])`
- If we add actual AMM limit orders in the future (such as 0x orders) then we would need to distinguish them between the user orders.

### Test Plan

Mostly refactored for new split, should be caught by existing CI.
