### PR TITLE
Use solvable orders and balance cache in one component

### DIFF
--- a/e2e/tests/eth_integration.rs
+++ b/e2e/tests/eth_integration.rs
@@ -112,7 +112,7 @@ async fn eth_integration(web3: Web3) {
         maintenance,
         price_estimator,
         block_stream,
-        ..
+        solvable_orders_cache,
     } = OrderbookServices::new(&web3, &gpv2, &uniswap_factory).await;
 
     let client = reqwest::Client::new();
@@ -184,6 +184,8 @@ async fn eth_integration(web3: Web3) {
         .await;
     assert_eq!(placement.unwrap().status(), 201);
 
+    solvable_orders_cache.update(0).await.unwrap();
+
     // Drive solution
     let uniswap_pair_provider = Arc::new(UniswapPairProvider {
         factory: uniswap_factory.clone(),
@@ -252,6 +254,7 @@ async fn eth_integration(web3: Web3) {
 
     // Drive orderbook in order to check that all orders were settled
     maintenance.run_maintenance().await.unwrap();
+    solvable_orders_cache.update(0).await.unwrap();
 
     let orders = create_orderbook_api(&web3, weth.address())
         .get_orders()

--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -145,6 +145,7 @@ async fn onchain_settlement(web3: Web3) {
         price_estimator,
         maintenance,
         block_stream,
+        solvable_orders_cache,
     } = OrderbookServices::new(&web3, &gpv2, &uniswap_factory).await;
 
     let client = reqwest::Client::new();
@@ -196,6 +197,8 @@ async fn onchain_settlement(web3: Web3) {
         factory: uniswap_factory.clone(),
         chain_id,
     });
+
+    solvable_orders_cache.update(0).await.unwrap();
 
     // Drive solution
     let uniswap_liquidity = UniswapLikeLiquidity::new(
@@ -260,6 +263,7 @@ async fn onchain_settlement(web3: Web3) {
 
     // Drive orderbook in order to check the removal of settled order_b
     maintenance.run_maintenance().await.unwrap();
+    solvable_orders_cache.update(0).await.unwrap();
 
     let orders = create_orderbook_api(&web3, gpv2.native_token.address())
         .get_orders()

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -145,6 +145,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         price_estimator,
         maintenance,
         block_stream,
+        solvable_orders_cache,
     } = OrderbookServices::new(&web3, &gpv2, &uniswap_factory).await;
 
     let client = reqwest::Client::new();
@@ -169,6 +170,8 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         .send()
         .await;
     assert_eq!(placement.unwrap().status(), 201);
+
+    solvable_orders_cache.update(0).await.unwrap();
 
     let uniswap_pair_provider = Arc::new(UniswapPairProvider {
         factory: uniswap_factory.clone(),
@@ -254,6 +257,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
 
     // Drive orderbook in order to check the removal of settled order_b
     maintenance.run_maintenance().await.unwrap();
+    solvable_orders_cache.update(0).await.unwrap();
 
     let orders = create_orderbook_api(&web3, gpv2.native_token.address())
         .get_orders()

--- a/e2e/tests/smart_contract_orders.rs
+++ b/e2e/tests/smart_contract_orders.rs
@@ -99,6 +99,7 @@ async fn smart_contract_orders(web3: Web3) {
         price_estimator,
         block_stream,
         maintenance,
+        solvable_orders_cache,
     } = OrderbookServices::new(&web3, &gpv2, &uniswap_factory).await;
 
     let client = reqwest::Client::new();
@@ -122,6 +123,8 @@ async fn smart_contract_orders(web3: Web3) {
         .await
         .unwrap();
     assert_eq!(placement.status(), 201);
+
+    solvable_orders_cache.update(0).await.unwrap();
 
     let order_uid = placement.json::<OrderUid>().await.unwrap();
     let order_status = || async {
@@ -150,6 +153,7 @@ async fn smart_contract_orders(web3: Web3) {
 
     // Drive orderbook in order to check that the presignature event was received.
     maintenance.run_maintenance().await.unwrap();
+    solvable_orders_cache.update(0).await.unwrap();
     assert_eq!(order_status().await, OrderStatus::Open);
 
     // Drive solution

--- a/e2e/tests/vault_balances.rs
+++ b/e2e/tests/vault_balances.rs
@@ -102,6 +102,7 @@ async fn vault_balances(web3: Web3) {
     let OrderbookServices {
         price_estimator,
         block_stream,
+        solvable_orders_cache,
         ..
     } = OrderbookServices::new(&web3, &gpv2, &uniswap_factory).await;
 
@@ -130,6 +131,8 @@ async fn vault_balances(web3: Web3) {
         .send()
         .await;
     assert_eq!(placement.unwrap().status(), 201);
+
+    solvable_orders_cache.update(0).await.unwrap();
 
     // Drive solution
     let uniswap_pair_provider = Arc::new(UniswapPairProvider {

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -13,6 +13,7 @@ use model::{
 use primitive_types::H160;
 use std::{borrow::Cow, convert::TryInto};
 
+#[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait OrderStoring: Send + Sync {
     async fn insert_order(&self, order: &Order) -> Result<(), InsertionError>;

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -6,6 +6,7 @@ pub mod event_updater;
 pub mod fee;
 pub mod metrics;
 pub mod orderbook;
+pub mod solvable_orders;
 
 use crate::orderbook::Orderbook;
 use anyhow::{anyhow, Context as _, Result};

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -10,7 +10,9 @@ use orderbook::{
     fee::EthAwareMinFeeCalculator,
     metrics::Metrics,
     orderbook::Orderbook,
-    serve_task, verify_deployed_contract_constants,
+    serve_task,
+    solvable_orders::SolvableOrdersCache,
+    verify_deployed_contract_constants,
 };
 use primitive_types::H160;
 use shared::metrics::setup_metrics_registry;
@@ -216,12 +218,12 @@ async fn main() {
         database.as_ref().clone(),
         sync_start,
     );
-    let balance_fetcher = Web3BalanceFetcher::new(
+    let balance_fetcher = Arc::new(Web3BalanceFetcher::new(
         web3.clone(),
         vault,
         vault_relayer,
         settlement_contract.address(),
-    );
+    ));
 
     let gas_price_estimator = Arc::new(
         shared::gas_price_estimation::create_priority_estimator(
@@ -328,11 +330,24 @@ async fn main() {
         bad_token_detector.clone(),
     ));
 
+    let solvable_orders_cache = SolvableOrdersCache::new(
+        args.min_order_validity_period,
+        database.clone(),
+        balance_fetcher.clone(),
+        bad_token_detector.clone(),
+        current_block_stream.clone(),
+    );
+    let block = current_block_stream.borrow().number.unwrap().as_u64();
+    solvable_orders_cache
+        .update(block)
+        .await
+        .expect("failed to perform initial sovlable orders update");
+
     let orderbook = Arc::new(Orderbook::new(
         domain_separator,
         settlement_contract.address(),
         database.clone(),
-        Box::new(balance_fetcher),
+        balance_fetcher,
         fee_calculator.clone(),
         args.min_order_validity_period,
         bad_token_detector,
@@ -340,6 +355,7 @@ async fn main() {
         native_token.clone(),
         args.banned_users,
         args.enable_presign_orders,
+        solvable_orders_cache,
     ));
     let service_maintainer = ServiceMaintenance {
         maintainers: vec![database.clone(), Arc::new(event_updater), pool_fetcher],

--- a/orderbook/src/solvable_orders.rs
+++ b/orderbook/src/solvable_orders.rs
@@ -1,0 +1,379 @@
+use crate::{
+    account_balances::{BalanceFetching, Query},
+    database::orders::OrderStoring,
+    orderbook::filter_unsupported_tokens,
+};
+use anyhow::Result;
+use model::order::Order;
+use primitive_types::U256;
+use shared::{
+    bad_token::BadTokenDetecting, current_block::CurrentBlockStream, time::now_in_epoch_seconds,
+};
+use std::{
+    collections::{HashMap, HashSet},
+    iter::FromIterator,
+    sync::{Arc, Mutex, Weak},
+    time::{Duration, Instant},
+};
+use tokio::sync::Notify;
+
+/// Keeps track and updates the set of currently solvable orders.
+/// For this we also need to keep track of user sell token balances for open orders so this is
+/// retrievable as well.
+/// The cache is updated in the background whenever a new block appears or when the cache is
+/// explicitly notified that it should update for example because a new order got added to the order
+/// book.
+pub struct SolvableOrdersCache {
+    min_order_validity_period: Duration,
+    database: Arc<dyn OrderStoring>,
+    balance_fetcher: Arc<dyn BalanceFetching>,
+    bad_token_detector: Arc<dyn BadTokenDetecting>,
+    notify: Notify,
+    cache: Mutex<Inner>,
+}
+
+type Balances = HashMap<Query, U256>;
+
+struct Inner {
+    orders: Vec<Order>,
+    balances: Balances,
+    block: u64,
+    update_time: Instant,
+}
+
+impl SolvableOrdersCache {
+    pub fn new(
+        min_order_validity_period: Duration,
+        database: Arc<dyn OrderStoring>,
+        balance_fetcher: Arc<dyn BalanceFetching>,
+        bad_token_detector: Arc<dyn BadTokenDetecting>,
+        current_block: CurrentBlockStream,
+    ) -> Arc<Self> {
+        let self_ = Arc::new(Self {
+            min_order_validity_period,
+            database,
+            balance_fetcher,
+            bad_token_detector,
+            notify: Default::default(),
+            cache: Mutex::new(Inner {
+                orders: Default::default(),
+                balances: Default::default(),
+                block: 0,
+                update_time: Instant::now(),
+            }),
+        });
+        tokio::task::spawn(update_task(Arc::downgrade(&self_), current_block));
+        self_
+    }
+
+    pub fn cached_balance(&self, key: &Query) -> Option<U256> {
+        let inner = self.cache.lock().unwrap();
+        inner.balances.get(key).copied()
+    }
+
+    /// Orders and timestamp at which last update happened.
+    pub fn cached_solvable_orders(&self) -> (Vec<Order>, Instant) {
+        let inner = self.cache.lock().unwrap();
+        (inner.orders.clone(), inner.update_time)
+    }
+
+    /// The cache will update the solvable orders and missing balances as soon as possible.
+    pub fn request_update(&self) {
+        self.notify.notify_one();
+    }
+
+    /// Manually update solvable orders. Usually called by the background updating task.
+    pub async fn update(&self, block: u64) -> Result<()> {
+        let min_valid_to = now_in_epoch_seconds() + self.min_order_validity_period.as_secs() as u32;
+        let orders = self.database.solvable_orders(min_valid_to).await?;
+        let orders = filter_unsupported_tokens(orders, self.bad_token_detector.as_ref()).await?;
+
+        // If we update due to an explicit notification we can reuse existing balances as they
+        // cannot have changed.
+        let old_balances = {
+            let inner = self.cache.lock().unwrap();
+            if inner.block == block {
+                inner.balances.clone()
+            } else {
+                HashMap::new()
+            }
+        };
+        let (mut new_balances, missing_queries) = new_balances(&old_balances, &orders);
+        let fetched_balances = self.balance_fetcher.get_balances(&missing_queries).await;
+        for (query, balance) in missing_queries.into_iter().zip(fetched_balances) {
+            let balance = match balance {
+                Ok(balance) => balance,
+                Err(err) => {
+                    tracing::warn!(
+                        owner = %query.owner,
+                        token = %query.token,
+                        source = ?query.source,
+                        error = ?err,
+                        "failed to get balance"
+                    );
+                    continue;
+                }
+            };
+            new_balances.insert(query, balance);
+        }
+
+        let mut orders = solvable_orders(orders, &new_balances);
+        for order in &mut orders {
+            let query = Query::from_order(order);
+            order.order_meta_data.available_balance = new_balances.get(&query).copied();
+        }
+
+        *self.cache.lock().unwrap() = Inner {
+            orders,
+            balances: new_balances,
+            block,
+            update_time: Instant::now(),
+        };
+
+        Ok(())
+    }
+}
+
+/// Returns existing balances and Vec of queries that need to be peformed.
+fn new_balances(old_balances: &Balances, orders: &[Order]) -> (HashMap<Query, U256>, Vec<Query>) {
+    let mut new_balances = HashMap::new();
+    let mut missing_queries = HashSet::new();
+    for order in orders {
+        let query = Query::from_order(order);
+        match old_balances.get(&query) {
+            Some(balance) => {
+                new_balances.insert(query, *balance);
+            }
+            None => {
+                missing_queries.insert(query);
+            }
+        }
+    }
+    let missing_queries = Vec::from_iter(missing_queries);
+    (new_balances, missing_queries)
+}
+
+// The order book has to make a choice for which orders to include when a user has multiple orders
+// selling the same token but not enough balance for all of them.
+// Assumes balance fetcher is already tracking all balances.
+fn solvable_orders(mut orders: Vec<Order>, balances: &Balances) -> Vec<Order> {
+    let mut orders_map = HashMap::<Query, Vec<Order>>::new();
+    orders.sort_by_key(|order| std::cmp::Reverse(order.order_meta_data.creation_date));
+    for order in orders {
+        let key = Query::from_order(&order);
+        orders_map.entry(key).or_default().push(order);
+    }
+
+    let mut result = Vec::new();
+    for (key, orders) in orders_map {
+        let mut remaining_balance = match balances.get(&key) {
+            Some(balance) => *balance,
+            None => continue,
+        };
+        for order in orders {
+            // TODO: This is overly pessimistic for partially filled orders where the needed balance
+            // is lower. For partially fillable orders that cannot be fully filled because of the
+            // balance we could also give them as much balance as possible instead of skipping. For
+            // that we first need a way to communicate this to the solver. We could repurpose
+            // availableBalance for this.
+            let needed_balance = match order
+                .order_creation
+                .sell_amount
+                .checked_add(order.order_creation.fee_amount)
+            {
+                Some(balance) => balance,
+                None => continue,
+            };
+            if let Some(balance) = remaining_balance.checked_sub(needed_balance) {
+                remaining_balance = balance;
+                result.push(order);
+            }
+        }
+    }
+    result
+}
+
+/// Keep updating the cache when the current block changes or an update notification happens.
+/// Exits when this becomes the only reference to the cache.
+async fn update_task(cache: Weak<SolvableOrdersCache>, mut current_block: CurrentBlockStream) {
+    loop {
+        let cache = match cache.upgrade() {
+            Some(self_) => self_,
+            None => {
+                tracing::debug!("exiting solvable orders update task");
+                break;
+            }
+        };
+        {
+            let new_block = current_block.changed();
+            let notified = cache.notify.notified();
+            futures::pin_mut!(new_block);
+            futures::pin_mut!(notified);
+            futures::future::select(new_block, notified).await;
+        }
+        let block = match current_block.borrow().number {
+            Some(block) => block.as_u64(),
+            None => {
+                tracing::error!("no block number");
+                continue;
+            }
+        };
+        match cache.update(block).await {
+            Ok(()) => tracing::debug!("updated solvable orders"),
+            Err(err) => tracing::error!(?err, "failed to update solvable orders"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{account_balances::MockBalanceFetching, database::orders::MockOrderStoring};
+    use chrono::{DateTime, NaiveDateTime, Utc};
+    use maplit::hashmap;
+    use model::order::{OrderCreation, OrderMetaData, SellTokenSource};
+    use primitive_types::H160;
+
+    #[tokio::test]
+    async fn filters_insufficient_balances() {
+        let mut orders = vec![
+            Order {
+                order_creation: OrderCreation {
+                    sell_amount: 3.into(),
+                    fee_amount: 3.into(),
+                    ..Default::default()
+                },
+                order_meta_data: OrderMetaData {
+                    creation_date: DateTime::from_utc(NaiveDateTime::from_timestamp(2, 0), Utc),
+                    ..Default::default()
+                },
+            },
+            Order {
+                order_creation: OrderCreation {
+                    sell_amount: 2.into(),
+                    fee_amount: 2.into(),
+                    ..Default::default()
+                },
+                order_meta_data: OrderMetaData {
+                    creation_date: DateTime::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
+                    ..Default::default()
+                },
+            },
+        ];
+
+        let balances = hashmap! {Query::from_order(&orders[0]) => U256::from(9)};
+        let orders_ = solvable_orders(orders.clone(), &balances);
+        // Second order has lower timestamp so it isn't picked.
+        assert_eq!(orders_, orders[..1]);
+        orders[1].order_meta_data.creation_date =
+            DateTime::from_utc(NaiveDateTime::from_timestamp(3, 0), Utc);
+        let orders_ = solvable_orders(orders.clone(), &balances);
+        assert_eq!(orders_, orders[1..]);
+    }
+
+    #[tokio::test]
+    async fn caches_orders_and_balances() {
+        let mut balance_fetcher = MockBalanceFetching::new();
+        let mut order_storing = MockOrderStoring::new();
+        let (_, receiver) = tokio::sync::watch::channel(Default::default());
+        let bad_token_detector =
+            shared::bad_token::list_based::ListBasedDetector::deny_list(Vec::new());
+
+        let owner = H160::from_low_u64_le(0);
+        let sell_token_0 = H160::from_low_u64_le(1);
+        let sell_token_1 = H160::from_low_u64_le(2);
+
+        let orders = [
+            Order {
+                order_creation: OrderCreation {
+                    sell_token: sell_token_0,
+                    sell_token_balance: SellTokenSource::Erc20,
+                    ..Default::default()
+                },
+                order_meta_data: OrderMetaData {
+                    owner,
+                    ..Default::default()
+                },
+            },
+            Order {
+                order_creation: OrderCreation {
+                    sell_token: sell_token_1,
+                    sell_token_balance: SellTokenSource::Erc20,
+                    ..Default::default()
+                },
+                order_meta_data: OrderMetaData {
+                    owner,
+                    ..Default::default()
+                },
+            },
+        ];
+
+        order_storing
+            .expect_solvable_orders()
+            .times(1)
+            .return_once({
+                let orders = orders.clone();
+                move |_| Ok(vec![orders[0].clone()])
+            });
+        order_storing
+            .expect_solvable_orders()
+            .times(1)
+            .return_once({
+                let orders = orders.clone();
+                move |_| Ok(orders.into())
+            });
+        order_storing
+            .expect_solvable_orders()
+            .times(1)
+            .return_once(|_| Ok(Vec::new()));
+
+        balance_fetcher
+            .expect_get_balances()
+            .times(1)
+            .return_once(|_| vec![Ok(1.into())]);
+        balance_fetcher
+            .expect_get_balances()
+            .times(1)
+            .return_once(|_| vec![Ok(2.into())]);
+        balance_fetcher
+            .expect_get_balances()
+            .times(1)
+            .return_once(|_| Vec::new());
+
+        let cache = SolvableOrdersCache::new(
+            Duration::from_secs(0),
+            Arc::new(order_storing),
+            Arc::new(balance_fetcher),
+            Arc::new(bad_token_detector),
+            receiver,
+        );
+
+        cache.update(0).await.unwrap();
+        assert_eq!(
+            cache.cached_balance(&Query::from_order(&orders[0])),
+            Some(1.into())
+        );
+        assert_eq!(cache.cached_balance(&Query::from_order(&orders[1])), None);
+        let orders_ = cache.cached_solvable_orders().0;
+        assert_eq!(orders_.len(), 1);
+        assert_eq!(orders_[0].order_meta_data.available_balance, Some(1.into()));
+
+        cache.update(0).await.unwrap();
+        assert_eq!(
+            cache.cached_balance(&Query::from_order(&orders[0])),
+            Some(1.into())
+        );
+        assert_eq!(
+            cache.cached_balance(&Query::from_order(&orders[1])),
+            Some(2.into())
+        );
+        let orders_ = cache.cached_solvable_orders().0;
+        assert_eq!(orders_.len(), 2);
+
+        cache.update(0).await.unwrap();
+        assert_eq!(cache.cached_balance(&Query::from_order(&orders[0])), None,);
+        assert_eq!(cache.cached_balance(&Query::from_order(&orders[1])), None,);
+        let orders_ = cache.cached_solvable_orders().0;
+        assert_eq!(orders_.len(), 0);
+    }
+}


### PR DESCRIPTION
Second part that adds the new component which keeps track of solvable orders and related balances.
Part of #967


### Test Plan
new unit tests, TODO manual test
