### PR TITLE
Pick default amount to estimate prices with based on network id

### DIFF
--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -167,6 +167,13 @@ async fn main() {
         .version()
         .await
         .expect("Failed to retrieve network version ID");
+
+    let amount_to_estimate_prices_with = args
+        .shared
+        .amount_to_estimate_prices_with
+        .or_else(|| shared::arguments::default_amount_to_estimate_prices_with(&network))
+        .expect("No amount to estimate prices with set.");
+
     let vault = if BalancerV2Vault::raw_contract()
         .networks
         .contains_key(&network)
@@ -311,7 +318,7 @@ async fn main() {
         base_tokens,
         bad_token_detector.clone(),
         native_token.address(),
-        args.shared.amount_to_estimate_prices_with,
+        amount_to_estimate_prices_with,
     ));
     let fee_calculator = Arc::new(EthAwareMinFeeCalculator::new(
         price_estimator.clone(),

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -92,14 +92,14 @@ pub struct Arguments {
     )]
     pub block_stream_poll_interval_seconds: Duration,
 
-    /// Default is one atom of native_token (i.e. price estimation uses spot prices).
+    /// The amount in native tokens atoms to use for price estimation. Should be reasonably large so
+    // that small pools do not influence the prices.
     #[structopt(
         long,
         env,
-        default_value = "1",
         parse(try_from_str = U256::from_dec_str)
     )]
-    pub amount_to_estimate_prices_with: U256,
+    pub amount_to_estimate_prices_with: Option<U256>,
 }
 
 fn parse_fee_factor(s: &str) -> Result<f64> {
@@ -119,4 +119,14 @@ pub fn wei_from_base_unit(s: &str) -> anyhow::Result<U256> {
 pub fn wei_from_gwei(s: &str) -> anyhow::Result<f64> {
     let in_gwei: f64 = s.parse()?;
     Ok(in_gwei * 10e9)
+}
+
+pub fn default_amount_to_estimate_prices_with(network_id: &str) -> Option<U256> {
+    match network_id {
+        // Mainnet, Rinkeby
+        "1" | "4" => Some(10u128.pow(18).into()),
+        // Xdai
+        "100" => Some(10u128.pow(21).into()),
+        _ => None,
+    }
 }

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -250,6 +250,12 @@ async fn main() {
     // We should always use the native token as a base token.
     base_tokens.insert(native_token_contract.address());
 
+    let amount_to_estimate_prices_with = args
+        .shared
+        .amount_to_estimate_prices_with
+        .or_else(|| shared::arguments::default_amount_to_estimate_prices_with(&network_id))
+        .expect("No amount to estimate prices with set.");
+
     let token_info_fetcher = Arc::new(CachedTokenInfoFetcher::new(Box::new(TokenInfoFetcher {
         web3: web3.clone(),
     })));
@@ -341,7 +347,7 @@ async fn main() {
         // Order book already filters bad tokens
         Arc::new(ListBasedDetector::deny_list(Vec::new())),
         native_token_contract.address(),
-        args.shared.amount_to_estimate_prices_with,
+        amount_to_estimate_prices_with,
     ));
     let uniswap_like_liquidity = build_amm_artifacts(
         &pool_caches,


### PR DESCRIPTION
The previous default of 1 is problematic because it leads to bad or
failign price estimates. By having a built in default for known networks
we make running locally easier because we don't have to remember to set
this parameter.

### Test Plan
manual test
