### PR TITLE
Forward Stable Pools to HTTP solver.

### DIFF
--- a/shared/src/sources/balancer/pool_cache.rs
+++ b/shared/src/sources/balancer/pool_cache.rs
@@ -1,3 +1,4 @@
+use crate::conversions::U256Ext;
 use crate::sources::balancer::pool_storage::{PoolEvaluating, RegisteredPool};
 use crate::{
     recent_block_cache::{Block, CacheFetching, CacheKey, CacheMetrics, RecentBlockCache},
@@ -14,6 +15,7 @@ use crate::{
 use anyhow::Result;
 use contracts::{BalancerV2StablePool, BalancerV2Vault, BalancerV2WeightedPool};
 use ethcontract::{batch::CallBatch, errors::MethodError, BlockId, Bytes, H160, H256, U256};
+use num::BigRational;
 use std::{collections::HashSet, sync::Arc};
 
 pub struct PoolReserveFetcher {
@@ -199,8 +201,11 @@ fn handle_results(results: Vec<FetchedBalancerPool>) -> Result<Vec<BalancerPool>
                             .amplification_parameter
                             .expect("Stable pools must have this set."),
                     )? {
-                        // We only keep the U256 value and disregard isUpdating and precision.
-                        Some(state) => state.0,
+                        // This is the ratio of amplification_parameter / precision.
+                        Some((amplification_factor, _, precision)) => BigRational::new(
+                            amplification_factor.to_big_int(),
+                            precision.to_big_int(),
+                        ),
                         None => return Ok(acc),
                     };
                     acc.push(BalancerPool::Stable(StablePool::new(

--- a/shared/src/sources/balancer/pool_fetching.rs
+++ b/shared/src/sources/balancer/pool_fetching.rs
@@ -21,6 +21,7 @@ use anyhow::{anyhow, Result};
 use contracts::BalancerV2Vault;
 use ethcontract::{H160, H256, U256};
 use model::TokenPair;
+use num::BigRational;
 use reqwest::Client;
 use std::{
     collections::{HashMap, HashSet},
@@ -196,7 +197,7 @@ pub struct StablePool {
     pub pool_id: H256,
     pub pool_address: H160,
     pub swap_fee_percentage: Bfp,
-    pub amplification_parameter: U256,
+    pub amplification_parameter: BigRational,
     pub reserves: HashMap<H160, TokenState>,
     pub paused: bool,
 }
@@ -206,7 +207,7 @@ impl StablePool {
         pool_data: RegisteredStablePool,
         balances: Vec<U256>,
         swap_fee_percentage: Bfp,
-        amplification_parameter: U256,
+        amplification_parameter: BigRational,
         paused: bool,
     ) -> Self {
         let mut reserves = HashMap::new();
@@ -331,7 +332,7 @@ mod tests {
                 pool_id: H256::from_low_u64_be(1),
                 pool_address: Default::default(),
                 swap_fee_percentage: Bfp::zero(),
-                amplification_parameter: Default::default(),
+                amplification_parameter: BigRational::new(10.into(), 1000.into()),
                 reserves: Default::default(),
                 paused: false,
             }),
@@ -359,7 +360,7 @@ mod tests {
             pool_id: H256::from_low_u64_be(1),
             pool_address: Default::default(),
             swap_fee_percentage: Bfp::zero(),
-            amplification_parameter: Default::default(),
+            amplification_parameter: BigRational::new(1.into(), 2.into()),
             reserves: Default::default(),
             paused: false,
         });
@@ -428,7 +429,7 @@ mod tests {
             pool_id: H256::from_low_u64_be(2),
             pool_address: H160::from_low_u64_be(2),
             swap_fee_percentage: Bfp::one(),
-            amplification_parameter: U256::one(),
+            amplification_parameter: BigRational::from_integer(2.into()),
             reserves: hashmap! { H160::from_low_u64_be(2) => stable_pool_state.clone() },
             paused: true,
         });

--- a/shared/src/sources/balancer/pool_init.rs
+++ b/shared/src/sources/balancer/pool_init.rs
@@ -352,9 +352,10 @@ mod tests {
         swap::fixed_point::Bfp,
     };
     use anyhow::bail;
-    use ethcontract::{H256, U256};
+    use ethcontract::H256;
     use maplit::hashmap;
     use mockall::{predicate::*, Sequence};
+    use num::BigRational;
 
     #[tokio::test]
     async fn initializes_empty_pools() {
@@ -645,7 +646,7 @@ mod tests {
                         tokens: vec![],
                         scaling_exponents: vec![],
                     },
-                    amplification_parameter: U256::one(),
+                    amplification_parameter: BigRational::from_integer(3.into()),
                 })
             });
 

--- a/shared/src/sources/balancer/pool_storage.rs
+++ b/shared/src/sources/balancer/pool_storage.rs
@@ -372,6 +372,7 @@ mod tests {
     };
     use maplit::{hashmap, hashset};
     use mockall::predicate::eq;
+    use num::BigRational;
 
     pub type PoolInitData = (Vec<H256>, Vec<H160>, Vec<H160>, Vec<Bfp>, Vec<PoolCreated>);
     fn pool_init_data(start: usize, end: usize, pool_type: PoolType) -> PoolInitData {
@@ -537,7 +538,7 @@ mod tests {
                     tokens: vec![tokens[i], tokens[i + 1]],
                     scaling_exponents: vec![0, 0],
                 },
-                amplification_parameter: Default::default(),
+                amplification_parameter: BigRational::from_integer(1.into()),
             };
             dummy_data_fetcher
                 .expect_get_stable_pool_data()
@@ -727,7 +728,7 @@ mod tests {
                     tokens: vec![tokens[i], tokens[i + 1]],
                     scaling_exponents: vec![0, 0],
                 },
-                amplification_parameter: Default::default(),
+                amplification_parameter: BigRational::from_integer(1.into()),
             };
             dummy_data_fetcher
                 .expect_get_stable_pool_data()
