### PR TITLE
* Fee scaling based on app ID

### DIFF
--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -22,6 +22,7 @@ use shared::{
     Web3,
 };
 use solver::orderbook::OrderBookApi;
+use std::collections::HashMap;
 use std::{num::NonZeroU64, str::FromStr, sync::Arc, time::Duration};
 
 pub const API_HOST: &str = "http://127.0.0.1:8080";
@@ -190,6 +191,7 @@ impl OrderbookServices {
             db.clone(),
             0.0,
             bad_token_detector.clone(),
+            HashMap::default(),
         ));
         let balance_fetcher = Arc::new(Web3BalanceFetcher::new(
             web3.clone(),

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -578,18 +578,16 @@ mod tests {
             .await
             .unwrap();
         let lower_fee = fee - U256::one();
-        assert_eq!(
+        assert!(
             fee_estimator
                 .is_valid_fee(sell_token, lower_fee, BALANCER_APP_ID)
-                .await,
-            true
+                .await
         );
         let half_lower_fee = lower_fee / U256::from(2);
-        assert_eq!(
-            fee_estimator
+        assert!(
+            !fee_estimator
                 .is_valid_fee(sell_token, half_lower_fee, BALANCER_APP_ID)
-                .await,
-            false
+                .await
         );
     }
 }

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -259,11 +259,10 @@ impl MinFeeCalculating for MinFeeCalculator {
 
     // Returns true if the fee satisfies a previous not yet expired estimate, or the fee is high enough given the current estimate.
     async fn is_valid_fee(&self, sell_token: H160, fee: U256, app_data: [u8; 32]) -> bool {
-        let app_based_fee_factor = self
+        let app_based_fee_factor = *self
             .partner_additional_fee_factors
             .get(&H256::from(app_data))
-            .unwrap_or(&1.0)
-            .clone();
+            .unwrap_or(&1.0);
 
         if let Ok(Some(past_fee)) = self
             .measurements

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -1,4 +1,5 @@
 use contracts::{BalancerV2Vault, GPv2Settlement, WETH9};
+use ethcontract::H256;
 use model::{
     order::{OrderUid, BUY_ETH_ADDRESS},
     DomainSeparator,
@@ -23,10 +24,13 @@ use shared::{
             AmmPairProviderFinder, BalancerVaultFinder, TokenOwnerFinding, TraceCallDetector,
         },
     },
+    baseline_solver::BaseTokens,
     current_block::current_block_stream,
     maintenance::ServiceMaintenance,
+    metrics::setup_metrics_registry,
     paraswap_api::DefaultParaswapApi,
     paraswap_price_estimator::ParaswapPriceEstimator,
+    price_estimate::PriceEstimatorType,
     price_estimate::{BaselinePriceEstimator, PriceEstimating},
     recent_block_cache::CacheConfig,
     sources::{
@@ -41,18 +45,10 @@ use shared::{
     transport::create_instrumented_transport,
     transport::http::HttpTransport,
 };
-use std::collections::HashMap;
-use std::{
-    collections::HashSet, iter::FromIterator as _, net::SocketAddr, sync::Arc, time::Duration,
-use shared::{
-    baseline_solver::BaseTokens, metrics::setup_metrics_registry,
-    price_estimate::PriceEstimatorType,
-};
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 use structopt::StructOpt;
 use tokio::task;
 use url::Url;
-use ethcontract::H256;
 
 #[derive(Debug, StructOpt)]
 struct Arguments {

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -128,6 +128,13 @@ struct Arguments {
     )]
     solvable_orders_max_update_age: Duration,
 
+    /// Used to specify additional fee subsidy factor based on app_ids contained in orders.
+    /// Should take the form of a json string as shown in the following example:
+    /// '{"0x0000000000000000000000000000000000000000000000000000000000000000":0.5,"$PROJECT_APP_ID":0.7}'
+    ///
+    /// Furthermore, a value of
+    /// - 1 means no subsidy and is the default for all app_data not contained in this list.
+    /// - 0.5 means that this project pays only 50% of the estimated fees.
     #[structopt(
         long,
         env,

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -46,6 +46,7 @@ use std::{
 use structopt::StructOpt;
 use tokio::task;
 use url::Url;
+use ethcontract::H256;
 
 #[derive(Debug, StructOpt)]
 struct Arguments {
@@ -131,7 +132,7 @@ struct Arguments {
         default_value = "{}",
         parse(try_from_str = serde_json::from_str),
     )]
-    partner_additional_fee_factors: HashMap<[u8; 32], f64>, // '{"$BALANCER_APP_ID":0.5,"$METAMASK_APP_ID":0.7}'
+    partner_additional_fee_factors: HashMap<H256, f64>, // '{"$BALANCER_APP_ID":0.5,"$METAMASK_APP_ID":0.7}'
 }
 
 pub async fn database_metrics(metrics: Arc<Metrics>, database: Postgres) -> ! {

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -39,6 +39,7 @@ use shared::{
     transport::create_instrumented_transport,
     transport::http::HttpTransport,
 };
+use std::collections::HashMap;
 use std::{
     collections::HashSet, iter::FromIterator as _, net::SocketAddr, sync::Arc, time::Duration,
 };
@@ -123,6 +124,14 @@ struct Arguments {
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
     solvable_orders_max_update_age: Duration,
+
+    #[structopt(
+        long,
+        env,
+        default_value = "{}",
+        parse(try_from_str = serde_json::from_str),
+    )]
+    partner_additional_fee_factors: HashMap<[u8; 32], f64>, // '{"$BALANCER_APP_ID":0.5,"$METAMASK_APP_ID":0.7}'
 }
 
 pub async fn database_metrics(metrics: Arc<Metrics>, database: Postgres) -> ! {
@@ -336,6 +345,7 @@ async fn main() {
         database.clone(),
         args.shared.fee_factor,
         bad_token_detector.clone(),
+        args.partner_additional_fee_factors,
     ));
 
     let solvable_orders_cache = SolvableOrdersCache::new(

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -137,7 +137,7 @@ impl Orderbook {
         }
         if !self
             .fee_validator
-            .is_valid_fee(order.sell_token, order.fee_amount)
+            .is_valid_fee(order.sell_token, order.fee_amount, order.app_data)
             .await
         {
             return Ok(AddOrderResult::InsufficientFee);


### PR DESCRIPTION
Part of #1067

We introduce a new config parameter `partner-additional-fee-factors` which holds a hashmap of app data and fee factors which are applied at the time of fee validation (right before an order is written to the orderbook).

Note that all the values involved are U256, so we used some f64 lossy conversion to apply these fractional amounts

### Test Plan
Introduced new test which passes when it should and fails when it shouldn't.


To test with new config parameters run the orderbook with

```
--partner-additional-fee-factors '{"0xE9F29AE547955463ED535162AEFEE525D8D309571A2B18BC26086C8C35D781EB":0.5, "0xE4D1AB10F2C9FFE7BDD23C315B03F18CFF90888D6B2BB5022BACD46AB9CDDF24": 0.7}'
```

and find this displayed as a log at the start

<img width="732" alt="Screenshot 2021-09-21 at 3 15 22 PM" src="https://user-images.githubusercontent.com/11778116/134177566-8f74d3ae-97fe-4f6f-8acc-0c59dde0aac2.png">

This (e2e) test along with the newly added unit tests confirm new functionality is working as expected.

