### PR TITLE
Update error message for smart contract receiving eth

### DIFF
--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -81,8 +81,8 @@ pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
         Ok(AddOrderResult::TransferEthToContract) => (
             super::error(
                 "TransferEthToContract",
-                "Setting receiver to a smart contract wallet when buying Ether \
-                 is currently not supported",
+                "Sending Ether to a smart contract wallets is currently not \
+                 supported",
             ),
             StatusCode::BAD_REQUEST,
         ),


### PR DESCRIPTION
Now that we accept orders from a smart contract, the check `TransferEthToContract` might be triggered even if the receiver is not set. This PR slightly rephrases the error message.