@@ -754,7 +755,7 @@ mod tests {
                         tokens: vec![new_token],
                         scaling_exponents: vec![0],
                     },
-                    amplification_parameter: Default::default(),
+                    amplification_parameter: BigRational::from_integer(1.into()),
                 })
             });
 

--- a/solver/src/interactions/allowances.rs
+++ b/solver/src/interactions/allowances.rs
@@ -87,8 +87,7 @@ impl Allowances {
 /// An ERC20 approval interaction.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Approval {
-    /// The exisisting allowance is sufficient, so no additional `approve` is
-    /// required.
+    /// The existing allowance is sufficient, so no additional `approve` is required.
     AllowanceSufficient,
 
     /// An ERC20 approve is needed. This interaction always approves U256::MAX

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -4,13 +4,13 @@ pub mod slippage;
 pub mod uniswap;
 
 use crate::settlement::SettlementEncoder;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 #[cfg(test)]
 use model::order::Order;
 use model::{order::OrderKind, TokenPair};
 use num::{rational::Ratio, BigRational};
 use primitive_types::{H160, U256};
-use shared::sources::balancer::pool_fetching::WeightedTokenState;
+use shared::sources::balancer::pool_fetching::{TokenState, WeightedTokenState};
 #[cfg(test)]
 use shared::sources::uniswap::pool_fetching::Pool;
 use std::collections::HashMap;
@@ -21,7 +21,7 @@ use strum_macros::{AsStaticStr, EnumVariantNames};
 #[derive(Clone, AsStaticStr, EnumVariantNames, Debug)]
 pub enum Liquidity {
     ConstantProduct(ConstantProductOrder),
-    WeightedProduct(WeightedProductOrder),
+    Balancer(BalancerOrder),
 }
 
 /// A trait associating some liquidity model to how it is executed and encoded
@@ -144,30 +144,41 @@ pub struct WeightedProductOrder {
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
 }
 
-impl WeightedProductOrder {
-    pub fn token_pairs(&self) -> Vec<TokenPair> {
-        // The `HashMap` docs specifically say that we can't rely on ordering
-        // of keys (even across multiple calls). So, first collect all tokens
-        // into a collection and then use it to make the final enumeration with
-        // all token pair permutations.
-        let tokens = self.reserves.keys().collect::<Vec<_>>();
-        tokens
-            .iter()
-            .enumerate()
-            .flat_map(|(i, &token_a)| {
-                tokens[i + 1..].iter().map(move |&token_b| {
-                    TokenPair::new(*token_a, *token_b)
-                        .expect("unexpected duplicate key in hash map")
-                })
-            })
-            .collect()
-    }
-}
-
 impl std::fmt::Debug for WeightedProductOrder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Weighted Product AMM {:?}", self.reserves.keys())
     }
+}
+
+#[derive(Clone)]
+pub struct StablePoolOrder {
+    pub reserves: HashMap<H160, TokenState>,
+    pub fee: BigRational,
+    pub amplification_parameter: U256,
+    pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
+}
+
+impl std::fmt::Debug for StablePoolOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Stable Pool AMM {:?}", self.reserves.keys())
+    }
+}
+
+pub fn token_pairs<T>(reserves: &HashMap<H160, T>) -> Vec<TokenPair> {
+    // The `HashMap` docs specifically say that we can't rely on ordering
+    // of keys (even across multiple calls). So, first collect all tokens
+    // into a collection and then use it to make the final enumeration with
+    // all token pair permutations.
+    let tokens = reserves.keys().collect::<Vec<_>>();
+    tokens
+        .iter()
+        .enumerate()
+        .flat_map(|(i, &token_a)| {
+            tokens[i + 1..].iter().map(move |&token_b| {
+                TokenPair::new(*token_a, *token_b).expect("unexpected duplicate key in hash map")
+            })
+        })
+        .collect()
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -198,6 +209,50 @@ impl Settleable for WeightedProductOrder {
     }
 }
 
