### PR TITLE
[Easy] Full Test Covereage for Orderbook Conversions

### DIFF
--- a/orderbook/src/conversions.rs
+++ b/orderbook/src/conversions.rs
@@ -50,3 +50,120 @@ pub fn h256_from_vec(vec: Vec<u8>) -> Result<H256> {
         .map_err(|_| anyhow!("h256 has wrong length"))?;
     Ok(H256::from(array))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num::{One, Zero};
+    use std::str::FromStr;
+
+    #[test]
+    fn u256_to_big_uint_() {
+        assert_eq!(u256_to_big_uint(&U256::zero()), BigUint::zero());
+        assert_eq!(u256_to_big_uint(&U256::one()), BigUint::one());
+        assert_eq!(
+            u256_to_big_uint(&U256::MAX),
+            BigUint::from_str(
+                "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn u256_to_big_decimal_() {
+        assert_eq!(u256_to_big_decimal(&U256::zero()), BigDecimal::zero());
+        assert_eq!(u256_to_big_decimal(&U256::one()), BigDecimal::one());
+        assert_eq!(
+            u256_to_big_decimal(&U256::MAX),
+            BigDecimal::from_str(
+                "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn bigint_to_u256_() {
+        assert_eq!(bigint_to_u256(&BigInt::zero()), Some(U256::zero()));
+        assert_eq!(bigint_to_u256(&BigInt::one()), Some(U256::one()));
+
+        let max_u256_as_bigint = BigInt::from_str(
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        )
+        .unwrap();
+        assert_eq!(bigint_to_u256(&max_u256_as_bigint), Some(U256::MAX));
+
+        assert!(bigint_to_u256(&(max_u256_as_bigint + BigInt::one())).is_none());
+        assert!(bigint_to_u256(&BigInt::from(-1)).is_none());
+    }
+
+    #[test]
+    fn big_decimal_to_big_uint_() {
+        assert_eq!(
+            big_decimal_to_big_uint(&BigDecimal::zero()),
+            Some(BigUint::zero())
+        );
+        assert_eq!(
+            big_decimal_to_big_uint(&BigDecimal::one()),
+            Some(BigUint::one())
+        );
+
+        assert!(big_decimal_to_big_uint(&BigDecimal::from(-1)).is_none());
+        assert!(big_decimal_to_big_uint(
+            &BigDecimal::from_str(
+                "9115792089237316195423570985008687907853269984665640564039457584007913129639935"
+            )
+            .unwrap()
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn big_decimal_to_u256_() {
+        assert_eq!(big_decimal_to_u256(&BigDecimal::zero()), Some(U256::zero()));
+        assert_eq!(big_decimal_to_u256(&BigDecimal::one()), Some(U256::one()));
+        assert!(big_decimal_to_u256(&BigDecimal::from(-1)).is_none());
+
+        let max_u256_as_big_decimal = BigDecimal::from_str(
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        )
+        .unwrap();
+        assert_eq!(
+            big_decimal_to_u256(&max_u256_as_big_decimal),
+            Some(U256::MAX)
+        );
+
+        assert!(big_decimal_to_u256(&(max_u256_as_big_decimal + BigDecimal::one())).is_none());
+    }
+
+    #[test]
+    fn h160_from_vec_() {
+        let valid_input = [1u8; 20].to_vec();
+        assert_eq!(
+            h160_from_vec(valid_input).unwrap(),
+            H160::from_slice(&[1u8; 20])
+        );
+
+        let wrong_length = vec![0u8];
+        assert_eq!(
+            h160_from_vec(wrong_length).unwrap_err().to_string(),
+            "h160 has wrong length"
+        );
+    }
+
+    #[test]
+    fn h256_from_vec_() {
+        let valid_input = [1u8; 32].to_vec();
+        assert_eq!(
+            h256_from_vec(valid_input).unwrap(),
+            H256::from_slice(&[1u8; 32])
+        );
+
+        let wrong_length = vec![0u8];
+        assert_eq!(
+            h256_from_vec(wrong_length).unwrap_err().to_string(),
+            "h160 has wrong length"
+        );
+    }
+}

--- a/orderbook/src/conversions.rs
+++ b/orderbook/src/conversions.rs
@@ -163,7 +163,7 @@ mod tests {
         let wrong_length = vec![0u8];
         assert_eq!(
             h256_from_vec(wrong_length).unwrap_err().to_string(),
-            "h160 has wrong length"
+            "h256 has wrong length"
         );
     }
 }

--- a/orderbook/src/conversions.rs
+++ b/orderbook/src/conversions.rs
@@ -108,8 +108,6 @@ mod tests {
             big_decimal_to_big_uint(&BigDecimal::one()),
             Some(BigUint::one())
         );
-
-        assert!(big_decimal_to_big_uint(&BigDecimal::from(-1)).is_none());
         assert!(big_decimal_to_big_uint(
             &BigDecimal::from_str(
                 "9115792089237316195423570985008687907853269984665640564039457584007913129639935"
@@ -117,6 +115,9 @@ mod tests {
             .unwrap()
         )
         .is_some());
+
+        assert!(big_decimal_to_big_uint(&BigDecimal::from(-1)).is_none());
+        assert!(big_decimal_to_u256(&BigDecimal::from_str("0.5").unwrap()).is_none());
     }
 
     #[test]
@@ -124,7 +125,7 @@ mod tests {
         assert_eq!(big_decimal_to_u256(&BigDecimal::zero()), Some(U256::zero()));
         assert_eq!(big_decimal_to_u256(&BigDecimal::one()), Some(U256::one()));
         assert!(big_decimal_to_u256(&BigDecimal::from(-1)).is_none());
-
+        assert!(big_decimal_to_u256(&BigDecimal::from_str("0.5").unwrap()).is_none());
         let max_u256_as_big_decimal = BigDecimal::from_str(
             "115792089237316195423570985008687907853269984665640564039457584007913129639935",
         )
@@ -133,7 +134,6 @@ mod tests {
             big_decimal_to_u256(&max_u256_as_big_decimal),
             Some(U256::MAX)
         );
-
         assert!(big_decimal_to_u256(&(max_u256_as_big_decimal + BigDecimal::one())).is_none());
     }
 


### PR DESCRIPTION
This file had been previously untested. This PR adds a complete suite of unit tests for these converters 

generally these test check, 0, 1, max along with -1, 0.5 and max + 1 where appropriate.

While doing this I noticed that we have another duplicated method for bigint to u255 in the shared crate (logged here #1106)

### Test Plan
New tests! Otherwise no logic changes.
