### PR TITLE
Add command line configuration for public optimization solvers

### DIFF
--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -49,13 +49,21 @@ struct Arguments {
     #[structopt(long, env = "MIP_SOLVER_URL", default_value = "http://localhost:8000")]
     mip_solver_url: Url,
 
-    /// The API endpoint to call the mip v2 solver
+    /// The authorization token for connecting to a publically hosted MIP solver.
+    #[structopt(long, env = "MIP_SOLVER_API_KEY")]
+    mip_solver_api_key: Option<String>,
+
+    /// The API endpoint to call the Quasimodo solver
     #[structopt(
         long,
         env = "QUASIMODO_SOLVER_URL",
         default_value = "http://localhost:8000"
     )]
     quasimodo_solver_url: Url,
+
+    /// The authorization token for connecting to a publically hosted Quasimodo solver.
+    #[structopt(long, env = "QUASIMODO_SOLVER_API_KEY")]
+    quasimodo_solver_api_key: Option<String>,
 
     /// The private key used by the driver to sign transactions.
     #[structopt(short = "k", long, env = "PRIVATE_KEY", hide_env_values = true)]
@@ -385,7 +393,9 @@ async fn main() {
         base_tokens,
         native_token_contract.address(),
         args.mip_solver_url,
+        args.mip_solver_api_key,
         args.quasimodo_solver_url,
+        args.quasimodo_solver_api_key,
         &settlement_contract,
         token_info_fetcher,
         price_estimator.clone(),

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -156,26 +156,27 @@ pub fn create(
     ));
     let http_solver_cache = http_solver::InstanceCache::default();
     // Helper function to create http solver instances.
-    let create_http_solver = |account: Account, url: Url, api_key: Option<String>, name: &'static str| -> HttpSolver {
-        HttpSolver::new(
-            name,
-            account,
-            url,
-            api_key,
-            SolverConfig {
-                max_nr_exec_orders: 100,
-            },
-            native_token,
-            token_info_fetcher.clone(),
-            price_estimator.clone(),
-            buffer_retriever.clone(),
-            network_id.clone(),
-            chain_id,
-            fee_factor,
-            client.clone(),
-            http_solver_cache.clone(),
-        )
-    };
+    let create_http_solver =
+        |account: Account, url: Url, api_key: Option<String>, name: &'static str| -> HttpSolver {
+            HttpSolver::new(
+                name,
+                account,
+                url,
+                api_key,
+                SolverConfig {
+                    max_nr_exec_orders: 100,
+                },
+                native_token,
+                token_info_fetcher.clone(),
+                price_estimator.clone(),
+                buffer_retriever.clone(),
+                network_id.clone(),
+                chain_id,
+                fee_factor,
+                client.clone(),
+                http_solver_cache.clone(),
+            )
+        };
 
     solvers
         .into_iter()

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -127,7 +127,9 @@ pub fn create(
     base_tokens: HashSet<H160>,
     native_token: H160,
     mip_solver_url: Url,
+    mip_solver_api_key: Option<String>,
     quasimodo_solver_url: Url,
+    quasimodo_solver_api_key: Option<String>,
     settlement_contract: &GPv2Settlement,
     token_info_fetcher: Arc<dyn TokenInfoFetching>,
     price_estimator: Arc<dyn PriceEstimating>,
@@ -154,12 +156,12 @@ pub fn create(
     ));
     let http_solver_cache = http_solver::InstanceCache::default();
     // Helper function to create http solver instances.
