### PR TITLE
Replace fee estimation error with price estimation error

### DIFF
--- a/orderbook/src/api/get_fee_and_quote.rs
+++ b/orderbook/src/api/get_fee_and_quote.rs
@@ -1,4 +1,4 @@
-use crate::fee::{MinFeeCalculating, MinFeeCalculationError};
+use crate::fee::MinFeeCalculating;
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
 use ethcontract::{H160, U256};
@@ -73,16 +73,6 @@ enum Error {
     AmountIsZero,
     SellAmountDoesNotCoverFee,
     Other(anyhow::Error),
-}
-
-impl From<MinFeeCalculationError> for Error {
-    fn from(other: MinFeeCalculationError) -> Self {
-        match other {
-            MinFeeCalculationError::NoLiquidity => Error::NoLiquidity,
-            MinFeeCalculationError::UnsupportedToken(token) => Error::UnsupportedToken(token),
-            MinFeeCalculationError::Other(error) => Error::Other(error),
-        }
-    }
 }
 
 impl From<PriceEstimationError> for Error {


### PR DESCRIPTION
They have the same cases and it makes sense the fee estimation forwards
this error. This also simplifies some of the logic inside of the fee
estimator because we can replace Result<Option<_>> with Result<_> .

Noticed this while doing a refactor of the price estimation trait in preparation for implementing it with Paraswap which will happen in another PR.

### Test Plan
existing tests