### PR TITLE
Testing Model Crate Part 2

### DIFF
--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -876,7 +876,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn debug_order_data() {
         dbg!(Order::default());
     }

--- a/model/src/signature.rs
+++ b/model/src/signature.rs
@@ -8,7 +8,7 @@ use web3::{
     types::Recovery,
 };
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug, Deserialize, Serialize, Hash)]
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Serialize, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum SigningScheme {
     Eip712,
@@ -279,6 +279,7 @@ impl<'de> Deserialize<'de> for EcdsaSignature {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn presign_validates_to_account() {
@@ -291,5 +292,107 @@ mod tests {
     #[test]
     fn presign_fails_to_convert_to_ecdsa_signature() {
         assert!(SigningScheme::PreSign.try_to_ecdsa_scheme().is_none());
+    }
+
+    #[test]
+    fn signature_from_bytes() {
+        assert_eq!(
+            Signature::from_bytes(SigningScheme::Eip712, &[0u8; 20])
+                .unwrap_err()
+                .to_string(),
+            "ECDSA signature must be 65 bytes long"
+        );
+        assert_eq!(
+            Signature::from_bytes(SigningScheme::EthSign, &[0u8; 20])
+                .unwrap_err()
+                .to_string(),
+            "ECDSA signature must be 65 bytes long"
+        );
+        assert_eq!(
+            Signature::from_bytes(SigningScheme::PreSign, &[0u8; 32])
+                .unwrap_err()
+                .to_string(),
+            "pre-signature must be exactly 20 bytes long"
+        );
+
+        assert_eq!(
+            Signature::from_bytes(SigningScheme::Eip712, &[0u8; 65]).unwrap(),
+            Signature::default_with(SigningScheme::Eip712)
+        );
+        assert_eq!(
+            Signature::from_bytes(SigningScheme::EthSign, &[0u8; 65]).unwrap(),
+            Signature::default_with(SigningScheme::EthSign)
+        );
+        assert_eq!(
+            Signature::from_bytes(SigningScheme::PreSign, &[0u8; 20]).unwrap(),
+            Signature::default_with(SigningScheme::PreSign)
+        );
+    }
+
+    #[test]
+    fn signature_to_bytes() {
+        assert_eq!(
+            Signature::default_with(SigningScheme::Eip712).to_bytes(),
+            [0u8; 65].to_vec()
+        );
+        assert_eq!(
+            Signature::default_with(SigningScheme::EthSign).to_bytes(),
+            [0u8; 65].to_vec()
+        );
+        assert_eq!(
+            Signature::default_with(SigningScheme::PreSign).to_bytes(),
+            [0u8; 20].to_vec()
+        );
+        // and something non-trivial
+        assert_eq!(
+            Signature::from_bytes(SigningScheme::PreSign, &[1u8; 20])
+                .unwrap()
+                .to_bytes(),
+            [1u8; 20].to_vec()
+        );
+    }
+
+    #[test]
+    fn ecdsa_scheme_conversion() {
+        for ecdsa_scheme in [EcdsaSigningScheme::Eip712, EcdsaSigningScheme::EthSign] {
+            let scheme = SigningScheme::from(ecdsa_scheme);
+            assert!(scheme.is_ecdsa_scheme())
+        }
+        assert!(!SigningScheme::PreSign.is_ecdsa_scheme())
+    }
+
+    #[test]
+    fn deserialize_and_back() {
+        let value = json!(
+        {
+            "signature": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "signingScheme": "eip712"
+        });
+        let expected = Signature::default();
+        let deserialized: Signature = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(deserialized, expected);
+        let serialized = serde_json::to_value(expected).unwrap();
+        assert_eq!(value, serialized);
+
+        assert_eq!(
+            serde_json::from_value::<Signature>(json!(
+            {
+                "signature": "1234",
+                "signingScheme": "eip712"
+            }))
+                .unwrap_err()
+                .to_string(),
+            "\"1234\" can't be decoded as hex ecdsa signature because it does not start with '0x'"
+        );
+        assert_eq!(
+            serde_json::from_value::<Signature>(json!(
+            {
+                "signature": "0x42",
+                "signingScheme": "eip712"
+            }))
+                .unwrap_err()
+                .to_string(),
+            "failed to decode \"42\" as hex ecdsa signature: Invalid string length"
+        );
     }
 }

--- a/model/src/signature.rs
+++ b/model/src/signature.rs
@@ -380,8 +380,8 @@ mod tests {
                 "signature": "1234",
                 "signingScheme": "eip712"
             }))
-                .unwrap_err()
-                .to_string(),
+            .unwrap_err()
+            .to_string(),
             "\"1234\" can't be decoded as hex ecdsa signature because it does not start with '0x'"
         );
         assert_eq!(
@@ -390,8 +390,8 @@ mod tests {
                 "signature": "0x42",
                 "signingScheme": "eip712"
             }))
-                .unwrap_err()
-                .to_string(),
+            .unwrap_err()
+            .to_string(),
             "failed to decode \"42\" as hex ecdsa signature: Invalid string length"
         );
     }

--- a/model/src/trade.rs
+++ b/model/src/trade.rs
@@ -5,7 +5,7 @@ use num_bigint::BigUint;
 use primitive_types::{H160, H256};
 use serde::{Deserialize, Serialize};
 
-#[derive(Eq, PartialEq, Clone, Debug, Default, Deserialize, Serialize, Hash)]
+#[derive(Eq, PartialEq, Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Trade {
     pub block_number: u64,
@@ -62,5 +62,10 @@ mod tests {
         assert_eq!(deserialized, expected);
         let serialized = serde_json::to_value(expected).unwrap();
         assert_eq!(serialized, value);
+    }
+
+    #[test]
+    fn debug_trade_data() {
+        dbg!(Trade::default());
     }
 }

--- a/orderbook/src/database/trades.rs
+++ b/orderbook/src/database/trades.rs
@@ -117,13 +117,16 @@ impl TradesQueryRow {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::database::events::{Event, Settlement as DbSettlement, Trade as DbTrade};
-    use crate::database::orders::OrderStoring;
+    use crate::database::{
+        events::{Event, Settlement as DbSettlement, Trade as DbTrade},
+        orders::OrderStoring,
+    };
     use ethcontract::H256;
-    use model::order::{Order, OrderCreation, OrderMetaData};
-    use model::trade::Trade;
+    use model::{
+        order::{Order, OrderCreation, OrderMetaData},
+        trade::Trade,
+    };
     use shared::event_handling::EventIndex;
-    use std::collections::HashSet;
 
     async fn generate_owners_and_order_ids(
         num_owners: usize,
@@ -190,8 +193,8 @@ mod tests {
             .await
             .unwrap()
             .into_iter()
-            .collect::<HashSet<_>>();
-        let expected = expected.iter().cloned().collect::<HashSet<_>>();
+            .collect::<Vec<_>>();
+        let expected = expected.to_vec();
         assert_eq!(filtered, expected);
     }
 


### PR DESCRIPTION
Improving test coverage of signature, and trade.

Note that this PR also
- removed the #[ignore] tag on the order debug test as our report was considering this untested code.
- removes `#[derive(Hash)]` from `Trade` as it was only every used in a single unit test.
- removes `#[derive(Deserialize)]` from `SigningScheme` since it wasn't used either.

The result of this and the previous PR bring our model crate up to about 90% average coverage as seen in this screenshot.

<img width="1014" alt="Screenshot 2021-09-09 at 11 04 22 PM" src="https://user-images.githubusercontent.com/11778116/132763237-22668734-0145-4389-9a4e-ce448d280e65.png">


### Test Plan
Only new tests introduced.