-    let create_http_solver = |account: Account, url: Url, name: &'static str| -> HttpSolver {
+    let create_http_solver = |account: Account, url: Url, api_key: Option<String>, name: &'static str| -> HttpSolver {
         HttpSolver::new(
             name,
             account,
             url,
-            None,
+            api_key,
             SolverConfig {
                 max_nr_exec_orders: 100,
             },
@@ -181,12 +183,16 @@ pub fn create(
             let solver = match solver_type {
                 SolverType::Naive => shared(NaiveSolver::new(account)),
                 SolverType::Baseline => shared(BaselineSolver::new(account, base_tokens.clone())),
-                SolverType::Mip => {
-                    shared(create_http_solver(account, mip_solver_url.clone(), "Mip"))
-                }
+                SolverType::Mip => shared(create_http_solver(
+                    account,
+                    mip_solver_url.clone(),
+                    mip_solver_api_key.clone(),
+                    "Mip",
+                )),
                 SolverType::Quasimodo => shared(create_http_solver(
                     account,
                     quasimodo_solver_url.clone(),
+                    quasimodo_solver_api_key.clone(),
                     "Quasimodo",
                 )),
                 SolverType::OneInch => {

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -427,9 +427,9 @@ impl HttpSolver {
         // the driver code that calls us also enforces the timeout.
         let mut request = self.client.post(url).timeout(Duration::from_secs(u64::MAX));
         if let Some(api_key) = &self.api_key {
-            let mut header = HeaderValue::from_str(api_key.as_str()).unwrap();
+            let mut header = format!("Basic {}", api_key).parse::<HeaderValue>()?;
             header.set_sensitive(true);
-            request = request.header("X-API-KEY", header);
+            request = request.header("Authorization", header);
         }
         let body = serde_json::to_string(&model).context("failed to encode body")?;
         tracing::trace!("request {}", body);


### PR DESCRIPTION
This PR adds additional command line arguments for configuring the solver to connect to the public MIP and Quasimodo solvers for testing.

One thing I'm not too happy about is that this PR conflates an "API key" for a basic authentication token, but :shrug:. Ultimately its just naming.

### Test Plan

Run with dry-run mode against public Quasimodo solver:
```
$ cargo run -p solver -- --transaction-strategy DryRun --orderbook-url https://protocol-rinkeby.dev.gnosisdev.com --solvers Quasimodo --quasimodo-solver-url $URL --quasimodo-solver-api-key $(printf "$USER:$PASSWD" | base64)
...
2021-09-07T11:25:01.111Z DEBUG solver::driver: solver Quasimodo found solution:
Settlement { encoder: SettlementEncoder { tokens: [0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d, 0xc778417e063141139fce010982780140aa0cd5ab], clearing_prices: {0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d: 389653069831759, 0xc778417e063141139fce010982780140aa0cd5ab: 1000000000000000000}, trades: [Trade { order: Order { order_meta_data: OrderMetaData { creation_date: 2021-09-07T11:24:05.830519Z, owner: 0x3a2c5d8f209f12bdcd84a46d6eeb136cbb0ccb9c, uid: 0x847756eb9d854c4ff71f79efe1dc1a925139da85671d888014b081ed12ba23503a2c5d8f209f12bdcd84a46d6eeb136cbb0ccb9c613752d9, available_balance: Some(3307543720270769865400), executed_buy_amount: 0, executed_sell_amount: 0, executed_sell_amount_before_fees: 0, executed_fee_amount: 0, invalidated: false, status: Open, settlement_contract: 0x9008d19f58aabd9ed0d60971565aa8510560ab41 }, order_creation: OrderCreation { sell_token: 0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d, buy_token: 0xc778417e063141139fce010982780140aa0cd5ab, receiver: Some(0x3a2c5d8f209f12bdcd84a46d6eeb136cbb0ccb9c), sell_amount: 306517698096275649336, buy_amount: 108577783655434667, valid_to: 1631015641, app_data: 0xe4d1ab10f2c9ffe7bdd23c315b03f18cff90888d6b2bb5022bacd46ab9cddf24, fee_amount: 1026022174494216064, kind: Sell, partially_fillable: false, signature: Eip712(EcdsaSignature { r: 0x49be18836f3410f2df360edf4fe88a877a8f3d1ed8a97eabf7c934c10ab36662, s: 0x1ffc9325caa0fb9768f5585605c92cb1c64f5792070a8afd7cab83e383685849, v: 28 }), sell_token_balance: Erc20, buy_token_balance: Erc20 } }, sell_token_index: 0, buy_token_index: 1, executed_amount: 306517698096275649336 }], execution_plan: [AllowanceSufficient, UniswapInteraction { router: IUniswapLikeRouter(0x7a250d5630b4cf539739df2c5dacb4c659f2488d), settlement: GPv2Settlement(0x9008d19f58aabd9ed0d60971565aa8510560ab41), amount_out: 119435562020978145, amount_in_max: 306824215794371922711, token_in: 0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d, token_out: 0xc778417e063141139fce010982780140aa0cd5ab }], unwraps: [] } }
...
```
