### PR TITLE
Make max solvable orders update age configurable

### DIFF
--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -216,6 +216,7 @@ impl OrderbookServices {
             vec![],
             true,
             solvable_orders_cache.clone(),
+            Duration::from_secs(600),
         ));
         let maintenance = ServiceMaintenance {
             maintainers: vec![db.clone(), event_updater],

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -114,6 +114,15 @@ struct Arguments {
     /// This flag can be removed once DDoS protection is implemented.
     #[structopt(long, env, parse(try_from_str), default_value = "false")]
     pub enable_presign_orders: bool,
+
+    /// If solvable orders haven't been successfully update in this time attempting to get them
+    /// errors and our liveness check fails.
+    #[structopt(
+        long,
+        default_value = "300",
+        parse(try_from_str = shared::arguments::duration_from_seconds),
+    )]
+    solvable_orders_max_update_age: Duration,
 }
 
 pub async fn database_metrics(metrics: Arc<Metrics>, database: Postgres) -> ! {
@@ -356,6 +365,7 @@ async fn main() {
         args.banned_users,
         args.enable_presign_orders,
         solvable_orders_cache,
+        args.solvable_orders_max_update_age,
     ));
     let service_maintainer = ServiceMaintenance {
         maintainers: vec![database.clone(), Arc::new(event_updater), pool_fetcher],

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -66,6 +66,7 @@ pub struct Orderbook {
     banned_users: Vec<H160>,
     enable_presign_orders: bool,
     solvable_orders: Arc<SolvableOrdersCache>,
+    solvable_orders_max_update_age: Duration,
 }
 
 impl Orderbook {
@@ -83,6 +84,7 @@ impl Orderbook {
         banned_users: Vec<H160>,
         enable_presign_orders: bool,
         solvable_orders: Arc<SolvableOrdersCache>,
+        solvable_orders_max_update_age: Duration,
     ) -> Self {
         Self {
             domain_separator,
@@ -97,6 +99,7 @@ impl Orderbook {
             banned_users,
             enable_presign_orders,
             solvable_orders,
+            solvable_orders_max_update_age,
         }
     }
 
@@ -274,10 +277,9 @@ impl Orderbook {
     }
 
     pub async fn get_solvable_orders(&self) -> Result<Vec<Order>> {
-        const MAX_UPDATE_AGE: Duration = Duration::from_secs(60);
         let (orders, timestamp) = self.solvable_orders.cached_solvable_orders();
         ensure!(
-            timestamp.elapsed() <= MAX_UPDATE_AGE,
+            timestamp.elapsed() <= self.solvable_orders_max_update_age,
             "solvable orders are out of date"
         );
         Ok(orders)


### PR DESCRIPTION
and increase default. Increasing because I have observed on staging that
our node sometimes goes a minute without seeing a new block like at

> 2021-09-08T16:14:10.255Z DEBUG shared::maintenance: running maintenance on block number Some(13186132) hash Some(0xae062d87f14eec31d9e9e8b02ba2a1c01b7827de8c739718469406777649e863)

### Test Plan
local run prints that this argument is set to 300
