### PR TITLE
Move native token price estimation amount of the trait

### DIFF
--- a/e2e/tests/eth_integration.rs
+++ b/e2e/tests/eth_integration.rs
@@ -234,6 +234,7 @@ async fn eth_integration(web3: Web3) {
             gas_price_cap: f64::MAX,
             transaction_strategy: solver::settlement_submission::TransactionStrategy::PublicMempool,
         },
+        1_000_000_000_000_000_000_u128.into(),
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -243,6 +243,7 @@ async fn onchain_settlement(web3: Web3) {
             gas_price_cap: f64::MAX,
             transaction_strategy: solver::settlement_submission::TransactionStrategy::PublicMempool,
         },
+        1_000_000_000_000_000_000_u128.into(),
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -189,6 +189,7 @@ impl OrderbookServices {
             db.clone(),
             0.0,
             bad_token_detector.clone(),
+            1_000_000_000_000_000_000_u128.into(),
         ));
         let balance_fetcher = Arc::new(Web3BalanceFetcher::new(
             web3.clone(),

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -229,6 +229,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             gas_price_cap: f64::MAX,
             transaction_strategy: solver::settlement_submission::TransactionStrategy::PublicMempool,
         },
+        1_000_000_000_000_000_000_u128.into(),
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/smart_contract_orders.rs
+++ b/e2e/tests/smart_contract_orders.rs
@@ -204,6 +204,7 @@ async fn smart_contract_orders(web3: Web3) {
             gas_price_cap: f64::MAX,
             transaction_strategy: solver::settlement_submission::TransactionStrategy::PublicMempool,
         },
+        1_000_000_000_000_000_000_u128.into(),
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/vault_balances.rs
+++ b/e2e/tests/vault_balances.rs
@@ -182,6 +182,7 @@ async fn vault_balances(web3: Web3) {
             gas_price_cap: f64::MAX,
             transaction_strategy: solver::settlement_submission::TransactionStrategy::PublicMempool,
         },
+        1_000_000_000_000_000_000_u128.into(),
     );
     driver.single_run().await.unwrap();
 

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -179,7 +179,7 @@ async fn main() {
         .await
         .expect("Failed to retrieve network version ID");
 
-    let amount_to_estimate_prices_with = args
+    let native_token_price_estimation_amount = args
         .shared
         .amount_to_estimate_prices_with
         .or_else(|| shared::arguments::default_amount_to_estimate_prices_with(&network))
@@ -327,7 +327,7 @@ async fn main() {
         base_tokens,
         bad_token_detector.clone(),
         native_token.address(),
-        amount_to_estimate_prices_with,
+        native_token_price_estimation_amount,
     ));
     let fee_calculator = Arc::new(EthAwareMinFeeCalculator::new(
         price_estimator.clone(),
@@ -336,6 +336,7 @@ async fn main() {
         database.clone(),
         args.shared.fee_factor,
         bad_token_detector.clone(),
+        native_token_price_estimation_amount,
     ));
 
     let solvable_orders_cache = SolvableOrdersCache::new(

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -93,7 +93,8 @@ pub struct Arguments {
     pub block_stream_poll_interval_seconds: Duration,
 
     /// The amount in native tokens atoms to use for price estimation. Should be reasonably large so
-    // that small pools do not influence the prices.
+    // that small pools do not influence the prices. If not set a reasonable default is used based
+    // on network id.
     #[structopt(
         long,
         env,

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -1,15 +1,15 @@
 pub mod solver_settlements;
 
 use self::solver_settlements::RatedSettlement;
-use crate::liquidity::LimitOrder;
-use crate::solver::{Auction, SettlementWithSolver, Solvers};
 use crate::{
+    liquidity::LimitOrder,
     liquidity_collector::LiquidityCollector,
     metrics::SolverMetrics,
     settlement::Settlement,
     settlement_simulation,
     settlement_submission::{self, retry::is_transaction_failure, SolutionSubmitter},
     solver::Solver,
+    solver::{Auction, SettlementWithSolver, Solvers},
 };
 use anyhow::{anyhow, Context, Error, Result};
 use contracts::GPv2Settlement;
@@ -19,10 +19,10 @@ use gas_estimation::GasPriceEstimating;
 use itertools::{Either, Itertools};
 use model::order::{OrderUid, BUY_ETH_ADDRESS};
 use num::BigRational;
-use primitive_types::H160;
-use shared::price_estimate;
+use primitive_types::{H160, U256};
 use shared::{
     current_block::{self, CurrentBlockStream},
+    price_estimate,
     price_estimate::PriceEstimating,
     recent_block_cache::Block,
     token_list::TokenList,
@@ -54,6 +54,7 @@ pub struct Driver {
     fee_factor: f64,
     solution_submitter: SolutionSubmitter,
     solve_id: u64,
+    native_token_amount_to_estimate_prices_with: U256,
 }
 impl Driver {
     #[allow(clippy::too_many_arguments)]
@@ -75,6 +76,7 @@ impl Driver {
         block_stream: CurrentBlockStream,
         fee_factor: f64,
         solution_submitter: SolutionSubmitter,
+        native_token_amount_to_estimate_prices_with: U256,
     ) -> Self {
         Self {
             settlement_contract,
@@ -96,6 +98,7 @@ impl Driver {
             fee_factor,
             solution_submitter,
             solve_id: 0,
+            native_token_amount_to_estimate_prices_with,
         }
     }
 
@@ -374,9 +377,13 @@ impl Driver {
             .get_liquidity_for_orders(&orders, Block::Number(current_block_during_liquidity_fetch))
             .await?;
 
-        let estimated_prices =
-            collect_estimated_prices(self.price_estimator.as_ref(), self.native_token, &orders)
-                .await;
+        let estimated_prices = collect_estimated_prices(
+            self.price_estimator.as_ref(),
+            self.native_token_amount_to_estimate_prices_with,
+            self.native_token,
+            &orders,
+        )
+        .await;
         tracing::debug!("estimated prices: {:?}", estimated_prices);
 
         let orders = orders_with_price_estimates(orders, &estimated_prices);
@@ -506,13 +513,13 @@ impl Driver {
 
 pub async fn collect_estimated_prices(
     price_estimator: &dyn PriceEstimating,
+    native_token_amount_to_estimate_prices_with: U256,
     native_token: H160,
     orders: &[LimitOrder],
 ) -> HashMap<H160, BigRational> {
     // Computes set of traded tokens (limit orders only).
     // NOTE: The native token is always added.
 
-    let amount = price_estimator.native_token_amount_to_estimate_prices_with();
     let queries = orders
         .iter()
         .flat_map(|order| [order.sell_token, order.buy_token])
@@ -524,7 +531,7 @@ pub async fn collect_estimated_prices(
             // but native_token is used here anyway for better logging/debugging.
             sell_token: native_token,
             buy_token: token,
-            in_amount: amount,
+            in_amount: native_token_amount_to_estimate_prices_with,
             kind: model::order::OrderKind::Sell,
         })
         .collect::<Vec<_>>();
@@ -626,7 +633,8 @@ mod tests {
             settlement_handling: CapturingSettlementHandler::arc(),
             id: "0".into(),
         }];
-        let prices = collect_estimated_prices(&price_estimator, native_token, &orders).await;
+        let prices =
+            collect_estimated_prices(&price_estimator, 1.into(), native_token, &orders).await;
         assert_eq!(prices.len(), 4);
         assert!(prices.contains_key(&sell_token));
         assert!(prices.contains_key(&buy_token));
@@ -651,7 +659,8 @@ mod tests {
             settlement_handling: CapturingSettlementHandler::arc(),
             id: "0".into(),
         }];
-        let prices = collect_estimated_prices(&price_estimator, native_token, &orders).await;
+        let prices =
+            collect_estimated_prices(&price_estimator, 1.into(), native_token, &orders).await;
         assert_eq!(prices.len(), 2);
     }
 
@@ -676,7 +685,8 @@ mod tests {
             settlement_handling: CapturingSettlementHandler::arc(),
             id: "0".into(),
         }];
-        let prices = collect_estimated_prices(&price_estimator, native_token, &liquidity).await;
+        let prices =
+            collect_estimated_prices(&price_estimator, 1.into(), native_token, &liquidity).await;
         assert_eq!(prices.len(), 3);
         assert!(prices.contains_key(&sell_token));
         assert!(prices.contains_key(&native_token));

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -256,7 +256,7 @@ async fn main() {
     // We should always use the native token as a base token.
     base_tokens.insert(native_token_contract.address());
 
-    let amount_to_estimate_prices_with = args
+    let native_token_price_estimation_amount = args
         .shared
         .amount_to_estimate_prices_with
         .or_else(|| shared::arguments::default_amount_to_estimate_prices_with(&network_id))
@@ -353,7 +353,7 @@ async fn main() {
         // Order book already filters bad tokens
         Arc::new(ListBasedDetector::deny_list(Vec::new())),
         native_token_contract.address(),
-        amount_to_estimate_prices_with,
+        native_token_price_estimation_amount,
     ));
     let uniswap_like_liquidity = build_amm_artifacts(
         &pool_caches,
@@ -403,6 +403,7 @@ async fn main() {
         args.disabled_paraswap_dexs,
         args.paraswap_partner_header_value,
         client.clone(),
+        native_token_price_estimation_amount,
     )
     .expect("failure creating solvers");
     let liquidity_collector = LiquidityCollector {
@@ -464,6 +465,7 @@ async fn main() {
         current_block_stream.clone(),
         args.shared.fee_factor,
         solution_submitter,
+        native_token_price_estimation_amount,
     );
 
     let maintainer = ServiceMaintenance {

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -143,6 +143,7 @@ pub fn create(
     disabled_paraswap_dexs: Vec<String>,
     paraswap_partner_header_value: Option<String>,
     client: Client,
+    native_token_amount_to_estimate_prices_with: U256,
 ) -> Result<Solvers> {
     // Tiny helper function to help out with type inference. Otherwise, all
     // `Box::new(...)` expressions would have to be cast `as Box<dyn Solver>`.
@@ -175,6 +176,7 @@ pub fn create(
             fee_factor,
             client.clone(),
             http_solver_cache.clone(),
+            native_token_amount_to_estimate_prices_with,
         )
     };
 

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -87,6 +87,7 @@ pub struct HttpSolver {
     chain_id: u64,
     instance_cache: InstanceCache,
     fee_factor: f64,
+    native_token_amount_to_estimate_prices_with: U256,
 }
 
 impl HttpSolver {
@@ -106,6 +107,7 @@ impl HttpSolver {
         fee_factor: f64,
         client: Client,
         instance_cache: InstanceCache,
+        native_token_amount_to_estimate_prices_with: U256,
     ) -> Self {
         Self {
             name,
@@ -122,6 +124,7 @@ impl HttpSolver {
             chain_id,
             instance_cache,
             fee_factor,
+            native_token_amount_to_estimate_prices_with,
         }
     }
 
@@ -313,15 +316,12 @@ impl HttpSolver {
     ) -> Result<(BatchAuctionModel, SettlementContext)> {
         let tokens = self.map_tokens_for_solver(&orders, &liquidity);
 
-        let amount = self
-            .price_estimator
-            .native_token_amount_to_estimate_prices_with();
         let queries = tokens
             .iter()
             .map(|token| price_estimate::Query {
                 sell_token: self.native_token,
                 buy_token: *token,
-                in_amount: amount,
+                in_amount: self.native_token_amount_to_estimate_prices_with,
                 kind: OrderKind::Sell,
             })
             .collect::<Vec<_>>();
@@ -687,6 +687,7 @@ mod tests {
             1.,
             Client::new(),
             Default::default(),
+            1.into(),
         );
         let base = |x: u128| x * 10u128.pow(18);
         let limit_orders = vec![LimitOrder {


### PR DESCRIPTION
It makes more sense to have this constant in the components that need
prices without amounts than the price estimator.

As discussed in https://github.com/gnosis/gp-v2-services/pull/1109#discussion_r705475213 .

### Test Plan
existing tests