+impl Settleable for StablePoolOrder {
+    type Execution = AmmOrderExecution;
+
+    fn settlement_handling(&self) -> &dyn SettlementHandling<Self> {
+        &*self.settlement_handling
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum BalancerOrder {
+    Weighted(WeightedProductOrder),
+    Stable(StablePoolOrder),
+}
+
+impl BalancerOrder {
+    pub fn tokens(&self) -> Vec<H160> {
+        match self {
+            BalancerOrder::Weighted(order) => order.reserves.keys().cloned().collect(),
+            BalancerOrder::Stable(order) => order.reserves.keys().cloned().collect(),
+        }
+    }
+
+    pub fn fee(&self) -> BigRational {
+        match self {
+            BalancerOrder::Weighted(order) => order.fee.clone(),
+            BalancerOrder::Stable(order) => order.fee.clone(),
+        }
+    }
+
+    pub fn try_as_weighted(&self) -> Result<WeightedProductOrder> {
+        match self {
+            BalancerOrder::Weighted(wp_order) => Ok(wp_order.clone()),
+            BalancerOrder::Stable(_) => Err(anyhow!("Not a weighted pool order")),
+        }
+    }
+
+    pub fn try_as_stable(&self) -> Result<StablePoolOrder> {
+        match self {
+            BalancerOrder::Stable(st_order) => Ok(st_order.clone()),
+            BalancerOrder::Weighted(_) => Err(anyhow!("Not a stable pool order")),
+        }
+    }
+}
+
 #[cfg(test)]
 impl Default for ConstantProductOrder {
     fn default() -> Self {
@@ -222,10 +277,21 @@ impl Default for WeightedProductOrder {
 }
 
 #[cfg(test)]
+impl Default for StablePoolOrder {
+    fn default() -> Self {
+        StablePoolOrder {
+            reserves: Default::default(),
+            fee: num::Zero::zero(),
+            amplification_parameter: Default::default(),
+            settlement_handling: tests::CapturingSettlementHandler::arc(),
+        }
+    }
+}
+
+#[cfg(test)]
 pub mod tests {
     use super::*;
     use maplit::hashmap;
-    use shared::sources::balancer::pool_fetching::TokenState;
     use std::sync::Mutex;
 
     pub struct CapturingSettlementHandler<L>
@@ -304,26 +370,14 @@ pub mod tests {
     }
 
     #[test]
-    fn weighted_pool_enumerate_token_pairs() {
-        let token_state = WeightedTokenState {
-            token_state: TokenState {
-                balance: 0.into(),
-                scaling_exponent: 0,
-            },
-            weight: "0.25".parse().unwrap(),
+    fn enumerate_token_pairs() {
+        let token_map: HashMap<_, Option<u32>> = hashmap! {
+            H160([0x11; 20]) => None,
+            H160([0x22; 20]) => None,
+            H160([0x33; 20]) => None,
+            H160([0x44; 20]) => None,
         };
-        let pool = WeightedProductOrder {
-            reserves: hashmap! {
-                H160([0x11; 20]) => token_state.clone(),
-                H160([0x22; 20]) => token_state.clone(),
-                H160([0x33; 20]) => token_state.clone(),
-                H160([0x44; 20]) => token_state,
-            },
-            ..Default::default()
-        };
-
-        // Sort pairs for deterministic order in the result for testing.
-        let mut pairs = pool.token_pairs();
+        let mut pairs = token_pairs(&token_map);
         pairs.sort();
 
         assert_eq!(

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -154,7 +154,7 @@ impl std::fmt::Debug for WeightedProductOrder {
 pub struct StablePoolOrder {
     pub reserves: HashMap<H160, TokenState>,
     pub fee: BigRational,
-    pub amplification_parameter: U256,
+    pub amplification_parameter: BigRational,
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
 }
 
@@ -282,7 +282,7 @@ impl Default for StablePoolOrder {
         StablePoolOrder {
             reserves: Default::default(),
             fee: num::Zero::zero(),
-            amplification_parameter: Default::default(),
+            amplification_parameter: BigRational::from_integer(1.into()),
             settlement_handling: tests::CapturingSettlementHandler::arc(),
         }
     }

--- a/solver/src/liquidity/balancer.rs
+++ b/solver/src/liquidity/balancer.rs
@@ -1,5 +1,6 @@
 //! Module for providing Balancer V2 pool liquidity to the solvers.
 
+use crate::liquidity::{BalancerOrder, StablePoolOrder};
 use crate::{
     interactions::{
         allowances::{AllowanceManager, AllowanceManaging, Allowances},
@@ -67,7 +68,7 @@ impl BalancerV2Liquidity {
         &self,
         orders: &[LimitOrder],
         block: Block,
-    ) -> Result<Vec<WeightedProductOrder>> {
+    ) -> Result<Vec<BalancerOrder>> {
         let pairs = orders
             .iter()
             .flat_map(|order| {
@@ -91,19 +92,33 @@ impl BalancerV2Liquidity {
         let liquidity = pools
             .into_iter()
             .filter_map(|pool| {
-                let weighted_pool = pool.try_into_weighted().ok()?;
-                Some(WeightedProductOrder {
-                    reserves: weighted_pool.reserves,
-                    fee: weighted_pool.swap_fee_percentage.into(),
-                    settlement_handling: Arc::new(SettlementHandler {
-                        pool_id: weighted_pool.pool_id,
-                        contracts: self.contracts.clone(),
-                        allowances: allowances.clone(),
-                    }),
-                })
+                if pool.is_weighted() {
+                    let weighted_pool = pool.try_into_weighted().unwrap();
+                    Some(BalancerOrder::Weighted(WeightedProductOrder {
+                        reserves: weighted_pool.reserves,
+                        fee: weighted_pool.swap_fee_percentage.into(),
+                        settlement_handling: Arc::new(SettlementHandler {
+                            pool_id: weighted_pool.pool_id,
+                            contracts: self.contracts.clone(),
+                            allowances: allowances.clone(),
+                        }),
+                    }))
+                } else {
+                    // This branch covers the case of Stable and "Other" PoolType
+                    let stable_pool = pool.try_into_stable().ok()?;
+                    Some(BalancerOrder::Stable(StablePoolOrder {
+                        reserves: stable_pool.reserves,
+                        fee: stable_pool.swap_fee_percentage.into(),
+                        amplification_parameter: stable_pool.amplification_parameter,
+                        settlement_handling: Arc::new(SettlementHandler {
+                            pool_id: stable_pool.pool_id,
+                            contracts: self.contracts.clone(),
+                            allowances: allowances.clone(),
+                        }),
+                    }))
+                }
             })
             .collect();
-        // TODO(bh2smith) - fetch stable pools in following PR.
         Ok(liquidity)
     }
 }
@@ -116,6 +131,22 @@ struct SettlementHandler {
 
 impl SettlementHandling<WeightedProductOrder> for SettlementHandler {
     fn encode(&self, execution: AmmOrderExecution, encoder: &mut SettlementEncoder) -> Result<()> {
+        self.inner_encode(execution, encoder)
+    }
+}
+
+impl SettlementHandling<StablePoolOrder> for SettlementHandler {
+    fn encode(&self, execution: AmmOrderExecution, encoder: &mut SettlementEncoder) -> Result<()> {
+        self.inner_encode(execution, encoder)
+    }
+}
+
+impl SettlementHandler {
+    fn inner_encode(
+        &self,
+        execution: AmmOrderExecution,
+        encoder: &mut SettlementEncoder,
+    ) -> Result<()> {
         let (asset_in, amount_in) = execution.input;
         let (asset_out, amount_out) = execution.output;
 
@@ -128,7 +159,7 @@ impl SettlementHandling<WeightedProductOrder> for SettlementHandler {
             asset_out,
             amount_out,
             amount_in_max: slippage::amount_plus_max_slippage(amount_in),
-            // Balancer pools allow passing additonal user data in order to
+            // Balancer pools allow passing additional user data in order to
             // control pool behaviour for swaps. That being said, weighted pools
             // do not seem to make use of this at the moment so leave it empty.
             user_data: Default::default(),
@@ -141,10 +172,9 @@ impl SettlementHandling<WeightedProductOrder> for SettlementHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        interactions::allowances::{Approval, MockAllowanceManaging},
-        settlement::Interaction,
-    };
+    use crate::interactions::allowances::{Approval, MockAllowanceManaging};
+    use crate::settlement::Interaction;
+    use ethcontract::U256;
     use maplit::{hashmap, hashset};
     use mockall::predicate::*;
     use model::TokenPair;
@@ -152,11 +182,10 @@ mod tests {
     use shared::{
         dummy_contract,
         sources::balancer::pool_fetching::{
-            BalancerPool, BalancerPoolState, MockBalancerPoolFetching, TokenState, WeightedPool,
+            BalancerPool, MockBalancerPoolFetching, StablePool, TokenState, WeightedPool,
             WeightedTokenState,
         },
     };
-    use std::collections::HashMap;
 
     fn dummy_contracts() -> Arc<Contracts> {
         Arc::new(Contracts {
@@ -226,6 +255,23 @@ mod tests {
                 },
                 paused: true,
             }),
+            BalancerPool::Stable(StablePool {
+                pool_id: H256([0x92; 32]),
+                pool_address: H160([0x92; 20]),
+                swap_fee_percentage: "0.002".parse().unwrap(),
+                amplification_parameter: U256::one(),
+                reserves: hashmap! {
+                    H160([0x73; 20]) => TokenState {
+                            balance: 1_000_000_000_000_000_000u128.into(),
+                            scaling_exponent: 0,
+                        },
+                    H160([0xb0; 20]) => TokenState {
+                            balance: 1_000_000_000_000_000_000u128.into(),
+                            scaling_exponent: 0,
+                        }
+                },
+                paused: true,
+            }),
         ];
 
         // Fetches pools for all relevant tokens, in this example, there is no
@@ -292,32 +338,29 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(liquidity.len(), 2);
-        let a: HashMap<H160, BalancerPoolState> = liquidity[0]
-            .clone()
-            .reserves
-            .into_iter()
-            .map(|(key, val)| (key, BalancerPoolState::Weighted(val)))
-            .collect();
+        assert_eq!(liquidity.len(), 3);
+        let a = liquidity[0].clone().try_as_weighted().unwrap().reserves;
         assert_eq!(
-            (&a, &liquidity[0].fee),
+            (&a, &liquidity[0].fee()),
             (
-                &pools[0].reserves(),
+                &pools[0].try_into_weighted().unwrap().reserves,
                 &BigRational::new(2.into(), 1000.into())
             ),
         );
-
-        let b: HashMap<H160, BalancerPoolState> = liquidity[1]
-            .clone()
-            .reserves
-            .into_iter()
-            .map(|(key, val)| (key, BalancerPoolState::Weighted(val)))
-            .collect();
+        let b = liquidity[1].clone().try_as_weighted().unwrap().reserves;
         assert_eq!(
-            (&b, &liquidity[1].fee),
+            (&b, &liquidity[1].fee()),
             (
-                &pools[1].reserves(),
+                &pools[1].try_into_weighted().unwrap().reserves,
                 &BigRational::new(1.into(), 1000.into())
+            ),
+        );
+        let c = liquidity[2].clone().try_as_stable().unwrap().reserves;
+        assert_eq!(
+            (&c, &liquidity[2].fee()),
+            (
+                &pools[2].try_into_stable().unwrap().reserves,
+                &BigRational::new(2.into(), 1000.into())
             ),
         );
     }
@@ -338,24 +381,24 @@ mod tests {
         };
 
         let mut encoder = SettlementEncoder::new(Default::default());
-        handler
-            .encode(
-                AmmOrderExecution {
-                    input: (H160([0x70; 20]), 10.into()),
-                    output: (H160([0x71; 20]), 11.into()),
-                },
-                &mut encoder,
-            )
-            .unwrap();
-        handler
-            .encode(
-                AmmOrderExecution {
-                    input: (H160([0x71; 20]), 12.into()),
-                    output: (H160([0x72; 20]), 13.into()),
-                },
-                &mut encoder,
-            )
-            .unwrap();
+        SettlementHandling::<WeightedProductOrder>::encode(
+            &handler,
+            AmmOrderExecution {
+                input: (H160([0x70; 20]), 10.into()),
+                output: (H160([0x71; 20]), 11.into()),
+            },
+            &mut encoder,
+        )
+        .unwrap();
+        SettlementHandling::<WeightedProductOrder>::encode(
+            &handler,
+            AmmOrderExecution {
+                input: (H160([0x71; 20]), 12.into()),
+                output: (H160([0x72; 20]), 13.into()),
+            },
+            &mut encoder,
+        )
+        .unwrap();
 
         let [_, interactions, _] = encoder.finish().interactions;
         assert_eq!(

--- a/solver/src/liquidity/balancer.rs
+++ b/solver/src/liquidity/balancer.rs
@@ -174,7 +174,6 @@ mod tests {
     use super::*;
     use crate::interactions::allowances::{Approval, MockAllowanceManaging};
     use crate::settlement::Interaction;
-    use ethcontract::U256;
     use maplit::{hashmap, hashset};
     use mockall::predicate::*;
     use model::TokenPair;
@@ -259,7 +258,7 @@ mod tests {
                 pool_id: H256([0x92; 32]),
                 pool_address: H160([0x92; 20]),
                 swap_fee_percentage: "0.002".parse().unwrap(),
-                amplification_parameter: U256::one(),
+                amplification_parameter: BigRational::from_integer(1.into()),
                 reserves: hashmap! {
                     H160([0x73; 20]) => TokenState {
                             balance: 1_000_000_000_000_000_000u128.into(),

--- a/solver/src/liquidity_collector.rs
+++ b/solver/src/liquidity_collector.rs
@@ -48,7 +48,7 @@ impl LiquidityCollector {
                     .await
                     .context("failed to get Balancer liquidity")?
                     .into_iter()
-                    .map(Liquidity::WeightedProduct),
+                    .map(Liquidity::Balancer),
             );
         }
         tracing::debug!("got {} AMMs", amms.len());

--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -1,6 +1,7 @@
 use crate::{
     liquidity::{
-        AmmOrderExecution, ConstantProductOrder, LimitOrder, Liquidity, WeightedProductOrder,
+        token_pairs, AmmOrderExecution, BalancerOrder, ConstantProductOrder, LimitOrder, Liquidity,
+        WeightedProductOrder,
     },
     settlement::Settlement,
     solver::{Auction, Solver},
@@ -158,12 +159,22 @@ impl BaselineSolver {
                                 order: AmmOrder::ConstantProduct(order),
                             });
                         }
-                        Liquidity::WeightedProduct(order) => {
-                            for tokens in order.token_pairs() {
-                                amm_map.entry(tokens).or_default().push(Amm {
-                                    tokens,
-                                    order: AmmOrder::WeightedProduct(order.clone()),
-                                });
+                        Liquidity::Balancer(order) => {
+                            match &order {
+                                BalancerOrder::Weighted(weighted_product_order) => {
+                                    for tokens in token_pairs(&weighted_product_order.reserves) {
+                                        amm_map.entry(tokens).or_default().push(Amm {
+                                            tokens,
+                                            order: AmmOrder::WeightedProduct(
+                                                weighted_product_order.clone(),
+                                            ),
+                                        });
+                                    }
+                                }
+                                BalancerOrder::Stable(_) => {
+                                    // TODO - https://github.com/gnosis/gp-v2-services/issues/1074
+                                    tracing::warn!("Excluded stable pool from baseline solving.")
+                                }
                             }
                         }
                     }
@@ -575,7 +586,7 @@ mod tests {
                 fee: Ratio::new(3, 1000),
                 settlement_handling: CapturingSettlementHandler::arc(),
             }),
-            Liquidity::WeightedProduct(WeightedProductOrder {
+            Liquidity::Balancer(BalancerOrder::Weighted(WeightedProductOrder {
                 reserves: hashmap! {
                     addr!("c778417e063141139fce010982780140aa0cd5ab") => WeightedTokenState {
                         token_state: TokenState {
@@ -594,7 +605,7 @@ mod tests {
                 },
                 fee: Ratio::new(1.into(), 1000.into()),
                 settlement_handling: CapturingSettlementHandler::arc(),
-            }),
+            })),
         ];
 
         let solver = BaselineSolver::new(

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -4,7 +4,10 @@ mod settlement;
 
 use self::{model::*, settlement::SettlementContext};
 use crate::{
-    liquidity::{ConstantProductOrder, LimitOrder, Liquidity, WeightedProductOrder},
+    liquidity::{
+        BalancerOrder, ConstantProductOrder, LimitOrder, Liquidity, StablePoolOrder,
+        WeightedProductOrder,
+    },
     settlement::Settlement,
     settlement_submission::retry::is_transaction_failure,
     solver::{Auction, Solver},
@@ -129,7 +132,7 @@ impl HttpSolver {
             .flat_map(|order| [order.sell_token, order.buy_token]);
         let liquidity_tokens = liquidity.iter().flat_map(|liquidity| match liquidity {
             Liquidity::ConstantProduct(amm) => amm.tokens.into_iter().collect::<Vec<_>>(),
-            Liquidity::WeightedProduct(amm) => amm.reserves.keys().cloned().collect(),
+            Liquidity::Balancer(amm) => amm.tokens(),
         });
 
         order_tokens
@@ -207,6 +210,7 @@ impl HttpSolver {
         &self,
         constant_product_orders: &HashMap<usize, ConstantProductOrder>,
         weighted_product_orders: &HashMap<usize, WeightedProductOrder>,
+        stable_pool_orders: &HashMap<usize, StablePoolOrder>,
         gas_price: f64,
     ) -> HashMap<usize, AmmModel> {
         let uniswap_cost = self.uniswap_cost(gas_price);
@@ -244,7 +248,7 @@ impl HttpSolver {
                     .map(|(token, state)| {
                         (
                             *token,
-                            PoolTokenData {
+                            WeightedPoolTokenData {
                                 balance: state.token_state.balance,
                                 weight: BigRational::from(state.weight),
                             },
@@ -267,8 +271,37 @@ impl HttpSolver {
                 (*index + constant_product_models.len(), pool_model)
             })
             .collect();
+        let stable_pool_models: HashMap<_, AmmModel> = stable_pool_orders
+            .iter()
+            .map(|(index, amm)| {
+                let reserves = amm
+                    .reserves
+                    .iter()
+                    .map(|(token, state)| (*token, state.balance))
+                    .collect();
+                let pool_model = AmmModel {
+                    parameters: AmmParameters::Stable(StablePoolParameters {
+                        reserves,
+                        amplification_parameter: amm.amplification_parameter,
+                    }),
+                    fee: amm.fee.clone(),
+                    cost: CostModel {
+                        amount: balancer_cost,
+                        token: self.native_token,
+                    },
+                    mandatory: false,
+                };
+                // Note that in order to preserve unique keys of this hashmap, we use
+                // the current index + the length of the previous map.
+                (
+                    *index + constant_product_models.len() + weighted_product_models.len(),
+                    pool_model,
+                )
+            })
+            .collect();
         pool_model_map.extend(constant_product_models);
         pool_model_map.extend(weighted_product_models);
+        pool_model_map.extend(stable_pool_models);
         pool_model_map
     }
 
@@ -322,7 +355,8 @@ impl HttpSolver {
         let price_estimates: HashMap<H160, Result<BigRational, _>> =
             tokens.iter().cloned().zip(price_estimates).collect();
 
-        let (constant_product_liquidity, weighted_product_liquidity) = split_liquidity(liquidity);
+        let (constant_product_liquidity, weighted_product_liquidity, stable_pool_liquidity) =
+            split_liquidity(liquidity);
 
         // For the solver to run correctly we need to be sure that there are no isolated islands of
         // tokens without connection between them.
@@ -334,12 +368,15 @@ impl HttpSolver {
         let limit_orders = self.map_orders_for_solver(orders);
         let constant_product_orders = self.map_amm_orders_for_solver(constant_product_liquidity);
         let weighted_product_orders = self.map_amm_orders_for_solver(weighted_product_liquidity);
+        let stable_pool_orders = self.map_amm_orders_for_solver(stable_pool_liquidity);
+
         let token_models = self.token_models(&token_infos, &price_estimates, &buffers);
         let order_models = self.order_models(&limit_orders, gas_price);
         let amm_models = self
             .amm_models(
                 &constant_product_orders,
                 &weighted_product_orders,
+                &stable_pool_orders,
                 gas_price,
             )
             .into_iter()
@@ -357,6 +394,7 @@ impl HttpSolver {
             limit_orders,
             constant_product_orders,
             weighted_product_orders,
+            stable_pool_orders,
         };
         Ok((model, context))
     }
@@ -449,16 +487,28 @@ impl HttpSolver {
 
 fn split_liquidity(
     liquidity: Vec<Liquidity>,
-) -> (Vec<ConstantProductOrder>, Vec<WeightedProductOrder>) {
+) -> (
+    Vec<ConstantProductOrder>,
+    Vec<WeightedProductOrder>,
+    Vec<StablePoolOrder>,
+) {
     let mut constant_product_orders = Vec::new();
     let mut weighted_product_orders = Vec::new();
+    let mut stable_pool_orders = Vec::new();
     for order in liquidity {
         match order {
             Liquidity::ConstantProduct(order) => constant_product_orders.push(order),
-            Liquidity::WeightedProduct(order) => weighted_product_orders.push(order),
+            Liquidity::Balancer(order) => match order {
+                BalancerOrder::Weighted(wp_order) => weighted_product_orders.push(wp_order),
+                BalancerOrder::Stable(st_order) => stable_pool_orders.push(st_order),
+            },
         }
     }
-    (constant_product_orders, weighted_product_orders)
+    (
+        constant_product_orders,
+        weighted_product_orders,
+        stable_pool_orders,
+    )
 }
 
 // TODO: This currently does **NOT** consider balancer pools, but definitely should.

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -282,7 +282,7 @@ impl HttpSolver {
                 let pool_model = AmmModel {
                     parameters: AmmParameters::Stable(StablePoolParameters {
                         reserves,
-                        amplification_parameter: amm.amplification_parameter,
+                        amplification_parameter: amm.amplification_parameter.clone(),
                     }),
                     fee: amm.fee.clone(),
                     cost: CostModel {

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -94,12 +94,12 @@ pub struct WeightedProductPoolParameters {
 }
 
 #[serde_as]
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StablePoolParameters {
     #[serde_as(as = "HashMap<_, DecimalU256>")]
     pub reserves: HashMap<H160, U256>,
-    #[serde(with = "u256_decimal")]
-    pub amplification_parameter: U256,
+    #[serde(with = "ratio_as_decimal")]
+    pub amplification_parameter: BigRational,
 }
 
 #[serde_as]

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -1,5 +1,5 @@
 use super::model::*;
-use crate::liquidity::WeightedProductOrder;
+use crate::liquidity::{StablePoolOrder, WeightedProductOrder};
 use crate::{
     liquidity::{AmmOrderExecution, ConstantProductOrder, LimitOrder},
     settlement::Settlement,
@@ -17,6 +17,7 @@ pub struct SettlementContext {
     pub limit_orders: HashMap<usize, LimitOrder>,
     pub constant_product_orders: HashMap<usize, ConstantProductOrder>,
     pub weighted_product_orders: HashMap<usize, WeightedProductOrder>,
+    pub stable_pool_orders: HashMap<usize, StablePoolOrder>,
 }
 
 pub fn convert_settlement(
@@ -61,6 +62,7 @@ struct ExecutedAmm {
 enum ExecutedOrder {
     ConstantProduct(ConstantProductOrder),
     WeightedProduct(WeightedProductOrder),
+    StablePool(StablePoolOrder),
 }
 
 impl IntermediateSettlement {
@@ -70,6 +72,7 @@ impl IntermediateSettlement {
         let executed_amms = match_prepared_and_settled_amms(
             context.constant_product_orders,
             context.weighted_product_orders,
+            context.stable_pool_orders,
             settled.amms,
         )?;
         let prices = match_settled_prices(executed_limit_orders.as_slice(), settled.prices)?;
@@ -95,6 +98,9 @@ impl IntermediateSettlement {
                     settlement.with_liquidity(liquidity, execution)?
                 }
                 ExecutedOrder::WeightedProduct(liquidity) => {
+                    settlement.with_liquidity(liquidity, execution)?
+                }
+                ExecutedOrder::StablePool(liquidity) => {
                     settlement.with_liquidity(liquidity, execution)?
                 }
             }
@@ -128,12 +134,14 @@ fn match_prepared_and_settled_orders(
 fn match_prepared_and_settled_amms(
     mut prepared_constant_product_orders: HashMap<usize, ConstantProductOrder>,
     mut prepared_weighted_product_orders: HashMap<usize, WeightedProductOrder>,
+    mut prepared_stable_pool_orders: HashMap<usize, StablePoolOrder>,
     settled_orders: HashMap<usize, UpdatedAmmModel>,
 ) -> Result<Vec<ExecutedAmm>> {
     let mut amm_executions = vec![];
     // Recall, prepared amm for weighted products are shifted by the constant product amms
     // We declare this outside before prepared_constant_product_orders is mutated.
-    let shift = prepared_constant_product_orders.len();
+    let shift_a = prepared_constant_product_orders.len();
+    let shift_b = shift_a + prepared_weighted_product_orders.len();
     for (index, settled) in settled_orders
         .into_iter()
         .filter(|(_, settled)| settled.is_non_trivial())
@@ -149,7 +157,7 @@ fn match_prepared_and_settled_amms(
             (settled.buy_token, settled.exec_buy_amount),
             (settled.sell_token, settled.exec_sell_amount),
         );
-        if index < shift && prepared_constant_product_orders.contains_key(&index) {
+        if index < shift_a && prepared_constant_product_orders.contains_key(&index) {
             amm_executions.push(ExecutedAmm {
                 order: ExecutedOrder::ConstantProduct(
                     prepared_constant_product_orders.remove(&index).unwrap(),
@@ -157,12 +165,24 @@ fn match_prepared_and_settled_amms(
                 input,
                 output,
             });
-        } else if index >= shift && prepared_weighted_product_orders.contains_key(&(index - shift))
+        } else if index >= shift_a
+            && index < shift_b
+            && prepared_weighted_product_orders.contains_key(&(index - shift_a))
         {
             amm_executions.push(ExecutedAmm {
                 order: ExecutedOrder::WeightedProduct(
                     prepared_weighted_product_orders
-                        .remove(&(index - shift))
+                        .remove(&(index - shift_a))
+                        .unwrap(),
+                ),
+                input,
+                output,
+            });
+        } else if index >= shift_b && prepared_stable_pool_orders.contains_key(&(index - shift_b)) {
+            amm_executions.push(ExecutedAmm {
+                order: ExecutedOrder::StablePool(
+                    prepared_stable_pool_orders
+                        .remove(&(index - shift_b))
                         .unwrap(),
                 ),
                 input,
@@ -258,6 +278,24 @@ mod tests {
         };
         let weighted_product_orders = hashmap! { 0 => weighted_product_order };
 
+        let sp_amm_handler = CapturingSettlementHandler::arc();
+        let stable_pool_order = StablePoolOrder {
+            reserves: hashmap! {
+                t0 => TokenState {
+                    balance: U256::from(300),
+                    scaling_exponent: 0,
+                },
+                t1 => TokenState {
+                    balance: U256::from(400),
+                    scaling_exponent: 0,
+                },
+            },
+            fee: BigRational::new(3.into(), 1.into()),
+            amplification_parameter: U256::one(),
+            settlement_handling: sp_amm_handler.clone(),
+        };
+        let stable_pool_orders = hashmap! { 0 => stable_pool_order };
+
         let executed_order = ExecutedOrderModel {
             exec_buy_amount: 6.into(),
             exec_sell_amount: 7.into(),
@@ -275,7 +313,7 @@ mod tests {
             }],
         };
 
-        let updated_balancer = UpdatedAmmModel {
+        let updated_balancer_weighted = UpdatedAmmModel {
             execution: vec![ExecutedAmmModel {
                 sell_token: t1,
                 buy_token: t0,
@@ -287,9 +325,22 @@ mod tests {
                 }),
             }],
         };
+
+        let updated_balancer_stable = UpdatedAmmModel {
+            execution: vec![ExecutedAmmModel {
+                sell_token: t1,
+                buy_token: t0,
+                exec_sell_amount: U256::from(6),
+                exec_buy_amount: U256::from(4),
+                exec_plan: Some(ExecutionPlanCoordinatesModel {
+                    sequence: 2,
+                    position: 0,
+                }),
+            }],
+        };
         let settled = SettledBatchAuctionModel {
             orders: hashmap! { 0 => executed_order },
-            amms: hashmap! { 0 => updated_uniswap, 1 => updated_balancer },
+            amms: hashmap! { 0 => updated_uniswap, 1 => updated_balancer_weighted, 2 => updated_balancer_stable },
             ref_token: Some(t0),
             prices: hashmap! { t0 => 10.into(), t1 => 11.into() },
         };
@@ -298,6 +349,7 @@ mod tests {
             limit_orders: orders,
             constant_product_orders,
             weighted_product_orders,
+            stable_pool_orders,
         };
 
         let settlement = convert_settlement(settled, prepared).unwrap();
@@ -319,6 +371,13 @@ mod tests {
             vec![AmmOrderExecution {
                 input: (t0, 1.into()),
                 output: (t1, 2.into()),
+            }]
+        );
+        assert_eq!(
+            sp_amm_handler.calls(),
+            vec![AmmOrderExecution {
+                input: (t0, 4.into()),
+                output: (t1, 6.into()),
             }]
         );
     }
@@ -362,6 +421,23 @@ mod tests {
             settlement_handling: CapturingSettlementHandler::arc(),
         };
         let weighted_product_orders = hashmap! { 0usize => weighted_product_order.clone() };
+
+        let stable_pool_order = StablePoolOrder {
+            reserves: hashmap! {
+                token_c => TokenState {
+                    balance: U256::from(1234u128),
+                    scaling_exponent: 0
+                },
+                token_b => TokenState {
+                    balance: U256::from(5678u128),
+                    scaling_exponent: 0
+                },
+            },
+            fee: BigRational::new(1.into(), 1000.into()),
+            amplification_parameter: U256::one(),
+            settlement_handling: CapturingSettlementHandler::arc(),
+        };
+        let stable_pool_orders = hashmap! { 0usize => stable_pool_order.clone() };
 
         let solution_response = serde_json::from_str::<SettledBatchAuctionModel>(
             r#"{
@@ -476,6 +552,30 @@ mod tests {
                             }
                         }
                     ]
+                },
+                "3": {
+                    "kind": "Stable",
+                    "reserves": {
+                        "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": "1234",
+                        "0xc778417e063141139fce010982780140aa0cd5ab": "5678"
+                    },
+                    "fee": "0.001",
+                    "cost": {
+                        "token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                        "amount": "1771"
+                    },
+                    "execution": [
+                        {
+                            "sell_token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                            "buy_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
+                            "exec_sell_amount": "1",
+                            "exec_buy_amount": "2",
+                            "exec_plan": {
+                                "sequence": 0,
+                                "position": 3
+                            }
+                        }
+                    ]
                 }
             },
             "solver": {
@@ -505,26 +605,36 @@ mod tests {
         let matched_settlements = match_prepared_and_settled_amms(
             constant_product_orders,
             weighted_product_orders,
+            stable_pool_orders,
             solution_response.amms,
         );
         assert!(matched_settlements.is_ok());
         let prepared_amms = matched_settlements.unwrap();
         let executed_cp_order: ConstantProductOrder;
         let executed_wp_order: WeightedProductOrder;
+        let executed_sp_order: StablePoolOrder;
         match prepared_amms[0].order.clone() {
-            ExecutedOrder::ConstantProduct(_) => {
-                panic!("Expected WeightedProductOrder!");
-            }
             ExecutedOrder::WeightedProduct(order) => {
                 executed_wp_order = order;
+            }
+            _ => {
+                panic!("Expected WeightedProductOrder!");
             }
         }
         match prepared_amms[1].order.clone() {
             ExecutedOrder::ConstantProduct(order) => {
                 executed_cp_order = order;
             }
-            ExecutedOrder::WeightedProduct(_) => {
+            _ => {
                 panic!("Expected ConstantProductOrder!")
+            }
+        }
+        match prepared_amms[3].order.clone() {
+            ExecutedOrder::StablePool(order) => {
+                executed_sp_order = order;
+            }
+            _ => {
+                panic!("Expected StablePoolOrder!")
             }
         }
         assert_eq!(executed_cp_order.tokens, cpo_0.tokens);
@@ -549,5 +659,10 @@ mod tests {
             prepared_amms[0].output,
             (token_b, U256::from(354009510372384890u128))
         );
+
+        assert_eq!(executed_sp_order.reserves, stable_pool_order.reserves);
+        assert_eq!(executed_sp_order.fee, stable_pool_order.fee);
+        assert_eq!(prepared_amms[2].input, (token_c, U256::from(2)));
+        assert_eq!(prepared_amms[2].output, (token_b, U256::from(1)));
     }
 }

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -291,7 +291,7 @@ mod tests {
                 },
             },
             fee: BigRational::new(3.into(), 1.into()),
-            amplification_parameter: U256::one(),
+            amplification_parameter: BigRational::from_integer(1.into()),
             settlement_handling: sp_amm_handler.clone(),
         };
         let stable_pool_orders = hashmap! { 0 => stable_pool_order };
@@ -434,7 +434,7 @@ mod tests {
                 },
             },
             fee: BigRational::new(1.into(), 1000.into()),
-            amplification_parameter: U256::one(),
+            amplification_parameter: BigRational::from_integer(1.into()),
             settlement_handling: CapturingSettlementHandler::arc(),
         };
         let stable_pool_orders = hashmap! { 0usize => stable_pool_order.clone() };


### PR DESCRIPTION
This PR recreates #992 so its ready to merge once we wort out the `422 Unprocessable Entity` errors we are seeing with the MIP solver. From the original PR:

---

Following #998, this is the third part of #733.

Introducing all the models for passing Stable pool types into the http solver. Note the last remaining todo is the route to handling Stable Pools in the Baseline solver.

### Test Plan
Local test performed that Stable pools reach the point of forwarding to http solver. see inline comment where this was performed.

Include the following print statement here https://github.com/gnosis/gp-v2-services/blob/34af96b23b05a52e0ce4a3b29c87d88a3bdd7767/solver/src/solver/http_solver.rs#L371-L372
```
println!("Stable Pool Orders {:?}", stable_pool_orders.len());
println!("{:?}", stable_pool_orders[0]);
```
and placing an order of `USDC <-> DAI` which is a known [Balancer stable pool.](https://etherscan.io/address/0x06df3b2bbb68adc8b0e302443692037ed9f91b42)

resulting in the 1 expected stable pool
```
Stable Pool Orders 1
Stable Pool AMM [0xdac17f958d2ee523a2206206994597c13d831ec7, 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48, 0x6b175474e89094c44da98b954eedeac495271d0f]
```

Steps to Reproduce:

Run the solver like this:

```sh
cargo run --bin solver --
 --node-url https://mainnet.infura.io/v3/YOUR_INFURA_KEY
 --base-tokens 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2,0x6B175474E89094C44Da98b954EedeAC495271d0F,0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,0xdAC17F958D2ee523a2206206994597C13D831ec7,0xc00e94Cb662C3520282E6f5717214004A7f26888,0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2,0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599 
 --solvers Mip,Quasimodo 
 --baseline-sources Uniswap,Sushiswap,BalancerV2 
 --amount-to-estimate-prices-with 1000000000000000000 
 --private-key YOUR_PK
```
Get an order between USDC and DAI into the system.

Have added new structs into existing tests where appropriate, but am still thinking about a nice clean approach to testing these changes end to end (such a test would require running the solver and orderbook locally, placing an order involving a token that is known to be part of an existing stable pool - there are only three so far and they all have no liquidity the last I checked, intercepting the http solver request and verifying that the stable pool is passed along).
