### PR TITLE
Implement PriceEstimating on paraswap api

### DIFF
--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -13,6 +13,7 @@ pub mod maintenance;
 pub mod metrics;
 pub mod network;
 pub mod paraswap_api;
+pub mod paraswap_price_estimator;
 pub mod price_estimate;
 pub mod recent_block_cache;
 pub mod sources;

--- a/shared/src/paraswap_api.rs
+++ b/shared/src/paraswap_api.rs
@@ -14,7 +14,7 @@ const BASE_URL: &str = "https://apiv5.paraswap.io";
 /// Mockable implementation of the API for unit test
 #[mockall::automock]
 #[async_trait::async_trait]
-pub trait ParaswapApi {
+pub trait ParaswapApi: Send + Sync {
     async fn price(&self, query: PriceQuery) -> Result<PriceResponse, ParaswapResponseError>;
     async fn transaction(
         &self,
@@ -229,6 +229,7 @@ pub struct PriceResponse {
     pub dest_amount: U256,
     /// The token transfer proxy address to set an allowance for.
     pub token_transfer_proxy: H160,
+    pub gas_cost: U256,
 }
 
 impl<'de> Deserialize<'de> for PriceResponse {
@@ -250,6 +251,8 @@ impl<'de> Deserialize<'de> for PriceResponse {
             #[serde(with = "u256_decimal")]
             dest_amount: U256,
             token_transfer_proxy: H160,
+            #[serde(with = "u256_decimal")]
+            gas_cost: U256,
         }
 
         let parsed = ParsedRaw::deserialize(deserializer)?;
@@ -257,6 +260,7 @@ impl<'de> Deserialize<'de> for PriceResponse {
             src_amount,
             dest_amount,
             token_transfer_proxy,
+            gas_cost,
         } = serde_json::from_value::<PriceRoute>(parsed.price_route.clone())
             .map_err(D::Error::custom)?;
         Ok(PriceResponse {
@@ -264,6 +268,7 @@ impl<'de> Deserialize<'de> for PriceResponse {
             src_amount,
             dest_amount,
             token_transfer_proxy,
+            gas_cost,
         })
     }
 }

--- a/shared/src/paraswap_price_estimator.rs
+++ b/shared/src/paraswap_price_estimator.rs
@@ -1,0 +1,152 @@
+use crate::{
+    bad_token::BadTokenDetecting,
+    paraswap_api::{ParaswapApi, PriceQuery, Side},
+    price_estimate::{
+        ensure_token_supported, Estimate, PriceEstimating, PriceEstimationError, Query,
+    },
+    token_info::{TokenInfo, TokenInfoFetching},
+};
+use anyhow::{anyhow, Context, Result};
+use model::order::OrderKind;
+use primitive_types::H160;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+pub struct ParaswapPriceEstimator {
+    pub paraswap: Arc<dyn ParaswapApi>,
+    pub token_info: Arc<dyn TokenInfoFetching>,
+    pub bad_token_detector: Arc<dyn BadTokenDetecting>,
+    pub disabled_paraswap_dexs: Vec<String>,
+}
+
+impl ParaswapPriceEstimator {
+    async fn estimate_(
+        &self,
+        query: &Query,
+        token_infos: &HashMap<H160, TokenInfo>,
+    ) -> Result<Estimate, PriceEstimationError> {
+        if query.buy_token == query.sell_token {
+            return Ok(Estimate {
+                out_amount: query.in_amount,
+                gas: 0.into(),
+            });
+        }
+
+        ensure_token_supported(query.buy_token, self.bad_token_detector.as_ref()).await?;
+        ensure_token_supported(query.sell_token, self.bad_token_detector.as_ref()).await?;
+
+        let (src_token, dest_token, side) = match query.kind {
+            OrderKind::Buy => (query.buy_token, query.sell_token, Side::Buy),
+            OrderKind::Sell => (query.sell_token, query.buy_token, Side::Sell),
+        };
+        let price_query = PriceQuery {
+            src_token,
+            dest_token,
+            src_decimals: decimals(&src_token, token_infos)? as usize,
+            dest_decimals: decimals(&dest_token, token_infos)? as usize,
+            amount: query.in_amount,
+            side,
+            exclude_dexs: Some(self.disabled_paraswap_dexs.clone()),
+        };
+
+        let response = self
+            .paraswap
+            .price(price_query)
+            .await
+            .map_err(anyhow::Error::from)
+            .context("paraswap")?;
+        Ok(Estimate {
+            out_amount: response.dest_amount,
+            gas: response.gas_cost,
+        })
+    }
+}
+
+fn decimals(
+    token: &H160,
+    token_infos: &HashMap<H160, TokenInfo>,
+) -> Result<u8, PriceEstimationError> {
+    token_infos
+        .get(token)
+        .and_then(|info| info.decimals)
+        .ok_or_else(|| PriceEstimationError::Other(anyhow!("failed to get decimals")))
+}
+
+#[async_trait::async_trait]
+impl PriceEstimating for ParaswapPriceEstimator {
+    async fn estimate(&self, query: &Query) -> Result<Estimate, PriceEstimationError> {
+        let results = self.estimates(std::slice::from_ref(query)).await;
+        // Unwrap because it always returns the same number of results as queries.
+        results.into_iter().next().unwrap()
+    }
+
+    async fn estimates(&self, queries: &[Query]) -> Vec<Result<Estimate, PriceEstimationError>> {
+        let tokens = queries
+            .iter()
+            .flat_map(|query| [query.sell_token, query.buy_token])
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let token_infos = self.token_info.get_token_infos(&tokens).await;
+        // TODO: concurrency?
+        let mut results = Vec::new();
+        for query in queries {
+            results.push(self.estimate_(query, &token_infos).await);
+        }
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        bad_token::list_based::ListBasedDetector, paraswap_api::DefaultParaswapApi,
+        token_info::MockTokenInfoFetching,
+    };
+    use reqwest::Client;
+
+    #[tokio::test]
+    #[ignore]
+    async fn real_estimate() {
+        let mut token_info = MockTokenInfoFetching::new();
+        token_info.expect_get_token_infos().returning(|tokens| {
+            tokens
+                .iter()
+                .map(|token| (*token, TokenInfo { decimals: Some(18) }))
+                .collect()
+        });
+        let paraswap = DefaultParaswapApi {
+            client: Client::new(),
+            partner: "".to_string(),
+        };
+        let detector = ListBasedDetector::deny_list(Vec::new());
+        let estimator = ParaswapPriceEstimator {
+            paraswap: Arc::new(paraswap),
+            token_info: Arc::new(token_info),
+            bad_token_detector: Arc::new(detector),
+            disabled_paraswap_dexs: Vec::new(),
+        };
+
+        let weth = addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+        let gno = addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+        let query = Query {
+            sell_token: weth,
+            buy_token: gno,
+            in_amount: 10u128.pow(18).into(),
+            kind: OrderKind::Sell,
+        };
+
+        let result = estimator.estimate(&query).await;
+        dbg!(&result);
+        let estimate = result.unwrap();
+        println!(
+            "1 eth buys {} gno",
+            estimate.out_amount.to_f64_lossy() / 1e18
+        );
+        // You can compare this to
+        // <api url>/api/v1/markets/c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2-6810e776880c02933d47db1b9fc05908e5386b96/sell/1000000000000000000
+    }
+}

--- a/solver/src/solver/paraswap_solver.rs
+++ b/solver/src/solver/paraswap_solver.rs
@@ -304,6 +304,7 @@ mod tests {
                 src_amount: 100.into(),
                 dest_amount: 99.into(),
                 token_transfer_proxy: H160([0x42; 20]),
+                gas_cost: 0.into(),
             })
         });
         client
@@ -384,6 +385,7 @@ mod tests {
                 src_amount: 100.into(),
                 dest_amount: 99.into(),
                 token_transfer_proxy,
+                gas_cost: 0.into(),
             })
         });
         client
@@ -471,6 +473,7 @@ mod tests {
                 src_amount: 100.into(),
                 dest_amount: 99.into(),
                 token_transfer_proxy: H160([0x42; 20]),
+                gas_cost: 0.into(),
             })
         });
 


### PR DESCRIPTION
Next steps:
- add configuration option to use this in several places (user facing price estimates, fee, driver estimates, etc)
- pass driver price estimates into solvers so that paraswap doesn't have to get queried again
- introduce concurrency to price lookup
- use partner header in api

### Test Plan
added new ignored test. once this this can be configured to be used for api will manually test more tokens
