### PR TITLE
Also report simluation failure on latest for settlements that failed on liquidity fetching block.

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -269,6 +269,8 @@ impl Driver {
         };
 
         for (((solver, settlement), _previous_error), result) in errors.iter().zip(simulations) {
+            self.metrics
+                .settlement_simulation_failed_on_latest(solver.name());
             if let Err(error_at_earlier_block) = result {
                 tracing::warn!(
                     "{} settlement simulation failed at submission and block {}:\n{:?}",
@@ -280,9 +282,6 @@ impl Driver {
                 tracing::warn!("settlement failure for: \n{:#?}", settlement);
 
                 self.metrics.settlement_simulation_failed(solver.name());
-            } else {
-                self.metrics
-                    .settlement_simulation_failed_on_latest(solver.name());
             }
         }
     }


### PR DESCRIPTION
This PR makes it so `failures_on_latest` is incremented for all simulation failures. This will make it so `failures_on_latest >= failures`.

### Test Plan

Minor logic change, we can observe the metrics.
