### PR TITLE
Allow using Paraswap as price estimator in api

### DIFF
--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -1,5 +1,8 @@
 //! Contains command line arguments and related helpers that are shared between the binaries.
-use crate::{gas_price_estimation::GasEstimatorType, sources::BaselineSource};
+use crate::{
+    gas_price_estimation::GasEstimatorType, price_estimate::PriceEstimatorType,
+    sources::BaselineSource,
+};
 use anyhow::{ensure, Result};
 use ethcontract::{H160, U256};
 use std::{
@@ -101,6 +104,23 @@ pub struct Arguments {
         parse(try_from_str = U256::from_dec_str)
     )]
     pub amount_to_estimate_prices_with: Option<U256>,
+
+    /// Special partner authentication for Paraswap API (allowing higher rater limits)
+    #[structopt(long, env)]
+    pub paraswap_partner: Option<String>,
+
+    /// The list of disabled ParaSwap DEXs. By default, the `ParaSwapPool4`
+    /// DEX (representing a private market maker) is disabled as it increases
+    /// price by 1% if built transactions don't actually get executed.
+    #[structopt(long, env, default_value = "ParaSwapPool4", use_delimiter = true)]
+    pub disabled_paraswap_dexs: Vec<String>,
+
+    #[structopt(
+        long,
+        default_value = "Baseline",
+        possible_values = &PriceEstimatorType::variants(),
+    )]
+    pub price_estimator: PriceEstimatorType,
 }
 
 fn parse_fee_factor(s: &str) -> Result<f64> {

--- a/shared/src/price_estimate.rs
+++ b/shared/src/price_estimate.rs
@@ -18,7 +18,16 @@ use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
+use structopt::clap::arg_enum;
 use thiserror::Error;
+
+arg_enum! {
+    #[derive(Debug)]
+    pub enum PriceEstimatorType {
+        Baseline,
+        Paraswap,
+    }
+}
 
 #[derive(Error, Debug)]
 pub enum PriceEstimationError {

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -171,16 +171,6 @@ struct Arguments {
     #[structopt(long, env, default_value = "10")]
     paraswap_slippage_bps: u32,
 
-    /// The list of disabled ParaSwap DEXs. By default, the `ParaSwapPool4`
-    /// DEX (representing a private market maker) is disabled as it increases
-    /// price by 1% if built transactions don't actually get executed.
-    #[structopt(long, env, default_value = "ParaSwapPool4", use_delimiter = true)]
-    disabled_paraswap_dexs: Vec<String>,
-
-    /// Special partner authentication for Paraswap API (allowing higher rater limits)
-    #[structopt(long, env)]
-    paraswap_partner: Option<String>,
-
     /// The authorization for the archer api.
     #[structopt(long, env)]
     archer_authorization: Option<String>,
@@ -406,8 +396,8 @@ async fn main() {
         args.min_order_size_one_inch,
         args.disabled_one_inch_protocols,
         args.paraswap_slippage_bps,
-        args.disabled_paraswap_dexs,
-        args.paraswap_partner,
+        args.shared.disabled_paraswap_dexs,
+        args.shared.paraswap_partner,
         client.clone(),
         native_token_price_estimation_amount,
     )


### PR DESCRIPTION
moved configuration parameters from solver args to shared args.

### Test Plan
still compiles
