### PR TITLE
Add endpoint for user orders

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -378,6 +378,45 @@ paths:
           description: Token non-existent or not connected to native token
         500:
           description: Unexpected internal error while processing the request
+  /api/v1/account/{owner}/orders:
+    get:
+      summary: Get orders of one user paginated.
+      description: |
+        The orders are ordered by their creation date descending (newest orders first).
+        To enumerate all orders start with offset 0 and keep increasing the offset by the total
+        number of returned results. When a response contains less than the limit the last page has
+        been reached.
+      parameters:
+        - name: owner
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Address"
+        - name: offset
+          in: query
+          description: |
+            The pagination offset. Defaults to 0.
+          schema:
+            type: integer
+          required: false
+        - name: limit
+          in: query
+          description: |
+            The pagination limit. Defaults to 10. Maximum 1000. Minimum 1.
+          schema:
+            type: integer
+          required: false
+      responses:
+        200:
+          description: the orders
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Order"
+        400:
+          description: Problem with parameters like limit being too large.
 components:
   schemas:
     TransactionHash:

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -7,6 +7,7 @@ mod get_order_by_uid;
 mod get_orders;
 mod get_solvable_orders;
 mod get_trades;
+mod get_user_orders;
 
 use crate::{
     database::trades::TradeRetrieving,
@@ -40,12 +41,13 @@ pub fn handle_all_routes(
     let get_order = get_order_by_uid::get_order_by_uid(orderbook.clone());
     let get_solvable_orders = get_solvable_orders::get_solvable_orders(orderbook.clone());
     let get_trades = get_trades::get_trades(database);
-    let cancel_order = cancel_order::cancel_order(orderbook);
+    let cancel_order = cancel_order::cancel_order(orderbook.clone());
     let get_amount_estimate = get_markets::get_amount_estimate(price_estimator.clone());
     let get_fee_and_quote_sell =
         get_fee_and_quote::get_fee_and_quote_sell(fee_calculator.clone(), price_estimator.clone());
     let get_fee_and_quote_buy =
         get_fee_and_quote::get_fee_and_quote_buy(fee_calculator, price_estimator.clone());
+    let get_user_orders = get_user_orders::get_user_orders(orderbook);
     let cors = warp::cors()
         .allow_any_origin()
         .allow_methods(vec!["GET", "POST", "DELETE", "OPTIONS", "PUT", "PATCH"])
@@ -73,6 +75,8 @@ pub fn handle_all_routes(
             .unify()
             .or(get_fee_and_quote_buy
                 .map(|reply| LabelledReply::new(reply, "get_fee_and_quote_buy")))
+            .unify()
+            .or(get_user_orders.map(|reply| LabelledReply::new(reply, "get_user_orders")))
             .unify(),
     );
     routes_with_labels

--- a/orderbook/src/api/get_user_orders.rs
+++ b/orderbook/src/api/get_user_orders.rs
@@ -1,0 +1,104 @@
+use crate::{api::internal_error, orderbook::Orderbook};
+use anyhow::Result;
+use model::order::Order;
+use serde::Deserialize;
+use shared::H160Wrapper;
+use std::{convert::Infallible, sync::Arc};
+use warp::{
+    hyper::StatusCode,
+    reply::{self, with_status, Json, WithStatus},
+    Filter, Rejection, Reply,
+};
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+struct Query {
+    offset: Option<u64>,
+    limit: Option<u64>,
+}
+
+fn request() -> impl Filter<Extract = (H160Wrapper, Query), Error = Rejection> + Clone {
+    warp::path!("account" / H160Wrapper / "orders")
+        .and(warp::get())
+        .and(warp::query::<Query>())
+}
+
+fn response(result: Result<Vec<Order>>) -> WithStatus<Json> {
+    match result {
+        Ok(orders) => reply::with_status(reply::json(&orders), StatusCode::OK),
+        Err(err) => {
+            tracing::error!(?err, "get_user_orders error");
+            with_status(internal_error(), StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}
+
+pub fn get_user_orders(
+    orderbook: Arc<Orderbook>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    request().and_then(move |owner: H160Wrapper, query: Query| {
+        let orderbook = orderbook.clone();
+        async move {
+            const DEFAULT_OFFSET: u64 = 0;
+            const DEFAULT_LIMIT: u64 = 10;
+            const MIN_LIMIT: u64 = 1;
+            const MAX_LIMIT: u64 = 1000;
+            let offset = query.offset.unwrap_or(DEFAULT_OFFSET);
+            let limit = query.limit.unwrap_or(DEFAULT_LIMIT);
+            if !(MIN_LIMIT..=MAX_LIMIT).contains(&limit) {
+                return Ok(with_status(
+                    super::error(
+                        "LIMIT_OUT_OF_BOUNDS",
+                        &format!("The pagination limit is [{},{}].", MIN_LIMIT, MAX_LIMIT),
+                    ),
+                    StatusCode::BAD_REQUEST,
+                ));
+            }
+            let result = orderbook.get_user_orders(&owner.0, offset, limit).await;
+            Result::<_, Infallible>::Ok(response(result))
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::response_body;
+    use shared::addr;
+
+    #[tokio::test]
+    async fn request_() {
+        let path = "/account/0x0000000000000000000000000000000000000001/orders";
+        let result = warp::test::request()
+            .path(path)
+            .method("GET")
+            .filter(&request())
+            .await
+            .unwrap();
+        assert_eq!(
+            result.0 .0,
+            addr!("0000000000000000000000000000000000000001")
+        );
+        assert_eq!(result.1.offset, None);
+        assert_eq!(result.1.limit, None);
+
+        let path = "/account/0x0000000000000000000000000000000000000001/orders?offset=1&limit=2";
+        let result = warp::test::request()
+            .path(path)
+            .method("GET")
+            .filter(&request())
+            .await
+            .unwrap();
+        assert_eq!(result.1.offset, Some(1));
+        assert_eq!(result.1.limit, Some(2));
+    }
+
+    #[tokio::test]
+    async fn response_ok() {
+        let orders = vec![Order::default()];
+        let response = response(Ok(orders.clone())).into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body(response).await;
+        let response_orders: Vec<Order> = serde_json::from_slice(body.as_slice()).unwrap();
+        assert_eq!(response_orders, orders);
+    }
+}

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -287,6 +287,22 @@ impl Orderbook {
         set_available_balances(orders.as_mut_slice(), &balances);
         Ok(orders)
     }
+
+    pub async fn get_user_orders(
+        &self,
+        owner: &H160,
+        offset: u64,
+        limit: u64,
+    ) -> Result<Vec<Order>> {
+        let mut orders = self
+            .database
+            .user_orders(owner, offset, Some(limit))
+            .await?;
+        let balances =
+            track_and_get_balances(self.balance_fetcher.as_ref(), orders.as_slice()).await;
+        set_available_balances(orders.as_mut_slice(), &balances);
+        Ok(orders)
+    }
 }
 
 #[async_trait::async_trait]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -39,7 +39,7 @@ pub type Web3Transport = DynTransport;
 pub type Web3 = DynWeb3;
 
 /// Wraps H160 with FromStr and Deserialize that can handle a `0x` prefix.
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(transparent)]
 pub struct H160Wrapper(#[serde(with = "h160_hexadecimal")] pub H160);
 impl FromStr for H160Wrapper {


### PR DESCRIPTION
Part of #969

As we talked about I went with limit and offset.
I decided to make the offset default to 0 and the limit default to 10. While I would like to make the parameters mandatory to make it clear to api users that this is a paginated api I also feel it is nice to have defaults when you quickly want to see a users most recent orders by hand.
The limit can be at most 1000.

### Test Plan
new unit test and short curl test for endpoint