### PR TITLE
Remove automatic balance updating from order book

### DIFF
--- a/e2e/tests/eth_integration.rs
+++ b/e2e/tests/eth_integration.rs
@@ -112,7 +112,7 @@ async fn eth_integration(web3: Web3) {
         maintenance,
         price_estimator,
         block_stream,
-        ..
+        solvable_orders_cache,
     } = OrderbookServices::new(&web3, &gpv2, &uniswap_factory).await;
 
     let client = reqwest::Client::new();
@@ -184,6 +184,8 @@ async fn eth_integration(web3: Web3) {
         .await;
     assert_eq!(placement.unwrap().status(), 201);
 
+    solvable_orders_cache.update(0).await.unwrap();
+
     // Drive solution
     let uniswap_pair_provider = Arc::new(UniswapPairProvider {
         factory: uniswap_factory.clone(),
@@ -252,6 +254,7 @@ async fn eth_integration(web3: Web3) {
 
     // Drive orderbook in order to check that all orders were settled
     maintenance.run_maintenance().await.unwrap();
+    solvable_orders_cache.update(0).await.unwrap();
 
     let orders = create_orderbook_api(&web3, weth.address())
         .get_orders()

--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -145,6 +145,7 @@ async fn onchain_settlement(web3: Web3) {
         price_estimator,
         maintenance,
         block_stream,
+        solvable_orders_cache,
     } = OrderbookServices::new(&web3, &gpv2, &uniswap_factory).await;
 
     let client = reqwest::Client::new();
@@ -196,6 +197,8 @@ async fn onchain_settlement(web3: Web3) {
         factory: uniswap_factory.clone(),
         chain_id,
     });
+
+    solvable_orders_cache.update(0).await.unwrap();
 
     // Drive solution
     let uniswap_liquidity = UniswapLikeLiquidity::new(
@@ -260,6 +263,7 @@ async fn onchain_settlement(web3: Web3) {
 
     // Drive orderbook in order to check the removal of settled order_b
     maintenance.run_maintenance().await.unwrap();
+    solvable_orders_cache.update(0).await.unwrap();
 
     let orders = create_orderbook_api(&web3, gpv2.native_token.address())
         .get_orders()

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -145,6 +145,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         price_estimator,
         maintenance,
         block_stream,
+        solvable_orders_cache,
     } = OrderbookServices::new(&web3, &gpv2, &uniswap_factory).await;
 
     let client = reqwest::Client::new();
@@ -169,6 +170,8 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         .send()
         .await;
     assert_eq!(placement.unwrap().status(), 201);
+
+    solvable_orders_cache.update(0).await.unwrap();
 
     let uniswap_pair_provider = Arc::new(UniswapPairProvider {
         factory: uniswap_factory.clone(),
@@ -254,6 +257,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
 
     // Drive orderbook in order to check the removal of settled order_b
     maintenance.run_maintenance().await.unwrap();
+    solvable_orders_cache.update(0).await.unwrap();
 
     let orders = create_orderbook_api(&web3, gpv2.native_token.address())
         .get_orders()

--- a/e2e/tests/smart_contract_orders.rs
+++ b/e2e/tests/smart_contract_orders.rs
@@ -99,6 +99,7 @@ async fn smart_contract_orders(web3: Web3) {
         price_estimator,
         block_stream,
         maintenance,
+        solvable_orders_cache,
     } = OrderbookServices::new(&web3, &gpv2, &uniswap_factory).await;
 
     let client = reqwest::Client::new();
@@ -122,6 +123,8 @@ async fn smart_contract_orders(web3: Web3) {
         .await
         .unwrap();
     assert_eq!(placement.status(), 201);
+
+    solvable_orders_cache.update(0).await.unwrap();
 
     let order_uid = placement.json::<OrderUid>().await.unwrap();
     let order_status = || async {
@@ -150,6 +153,7 @@ async fn smart_contract_orders(web3: Web3) {
 
     // Drive orderbook in order to check that the presignature event was received.
     maintenance.run_maintenance().await.unwrap();
+    solvable_orders_cache.update(0).await.unwrap();
     assert_eq!(order_status().await, OrderStatus::Open);
 
     // Drive solution

--- a/e2e/tests/vault_balances.rs
+++ b/e2e/tests/vault_balances.rs
@@ -102,6 +102,7 @@ async fn vault_balances(web3: Web3) {
     let OrderbookServices {
         price_estimator,
         block_stream,
+        solvable_orders_cache,
         ..
     } = OrderbookServices::new(&web3, &gpv2, &uniswap_factory).await;
 
@@ -130,6 +131,8 @@ async fn vault_balances(web3: Web3) {
         .send()
         .await;
     assert_eq!(placement.unwrap().status(), 201);
+
+    solvable_orders_cache.update(0).await.unwrap();
 
     // Drive solution
     let uniswap_pair_provider = Arc::new(UniswapPairProvider {

--- a/orderbook/src/account_balances.rs
+++ b/orderbook/src/account_balances.rs
@@ -1,36 +1,35 @@
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use contracts::{BalancerV2Vault, ERC20};
 use ethcontract::{batch::CallBatch, Account};
-use futures::{
-    future::{self, join_all, BoxFuture},
-    FutureExt as _,
-};
-use model::order::SellTokenSource;
+use futures::{FutureExt, StreamExt};
+use model::order::{Order, SellTokenSource};
 use primitive_types::{H160, U256};
 use shared::{Web3, Web3Transport};
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use std::future::Future;
 use web3::types::{BlockId, BlockNumber, CallRequest};
 
-const MAX_BATCH_SIZE: usize = 100;
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub struct Query {
+    pub owner: H160,
+    pub token: H160,
+    pub source: SellTokenSource,
+}
+
+impl Query {
+    pub fn from_order(o: &Order) -> Self {
+        Self {
+            owner: o.order_meta_data.owner,
+            token: o.order_creation.sell_token,
+            source: o.order_creation.sell_token_balance,
+        }
+    }
+}
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait BalanceFetching: Send + Sync {
-    // Register owner and address for balance updates in the background
-    async fn register(&self, owner: H160, token: H160, source: SellTokenSource);
-
-    // Register multiple owner and addresses for balance updates in the background
-    async fn register_many(&self, owner_token_list: Vec<(H160, H160, SellTokenSource)>);
-
-    // Returns the latest balance available to the allowance manager for the given owner and token.
-    // Should be non-blocking. Returns None if balance has never been fetched.
-    fn get_balance(&self, owner: H160, token: H160, source: SellTokenSource) -> Option<U256>;
-
-    // Called periodically to perform potential updates on registered balances
-    async fn update(&self);
+    // Returns the balance available to the allowance manager for the given owner and token.
+    async fn get_balances(&self, queries: &[Query]) -> Vec<Result<U256>>;
 
     // Check that the settlement contract can make use of this user's token balance. This check
     // could fail if the user does not have enough balance, has not given the allowance to the
@@ -51,22 +50,6 @@ pub struct Web3BalanceFetcher {
     vault: Option<BalancerV2Vault>,
     vault_relayer: H160,
     settlement_contract: H160,
-    // Mapping of address, token to balance, allowance
-    balances: Mutex<HashMap<SubscriptionKey, SubscriptionValue>>,
-    metrics: Arc<dyn Metrics>,
-}
-
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-struct SubscriptionKey {
-    owner: H160,
-    token: H160,
-    source: SellTokenSource,
-}
-
-#[derive(Clone, Debug, Default)]
-struct SubscriptionValue {
-    balance: Option<U256>,
-    allowance: Option<U256>,
 }
 
 impl Web3BalanceFetcher {
@@ -75,65 +58,13 @@ impl Web3BalanceFetcher {
         vault: Option<BalancerV2Vault>,
         vault_relayer: H160,
         settlement_contract: H160,
-        metrics: Arc<dyn Metrics>,
     ) -> Self {
         Self {
             web3,
             vault,
             vault_relayer,
             settlement_contract,
-            balances: Default::default(),
-            metrics,
         }
-    }
-
-    async fn _register_many(&self, subscriptions: Vec<SubscriptionKey>) -> Result<()> {
-        let mut batch = CallBatch::new(self.web3.transport());
-
-        // Make sure subscriptions are registered for next update even if batch call fails.
-        // Note that we only add an entry if one does not already exist, this allows calls
-        // to `get_balance` to immediately return the previously cached value during the
-        // update.
-        {
-            let mut guard = self.balances.lock().expect("thread holding mutex panicked");
-            for subscription in &subscriptions {
-                guard.entry(*subscription).or_default();
-            }
-        }
-
-        let calls = subscriptions
-            .into_iter()
-            .map(|subscription| {
-                let token = ERC20::at(&self.web3, subscription.token);
-                let value = match (subscription.source, &self.vault) {
-                    (SellTokenSource::Erc20, _) => erc20_balance_query(
-                        &mut batch,
-                        token,
-                        subscription.owner,
-                        self.vault_relayer,
-                    ),
-                    (SellTokenSource::External, Some(vault)) => vault_external_balance_query(
-                        &mut batch,
-                        vault.clone(),
-                        token,
-                        subscription.owner,
-                        self.vault_relayer,
-                    ),
-                    _ => async { SubscriptionValue::default() }.boxed(),
-                };
-                future::join(future::ready(subscription), value)
-            })
-            .collect::<Vec<_>>();
-
-        batch.execute_all(usize::MAX).await;
-
-        let call_results = join_all(calls).await;
-        self.balances
-            .lock()
-            .expect("thread holding mutex panicked")
-            .extend(call_results);
-
-        Ok(())
     }
 
     async fn can_transfer_call(&self, token: H160, from: H160, amount: U256) -> bool {
@@ -178,116 +109,73 @@ impl Web3BalanceFetcher {
     }
 }
 
-fn erc20_balance_query<'a>(
-    batch: &mut CallBatch<&'a Web3Transport>,
+fn erc20_balance_query(
+    batch: &mut CallBatch<Web3Transport>,
     token: ERC20,
     owner: H160,
     spender: H160,
-) -> BoxFuture<'a, SubscriptionValue> {
+) -> impl Future<Output = Result<U256>> {
     let balance = token.balance_of(owner).batch_call(batch);
     let allowance = token.allowance(owner, spender).batch_call(batch);
-
     async move {
-        let (balance, allowance) = futures::join!(balance, allowance);
-
-        let mut value = SubscriptionValue::default();
-        match balance {
-            Ok(balance) => value.balance = Some(balance),
-            Err(_) => tracing::warn!(
-                "Couldn't fetch {:?} balance for {:?}",
-                token.address(),
-                owner
-            ),
-        }
-        match allowance {
-            Ok(allowance) => value.allowance = Some(allowance),
-            Err(_) => tracing::warn!(
-                "Couldn't fetch {:?} allowance from {:?} to {:?}",
-                token.address(),
-                owner,
-                spender
-            ),
-        }
-
-        value
+        let balance = balance.await.context("balance")?;
+        let allowance = allowance.await.context("allowance")?;
+        Ok(balance.min(allowance))
     }
-    .boxed()
 }
 
-fn vault_external_balance_query<'a>(
-    batch: &mut CallBatch<&'a Web3Transport>,
+fn vault_external_balance_query(
+    batch: &mut CallBatch<Web3Transport>,
     vault: BalancerV2Vault,
     token: ERC20,
     owner: H160,
     relayer: H160,
-) -> BoxFuture<'a, SubscriptionValue> {
-    let erc20 = erc20_balance_query(batch, token, owner, vault.address());
+) -> impl Future<Output = Result<U256>> {
+    let balance = token.balance_of(owner).batch_call(batch);
     let approval = vault.has_approved_relayer(owner, relayer).batch_call(batch);
-
     async move {
-        let (value, approval) = futures::join!(erc20, approval);
-        match approval {
-            Ok(true) => value,
-            Ok(false) => SubscriptionValue {
-                allowance: Some(0.into()),
-                ..value
-            },
-            Err(_) => {
-                tracing::warn!(
-                    "Couldn't fetch vault approval from {:?} to {:?}",
-                    owner,
-                    relayer
-                );
-                SubscriptionValue::default()
-            }
-        }
+        Ok(match approval.await.context("allowance")? {
+            true => balance.await.context("balance")?,
+            false => 0.into(),
+        })
     }
-    .boxed()
 }
 
 #[async_trait::async_trait]
 impl BalanceFetching for Web3BalanceFetcher {
-    async fn register(&self, owner: H160, token: H160, source: SellTokenSource) {
-        self.register_many(vec![(owner, token, source)]).await;
-    }
-
-    async fn register_many(&self, owner_token_list: Vec<(H160, H160, SellTokenSource)>) {
-        for chunk in owner_token_list.chunks(MAX_BATCH_SIZE) {
-            let subscriptions = chunk
-                .iter()
-                .map(|(owner, token, source)| SubscriptionKey {
-                    owner: *owner,
-                    token: *token,
-                    source: *source,
-                })
-                .collect();
-            let _ = self._register_many(subscriptions).await;
-        }
-    }
-
-    fn get_balance(&self, owner: H160, token: H160, source: SellTokenSource) -> Option<U256> {
-        let subscription = SubscriptionKey {
-            owner,
-            token,
-            source,
-        };
-        let SubscriptionValue { balance, allowance } = self
-            .balances
-            .lock()
-            .expect("thread holding mutex panicked")
-            .get(&subscription)
-            .cloned()
-            .unwrap_or_default();
-        Some(U256::min(balance?, allowance?))
-    }
-
-    async fn update(&self) {
-        let subscriptions: Vec<_> = {
-            let map = self.balances.lock().expect("mutex holding thread panicked");
-            map.keys().cloned().collect()
-        };
-        self.metrics.account_balance_update(subscriptions.len());
-        let _ = self._register_many(subscriptions).await;
+    async fn get_balances(&self, queries: &[Query]) -> Vec<Result<U256>> {
+        let mut batch = CallBatch::new(self.web3.transport().clone());
+        let futures = queries
+            .iter()
+            .map(|query| {
+                let token = ERC20::at(&self.web3, query.token);
+                match (query.source, &self.vault) {
+                    (SellTokenSource::Erc20, _) => {
+                        erc20_balance_query(&mut batch, token, query.owner, self.vault_relayer)
+                            .boxed()
+                    }
+                    (SellTokenSource::External, Some(vault)) => vault_external_balance_query(
+                        &mut batch,
+                        vault.clone(),
+                        token,
+                        query.owner,
+                        self.vault_relayer,
+                    )
+                    .boxed(),
+                    (SellTokenSource::External, None) => {
+                        async { Err(anyhow!("external balance but no vault")) }.boxed()
+                    }
+                    (SellTokenSource::Internal, _) => {
+                        async { Err(anyhow!("internal balances are not supported")) }.boxed()
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+        batch.execute_all(usize::MAX).await;
+        futures::stream::iter(futures)
+            .then(|future| future)
+            .collect()
+            .await
     }
 
     async fn can_transfer(
@@ -316,28 +204,12 @@ fn is_empty_or_truthy(bytes: &[u8]) -> bool {
     }
 }
 
-pub trait Metrics: Send + Sync + 'static {
-    fn account_balance_update(&self, accounts: usize);
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use contracts::{vault, BalancerV2Authorizer, ERC20Mintable};
     use hex_literal::hex;
     use shared::transport::create_env_test_transport;
-
-    struct NoopMetrics;
-
-    impl NoopMetrics {
-        fn arc() -> Arc<dyn Metrics> {
-            Arc::new(Self)
-        }
-    }
-
-    impl Metrics for NoopMetrics {
-        fn account_balance_update(&self, _: usize) {}
-    }
 
     #[tokio::test]
     #[ignore]
@@ -346,23 +218,22 @@ mod tests {
         let web3 = Web3::new(http);
         let settlement = contracts::GPv2Settlement::deployed(&web3).await.unwrap();
         let vault_relayer = settlement.vault_relayer().call().await.unwrap();
-        let fetcher = Web3BalanceFetcher::new(
-            web3,
-            None,
-            vault_relayer,
-            settlement.address(),
-            NoopMetrics::arc(),
-        );
+        let fetcher = Web3BalanceFetcher::new(web3, None, vault_relayer, settlement.address());
         let owner = H160(hex!("07c2af75788814BA7e5225b2F5c951eD161cB589"));
         let token = H160(hex!("dac17f958d2ee523a2206206994597c13d831ec7"));
 
-        fetcher.register(owner, token, SellTokenSource::Erc20).await;
-        assert!(
-            fetcher
-                .get_balance(owner, token, SellTokenSource::Erc20)
-                .unwrap()
-                >= U256::from(1000)
-        );
+        let result = fetcher
+            .get_balances(&[Query {
+                owner,
+                token,
+                source: SellTokenSource::Erc20,
+            }])
+            .await
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
+        assert!(result >= U256::from(1000));
 
         let call_result = fetcher.can_transfer_call(token, owner, 1000.into()).await;
         assert!(call_result);
@@ -371,30 +242,32 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn mainnet_cannot_transfer() {
+        // TODO: For this test to work we need to find a new address that has approved the contract
+        // for a token that takes a fee on transfer and still has balance nio that token.
+
         let http = create_env_test_transport();
         let web3 = Web3::new(http);
         let settlement = contracts::GPv2Settlement::deployed(&web3).await.unwrap();
         let vault_relayer = settlement.vault_relayer().call().await.unwrap();
-        let fetcher = Web3BalanceFetcher::new(
-            web3,
-            None,
-            vault_relayer,
-            settlement.address(),
-            NoopMetrics::arc(),
-        );
+        let fetcher = Web3BalanceFetcher::new(web3, None, vault_relayer, settlement.address());
         let owner = H160(hex!("78045485dc4ad96f60937dad4b01b118958761ae"));
         // Token takes a fee.
         let token = H160(hex!("bae5f2d8a1299e5c4963eaff3312399253f27ccb"));
 
-        fetcher.register(owner, token, SellTokenSource::Erc20).await;
-        assert!(
-            fetcher
-                .get_balance(owner, token, SellTokenSource::Erc20)
-                .unwrap()
-                >= U256::from(1000)
-        );
+        let result = fetcher
+            .get_balances(&[Query {
+                owner,
+                token,
+                source: SellTokenSource::Erc20,
+            }])
+            .await
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
+        assert!(result >= U256::from(811));
 
-        let call_result = fetcher.can_transfer_call(token, owner, 1000.into()).await;
+        let call_result = fetcher.can_transfer_call(token, owner, 811.into()).await;
         // The non trace method is less accurate and thinks the transfer is ok even though it isn't.
         assert!(call_result);
     }
@@ -420,23 +293,23 @@ mod tests {
             None,
             allowance_target.address(),
             H160::from_low_u64_be(1),
-            NoopMetrics::arc(),
         );
 
-        // Not available until registered
-        assert_eq!(
-            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::Erc20),
-            None,
-        );
+        let get_balance = || async {
+            fetcher
+                .get_balances(&[Query {
+                    owner: trader.address(),
+                    token: token.address(),
+                    source: SellTokenSource::Erc20,
+                }])
+                .await
+                .into_iter()
+                .next()
+                .unwrap()
+                .unwrap()
+        };
 
-        fetcher
-            .register(trader.address(), token.address(), SellTokenSource::Erc20)
-            .await;
-
-        assert_eq!(
-            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::Erc20),
-            Some(U256::zero()),
-        );
+        assert_eq!(get_balance().await, U256::zero());
 
         // Balance without approval should not affect available balance
         token
@@ -444,11 +317,7 @@ mod tests {
             .send()
             .await
             .unwrap();
-        fetcher.update().await;
-        assert_eq!(
-            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::Erc20),
-            Some(U256::zero()),
-        );
+        assert_eq!(get_balance().await, U256::zero(),);
 
         // Approving allowance_target should increase available balance
         token
@@ -456,11 +325,7 @@ mod tests {
             .send()
             .await
             .unwrap();
-        fetcher.update().await;
-        assert_eq!(
-            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::Erc20),
-            Some(100.into()),
-        );
+        assert_eq!(get_balance().await, 100.into(),);
 
         // Spending balance should decrease available balance
         token
@@ -468,11 +333,7 @@ mod tests {
             .send()
             .await
             .unwrap();
-        fetcher.update().await;
-        assert_eq!(
-            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::Erc20),
-            Some(U256::zero()),
-        );
+        assert_eq!(get_balance().await, U256::zero());
     }
 
     #[tokio::test]
@@ -511,7 +372,6 @@ mod tests {
             Some(vault.clone()),
             allowance_target.address(),
             H160::from_low_u64_be(1),
-            NoopMetrics::arc(),
         );
 
         assert!(!fetcher
@@ -605,23 +465,23 @@ mod tests {
             Some(vault.clone()),
             allowance_target.address(),
             H160::from_low_u64_be(1),
-            NoopMetrics::arc(),
         );
 
-        // Not available until registered
-        assert_eq!(
-            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::External),
-            None,
-        );
+        let get_balance = || async {
+            fetcher
+                .get_balances(&[Query {
+                    owner: trader.address(),
+                    token: token.address(),
+                    source: SellTokenSource::External,
+                }])
+                .await
+                .into_iter()
+                .next()
+                .unwrap()
+                .unwrap()
+        };
 
-        fetcher
-            .register(trader.address(), token.address(), SellTokenSource::External)
-            .await;
-
-        assert_eq!(
-            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::External),
-            Some(U256::zero()),
-        );
+        assert_eq!(get_balance().await, U256::zero());
 
         // Balance without allowance and approval should not affect available balance
         token
@@ -629,11 +489,7 @@ mod tests {
             .send()
             .await
             .unwrap();
-        fetcher.update().await;
-        assert_eq!(
-            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::External),
-            Some(U256::zero()),
-        );
+        assert_eq!(get_balance().await, U256::zero(),);
 
         // Balance without approval should not affect available balance
         token
@@ -642,11 +498,7 @@ mod tests {
             .send()
             .await
             .unwrap();
-        fetcher.update().await;
-        assert_eq!(
-            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::External),
-            Some(U256::zero()),
-        );
+        assert_eq!(get_balance().await, U256::zero(),);
 
         // Approving allowance_target as a relayer increase available balance
         vault
@@ -655,11 +507,7 @@ mod tests {
             .send()
             .await
             .unwrap();
-        fetcher.update().await;
-        assert_eq!(
-            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::External),
-            Some(100.into()),
-        );
+        assert_eq!(get_balance().await, 100.into());
 
         // Spending balance should decrease available balance
         token
@@ -668,10 +516,6 @@ mod tests {
             .send()
             .await
             .unwrap();
-        fetcher.update().await;
-        assert_eq!(
-            fetcher.get_balance(trader.address(), token.address(), SellTokenSource::External),
-            Some(50.into()),
-        );
+        assert_eq!(get_balance().await, 50.into());
     }
 }

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -13,6 +13,7 @@ use model::{
 use primitive_types::H160;
 use std::{borrow::Cow, convert::TryInto};
 
+#[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait OrderStoring: Send + Sync {
     async fn insert_order(&self, order: &Order) -> Result<(), InsertionError>;

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -6,6 +6,7 @@ pub mod event_updater;
 pub mod fee;
 pub mod metrics;
 pub mod orderbook;
+pub mod solvable_orders;
 
 use crate::orderbook::Orderbook;
 use anyhow::{anyhow, Context as _, Result};

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -221,7 +221,6 @@ async fn main() {
         vault,
         vault_relayer,
         settlement_contract.address(),
-        metrics.clone(),
     );
 
     let gas_price_estimator = Arc::new(
@@ -343,12 +342,7 @@ async fn main() {
         args.enable_presign_orders,
     ));
     let service_maintainer = ServiceMaintenance {
-        maintainers: vec![
-            orderbook.clone(),
-            database.clone(),
-            Arc::new(event_updater),
-            pool_fetcher,
-        ],
+        maintainers: vec![database.clone(), Arc::new(event_updater), pool_fetcher],
     };
     check_database_connection(orderbook.as_ref()).await;
 

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -10,7 +10,9 @@ use orderbook::{
     fee::EthAwareMinFeeCalculator,
     metrics::Metrics,
     orderbook::Orderbook,
-    serve_task, verify_deployed_contract_constants,
+    serve_task,
+    solvable_orders::SolvableOrdersCache,
+    verify_deployed_contract_constants,
 };
 use primitive_types::H160;
 use shared::metrics::setup_metrics_registry;
@@ -216,12 +218,12 @@ async fn main() {
         database.as_ref().clone(),
         sync_start,
     );
-    let balance_fetcher = Web3BalanceFetcher::new(
+    let balance_fetcher = Arc::new(Web3BalanceFetcher::new(
         web3.clone(),
         vault,
         vault_relayer,
         settlement_contract.address(),
-    );
+    ));
 
     let gas_price_estimator = Arc::new(
         shared::gas_price_estimation::create_priority_estimator(
@@ -328,11 +330,24 @@ async fn main() {
         bad_token_detector.clone(),
     ));
 
+    let solvable_orders_cache = SolvableOrdersCache::new(
+        args.min_order_validity_period,
+        database.clone(),
+        balance_fetcher.clone(),
+        bad_token_detector.clone(),
+        current_block_stream.clone(),
+    );
+    let block = current_block_stream.borrow().number.unwrap().as_u64();
+    solvable_orders_cache
+        .update(block)
+        .await
+        .expect("failed to perform initial sovlable orders update");
+
     let orderbook = Arc::new(Orderbook::new(
         domain_separator,
         settlement_contract.address(),
         database.clone(),
-        Box::new(balance_fetcher),
+        balance_fetcher,
         fee_calculator.clone(),
         args.min_order_validity_period,
         bad_token_detector,
@@ -340,6 +355,7 @@ async fn main() {
         native_token.clone(),
         args.banned_users,
         args.enable_presign_orders,
+        solvable_orders_cache,
     ));
     let service_maintainer = ServiceMaintenance {
         maintainers: vec![database.clone(), Arc::new(event_updater), pool_fetcher],

--- a/orderbook/src/metrics.rs
+++ b/orderbook/src/metrics.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use prometheus::{Histogram, HistogramOpts, HistogramVec, IntCounter, IntGauge, IntGaugeVec, Opts};
+use prometheus::{Histogram, HistogramOpts, HistogramVec, IntCounter, IntGaugeVec, Opts};
 use shared::{
     metrics::get_metrics_registry, sources::uniswap::pool_cache::PoolCacheMetrics,
     transport::instrumented::TransportMetrics,
@@ -20,8 +20,6 @@ pub struct Metrics {
     pool_cache_hits: IntCounter,
     pool_cache_misses: IntCounter,
     database_queries: HistogramVec,
-    /// account balance subscriptions
-    account_balance_queries: IntGauge,
 }
 
 impl Metrics {
@@ -67,12 +65,6 @@ impl Metrics {
         let database_queries = HistogramVec::new(opts, &["type"]).unwrap();
         registry.register(Box::new(database_queries.clone()))?;
 
-        let account_balance_queries = IntGauge::new(
-            "account_balance_queries",
-            "Number accounts whose balances are being tracked",
-        )?;
-        registry.register(Box::new(account_balance_queries.clone()))?;
-
         Ok(Self {
             api_requests,
             db_table_row_count,
@@ -80,7 +72,6 @@ impl Metrics {
             pool_cache_hits,
             pool_cache_misses,
             database_queries,
-            account_balance_queries,
         })
     }
 
@@ -109,12 +100,6 @@ impl PoolCacheMetrics for Metrics {
 impl crate::database::instrumented::Metrics for Metrics {
     fn database_query_histogram(&self, label: &str) -> Histogram {
         self.database_queries.with_label_values(&[label])
-    }
-}
-
-impl crate::account_balances::Metrics for Metrics {
-    fn account_balance_update(&self, accounts: usize) {
-        self.account_balance_queries.set(accounts as _);
     }
 }
 

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -293,9 +293,7 @@ impl Orderbook {
             .database
             .user_orders(owner, offset, Some(limit))
             .await?;
-        let balances =
-            track_and_get_balances(self.balance_fetcher.as_ref(), orders.as_slice()).await;
-        set_available_balances(orders.as_mut_slice(), &balances);
+        set_available_balances(orders.as_mut_slice(), &self.solvable_orders);
         Ok(orders)
     }
 }

--- a/orderbook/src/solvable_orders.rs
+++ b/orderbook/src/solvable_orders.rs
@@ -1,0 +1,379 @@
+use crate::{
+    account_balances::{BalanceFetching, Query},
+    database::orders::OrderStoring,
+    orderbook::filter_unsupported_tokens,
+};
+use anyhow::Result;
+use model::order::Order;
+use primitive_types::U256;
+use shared::{
+    bad_token::BadTokenDetecting, current_block::CurrentBlockStream, time::now_in_epoch_seconds,
+};
+use std::{
+    collections::{HashMap, HashSet},
+    iter::FromIterator,
+    sync::{Arc, Mutex, Weak},
+    time::{Duration, Instant},
+};
+use tokio::sync::Notify;
+
+/// Keeps track and updates the set of currently solvable orders.
+/// For this we also need to keep track of user sell token balances for open orders so this is
+/// retrievable as well.
+/// The cache is updated in the background whenever a new block appears or when the cache is
+/// explicitly notified that it should update for example because a new order got added to the order
+/// book.
+pub struct SolvableOrdersCache {
+    min_order_validity_period: Duration,
+    database: Arc<dyn OrderStoring>,
+    balance_fetcher: Arc<dyn BalanceFetching>,
+    bad_token_detector: Arc<dyn BadTokenDetecting>,
+    notify: Notify,
+    cache: Mutex<Inner>,
+}
+
+type Balances = HashMap<Query, U256>;
+
+struct Inner {
+    orders: Vec<Order>,
+    balances: Balances,
+    block: u64,
+    update_time: Instant,
+}
+
+impl SolvableOrdersCache {
+    pub fn new(
+        min_order_validity_period: Duration,
+        database: Arc<dyn OrderStoring>,
+        balance_fetcher: Arc<dyn BalanceFetching>,
+        bad_token_detector: Arc<dyn BadTokenDetecting>,
+        current_block: CurrentBlockStream,
+    ) -> Arc<Self> {
+        let self_ = Arc::new(Self {
+            min_order_validity_period,
+            database,
+            balance_fetcher,
+            bad_token_detector,
+            notify: Default::default(),
+            cache: Mutex::new(Inner {
+                orders: Default::default(),
+                balances: Default::default(),
+                block: 0,
+                update_time: Instant::now(),
+            }),
+        });
+        tokio::task::spawn(update_task(Arc::downgrade(&self_), current_block));
+        self_
+    }
+
+    pub fn cached_balance(&self, key: &Query) -> Option<U256> {
+        let inner = self.cache.lock().unwrap();
+        inner.balances.get(key).copied()
+    }
+
+    /// Orders and timestamp at which last update happened.
+    pub fn cached_solvable_orders(&self) -> (Vec<Order>, Instant) {
+        let inner = self.cache.lock().unwrap();
+        (inner.orders.clone(), inner.update_time)
+    }
+
+    /// The cache will update the solvable orders and missing balances as soon as possible.
+    pub fn request_update(&self) {
+        self.notify.notify_one();
+    }
+
+    /// Manually update solvable orders. Usually called by the background updating task.
+    pub async fn update(&self, block: u64) -> Result<()> {
+        let min_valid_to = now_in_epoch_seconds() + self.min_order_validity_period.as_secs() as u32;
+        let orders = self.database.solvable_orders(min_valid_to).await?;
+        let orders = filter_unsupported_tokens(orders, self.bad_token_detector.as_ref()).await?;
+
+        // If we update due to an explicit notification we can reuse existing balances as they
+        // cannot have changed.
+        let old_balances = {
+            let inner = self.cache.lock().unwrap();
+            if inner.block == block {
+                inner.balances.clone()
+            } else {
+                HashMap::new()
+            }
+        };
+        let (mut new_balances, missing_queries) = new_balances(&old_balances, &orders);
+        let fetched_balances = self.balance_fetcher.get_balances(&missing_queries).await;
+        for (query, balance) in missing_queries.into_iter().zip(fetched_balances) {
+            let balance = match balance {
+                Ok(balance) => balance,
+                Err(err) => {
+                    tracing::warn!(
+                        owner = %query.owner,
+                        token = %query.token,
+                        source = ?query.source,
+                        error = ?err,
+                        "failed to get balance"
+                    );
+                    continue;
+                }
+            };
+            new_balances.insert(query, balance);
+        }
+
+        let mut orders = solvable_orders(orders, &new_balances);
+        for order in &mut orders {
+            let query = Query::from_order(order);
+            order.order_meta_data.available_balance = new_balances.get(&query).copied();
+        }
+
+        *self.cache.lock().unwrap() = Inner {
+            orders,
+            balances: new_balances,
+            block,
+            update_time: Instant::now(),
+        };
+
+        Ok(())
+    }
+}
+
+/// Returns existing balances and Vec of queries that need to be peformed.
+fn new_balances(old_balances: &Balances, orders: &[Order]) -> (HashMap<Query, U256>, Vec<Query>) {
+    let mut new_balances = HashMap::new();
+    let mut missing_queries = HashSet::new();
+    for order in orders {
+        let query = Query::from_order(order);
+        match old_balances.get(&query) {
+            Some(balance) => {
+                new_balances.insert(query, *balance);
+            }
+            None => {
+                missing_queries.insert(query);
+            }
+        }
+    }
+    let missing_queries = Vec::from_iter(missing_queries);
+    (new_balances, missing_queries)
+}
+
+// The order book has to make a choice for which orders to include when a user has multiple orders
+// selling the same token but not enough balance for all of them.
+// Assumes balance fetcher is already tracking all balances.
+fn solvable_orders(mut orders: Vec<Order>, balances: &Balances) -> Vec<Order> {
+    let mut orders_map = HashMap::<Query, Vec<Order>>::new();
+    orders.sort_by_key(|order| std::cmp::Reverse(order.order_meta_data.creation_date));
+    for order in orders {
+        let key = Query::from_order(&order);
+        orders_map.entry(key).or_default().push(order);
+    }
+
+    let mut result = Vec::new();
+    for (key, orders) in orders_map {
+        let mut remaining_balance = match balances.get(&key) {
+            Some(balance) => *balance,
+            None => continue,
+        };
+        for order in orders {
+            // TODO: This is overly pessimistic for partially filled orders where the needed balance
+            // is lower. For partially fillable orders that cannot be fully filled because of the
+            // balance we could also give them as much balance as possible instead of skipping. For
+            // that we first need a way to communicate this to the solver. We could repurpose
+            // availableBalance for this.
+            let needed_balance = match order
+                .order_creation
+                .sell_amount
+                .checked_add(order.order_creation.fee_amount)
+            {
+                Some(balance) => balance,
+                None => continue,
+            };
+            if let Some(balance) = remaining_balance.checked_sub(needed_balance) {
+                remaining_balance = balance;
+                result.push(order);
+            }
+        }
+    }
+    result
+}
+
+/// Keep updating the cache when the current block changes or an update notification happens.
+/// Exits when this becomes the only reference to the cache.
+async fn update_task(cache: Weak<SolvableOrdersCache>, mut current_block: CurrentBlockStream) {
+    loop {
+        let cache = match cache.upgrade() {
+            Some(self_) => self_,
+            None => {
+                tracing::debug!("exiting solvable orders update task");
+                break;
+            }
+        };
+        {
+            let new_block = current_block.changed();
+            let notified = cache.notify.notified();
+            futures::pin_mut!(new_block);
+            futures::pin_mut!(notified);
+            futures::future::select(new_block, notified).await;
+        }
+        let block = match current_block.borrow().number {
+            Some(block) => block.as_u64(),
+            None => {
+                tracing::error!("no block number");
+                continue;
+            }
+        };
+        match cache.update(block).await {
+            Ok(()) => tracing::debug!("updated solvable orders"),
+            Err(err) => tracing::error!(?err, "failed to update solvable orders"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{account_balances::MockBalanceFetching, database::orders::MockOrderStoring};
+    use chrono::{DateTime, NaiveDateTime, Utc};
+    use maplit::hashmap;
+    use model::order::{OrderCreation, OrderMetaData, SellTokenSource};
+    use primitive_types::H160;
+
+    #[tokio::test]
+    async fn filters_insufficient_balances() {
+        let mut orders = vec![
+            Order {
+                order_creation: OrderCreation {
+                    sell_amount: 3.into(),
+                    fee_amount: 3.into(),
+                    ..Default::default()
+                },
+                order_meta_data: OrderMetaData {
+                    creation_date: DateTime::from_utc(NaiveDateTime::from_timestamp(2, 0), Utc),
+                    ..Default::default()
+                },
+            },
+            Order {
+                order_creation: OrderCreation {
+                    sell_amount: 2.into(),
+                    fee_amount: 2.into(),
+                    ..Default::default()
+                },
+                order_meta_data: OrderMetaData {
+                    creation_date: DateTime::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
+                    ..Default::default()
+                },
+            },
+        ];
+
+        let balances = hashmap! {Query::from_order(&orders[0]) => U256::from(9)};
+        let orders_ = solvable_orders(orders.clone(), &balances);
+        // Second order has lower timestamp so it isn't picked.
+        assert_eq!(orders_, orders[..1]);
+        orders[1].order_meta_data.creation_date =
+            DateTime::from_utc(NaiveDateTime::from_timestamp(3, 0), Utc);
+        let orders_ = solvable_orders(orders.clone(), &balances);
+        assert_eq!(orders_, orders[1..]);
+    }
+
+    #[tokio::test]
+    async fn caches_orders_and_balances() {
+        let mut balance_fetcher = MockBalanceFetching::new();
+        let mut order_storing = MockOrderStoring::new();
+        let (_, receiver) = tokio::sync::watch::channel(Default::default());
+        let bad_token_detector =
+            shared::bad_token::list_based::ListBasedDetector::deny_list(Vec::new());
+
+        let owner = H160::from_low_u64_le(0);
+        let sell_token_0 = H160::from_low_u64_le(1);
+        let sell_token_1 = H160::from_low_u64_le(2);
+
+        let orders = [
+            Order {
+                order_creation: OrderCreation {
+                    sell_token: sell_token_0,
+                    sell_token_balance: SellTokenSource::Erc20,
+                    ..Default::default()
+                },
+                order_meta_data: OrderMetaData {
+                    owner,
+                    ..Default::default()
+                },
+            },
+            Order {
+                order_creation: OrderCreation {
+                    sell_token: sell_token_1,
+                    sell_token_balance: SellTokenSource::Erc20,
+                    ..Default::default()
+                },
+                order_meta_data: OrderMetaData {
+                    owner,
+                    ..Default::default()
+                },
+            },
+        ];
+
+        order_storing
+            .expect_solvable_orders()
+            .times(1)
+            .return_once({
+                let orders = orders.clone();
+                move |_| Ok(vec![orders[0].clone()])
+            });
+        order_storing
+            .expect_solvable_orders()
+            .times(1)
+            .return_once({
+                let orders = orders.clone();
+                move |_| Ok(orders.into())
+            });
+        order_storing
+            .expect_solvable_orders()
+            .times(1)
+            .return_once(|_| Ok(Vec::new()));
+
+        balance_fetcher
+            .expect_get_balances()
+            .times(1)
+            .return_once(|_| vec![Ok(1.into())]);
+        balance_fetcher
+            .expect_get_balances()
+            .times(1)
+            .return_once(|_| vec![Ok(2.into())]);
+        balance_fetcher
+            .expect_get_balances()
+            .times(1)
+            .return_once(|_| Vec::new());
+
+        let cache = SolvableOrdersCache::new(
+            Duration::from_secs(0),
+            Arc::new(order_storing),
+            Arc::new(balance_fetcher),
+            Arc::new(bad_token_detector),
+            receiver,
+        );
+
+        cache.update(0).await.unwrap();
+        assert_eq!(
+            cache.cached_balance(&Query::from_order(&orders[0])),
+            Some(1.into())
+        );
+        assert_eq!(cache.cached_balance(&Query::from_order(&orders[1])), None);
+        let orders_ = cache.cached_solvable_orders().0;
+        assert_eq!(orders_.len(), 1);
+        assert_eq!(orders_[0].order_meta_data.available_balance, Some(1.into()));
+
+        cache.update(0).await.unwrap();
+        assert_eq!(
+            cache.cached_balance(&Query::from_order(&orders[0])),
+            Some(1.into())
+        );
+        assert_eq!(
+            cache.cached_balance(&Query::from_order(&orders[1])),
+            Some(2.into())
+        );
+        let orders_ = cache.cached_solvable_orders().0;
+        assert_eq!(orders_.len(), 2);
+
+        cache.update(0).await.unwrap();
+        assert_eq!(cache.cached_balance(&Query::from_order(&orders[0])), None,);
+        assert_eq!(cache.cached_balance(&Query::from_order(&orders[1])), None,);
+        let orders_ = cache.cached_solvable_orders().0;
+        assert_eq!(orders_.len(), 0);
+    }
+}


### PR DESCRIPTION
First part of moving to a permanent solvable orders + balances cache in one component.
While I expect it to be functional this PR isn't meant to be merged standalone as it removes all caching. I split it out for easier review to not have the many changes to account_balances and the new component in one PR.
This PR removes all caching functionality from the balance fetcher keeping only the raw operations.
The second PR will introduce the new component that keeps track of solvable orders and related balances.

Part of https://github.com/gnosis/gp-v2-services/issues/967

### Test Plan
existing tests but also not meant to be merged alone. ran the ignored balance fetcher tests.