### PR TITLE
Always target same time limit for gas price

### DIFF
--- a/solver/src/settlement_submission/gas_price_stream.rs
+++ b/solver/src/settlement_submission/gas_price_stream.rs
@@ -1,11 +1,12 @@
 use super::GAS_PRICE_REFRESH_INTERVAL;
 use futures::{stream, Stream, StreamExt};
 use gas_estimation::GasPriceEstimating;
+use std::time::Duration;
 
 // Create a never ending stream of gas prices based on checking the estimator in fixed intervals
 // and enforcing the minimum increase. Errors are ignored.
 pub fn gas_price_stream(
-    target_confirm_time: std::time::Instant,
+    time_limit: Duration,
     gas_price_cap: f64,
     gas_limit: f64,
     estimator: &dyn GasPriceEstimating,
@@ -19,11 +20,7 @@ pub fn gas_price_stream(
         } else {
             tokio::time::sleep(GAS_PRICE_REFRESH_INTERVAL).await;
         }
-        let remaining_time = tokio::time::Instant::from_std(target_confirm_time)
-            .saturating_duration_since(tokio::time::Instant::now());
-        let estimate = estimator
-            .estimate_with_limits(gas_limit, remaining_time)
-            .await;
+        let estimate = estimator.estimate_with_limits(gas_limit, time_limit).await;
         Some((estimate, false))
     })
     .filter_map(|gas_price_result| async move {
@@ -44,9 +41,7 @@ pub fn gas_price_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::stream::StreamExt;
     use std::time::Duration;
-    use tokio::time;
 
     struct TestEstimator;
 
@@ -55,27 +50,5 @@ mod tests {
         async fn estimate_with_limits(&self, _: f64, time_limit: Duration) -> anyhow::Result<f64> {
             Ok(20. - time_limit.as_secs_f64())
         }
-    }
-
-    #[tokio::test]
-    async fn stream_uses_current_time() {
-        time::pause();
-
-        let estimator = TestEstimator;
-        let stream = gas_price_stream(
-            (tokio::time::Instant::now() + Duration::from_secs(20)).into_std(),
-            f64::INFINITY,
-            0.,
-            &estimator,
-            None,
-        );
-        futures::pin_mut!(stream);
-
-        let next = stream.next().await.unwrap();
-        assert_eq!(next as u32, 0);
-        let next = stream.next().await.unwrap();
-        assert_eq!(next as u32, 15);
-        let next = stream.next().await.unwrap();
-        assert_eq!(next as u32, 20);
     }
 }

--- a/solver/src/settlement_submission/rpc.rs
+++ b/solver/src/settlement_submission/rpc.rs
@@ -10,10 +10,7 @@ use ethcontract::{dyns::DynTransport, Account, TransactionHash, Web3};
 use futures::stream::StreamExt;
 use gas_estimation::GasPriceEstimating;
 use primitive_types::{H160, U256};
-use std::{
-    borrow::Cow,
-    time::{Duration, Instant},
-};
+use std::{borrow::Cow, time::Duration};
 use transaction_retry::RetryResult;
 
 // Submit a settlement to the contract, updating the transaction with gas prices if they increase.
@@ -73,7 +70,7 @@ pub async fn submit(
         transaction_retry::gas_price_increase::minimum_increase(gas_price.to_f64_lossy())
     });
     let stream = gas_price_stream(
-        Instant::now() + target_confirm_time,
+        target_confirm_time,
         gas_price_cap,
         gas_limit,
         gas,


### PR DESCRIPTION
instead of adjusting based on already passed time.

This is basically a revert of https://github.com/gnosis/gp-v2-services/pull/728 motivated by high gas prices. The reason for that is that if our estimates go to 0 seconds we can get extreme gas prices compared to a more reasonable estimate and the gas price is more predictable. We don't really need to absolutely be in the next block and we would rather pay less gas even if that means being only the second next block.
Adapting the time limit would make sense if we had transactions something like 10 minutes in the future but for our short time windows I prefer the a fixed time limit.
After merging this we can look at if it changes submission to mining time significantly.

### Test Plan
still compiles
