### PR TITLE
Make recover_gas_price_from_pending_transaction optional

### DIFF
--- a/solver/src/settlement_submission/public_mempool.rs
+++ b/solver/src/settlement_submission/public_mempool.rs
@@ -34,7 +34,13 @@ pub async fn submit(
         .context("failed to get transaction_count")?;
     let pending_gas_price = recover_gas_price_from_pending_transaction(&web3, &address, nonce)
         .await
-        .context("failed to get pending gas price")?;
+        .unwrap_or_else(|e| {
+            tracing::info!(
+                "Cannot get pending gas price due to {}, assuming no pending settlement",
+                e
+            );
+            None
+        });
 
     // Account for some buffer in the gas limit in case racing state changes result in slightly more heavy computation at execution time
     let gas_limit = gas_estimate.to_f64_lossy() * ESTIMATE_GAS_LIMIT_FACTOR;


### PR DESCRIPTION
If we want to submit solutions via the private taichi network, we cannot inspect the pending txs from the mempool (because they are private). They are using erigon and have the `txpool` RPC module disabled. This PR makes it so that failure to fetch the pending gas price doesn't lead to a failure to process the batch.

Alternatively, we could create a taichi solution submission strategy, however all the other aspects would be the same as in PublicMempool.

### Test Plan
Submitted a tx via https://api.taichi.network:10001/rpc/private

https://etherscan.io/tx/0x7373c59631328c32163db76d7336abf9563c935a7bc8115adf36706c3ce7eb37
