### PR TITLE
Bump gas-estimation to v0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,12 +1037,11 @@ dependencies = [
 [[package]]
 name = "gas-estimation"
 version = "0.1.0"
-source = "git+https://github.com/gnosis/gp-gas-estimation.git?tag=v0.3.1#fac59263985d1ce15fc8e04650f79504aeddf2c9"
+source = "git+https://github.com/gnosis/gp-gas-estimation.git?tag=v0.3.2#b6b4808e182cacd660913a408d3938ef024c86fe"
 dependencies = [
  "anyhow",
  "async-trait",
  "futures",
- "log",
  "primitive-types",
  "serde",
  "serde_json",

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -24,7 +24,7 @@ contracts = { path = "../contracts" }
 either = "1.0"
 ethcontract = { version = "0.15.1", default-features = false }
 futures = "0.3.17"
-gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.3.1", features = ["web3_"] }
+gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.3.2", features = ["web3_"] }
 hex = { version = "0.4", default-features = false }
 hex-literal = "0.3"
 maplit = "1.0"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -15,7 +15,7 @@ derivative = "2.2"
 ethcontract = { version = "0.15.1", default-features = false }
 ethcontract-mock = "0.15.3"
 futures = "0.3"
-gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.3.1", features = ["web3_", "tokio_"] }
+gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.3.2", features = ["web3_", "tokio_"] }
 hex = { version = "0.4", default-features = false }
 hex-literal = "0.3"
 itertools = "0.10"

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -24,7 +24,7 @@ derive_more = "0.99"
 ethcontract = { version = "0.15.1", default-features = false }
 ethcontract-mock = "0.15.3"
 futures = "0.3"
-gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.3.1", features = ["web3_"] }
+gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.3.2", features = ["web3_"] }
 hex = "0.4"
 hex-literal = "0.3"
 itertools = "0.10"


### PR DESCRIPTION
This PR updates to the latest `gp-gas-estimation` crate version. It should clean up all the
```
2021-09-08T08:35:23.291Z ERROR gas_estimation::gasnow_websocket: websocket stream failed err=Protocol(ResetWithoutClosingHandshake)
```

Alerts we've been seeing.

### Test Plan

CI.
