### PR TITLE
[Easy] Improving Test Coverage of model/*

### DIFF
--- a/model/src/appdata_hexadecimal.rs
+++ b/model/src/appdata_hexadecimal.rs
@@ -56,6 +56,14 @@ mod tests {
     use serde_json::Value;
 
     #[test]
+    fn works_on_32_byte_string() {
+        let value = Value::String(
+            "0x0ddeb6e4a814908832cc25d11311c514e7efe6af3c9bafeb0d241129cf7f4d83".to_string(),
+        );
+        assert!(deserialize(value).is_ok());
+    }
+
+    #[test]
     fn does_not_start_with_0x() {
         let value = Value::String("00".to_string());
         assert!(deserialize(value).is_err());

--- a/model/src/h160_hexadecimal.rs
+++ b/model/src/h160_hexadecimal.rs
@@ -68,3 +68,33 @@ where
 
     deserializer.deserialize_str(Visitor {})
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    #[test]
+    fn works_on_20_byte_string() {
+        let value = Value::String("0x9008D19f58AAbD9eD0D60971565AA8510560ab41".to_string());
+        assert!(deserialize(value).is_ok());
+    }
+
+    #[test]
+    fn does_not_start_with_0x() {
+        let value = Value::String("00".to_string());
+        assert!(deserialize(value).is_err());
+    }
+
+    #[test]
+    fn invalid_characters() {
+        let value = Value::String("asdf".to_string());
+        assert!(deserialize(value).is_err());
+    }
+
+    #[test]
+    fn invalid_length() {
+        let value = Value::String("0x00".to_string());
+        assert!(deserialize(value).is_err());
+    }
+}

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -164,7 +164,7 @@ mod tests {
         let token_a = H160::from_low_u64_be(0);
         let token_b = H160::from_low_u64_be(1);
         let token_c = H160::from_low_u64_be(2);
-        let pair = TokenPair::new(token_a.clone(), token_b.clone()).unwrap();
+        let pair = TokenPair::new(token_a, token_b).unwrap();
 
         assert!(pair.contains(&token_a));
         assert!(pair.contains(&token_b));
@@ -176,7 +176,7 @@ mod tests {
         let token_a = H160::from_low_u64_be(0);
         let token_b = H160::from_low_u64_be(1);
         let token_c = H160::from_low_u64_be(2);
-        let pair = TokenPair::new(token_a.clone(), token_b.clone()).unwrap();
+        let pair = TokenPair::new(token_a, token_b).unwrap();
 
         assert_eq!(pair.other(&token_a), Some(token_b));
         assert_eq!(pair.other(&token_b), Some(token_a));

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -16,7 +16,7 @@ use std::fmt;
 use web3::signing;
 
 /// Erc20 token pair specified by two contract addresses.
-#[derive(Eq, PartialEq, Copy, Clone, Debug, Hash, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct TokenPair(H160, H160);
 
 impl TokenPair {
@@ -85,7 +85,7 @@ impl<'a> IntoIterator for &'a TokenPair {
     }
 }
 
-#[derive(Copy, Eq, PartialEq, Clone, Default)]
+#[derive(Copy, Clone, Default, Eq, PartialEq)]
 pub struct DomainSeparator(pub [u8; 32]);
 
 impl std::str::FromStr for DomainSeparator {
@@ -107,7 +107,7 @@ impl std::fmt::Debug for DomainSeparator {
 }
 
 impl DomainSeparator {
-    pub fn get_domain_separator(chain_id: u64, contract_address: H160) -> Self {
+    pub fn new(chain_id: u64, contract_address: H160) -> Self {
         lazy_static! {
             /// The EIP-712 domain name used for computing the domain separator.
             static ref DOMAIN_NAME: [u8; 32] = signing::keccak256(b"Gnosis Protocol");
@@ -136,18 +136,51 @@ impl DomainSeparator {
 mod tests {
     use super::*;
     use hex_literal::hex;
+    use std::cmp::Ordering;
+    use std::str::FromStr;
+
+    #[test]
+    fn domain_separator_from_str() {
+        assert!(DomainSeparator::from_str(
+            "9d7e07ef92761aa9453ae5ff25083a2b19764131b15295d3c7e89f1f1b8c67d9"
+        )
+        .is_ok());
+    }
 
     #[test]
     fn domain_separator_rinkeby() {
         let contract_address: H160 = hex!("91D6387ffbB74621625F39200d91a50386C9Ab15").into();
         let chain_id: u64 = 4;
-        let domain_separator_rinkeby =
-            DomainSeparator::get_domain_separator(chain_id, contract_address);
+        let domain_separator_rinkeby = DomainSeparator::new(chain_id, contract_address);
         // domain separator is taken from rinkeby deployment at address 91D6387ffbB74621625F39200d91a50386C9Ab15
         let expected_domain_separator = DomainSeparator(hex!(
             "9d7e07ef92761aa9453ae5ff25083a2b19764131b15295d3c7e89f1f1b8c67d9"
         ));
         assert_eq!(domain_separator_rinkeby, expected_domain_separator);
+    }
+
+    #[test]
+    fn token_pair_contains() {
+        let token_a = H160::from_low_u64_be(0);
+        let token_b = H160::from_low_u64_be(1);
+        let token_c = H160::from_low_u64_be(2);
+        let pair = TokenPair::new(token_a.clone(), token_b.clone()).unwrap();
+
+        assert!(pair.contains(&token_a));
+        assert!(pair.contains(&token_b));
+        assert!(!pair.contains(&token_c));
+    }
+
+    #[test]
+    fn token_pair_other() {
+        let token_a = H160::from_low_u64_be(0);
+        let token_b = H160::from_low_u64_be(1);
+        let token_c = H160::from_low_u64_be(2);
+        let pair = TokenPair::new(token_a.clone(), token_b.clone()).unwrap();
+
+        assert_eq!(pair.other(&token_a), Some(token_b));
+        assert_eq!(pair.other(&token_b), Some(token_a));
+        assert_eq!(pair.other(&token_c), None);
     }
 
     #[test]
@@ -182,5 +215,20 @@ mod tests {
         assert_eq!(iter.next(), Some(token_a));
         assert_eq!(iter.next(), Some(token_b));
         assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn token_pair_ordering() {
+        let token_a = H160::from_low_u64_be(0);
+        let token_b = H160::from_low_u64_be(1);
+        let token_c = H160::from_low_u64_be(2);
+        let pair_ab = TokenPair::new(token_a, token_b).unwrap();
+        let pair_bc = TokenPair::new(token_b, token_c).unwrap();
+        let pair_ca = TokenPair::new(token_c, token_a).unwrap();
+
+        assert_eq!(pair_ab.cmp(&pair_bc), Ordering::Less);
+        assert_eq!(pair_ab.cmp(&pair_ca), Ordering::Less);
+        assert_eq!(pair_bc.cmp(&pair_ca), Ordering::Greater);
+        assert_eq!(pair_ab.cmp(&TokenPair::first_ord()), Ordering::Equal);
     }
 }

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -845,12 +845,15 @@ mod tests {
             .with_buy_token(H160::zero())
             .with_buy_amount(80.into())
             .with_valid_to(u32::MAX)
-            .with_app_data([1u8;32])
+            .with_app_data([1u8; 32])
             .with_fee_amount(U256::from(1337))
             .with_partially_fillable(true)
             .with_sell_token_balance(SellTokenSource::External)
             .with_buy_token_balance(BuyTokenDestination::Internal)
-            .with_creation_date(DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(3, 0), Utc))
+            .with_creation_date(DateTime::<Utc>::from_utc(
+                NaiveDateTime::from_timestamp(3, 0),
+                Utc,
+            ))
             .with_presign(H160::from_low_u64_be(1))
             .with_kind(OrderKind::Sell)
             .sign_with(

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -426,7 +426,6 @@ impl Default for OrderMetaData {
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct OrderUid(pub [u8; 56]);
 
-#[cfg(test)]
 impl OrderUid {
     /// Intended for easier uid creation in tests.
     pub fn from_integer(i: u32) -> Self {

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -67,6 +67,7 @@ impl Order {
         let owner = order_creation
             .signature
             .validate(domain, &order_creation.hash_struct())?;
+        // TODO - test this function when validate returns None.
         Some(Self {
             order_meta_data: OrderMetaData {
                 creation_date: chrono::offset::Utc::now(),
@@ -425,6 +426,7 @@ impl Default for OrderMetaData {
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct OrderUid(pub [u8; 56]);
 
+#[cfg(test)]
 impl OrderUid {
     /// Intended for easier uid creation in tests.
     pub fn from_integer(i: u32) -> Self {
@@ -717,6 +719,29 @@ mod tests {
         }
     }
 
+    #[test]
+    fn order_actual_receiver() {
+        // Isn't it a bit weird that the default order struct has such an arbitrary receiver?
+        assert_eq!(
+            Order::default().actual_receiver(),
+            H160(hex!("7e5f4552091a69125d5dfcb7b8c2659029395bdf"))
+        );
+
+        let mut order = Order::default();
+        let receiver = H160::from_low_u64_be(1);
+        order.order_creation.receiver = Some(receiver);
+        assert_eq!(order.actual_receiver(), receiver);
+    }
+
+    #[test]
+    fn order_with_app_data() {
+        let mut order = Order::default();
+
+        let receiver = H160::from_low_u64_be(1);
+        order.order_creation.receiver = Some(receiver);
+        assert_eq!(order.actual_receiver(), receiver);
+    }
+
     // from the test `should compute order unique identifier` in
     // <https://github.com/gnosis/gp-v2-contracts/blob/v1.0.1/test/GPv2Signing.test.ts#L143>
     #[test]
@@ -821,6 +846,13 @@ mod tests {
             .with_buy_token(H160::zero())
             .with_buy_amount(80.into())
             .with_valid_to(u32::MAX)
+            .with_app_data([1u8;32])
+            .with_fee_amount(U256::from(1337))
+            .with_partially_fillable(true)
+            .with_sell_token_balance(SellTokenSource::External)
+            .with_buy_token_balance(BuyTokenDestination::Internal)
+            .with_creation_date(DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(3, 0), Utc))
+            .with_presign(H160::from_low_u64_be(1))
             .with_kind(OrderKind::Sell)
             .sign_with(
                 EcdsaSigningScheme::Eip712,

--- a/model/src/ratio_as_decimal.rs
+++ b/model/src/ratio_as_decimal.rs
@@ -80,7 +80,7 @@ fn sign_03_to_04(sign_03: Sign03) -> Sign04 {
 
 #[cfg(test)]
 mod tests {
-    use crate::ratio_as_decimal::{deserialize, serialize};
+    use super::*;
     use num::{BigRational, Zero};
     use serde_json::json;
     use serde_json::value::Serializer;
@@ -125,5 +125,16 @@ mod tests {
             deserialize(json!("-1")).unwrap(),
             BigRational::new((-1).into(), 1.into())
         );
+    }
+
+    #[test]
+    fn sign_conversions() {
+        assert_eq!(sign_04_to_03(Sign04::Minus), Sign03::Minus);
+        assert_eq!(sign_04_to_03(Sign04::Plus), Sign03::Plus);
+        assert_eq!(sign_04_to_03(Sign04::NoSign), Sign03::NoSign);
+
+        assert_eq!(sign_03_to_04(Sign03::Minus), Sign04::Minus);
+        assert_eq!(sign_03_to_04(Sign03::Plus), Sign04::Plus);
+        assert_eq!(sign_03_to_04(Sign03::NoSign), Sign04::NoSign);
     }
 }

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -62,7 +62,7 @@ pub async fn verify_deployed_contract_constants(
             .0,
     );
 
-    let domain_separator = DomainSeparator::get_domain_separator(chain_id, contract.address());
+    let domain_separator = DomainSeparator::new(chain_id, contract.address());
     if !bytecode.contains(&hex::encode(domain_separator.0)) {
         return Err(anyhow!("Bytecode did not contain domain separator"));
     }

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -193,8 +193,7 @@ async fn main() {
     verify_deployed_contract_constants(&settlement_contract, chain_id)
         .await
         .expect("Deployed contract constants don't match the ones in this binary");
-    let domain_separator =
-        DomainSeparator::get_domain_separator(chain_id, settlement_contract.address());
+    let domain_separator = DomainSeparator::new(chain_id, settlement_contract.address());
     let postgres = Postgres::new(args.db_url.as_str()).expect("failed to create database");
     let database = Arc::new(database::instrumented::Instrumented::new(
         postgres.clone(),


### PR DESCRIPTION
In attempt to improve our coverage report, I have added some simple new unit tests to increase coverage in `model/*`

Note that I also alphabetized some derive statements and renamed `get_domain_separator` to `new` based on a warning that `get_*` methods usually take a reference to self.


While doing this I noticed a few things:

- `appdata_hexadecimal` and `h160_hexadecimal` are almost identical files and could probably be generalized. The only difference is that one operates on 32 bytes while the other on 20.

- there is a method inside deserialize called `expecting`, that I don't know how to call which is still uncovered.

```rs
fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
    write!(formatter, "32 bytes appdata as a hex encoded string")
}
```

- The coverage report itself suggests that structs with fancy decorators (such as OrderCreation) are "uncovered". So, for example, every single line (almost 30 lines) in the declaration of this struct is deemed uncovered.
```rs
#[derivative(Debug)]
#[serde(rename_all = "camelCase")]
pub struct OrderCreation {
....
}
```

There is still some things to tackle in this module, but this is already a good start.

### Test Plan
New tests + existing CI
