### PR TITLE
This PR additionally logs the settlement model on conversion failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,12 +1037,11 @@ dependencies = [
 [[package]]
 name = "gas-estimation"
 version = "0.1.0"
-source = "git+https://github.com/gnosis/gp-gas-estimation.git?tag=v0.3.3#b8b018545d0a4891135a1010ffab6b8425a89815"
+source = "git+https://github.com/gnosis/gp-gas-estimation.git?tag=v0.3.2#b6b4808e182cacd660913a408d3938ef024c86fe"
 dependencies = [
  "anyhow",
  "async-trait",
  "futures",
- "http",
  "primitive-types",
  "serde",
  "serde_json",

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -128,7 +128,7 @@ pub struct FeeModel {
 }
 
 #[serde_as]
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct SettledBatchAuctionModel {
     pub orders: HashMap<usize, ExecutedOrderModel>,
     #[serde(default)]
@@ -154,7 +154,7 @@ pub struct MetadataModel {
     pub environment: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ExecutedOrderModel {
     #[serde(with = "u256_decimal")]
     pub exec_sell_amount: U256,
@@ -162,7 +162,7 @@ pub struct ExecutedOrderModel {
     pub exec_buy_amount: U256,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct UpdatedAmmModel {
     /// We ignore additional incoming amm fields we don't need.
     pub execution: Vec<ExecutedAmmModel>,

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -24,8 +24,15 @@ pub fn convert_settlement(
     settled: SettledBatchAuctionModel,
     context: SettlementContext,
 ) -> Result<Settlement> {
-    let intermediate = IntermediateSettlement::new(settled, context)?;
-    intermediate.into_settlement()
+    match IntermediateSettlement::new(settled.clone(), context)
+        .and_then(|intermediate| intermediate.into_settlement())
+    {
+        Ok(settlement) => Ok(settlement),
+        Err(err) => {
+            tracing::debug!("failed to process HTTP solver result: {:?}", settled);
+            Err(err)
+        }
+    }
 }
 
 // An intermediate representation between SettledBatchAuctionModel and Settlement useful for doing


### PR DESCRIPTION
This PR adds a new `debug` log with the parsed output from the HTTP solver if it fails to build a settlement from it. This is in response to the recent:
```
2021-09-21T05:14:09.938Z ERROR solver::driver: solver Quasimodo error: invalid token ...
```

Errors we've been seeing in the alerts channel, to try and debug what is wrong.

### Test Plan

Just a log.
