### PR TITLE
Stable Pool Amplification Parameter Precision

### DIFF
--- a/shared/src/sources/balancer/info_fetching.rs
+++ b/shared/src/sources/balancer/info_fetching.rs
@@ -111,7 +111,7 @@ impl PoolInfoFetching for PoolInfoFetcher {
         let tokens = token_data.await?.0;
         let scaling_exponents = self.get_scaling_exponents(&tokens).await?;
         let amplification_data = amplification_parameter.await?;
-                let amplification_parameter = BigRational::new(
+        let amplification_parameter = BigRational::new(
             amplification_data.0.to_big_int(),
             amplification_data.2.to_big_int(),
         );

--- a/shared/src/sources/balancer/info_fetching.rs
+++ b/shared/src/sources/balancer/info_fetching.rs
@@ -1,13 +1,14 @@
 //! Responsible for conversion of a `pool_address` into `WeightedPoolInfo` which is used by the
 //! event handler to construct a `RegisteredWeightedPool`.
 use crate::{
-    sources::balancer::swap::fixed_point::Bfp, sources::uniswap::pool_fetching::MAX_BATCH_SIZE,
-    token_info::TokenInfoFetching, Web3,
+    conversions::U256Ext, sources::balancer::swap::fixed_point::Bfp,
+    sources::uniswap::pool_fetching::MAX_BATCH_SIZE, token_info::TokenInfoFetching, Web3,
 };
 use anyhow::{anyhow, Result};
 use contracts::{BalancerV2StablePool, BalancerV2Vault, BalancerV2WeightedPool};
-use ethcontract::{batch::CallBatch, Bytes, H160, H256, U256};
+use ethcontract::{batch::CallBatch, Bytes, H160, H256};
 use mockall::*;
+use num::BigRational;
 use std::sync::Arc;
 
 #[derive(Clone, Debug)]
@@ -26,7 +27,7 @@ pub struct WeightedPoolInfo {
 #[derive(Clone, Debug)]
 pub struct StablePoolInfo {
     pub common: CommonPoolInfo,
-    pub amplification_parameter: U256,
+    pub amplification_parameter: BigRational,
 }
 
 /// Via `PoolInfoFetcher` (leverages a combination of `Web3` and `TokenInfoFetching`)
@@ -109,13 +110,16 @@ impl PoolInfoFetching for PoolInfoFetcher {
 
         let tokens = token_data.await?.0;
         let scaling_exponents = self.get_scaling_exponents(&tokens).await?;
+        let amplification_data = amplification_parameter.await?;
+        let amplification_parameter =
+            amplification_data.0.to_big_rational() / amplification_data.2.to_big_rational();
         Ok(StablePoolInfo {
             common: CommonPoolInfo {
                 pool_id,
                 tokens,
                 scaling_exponents,
             },
-            amplification_parameter: amplification_parameter.await?.0,
+            amplification_parameter,
         })
     }
 
@@ -140,6 +144,7 @@ impl PoolInfoFetching for PoolInfoFetcher {
 mod tests {
     use super::*;
     use crate::token_info::{MockTokenInfoFetching, TokenInfo};
+    use ethcontract::U256;
     use ethcontract_mock::Mock;
     use maplit::hashmap;
 
@@ -311,7 +316,7 @@ mod tests {
             .returns((tokens.clone(), vec![], U256::zero()));
         stable_pool
             .expect_call(BalancerV2StablePool::signatures().get_amplification_parameter())
-            .returns((U256::one(), false, U256::zero()));
+            .returns((U256::one(), false, U256::from(1000)));
 
         let mut token_info_fetcher = MockTokenInfoFetching::new();
         token_info_fetcher
@@ -341,6 +346,9 @@ mod tests {
         );
         assert_eq!(pool_info.common.pool_id, pool_id);
         assert_eq!(pool_info.common.scaling_exponents, vec![0u8, 1u8]);
-        assert_eq!(pool_info.amplification_parameter, U256::one());
+        assert_eq!(
+            pool_info.amplification_parameter,
+            BigRational::new(1.into(), 1000.into())
+        );
     }
 }

--- a/shared/src/sources/balancer/info_fetching.rs
+++ b/shared/src/sources/balancer/info_fetching.rs
@@ -110,11 +110,9 @@ impl PoolInfoFetching for PoolInfoFetcher {
 
         let tokens = token_data.await?.0;
         let scaling_exponents = self.get_scaling_exponents(&tokens).await?;
-        let amplification_data = amplification_parameter.await?;
-        let amplification_parameter = BigRational::new(
-            amplification_data.0.to_big_int(),
-            amplification_data.2.to_big_int(),
-        );
+        let (amplification_factor, _, precision) = amplification_parameter.await?;
+        let amplification_parameter =
+            BigRational::new(amplification_factor.to_big_int(), precision.to_big_int());
         Ok(StablePoolInfo {
             common: CommonPoolInfo {
                 pool_id,

--- a/shared/src/sources/balancer/info_fetching.rs
+++ b/shared/src/sources/balancer/info_fetching.rs
@@ -111,8 +111,10 @@ impl PoolInfoFetching for PoolInfoFetcher {
         let tokens = token_data.await?.0;
         let scaling_exponents = self.get_scaling_exponents(&tokens).await?;
         let amplification_data = amplification_parameter.await?;
-        let amplification_parameter =
-            amplification_data.0.to_big_rational() / amplification_data.2.to_big_rational();
+                let amplification_parameter = BigRational::new(
+            amplification_data.0.to_big_int(),
+            amplification_data.2.to_big_int(),
+        );
         Ok(StablePoolInfo {
             common: CommonPoolInfo {
                 pool_id,

--- a/shared/src/sources/balancer/pool_cache.rs
+++ b/shared/src/sources/balancer/pool_cache.rs
@@ -1,3 +1,4 @@
+use crate::conversions::U256Ext;
 use crate::sources::balancer::pool_storage::{PoolEvaluating, RegisteredPool};
 use crate::{
     recent_block_cache::{Block, CacheFetching, CacheKey, CacheMetrics, RecentBlockCache},
@@ -199,8 +200,8 @@ fn handle_results(results: Vec<FetchedBalancerPool>) -> Result<Vec<BalancerPool>
                             .amplification_parameter
                             .expect("Stable pools must have this set."),
                     )? {
-                        // We only keep the U256 value and disregard isUpdating and precision.
-                        Some(state) => state.0,
+                        // This is the ratio of amplification_parameter / precision.
+                        Some(state) => state.0.to_big_rational() / state.2.to_big_rational(),
                         None => return Ok(acc),
                     };
                     acc.push(BalancerPool::Stable(StablePool::new(

--- a/shared/src/sources/balancer/pool_cache.rs
+++ b/shared/src/sources/balancer/pool_cache.rs
@@ -15,6 +15,7 @@ use crate::{
 use anyhow::Result;
 use contracts::{BalancerV2StablePool, BalancerV2Vault, BalancerV2WeightedPool};
 use ethcontract::{batch::CallBatch, errors::MethodError, BlockId, Bytes, H160, H256, U256};
+use num::BigRational;
 use std::{collections::HashSet, sync::Arc};
 
 pub struct PoolReserveFetcher {
@@ -201,7 +202,10 @@ fn handle_results(results: Vec<FetchedBalancerPool>) -> Result<Vec<BalancerPool>
                             .expect("Stable pools must have this set."),
                     )? {
                         // This is the ratio of amplification_parameter / precision.
-                        Some(state) => state.0.to_big_rational() / state.2.to_big_rational(),
+                        Some((amplification_factor, _, precision)) => BigRational::new(
+                            amplification_factor.to_big_int(),
+                            precision.to_big_int(),
+                        ),
                         None => return Ok(acc),
                     };
                     acc.push(BalancerPool::Stable(StablePool::new(

--- a/shared/src/sources/balancer/pool_fetching.rs
+++ b/shared/src/sources/balancer/pool_fetching.rs
@@ -21,6 +21,7 @@ use anyhow::{anyhow, Result};
 use contracts::BalancerV2Vault;
 use ethcontract::{H160, H256, U256};
 use model::TokenPair;
+use num::BigRational;
 use reqwest::Client;
 use std::{
     collections::{HashMap, HashSet},
@@ -196,7 +197,7 @@ pub struct StablePool {
     pub pool_id: H256,
     pub pool_address: H160,
     pub swap_fee_percentage: Bfp,
-    pub amplification_parameter: U256,
+    pub amplification_parameter: BigRational,
     pub reserves: HashMap<H160, TokenState>,
     pub paused: bool,
 }
@@ -206,7 +207,7 @@ impl StablePool {
         pool_data: RegisteredStablePool,
         balances: Vec<U256>,
         swap_fee_percentage: Bfp,
-        amplification_parameter: U256,
+        amplification_parameter: BigRational,
         paused: bool,
     ) -> Self {
         let mut reserves = HashMap::new();
@@ -331,7 +332,7 @@ mod tests {
                 pool_id: H256::from_low_u64_be(1),
                 pool_address: Default::default(),
                 swap_fee_percentage: Bfp::zero(),
-                amplification_parameter: Default::default(),
+                amplification_parameter: BigRational::new(10.into(), 1000.into()),
                 reserves: Default::default(),
                 paused: false,
             }),
@@ -359,7 +360,7 @@ mod tests {
             pool_id: H256::from_low_u64_be(1),
             pool_address: Default::default(),
             swap_fee_percentage: Bfp::zero(),
-            amplification_parameter: Default::default(),
+            amplification_parameter: BigRational::new(1.into(), 2.into()),
             reserves: Default::default(),
             paused: false,
         });
@@ -428,7 +429,7 @@ mod tests {
             pool_id: H256::from_low_u64_be(2),
             pool_address: H160::from_low_u64_be(2),
             swap_fee_percentage: Bfp::one(),
-            amplification_parameter: U256::one(),
+            amplification_parameter: BigRational::from_integer(2.into()),
             reserves: hashmap! { H160::from_low_u64_be(2) => stable_pool_state.clone() },
             paused: true,
         });

--- a/shared/src/sources/balancer/pool_init.rs
+++ b/shared/src/sources/balancer/pool_init.rs
@@ -352,9 +352,10 @@ mod tests {
         swap::fixed_point::Bfp,
     };
     use anyhow::bail;
-    use ethcontract::{H256, U256};
+    use ethcontract::H256;
     use maplit::hashmap;
     use mockall::{predicate::*, Sequence};
+    use num::BigRational;
 
     #[tokio::test]
     async fn initializes_empty_pools() {
@@ -645,7 +646,7 @@ mod tests {
                         tokens: vec![],
                         scaling_exponents: vec![],
                     },
-                    amplification_parameter: U256::one(),
+                    amplification_parameter: BigRational::from_integer(3.into()),
                 })
             });
 

--- a/shared/src/sources/balancer/pool_storage.rs
+++ b/shared/src/sources/balancer/pool_storage.rs
@@ -372,6 +372,7 @@ mod tests {
     };
     use maplit::{hashmap, hashset};
     use mockall::predicate::eq;
+    use num::BigRational;
 
     pub type PoolInitData = (Vec<H256>, Vec<H160>, Vec<H160>, Vec<Bfp>, Vec<PoolCreated>);
     fn pool_init_data(start: usize, end: usize, pool_type: PoolType) -> PoolInitData {
@@ -537,7 +538,7 @@ mod tests {
                     tokens: vec![tokens[i], tokens[i + 1]],
                     scaling_exponents: vec![0, 0],
                 },
-                amplification_parameter: Default::default(),
+                amplification_parameter: BigRational::from_integer(1.into()),
             };
             dummy_data_fetcher
                 .expect_get_stable_pool_data()
@@ -727,7 +728,7 @@ mod tests {
                     tokens: vec![tokens[i], tokens[i + 1]],
                     scaling_exponents: vec![0, 0],
                 },
-                amplification_parameter: Default::default(),
+                amplification_parameter: BigRational::from_integer(1.into()),
             };
             dummy_data_fetcher
                 .expect_get_stable_pool_data()
@@ -754,7 +755,7 @@ mod tests {
                         tokens: vec![new_token],
                         scaling_exponents: vec![0],
                     },
-                    amplification_parameter: Default::default(),
+                    amplification_parameter: BigRational::from_integer(1.into()),
                 })
             });
 

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -154,7 +154,7 @@ impl std::fmt::Debug for WeightedProductOrder {
 pub struct StablePoolOrder {
     pub reserves: HashMap<H160, TokenState>,
     pub fee: BigRational,
-    pub amplification_parameter: U256,
+    pub amplification_parameter: BigRational,
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
 }
 
@@ -282,7 +282,7 @@ impl Default for StablePoolOrder {
         StablePoolOrder {
             reserves: Default::default(),
             fee: num::Zero::zero(),
-            amplification_parameter: Default::default(),
+            amplification_parameter: BigRational::from_integer(1.into()),
             settlement_handling: tests::CapturingSettlementHandler::arc(),
         }
     }

--- a/solver/src/liquidity/balancer.rs
+++ b/solver/src/liquidity/balancer.rs
@@ -174,7 +174,6 @@ mod tests {
     use super::*;
     use crate::interactions::allowances::{Approval, MockAllowanceManaging};
     use crate::settlement::Interaction;
-    use ethcontract::U256;
     use maplit::{hashmap, hashset};
     use mockall::predicate::*;
     use model::TokenPair;
@@ -259,7 +258,7 @@ mod tests {
                 pool_id: H256([0x92; 32]),
                 pool_address: H160([0x92; 20]),
                 swap_fee_percentage: "0.002".parse().unwrap(),
-                amplification_parameter: U256::one(),
+                amplification_parameter: BigRational::from_integer(1.into()),
                 reserves: hashmap! {
                     H160([0x73; 20]) => TokenState {
                             balance: 1_000_000_000_000_000_000u128.into(),

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -282,7 +282,7 @@ impl HttpSolver {
                 let pool_model = AmmModel {
                     parameters: AmmParameters::Stable(StablePoolParameters {
                         reserves,
-                        amplification_parameter: amm.amplification_parameter,
+                        amplification_parameter: amm.amplification_parameter.clone(),
                     }),
                     fee: amm.fee.clone(),
                     cost: CostModel {

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -94,12 +94,12 @@ pub struct WeightedProductPoolParameters {
 }
 
 #[serde_as]
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StablePoolParameters {
     #[serde_as(as = "HashMap<_, DecimalU256>")]
     pub reserves: HashMap<H160, U256>,
-    #[serde(with = "u256_decimal")]
-    pub amplification_parameter: U256,
+    #[serde(with = "ratio_as_decimal")]
+    pub amplification_parameter: BigRational,
 }
 
 #[serde_as]

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -291,7 +291,7 @@ mod tests {
                 },
             },
             fee: BigRational::new(3.into(), 1.into()),
-            amplification_parameter: U256::one(),
+            amplification_parameter: BigRational::from_integer(1.into()),
             settlement_handling: sp_amm_handler.clone(),
         };
         let stable_pool_orders = hashmap! { 0 => stable_pool_order };
@@ -434,7 +434,7 @@ mod tests {
                 },
             },
             fee: BigRational::new(1.into(), 1000.into()),
-            amplification_parameter: U256::one(),
+            amplification_parameter: BigRational::from_integer(1.into()),
             settlement_handling: CapturingSettlementHandler::arc(),
         };
         let stable_pool_orders = hashmap! { 0usize => stable_pool_order.clone() };


### PR DESCRIPTION
Although the precision is a hard coded value (in the stable pool contract), this could potentially change in the future. So we keep this value around and divide at fetching time. This changed what was U256 before to BigRational, which is parsed as decimal when forwarded to http solver.

### Test Plan
Updated tests involving stable pools.
