### PR TITLE
Refactor http solver

### DIFF
--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -4,9 +4,7 @@ mod settlement;
 
 use self::{model::*, settlement::SettlementContext};
 use crate::{
-    liquidity::{
-        ConstantProductOrder, LimitOrder, Liquidity, StablePoolOrder, WeightedProductOrder,
-    },
+    liquidity::{LimitOrder, Liquidity},
     settlement::Settlement,
     settlement_submission::retry::is_transaction_failure,
     solver::{Auction, Solver},
@@ -18,6 +16,7 @@ use buffers::{BufferRetrievalError, BufferRetrieving};
 use ethcontract::{Account, U256};
 use futures::{join, lock::Mutex};
 use lazy_static::lazy_static;
+use maplit::{btreemap, hashset};
 use num::{BigInt, BigRational};
 use primitive_types::H160;
 use reqwest::{header::HeaderValue, Client, Url};
@@ -27,16 +26,18 @@ use shared::{
     token_info::{TokenInfo, TokenInfoFetching},
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
+    iter::FromIterator as _,
     sync::Arc,
     time::{Duration, Instant},
 };
 
-// Estimates from multivariate linear regression here:
-// https://docs.google.com/spreadsheets/d/13UeUQ9DA4bHlcy9-i8d4nSLlCxSfjcXpTelvXYzyJzQ/edit?usp=sharing
 lazy_static! {
+    // Estimates from multivariate linear regression here:
+    // https://docs.google.com/spreadsheets/d/13UeUQ9DA4bHlcy9-i8d4nSLlCxSfjcXpTelvXYzyJzQ/edit?usp=sharing
     static ref GAS_PER_ORDER: U256 = U256::from(66_315);
     static ref GAS_PER_UNISWAP: U256 = U256::from(94_696);
+
     // Taken from a sample of two swaps
     // https://etherscan.io/tx/0x72d234d35fd169ef497ba0a1dc23258c96f278fb688d375d135eb012e5311009
     // https://etherscan.io/tx/0x1c345a6da1edb2bba953685a4cf85f6a0d967ac751f8c5b518578c5fd20a7c96
@@ -129,195 +130,14 @@ impl HttpSolver {
         }
     }
 
-    fn map_tokens_for_solver(&self, orders: &[LimitOrder], liquidity: &[Liquidity]) -> Vec<H160> {
-        let order_tokens = orders
-            .iter()
-            .flat_map(|order| [order.sell_token, order.buy_token]);
-        let liquidity_tokens = liquidity.iter().flat_map(|liquidity| match liquidity {
-            Liquidity::ConstantProduct(amm) => amm.tokens.into_iter().collect::<Vec<_>>(),
-            Liquidity::BalancerWeighted(amm) => amm.reserves.keys().copied().collect(),
-            Liquidity::BalancerStable(amm) => amm.reserves.keys().copied().collect(),
-        });
-
-        order_tokens
-            .chain(liquidity_tokens)
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect()
-    }
-
-    fn token_models(
-        &self,
-        token_infos: &HashMap<H160, TokenInfo>,
-        price_estimates: &HashMap<H160, f64>,
-        buffers: &HashMap<H160, U256>,
-    ) -> HashMap<H160, TokenInfoModel> {
-        token_infos
-            .iter()
-            .map(|(address, token_info)| {
-                let external_price = match price_estimates.get(address).copied() {
-                    Some(price) if price.is_finite() => Some(price),
-                    _ => None,
-                };
-                (
-                    *address,
-                    TokenInfoModel {
-                        decimals: token_info.decimals,
-                        external_price,
-                        normalize_priority: Some(if &self.native_token == address { 1 } else { 0 }),
-                        internal_buffer: buffers.get(address).copied(),
-                    },
-                )
-            })
-            .collect()
-    }
-
-    fn map_orders_for_solver(&self, orders: Vec<LimitOrder>) -> HashMap<usize, LimitOrder> {
-        orders.into_iter().enumerate().collect()
-    }
-
-    fn order_models(
-        &self,
-        orders: &HashMap<usize, LimitOrder>,
-        gas_price: f64,
-    ) -> HashMap<usize, OrderModel> {
-        let order_cost = self.order_cost(gas_price);
-        let mut result: HashMap<usize, OrderModel> = HashMap::new();
-        for (index, order) in orders {
-            let order_fee = self.order_fee(order);
-            let order = OrderModel {
-                sell_token: order.sell_token,
-                buy_token: order.buy_token,
-                sell_amount: order.sell_amount,
-                buy_amount: order.buy_amount,
-                allow_partial_fill: order.partially_fillable,
-                is_sell_order: matches!(order.kind, OrderKind::Sell),
-                fee: FeeModel {
-                    amount: order_fee,
-                    token: order.sell_token,
-                },
-                cost: CostModel {
-                    amount: order_cost,
-                    token: self.native_token,
-                },
-                is_liquidity_order: order.is_liquidity_order,
-            };
-            result.insert(*index, order);
-        }
-        result
-    }
-
-    fn map_amm_orders_for_solver<T>(&self, orders: Vec<T>) -> HashMap<usize, T> {
-        orders.into_iter().enumerate().collect()
-    }
-
-    fn amm_models(
-        &self,
-        constant_product_orders: &HashMap<usize, ConstantProductOrder>,
-        weighted_product_orders: &HashMap<usize, WeightedProductOrder>,
-        stable_pool_orders: &HashMap<usize, StablePoolOrder>,
-        gas_price: f64,
-    ) -> HashMap<usize, AmmModel> {
-        let uniswap_cost = self.uniswap_cost(gas_price);
-        let mut pool_model_map = HashMap::new();
-        let constant_product_models: HashMap<_, AmmModel> = constant_product_orders
-            .iter()
-            .map(|(index, amm)| {
-                let mut reserves = HashMap::new();
-                reserves.insert(amm.tokens.get().0, U256::from(amm.reserves.0));
-                reserves.insert(amm.tokens.get().1, U256::from(amm.reserves.1));
-                let pool_model = AmmModel {
-                    parameters: AmmParameters::ConstantProduct(ConstantProductPoolParameters {
-                        reserves,
-                    }),
-                    fee: BigRational::new(
-                        BigInt::from(*amm.fee.numer()),
-                        BigInt::from(*amm.fee.denom()),
-                    ),
-                    cost: CostModel {
-                        amount: uniswap_cost,
-                        token: self.native_token,
-                    },
-                    mandatory: false,
-                };
-                (*index, pool_model)
-            })
-            .collect();
-        let balancer_cost = self.balancer_cost(gas_price);
-        let weighted_product_models: HashMap<_, AmmModel> = weighted_product_orders
-            .iter()
-            .map(|(index, amm)| {
-                let reserves = amm
-                    .reserves
-                    .iter()
-                    .map(|(token, state)| {
-                        (
-                            *token,
-                            WeightedPoolTokenData {
-                                balance: state.token_state.balance,
-                                weight: BigRational::from(state.weight),
-                            },
-                        )
-                    })
-                    .collect();
-                let pool_model = AmmModel {
-                    parameters: AmmParameters::WeightedProduct(WeightedProductPoolParameters {
-                        reserves,
-                    }),
-                    fee: amm.fee.clone(),
-                    cost: CostModel {
-                        amount: balancer_cost,
-                        token: self.native_token,
-                    },
-                    mandatory: false,
-                };
-                // Note that in order to preserve unique keys of this hashmap, we use
-                // the current index + the length of the previous map.
-                (*index + constant_product_models.len(), pool_model)
-            })
-            .collect();
-        let stable_pool_models: HashMap<_, AmmModel> = stable_pool_orders
-            .iter()
-            .map(|(index, amm)| {
-                let reserves = amm
-                    .reserves
-                    .iter()
-                    .map(|(token, state)| (*token, state.balance))
-                    .collect();
-                let pool_model = AmmModel {
-                    parameters: AmmParameters::Stable(StablePoolParameters {
-                        reserves,
-                        amplification_parameter: amm.amplification_parameter.clone(),
-                    }),
-                    fee: amm.fee.clone(),
-                    cost: CostModel {
-                        amount: balancer_cost,
-                        token: self.native_token,
-                    },
-                    mandatory: false,
-                };
-                // Note that in order to preserve unique keys of this hashmap, we use
-                // the current index + the length of the previous map.
-                (
-                    *index + constant_product_models.len() + weighted_product_models.len(),
-                    pool_model,
-                )
-            })
-            .collect();
-        pool_model_map.extend(constant_product_models);
-        pool_model_map.extend(weighted_product_models);
-        pool_model_map.extend(stable_pool_models);
-        pool_model_map
-    }
-
     async fn prepare_model(
         &self,
-        mut orders: Vec<LimitOrder>,
+        orders: Vec<LimitOrder>,
         liquidity: Vec<Liquidity>,
         gas_price: f64,
         price_estimates: HashMap<H160, BigRational>,
     ) -> Result<(BatchAuctionModel, SettlementContext)> {
-        let tokens = self.map_tokens_for_solver(&orders, &liquidity);
+        let tokens = map_tokens_for_solver(&orders, &liquidity);
 
         let queries = tokens
             .iter()
@@ -368,7 +188,7 @@ impl HttpSolver {
             })
             .collect();
 
-        let mut new_price_estimates: HashMap<H160, f64> = queries
+        let mut all_price_estimates: HashMap<H160, f64> = queries
             .iter()
             .zip(new_price_estimates)
             .filter_map(|(query, estimate)| {
@@ -376,39 +196,24 @@ impl HttpSolver {
                 Some((query.buy_token, price))
             })
             .collect();
-        new_price_estimates.extend(
+        all_price_estimates.extend(
             price_estimates
                 .into_iter()
                 .filter_map(|(token, price)| Some((token, price.to_f64()?))),
         );
 
-        let (constant_product_liquidity, weighted_product_liquidity, stable_pool_liquidity) =
-            split_liquidity(liquidity);
+        // For the solver to run correctly we need to be sure that there are no
+        // isolated islands of tokens without connection between them.
+        let fee_connected_tokens = compute_fee_connected_tokens(&liquidity, self.native_token);
+        let gas_model = GasModel {
+            native_token: self.native_token,
+            gas_price,
+            fee_factor: self.fee_factor,
+        };
 
-        // For the solver to run correctly we need to be sure that there are no isolated islands of
-        // tokens without connection between them.
-        remove_orders_without_native_connection(
-            &mut orders,
-            &constant_product_liquidity,
-            &self.native_token,
-        );
-        let limit_orders = self.map_orders_for_solver(orders);
-        let constant_product_orders = self.map_amm_orders_for_solver(constant_product_liquidity);
-        let weighted_product_orders = self.map_amm_orders_for_solver(weighted_product_liquidity);
-        let stable_pool_orders = self.map_amm_orders_for_solver(stable_pool_liquidity);
-
-        let token_models = self.token_models(&token_infos, &new_price_estimates, &buffers);
-        let order_models = self.order_models(&limit_orders, gas_price);
-        let amm_models = self
-            .amm_models(
-                &constant_product_orders,
-                &weighted_product_orders,
-                &stable_pool_orders,
-                gas_price,
-            )
-            .into_iter()
-            .filter(|(_, model)| model.has_sufficient_reserves())
-            .collect();
+        let token_models = token_models(&token_infos, &all_price_estimates, &buffers, &gas_model);
+        let order_models = order_models(&orders, &fee_connected_tokens, &gas_model);
+        let amm_models = amm_models(&liquidity, &gas_model);
         let model = BatchAuctionModel {
             tokens: token_models,
             orders: order_models,
@@ -417,13 +222,7 @@ impl HttpSolver {
                 environment: Some(self.network_id.clone()),
             }),
         };
-        let context = SettlementContext {
-            limit_orders,
-            constant_product_orders,
-            weighted_product_orders,
-            stable_pool_orders,
-        };
-        Ok((model, context))
+        Ok((model, SettlementContext { orders, liquidity }))
     }
 
     async fn send(
@@ -484,23 +283,6 @@ impl HttpSolver {
             .with_context(|| format!("failed to decode response json, {}", context()))
     }
 
-    fn order_cost(&self, gas_price: f64) -> U256 {
-        U256::from_f64_lossy(gas_price) * *GAS_PER_ORDER
-    }
-
-    fn uniswap_cost(&self, gas_price: f64) -> U256 {
-        U256::from_f64_lossy(gas_price) * *GAS_PER_UNISWAP
-    }
-
-    fn balancer_cost(&self, gas_price: f64) -> U256 {
-        U256::from_f64_lossy(gas_price) * *GAS_PER_BALANCER_SWAP
-    }
-
-    fn order_fee(&self, order: &LimitOrder) -> U256 {
-        let ceiled_div = (order.fee_amount.to_f64_lossy() / self.fee_factor).ceil();
-        U256::from_f64_lossy(ceiled_div)
-    }
-
     pub fn generate_instance_name(&self) -> String {
         let now = chrono::Utc::now();
         format!(
@@ -512,43 +294,191 @@ impl HttpSolver {
     }
 }
 
-fn split_liquidity(
-    liquidity: Vec<Liquidity>,
-) -> (
-    Vec<ConstantProductOrder>,
-    Vec<WeightedProductOrder>,
-    Vec<StablePoolOrder>,
-) {
-    let mut constant_product_orders = Vec::new();
-    let mut weighted_product_orders = Vec::new();
-    let mut stable_pool_orders = Vec::new();
-    for order in liquidity {
-        match order {
-            Liquidity::ConstantProduct(order) => constant_product_orders.push(order),
-            Liquidity::BalancerWeighted(order) => weighted_product_orders.push(order),
-            Liquidity::BalancerStable(order) => stable_pool_orders.push(order),
-        }
-    }
-    (
-        constant_product_orders,
-        weighted_product_orders,
-        stable_pool_orders,
-    )
+struct GasModel {
+    native_token: H160,
+    gas_price: f64,
+    fee_factor: f64,
 }
 
-// TODO: This currently does **NOT** consider balancer pools, but definitely should.
-fn remove_orders_without_native_connection(
-    orders: &mut Vec<LimitOrder>,
-    amms: &[ConstantProductOrder],
-    native_token: &H160,
-) {
+impl GasModel {
+    fn cost_for_gas(&self, gas: U256) -> CostModel {
+        CostModel {
+            amount: U256::from_f64_lossy(self.gas_price) * gas,
+            token: self.native_token,
+        }
+    }
+
+    fn order_cost(&self) -> CostModel {
+        self.cost_for_gas(*GAS_PER_ORDER)
+    }
+
+    fn uniswap_cost(&self) -> CostModel {
+        self.cost_for_gas(*GAS_PER_UNISWAP)
+    }
+
+    fn balancer_cost(&self) -> CostModel {
+        self.cost_for_gas(*GAS_PER_BALANCER_SWAP)
+    }
+
+    fn order_fee(&self, order: &LimitOrder) -> FeeModel {
+        let ceiled_div = (order.fee_amount.to_f64_lossy() / self.fee_factor).ceil();
+        FeeModel {
+            amount: U256::from_f64_lossy(ceiled_div),
+            token: order.sell_token,
+        }
+    }
+}
+
+fn token_models(
+    token_infos: &HashMap<H160, TokenInfo>,
+    price_estimates: &HashMap<H160, f64>,
+    buffers: &HashMap<H160, U256>,
+    gas_model: &GasModel,
+) -> BTreeMap<H160, TokenInfoModel> {
+    token_infos
+        .iter()
+        .map(|(address, token_info)| {
+            let external_price = match price_estimates.get(address).copied() {
+                Some(price) if price.is_finite() => Some(price),
+                _ => None,
+            };
+            (
+                *address,
+                TokenInfoModel {
+                    decimals: token_info.decimals,
+                    external_price,
+                    normalize_priority: Some(if &gas_model.native_token == address {
+                        1
+                    } else {
+                        0
+                    }),
+                    internal_buffer: buffers.get(address).copied(),
+                },
+            )
+        })
+        .collect()
+}
+
+fn order_models(
+    orders: &[LimitOrder],
+    fee_connected_tokens: &HashSet<H160>,
+    gas_model: &GasModel,
+) -> BTreeMap<usize, OrderModel> {
+    orders
+        .iter()
+        .enumerate()
+        .filter_map(|(index, order)| {
+            if ![order.sell_token, order.buy_token]
+                .iter()
+                .any(|token| fee_connected_tokens.contains(token))
+            {
+                return None;
+            }
+
+            Some((
+                index,
+                OrderModel {
+                    sell_token: order.sell_token,
+                    buy_token: order.buy_token,
+                    sell_amount: order.sell_amount,
+                    buy_amount: order.buy_amount,
+                    allow_partial_fill: order.partially_fillable,
+                    is_sell_order: matches!(order.kind, OrderKind::Sell),
+                    fee: gas_model.order_fee(order),
+                    cost: gas_model.order_cost(),
+                    is_liquidity_order: order.is_liquidity_order,
+                },
+            ))
+        })
+        .collect()
+}
+
+fn amm_models(liquidity: &[Liquidity], gas_model: &GasModel) -> BTreeMap<usize, AmmModel> {
+    liquidity
+        .iter()
+        .map(|liquidity| match liquidity {
+            Liquidity::ConstantProduct(amm) => AmmModel {
+                parameters: AmmParameters::ConstantProduct(ConstantProductPoolParameters {
+                    reserves: btreemap! {
+                        amm.tokens.get().0 => amm.reserves.0.into(),
+                        amm.tokens.get().1 => amm.reserves.1.into(),
+                    },
+                }),
+                fee: BigRational::new(
+                    BigInt::from(*amm.fee.numer()),
+                    BigInt::from(*amm.fee.denom()),
+                ),
+                cost: gas_model.uniswap_cost(),
+                mandatory: false,
+            },
+            Liquidity::BalancerWeighted(amm) => AmmModel {
+                parameters: AmmParameters::WeightedProduct(WeightedProductPoolParameters {
+                    reserves: amm
+                        .reserves
+                        .iter()
+                        .map(|(token, state)| {
+                            (
+                                *token,
+                                WeightedPoolTokenData {
+                                    balance: state.token_state.balance,
+                                    weight: BigRational::from(state.weight),
+                                },
+                            )
+                        })
+                        .collect(),
+                }),
+                fee: amm.fee.clone(),
+                cost: gas_model.balancer_cost(),
+                mandatory: false,
+            },
+            Liquidity::BalancerStable(amm) => AmmModel {
+                parameters: AmmParameters::Stable(StablePoolParameters {
+                    reserves: amm
+                        .reserves
+                        .iter()
+                        .map(|(token, state)| (*token, state.balance))
+                        .collect(),
+                    amplification_parameter: amm.amplification_parameter.clone(),
+                }),
+                fee: amm.fee.clone(),
+                cost: gas_model.balancer_cost(),
+                mandatory: false,
+            },
+        })
+        .enumerate()
+        .filter(|(_, model)| model.has_sufficient_reserves())
+        .collect()
+}
+
+fn map_tokens_for_solver(orders: &[LimitOrder], liquidity: &[Liquidity]) -> Vec<H160> {
+    let mut token_set = HashSet::new();
+    token_set.extend(
+        orders
+            .iter()
+            .flat_map(|order| [order.sell_token, order.buy_token]),
+    );
+    for liquidity in liquidity.iter() {
+        match liquidity {
+            Liquidity::ConstantProduct(amm) => token_set.extend(amm.tokens),
+            Liquidity::BalancerWeighted(amm) => token_set.extend(amm.reserves.keys()),
+            Liquidity::BalancerStable(amm) => token_set.extend(amm.reserves.keys()),
+        }
+    }
+
+    Vec::from_iter(token_set)
+}
+
+fn compute_fee_connected_tokens(liquidity: &[Liquidity], native_token: H160) -> HashSet<H160> {
     // Find all tokens that are connected through potentially multiple amm hops to the fee.
     // TODO: Replace with a more optimal graph algorithm.
-    let mut amms = amms.iter().map(|amm| amm.tokens).collect::<HashSet<_>>();
-    let mut fee_connected_tokens = std::iter::once(*native_token).collect::<HashSet<_>>();
+    let mut pairs = liquidity
+        .iter()
+        .flat_map(|amm| amm.all_token_pairs())
+        .collect::<HashSet<_>>();
+    let mut fee_connected_tokens = hashset![native_token];
     loop {
         let mut added_token = false;
-        amms.retain(|token_pair| {
+        pairs.retain(|token_pair| {
             let tokens = token_pair.get();
             if fee_connected_tokens.contains(&tokens.0) {
                 fee_connected_tokens.insert(tokens.1);
@@ -562,16 +492,12 @@ fn remove_orders_without_native_connection(
                 true
             }
         });
-        if amms.is_empty() || !added_token {
+        if pairs.is_empty() || !added_token {
             break;
         }
     }
-    // Remove orders that are not connected.
-    orders.retain(|order| {
-        [order.buy_token, order.sell_token]
-            .iter()
-            .any(|token| fee_connected_tokens.contains(token))
-    });
+
+    fee_connected_tokens
 }
 
 #[async_trait::async_trait]
@@ -758,17 +684,25 @@ mod tests {
             H160::from_low_u64_be(4),
         ];
 
+        let gas_model = GasModel {
+            fee_factor: 1.,
+            gas_price: 1e9,
+            native_token,
+        };
+
         let amms = [(native_token, tokens[0]), (tokens[0], tokens[1])]
             .iter()
-            .map(|tokens| ConstantProductOrder {
-                tokens: TokenPair::new(tokens.0, tokens.1).unwrap(),
-                reserves: (0, 0),
-                fee: 0.into(),
-                settlement_handling: amm_handling.clone(),
+            .map(|tokens| {
+                Liquidity::ConstantProduct(ConstantProductOrder {
+                    tokens: TokenPair::new(tokens.0, tokens.1).unwrap(),
+                    reserves: (0, 0),
+                    fee: 0.into(),
+                    settlement_handling: amm_handling.clone(),
+                })
             })
             .collect::<Vec<_>>();
 
-        let mut orders = [
+        let orders = [
             (native_token, tokens[0]),
             (native_token, tokens[1]),
             (tokens[0], tokens[1]),
@@ -793,8 +727,14 @@ mod tests {
         })
         .collect::<Vec<_>>();
 
-        remove_orders_without_native_connection(&mut orders, &amms, &native_token);
-        assert_eq!(orders.len(), 6);
+        let fee_connected_tokens = compute_fee_connected_tokens(&amms, native_token);
+        assert_eq!(
+            fee_connected_tokens,
+            hashset![native_token, tokens[0], tokens[1]],
+        );
+
+        let order_models = order_models(&orders, &fee_connected_tokens, &gas_model);
+        assert_eq!(order_models.len(), 6);
     }
 
     #[test]

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -7,13 +7,13 @@ use num::BigRational;
 use primitive_types::U256;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct BatchAuctionModel {
-    pub tokens: HashMap<H160, TokenInfoModel>,
-    pub orders: HashMap<usize, OrderModel>,
-    pub amms: HashMap<usize, AmmModel>,
+    pub tokens: BTreeMap<H160, TokenInfoModel>,
+    pub orders: BTreeMap<usize, OrderModel>,
+    pub amms: BTreeMap<usize, AmmModel>,
     pub metadata: Option<MetadataModel>,
 }
 
@@ -77,8 +77,8 @@ pub enum AmmParameters {
 #[serde_as]
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ConstantProductPoolParameters {
-    #[serde_as(as = "HashMap<_, DecimalU256>")]
-    pub reserves: HashMap<H160, U256>,
+    #[serde_as(as = "BTreeMap<_, DecimalU256>")]
+    pub reserves: BTreeMap<H160, U256>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -91,14 +91,14 @@ pub struct WeightedPoolTokenData {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WeightedProductPoolParameters {
-    pub reserves: HashMap<H160, WeightedPoolTokenData>,
+    pub reserves: BTreeMap<H160, WeightedPoolTokenData>,
 }
 
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StablePoolParameters {
-    #[serde_as(as = "HashMap<_, DecimalU256>")]
-    pub reserves: HashMap<H160, U256>,
+    #[serde_as(as = "BTreeMap<_, DecimalU256>")]
+    pub reserves: BTreeMap<H160, U256>,
     #[serde(with = "ratio_as_decimal")]
     pub amplification_parameter: BigRational,
 }
@@ -203,7 +203,7 @@ pub struct ExecutionPlanCoordinatesModel {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use maplit::hashmap;
+    use maplit::btreemap;
     use serde_json::json;
 
     #[test]
@@ -281,7 +281,7 @@ mod tests {
         };
         let constant_product_pool_model = AmmModel {
             parameters: AmmParameters::ConstantProduct(ConstantProductPoolParameters {
-                reserves: hashmap! {
+                reserves: btreemap! {
                     buy_token => U256::from(100),
                     sell_token => U256::from(200),
                 },
@@ -295,7 +295,7 @@ mod tests {
         };
         let weighted_product_pool_model = AmmModel {
             parameters: AmmParameters::WeightedProduct(WeightedProductPoolParameters {
-                reserves: hashmap! {
+                reserves: btreemap! {
                     sell_token => WeightedPoolTokenData {
                         balance: U256::from(808),
                         weight: BigRational::new(2.into(), 10.into()),
@@ -314,7 +314,7 @@ mod tests {
             mandatory: true,
         };
         let model = BatchAuctionModel {
-            tokens: hashmap! {
+            tokens: btreemap! {
                 buy_token => TokenInfoModel {
                     decimals: Some(6),
                     external_price: Some(1.2),
@@ -328,8 +328,8 @@ mod tests {
                     internal_buffer: Some(U256::from(42)),
                 }
             },
-            orders: hashmap! { 0 => order_model },
-            amms: hashmap! { 0 => constant_product_pool_model, 1 => weighted_product_pool_model },
+            orders: btreemap! { 0 => order_model },
+            amms: btreemap! { 0 => constant_product_pool_model, 1 => weighted_product_pool_model },
             metadata: Some(MetadataModel {
                 environment: Some(String::from("Such Meta")),
             }),

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -102,25 +102,6 @@ impl IntermediateSettlement {
     }
 }
 
-fn match_settled_prices(
-    executed_limit_orders: &[ExecutedLimitOrder],
-    solver_prices: HashMap<H160, U256>,
-) -> Result<HashMap<H160, U256>> {
-    let mut prices = HashMap::new();
-    let executed_tokens = executed_limit_orders
-        .iter()
-        .flat_map(|order| vec![order.order.buy_token, order.order.sell_token]);
-    for token in executed_tokens {
-        if let Entry::Vacant(entry) = prices.entry(token) {
-            let price = solver_prices
-                .get(&token)
-                .ok_or_else(|| anyhow!("invalid token {}", token))?;
-            entry.insert(*price);
-        }
-    }
-    Ok(prices)
-}
-
 fn match_prepared_and_settled_orders(
     prepared_orders: Vec<LimitOrder>,
     settled_orders: HashMap<usize, ExecutedOrderModel>,
@@ -163,6 +144,25 @@ fn match_prepared_and_settled_amms(
             })
         })
         .collect()
+}
+
+fn match_settled_prices(
+    executed_limit_orders: &[ExecutedLimitOrder],
+    solver_prices: HashMap<H160, U256>,
+) -> Result<HashMap<H160, U256>> {
+    let mut prices = HashMap::new();
+    let executed_tokens = executed_limit_orders
+        .iter()
+        .flat_map(|order| vec![order.order.buy_token, order.order.sell_token]);
+    for token in executed_tokens {
+        if let Entry::Vacant(entry) = prices.entry(token) {
+            let price = solver_prices
+                .get(&token)
+                .ok_or_else(|| anyhow!("invalid token {}", token))?;
+            entry.insert(*price);
+        }
+    }
+    Ok(prices)
 }
 
 #[cfg(test)]
@@ -391,164 +391,164 @@ mod tests {
         ];
         let solution_response = serde_json::from_str::<SettledBatchAuctionModel>(
             r#"{
-                "ref_token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                "tokens": {
-                    "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d": {
-                        "decimals": 18,
-                        "estimated_price": "377939419103409",
-                        "normalize_priority": "0"
-                    },
-                    "0xc778417e063141139fce010982780140aa0cd5ab": {
-                        "decimals": 18,
-                        "estimated_price": "1000000000000000000",
-                        "normalize_priority": "1"
-                    },
-                    "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": {
-                        "decimals": 18,
-                        "estimated_price": "112874952666826941",
-                        "normalize_priority": "0"
-                    }
+            "ref_token": "0xc778417e063141139fce010982780140aa0cd5ab",
+            "tokens": {
+                "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d": {
+                    "decimals": 18,
+                    "estimated_price": "377939419103409",
+                    "normalize_priority": "0"
                 },
-                "prices": {
-                    "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d": "379669381779741",
-                    "0xc778417e063141139fce010982780140aa0cd5ab": "1000000000000000000",
-                    "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": "355227837551346618"
+                "0xc778417e063141139fce010982780140aa0cd5ab": {
+                    "decimals": 18,
+                    "estimated_price": "1000000000000000000",
+                    "normalize_priority": "1"
                 },
-                "orders": {
-                    "0": {
-                        "sell_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
-                        "buy_token": "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d",
-                        "sell_amount": "996570293625199060",
-                        "buy_amount": "289046068204476404625",
-                        "allow_partial_fill": false,
-                        "is_sell_order": true,
-                        "fee": {
-                            "token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
-                            "amount": "3429706374800940"
-                        },
-                        "cost": {
-                            "token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                            "amount": "98173121900550"
-                        },
-                        "exec_sell_amount": "996570293625199060",
-                        "exec_buy_amount": "932415220613609833982"
-                    }
-                },
-                "amms": {
-                    "0": {
-                        "kind": "ConstantProduct",
-                        "reserves": {
-                            "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d": "597249810824827988770940",
-                            "0xc778417e063141139fce010982780140aa0cd5ab": "225724246562756585230"
-                        },
-                        "fee": "0.003",
-                        "cost": {
-                            "token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                            "amount": "140188523735120"
-                        },
-                        "execution": [
-                            {
-                                "sell_token": "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d",
-                                "buy_token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                                "exec_sell_amount": "932415220613609833982",
-                                "exec_buy_amount": "354009510372389956",
-                                "exec_plan": {
-                                    "sequence": 0,
-                                    "position": 1
-                                }
-                            }
-                        ]
-                    },
-                    "1": {
-                        "execution": [
-                            {
-                                "sell_token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                                "buy_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
-                                "exec_sell_amount": "1",
-                                "exec_buy_amount": "2",
-                                "exec_plan": {
-                                    "sequence": 0,
-                                    "position": 2
-                                }
-                            }
-                        ]
-                    },
-                    "2": {
-                        "kind": "WeightedProduct",
-                        "reserves": {
-                            "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": {
-                                "balance": "1251682293173877359",
-                                "weight": "0.5"
-                            },
-                            "0xc778417e063141139fce010982780140aa0cd5ab": {
-                                "balance": "799086982149629058",
-                                "weight": "0.5"
-                            }
-                        },
-                        "fee": "0.001",
-                        "cost": {
-                            "token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                            "amount": "177648716400000"
-                        },
-                        "execution": [
-                            {
-                                "sell_token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                                "buy_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
-                                "exec_sell_amount": "354009510372384890",
-                                "exec_buy_amount": "996570293625184642",
-                                "exec_plan": {
-                                    "sequence": 0,
-                                    "position": 0
-                                }
-                            }
-                        ]
-                    },
-                    "3": {
-                        "kind": "Stable",
-                        "reserves": {
-                            "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": "1234",
-                            "0xc778417e063141139fce010982780140aa0cd5ab": "5678"
-                        },
-                        "fee": "0.001",
-                        "cost": {
-                            "token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                            "amount": "1771"
-                        },
-                        "execution": [
-                            {
-                                "sell_token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                                "buy_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
-                                "exec_sell_amount": "3",
-                                "exec_buy_amount": "4",
-                                "exec_plan": {
-                                    "sequence": 0,
-                                    "position": 3
-                                }
-                            }
-                        ]
-                    }
-                },
-                "solver": {
-                    "name": "standard",
-                    "args": [
-                        "--write_auxiliary_files",
-                        "--solver",
-                        "SCIP",
-                        "--output_dir",
-                        "/app/results"
-                    ],
-                    "runtime": 0.0,
-                    "runtime_preprocessing": 17.097073793411255,
-                    "runtime_solving": 123.31747031211853,
-                    "runtime_ring_finding": 0.0,
-                    "runtime_validation": 0.14400219917297363,
-                    "nr_variables": 24,
-                    "nr_bool_variables": 8,
-                    "optimality_gap": null,
-                    "solver_status": "ok",
-                    "termination_condition": "optimal",
-                    "exit_status": "completed"
+                "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": {
+                    "decimals": 18,
+                    "estimated_price": "112874952666826941",
+                    "normalize_priority": "0"
                 }
+            },
+            "prices": {
+                "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d": "379669381779741",
+                "0xc778417e063141139fce010982780140aa0cd5ab": "1000000000000000000",
+                "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": "355227837551346618"
+            },
+            "orders": {
+                "0": {
+                    "sell_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
+                    "buy_token": "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d",
+                    "sell_amount": "996570293625199060",
+                    "buy_amount": "289046068204476404625",
+                    "allow_partial_fill": false,
+                    "is_sell_order": true,
+                    "fee": {
+                        "token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
+                        "amount": "3429706374800940"
+                    },
+                    "cost": {
+                        "token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                        "amount": "98173121900550"
+                    },
+                    "exec_sell_amount": "996570293625199060",
+                    "exec_buy_amount": "932415220613609833982"
+                }
+            },
+            "amms": {
+                "0": {
+                    "kind": "ConstantProduct",
+                    "reserves": {
+                        "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d": "597249810824827988770940",
+                        "0xc778417e063141139fce010982780140aa0cd5ab": "225724246562756585230"
+                    },
+                    "fee": "0.003",
+                    "cost": {
+                        "token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                        "amount": "140188523735120"
+                    },
+                    "execution": [
+                        {
+                            "sell_token": "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d",
+                            "buy_token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                            "exec_sell_amount": "932415220613609833982",
+                            "exec_buy_amount": "354009510372389956",
+                            "exec_plan": {
+                                "sequence": 0,
+                                "position": 1
+                            }
+                        }
+                    ]
+                },
+                "1": {
+                    "execution": [
+                        {
+                            "sell_token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                            "buy_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
+                            "exec_sell_amount": "1",
+                            "exec_buy_amount": "2",
+                            "exec_plan": {
+                                "sequence": 0,
+                                "position": 2
+                            }
+                        }
+                    ]
+                },
+                "2": {
+                    "kind": "WeightedProduct",
+                    "reserves": {
+                        "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": {
+                            "balance": "1251682293173877359",
+                            "weight": "0.5"
+                        },
+                        "0xc778417e063141139fce010982780140aa0cd5ab": {
+                            "balance": "799086982149629058",
+                            "weight": "0.5"
+                        }
+                    },
+                    "fee": "0.001",
+                    "cost": {
+                        "token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                        "amount": "177648716400000"
+                    },
+                    "execution": [
+                        {
+                            "sell_token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                            "buy_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
+                            "exec_sell_amount": "354009510372384890",
+                            "exec_buy_amount": "996570293625184642",
+                            "exec_plan": {
+                                "sequence": 0,
+                                "position": 0
+                            }
+                        }
+                    ]
+                },
+                "3": {
+                    "kind": "Stable",
+                    "reserves": {
+                        "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": "1234",
+                        "0xc778417e063141139fce010982780140aa0cd5ab": "5678"
+                    },
+                    "fee": "0.001",
+                    "cost": {
+                        "token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                        "amount": "1771"
+                    },
+                    "execution": [
+                        {
+                            "sell_token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                            "buy_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
+                            "exec_sell_amount": "3",
+                            "exec_buy_amount": "4",
+                            "exec_plan": {
+                                "sequence": 0,
+                                "position": 3
+                            }
+                        }
+                    ]
+                }
+            },
+            "solver": {
+                "name": "standard",
+                "args": [
+                    "--write_auxiliary_files",
+                    "--solver",
+                    "SCIP",
+                    "--output_dir",
+                    "/app/results"
+                ],
+                "runtime": 0.0,
+                "runtime_preprocessing": 17.097073793411255,
+                "runtime_solving": 123.31747031211853,
+                "runtime_ring_finding": 0.0,
+                "runtime_validation": 0.14400219917297363,
+                "nr_variables": 24,
+                "nr_bool_variables": 8,
+                "optimality_gap": null,
+                "solver_status": "ok",
+                "termination_condition": "optimal",
+                "exit_status": "completed"
+            }
             }"#,
         )
         .unwrap();

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -1,7 +1,6 @@
 use super::model::*;
-use crate::liquidity::{StablePoolOrder, WeightedProductOrder};
 use crate::{
-    liquidity::{AmmOrderExecution, ConstantProductOrder, LimitOrder},
+    liquidity::{AmmOrderExecution, LimitOrder, Liquidity},
     settlement::Settlement,
 };
 use anyhow::{anyhow, Result};
@@ -14,10 +13,8 @@ use std::collections::{hash_map::Entry, HashMap};
 // struct combines the created model and a mapping of those identifiers to their original value.
 #[derive(Clone, Debug)]
 pub struct SettlementContext {
-    pub limit_orders: HashMap<usize, LimitOrder>,
-    pub constant_product_orders: HashMap<usize, ConstantProductOrder>,
-    pub weighted_product_orders: HashMap<usize, WeightedProductOrder>,
-    pub stable_pool_orders: HashMap<usize, StablePoolOrder>,
+    pub orders: Vec<LimitOrder>,
+    pub liquidity: Vec<Liquidity>,
 }
 
 pub fn convert_settlement(
@@ -58,30 +55,19 @@ impl ExecutedLimitOrder {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 struct ExecutedAmm {
     input: (H160, U256),
     output: (H160, U256),
-    order: ExecutedOrder,
-}
-
-#[derive(Clone)]
-enum ExecutedOrder {
-    ConstantProduct(ConstantProductOrder),
-    WeightedProduct(WeightedProductOrder),
-    StablePool(StablePoolOrder),
+    order: Liquidity,
 }
 
 impl IntermediateSettlement {
     fn new(settled: SettledBatchAuctionModel, context: SettlementContext) -> Result<Self> {
         let executed_limit_orders =
-            match_prepared_and_settled_orders(context.limit_orders, settled.orders)?;
-        let executed_amms = match_prepared_and_settled_amms(
-            context.constant_product_orders,
-            context.weighted_product_orders,
-            context.stable_pool_orders,
-            settled.amms,
-        )?;
+            match_prepared_and_settled_orders(context.orders, settled.orders)?;
+        let executed_amms = match_prepared_and_settled_amms(context.liquidity, settled.amms)?;
         let prices = match_settled_prices(executed_limit_orders.as_slice(), settled.prices)?;
         Ok(Self {
             executed_limit_orders,
@@ -101,105 +87,19 @@ impl IntermediateSettlement {
                 output: executed_amm.output,
             };
             match &executed_amm.order {
-                ExecutedOrder::ConstantProduct(liquidity) => {
+                Liquidity::ConstantProduct(liquidity) => {
                     settlement.with_liquidity(liquidity, execution)?
                 }
-                ExecutedOrder::WeightedProduct(liquidity) => {
+                Liquidity::BalancerWeighted(liquidity) => {
                     settlement.with_liquidity(liquidity, execution)?
                 }
-                ExecutedOrder::StablePool(liquidity) => {
+                Liquidity::BalancerStable(liquidity) => {
                     settlement.with_liquidity(liquidity, execution)?
                 }
             }
         }
         Ok(settlement)
     }
-}
-
-fn match_prepared_and_settled_orders(
-    mut prepared_orders: HashMap<usize, LimitOrder>,
-    settled_orders: HashMap<usize, ExecutedOrderModel>,
-) -> Result<Vec<ExecutedLimitOrder>> {
-    settled_orders
-        .into_iter()
-        .filter(|(_, settled)| {
-            !(settled.exec_sell_amount.is_zero() && settled.exec_buy_amount.is_zero())
-        })
-        .map(|(index, settled)| {
-            let prepared = prepared_orders
-                .remove(&index)
-                .ok_or_else(|| anyhow!("invalid order {}", index))?;
-            Ok(ExecutedLimitOrder {
-                order: prepared,
-                executed_buy_amount: settled.exec_buy_amount,
-                executed_sell_amount: settled.exec_sell_amount,
-            })
-        })
-        .collect()
-}
-
-fn match_prepared_and_settled_amms(
-    mut prepared_constant_product_orders: HashMap<usize, ConstantProductOrder>,
-    mut prepared_weighted_product_orders: HashMap<usize, WeightedProductOrder>,
-    mut prepared_stable_pool_orders: HashMap<usize, StablePoolOrder>,
-    settled_orders: HashMap<usize, UpdatedAmmModel>,
-) -> Result<Vec<ExecutedAmm>> {
-    let mut amm_executions = vec![];
-    // Recall, prepared amm for weighted products are shifted by the constant product amms
-    // We declare this outside before prepared_constant_product_orders is mutated.
-    let shift_a = prepared_constant_product_orders.len();
-    let shift_b = shift_a + prepared_weighted_product_orders.len();
-    for (index, settled) in settled_orders
-        .into_iter()
-        .filter(|(_, settled)| settled.is_non_trivial())
-        .flat_map(|(shifted_id, settled)| {
-            settled
-                .execution
-                .into_iter()
-                .map(move |exec| (shifted_id, exec))
-        })
-        .sorted_by(|a, b| a.1.exec_plan.cmp(&b.1.exec_plan))
-    {
-        let (input, output) = (
-            (settled.buy_token, settled.exec_buy_amount),
-            (settled.sell_token, settled.exec_sell_amount),
-        );
-        if index < shift_a && prepared_constant_product_orders.contains_key(&index) {
-            amm_executions.push(ExecutedAmm {
-                order: ExecutedOrder::ConstantProduct(
-                    prepared_constant_product_orders.remove(&index).unwrap(),
-                ),
-                input,
-                output,
-            });
-        } else if index >= shift_a
-            && index < shift_b
-            && prepared_weighted_product_orders.contains_key(&(index - shift_a))
-        {
-            amm_executions.push(ExecutedAmm {
-                order: ExecutedOrder::WeightedProduct(
-                    prepared_weighted_product_orders
-                        .remove(&(index - shift_a))
-                        .unwrap(),
-                ),
-                input,
-                output,
-            });
-        } else if index >= shift_b && prepared_stable_pool_orders.contains_key(&(index - shift_b)) {
-            amm_executions.push(ExecutedAmm {
-                order: ExecutedOrder::StablePool(
-                    prepared_stable_pool_orders
-                        .remove(&(index - shift_b))
-                        .unwrap(),
-                ),
-                input,
-                output,
-            });
-        } else {
-            return Err(anyhow!("Invalid AMM {}", index));
-        }
-    }
-    Ok(amm_executions)
 }
 
 fn match_settled_prices(
@@ -221,10 +121,57 @@ fn match_settled_prices(
     Ok(prices)
 }
 
+fn match_prepared_and_settled_orders(
+    prepared_orders: Vec<LimitOrder>,
+    settled_orders: HashMap<usize, ExecutedOrderModel>,
+) -> Result<Vec<ExecutedLimitOrder>> {
+    settled_orders
+        .into_iter()
+        .filter(|(_, settled)| {
+            !(settled.exec_sell_amount.is_zero() && settled.exec_buy_amount.is_zero())
+        })
+        .map(|(index, settled)| {
+            let prepared = prepared_orders
+                .get(index)
+                .ok_or_else(|| anyhow!("invalid order {}", index))?;
+            Ok(ExecutedLimitOrder {
+                order: prepared.clone(),
+                executed_buy_amount: settled.exec_buy_amount,
+                executed_sell_amount: settled.exec_sell_amount,
+            })
+        })
+        .collect()
+}
+
+fn match_prepared_and_settled_amms(
+    prepared_amms: Vec<Liquidity>,
+    settled_amms: HashMap<usize, UpdatedAmmModel>,
+) -> Result<Vec<ExecutedAmm>> {
+    settled_amms
+        .into_iter()
+        .filter(|(_, settled)| settled.is_non_trivial())
+        .flat_map(|(index, settled)| settled.execution.into_iter().map(move |exec| (index, exec)))
+        .sorted_by_key(|(_, a)| a.exec_plan.clone())
+        .map(|(index, settled)| {
+            Ok(ExecutedAmm {
+                order: prepared_amms
+                    .get(index)
+                    .ok_or_else(|| anyhow!("Invalid AMM {}", index))?
+                    .clone(),
+                input: (settled.buy_token, settled.exec_buy_amount),
+                output: (settled.sell_token, settled.exec_sell_amount),
+            })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::liquidity::tests::CapturingSettlementHandler;
+    use crate::liquidity::{
+        tests::CapturingSettlementHandler, ConstantProductOrder, StablePoolOrder,
+        WeightedProductOrder,
+    };
     use hex_literal::hex;
     use maplit::hashmap;
     use model::TokenPair;
@@ -241,7 +188,7 @@ mod tests {
         let t1 = H160::from_low_u64_be(1);
 
         let limit_handler = CapturingSettlementHandler::arc();
-        let limit_order = LimitOrder {
+        let orders = vec![LimitOrder {
             sell_token: t0,
             buy_token: t1,
             sell_amount: 1.into(),
@@ -252,57 +199,54 @@ mod tests {
             settlement_handling: limit_handler.clone(),
             is_liquidity_order: false,
             id: "0".to_string(),
-        };
-        let orders = hashmap! { 0 => limit_order };
+        }];
 
         let cp_amm_handler = CapturingSettlementHandler::arc();
-        let constant_product_order = ConstantProductOrder {
-            tokens: TokenPair::new(t0, t1).unwrap(),
-            reserves: (3, 4),
-            fee: 5.into(),
-            settlement_handling: cp_amm_handler.clone(),
-        };
-        let constant_product_orders = hashmap! { 0 => constant_product_order };
         let wp_amm_handler = CapturingSettlementHandler::arc();
-        let weighted_product_order = WeightedProductOrder {
-            reserves: hashmap! {
-                t0 => WeightedTokenState {
-                    token_state: TokenState {
-                        balance: U256::from(200),
-                        scaling_exponent: 4,
-                    },
-                    weight: Bfp::from(200_000_000_000_000_000),
-                },
-                t1 => WeightedTokenState {
-                    token_state: TokenState {
-                        balance: U256::from(800),
-                        scaling_exponent: 6,
-                    },
-                    weight: Bfp::from(800_000_000_000_000_000),
-                }
-            },
-            fee: BigRational::new(3.into(), 1.into()),
-            settlement_handling: wp_amm_handler.clone(),
-        };
-        let weighted_product_orders = hashmap! { 0 => weighted_product_order };
-
         let sp_amm_handler = CapturingSettlementHandler::arc();
-        let stable_pool_order = StablePoolOrder {
-            reserves: hashmap! {
-                t0 => TokenState {
-                    balance: U256::from(300),
-                    scaling_exponent: 0,
+        let liquidity = vec![
+            Liquidity::ConstantProduct(ConstantProductOrder {
+                tokens: TokenPair::new(t0, t1).unwrap(),
+                reserves: (3, 4),
+                fee: 5.into(),
+                settlement_handling: cp_amm_handler.clone(),
+            }),
+            Liquidity::BalancerWeighted(WeightedProductOrder {
+                reserves: hashmap! {
+                    t0 => WeightedTokenState {
+                        token_state: TokenState {
+                            balance: U256::from(200),
+                            scaling_exponent: 4,
+                        },
+                        weight: Bfp::from(200_000_000_000_000_000),
+                    },
+                    t1 => WeightedTokenState {
+                        token_state: TokenState {
+                            balance: U256::from(800),
+                            scaling_exponent: 6,
+                        },
+                        weight: Bfp::from(800_000_000_000_000_000),
+                    }
                 },
-                t1 => TokenState {
-                    balance: U256::from(400),
-                    scaling_exponent: 0,
+                fee: BigRational::new(3.into(), 1.into()),
+                settlement_handling: wp_amm_handler.clone(),
+            }),
+            Liquidity::BalancerStable(StablePoolOrder {
+                reserves: hashmap! {
+                    t0 => TokenState {
+                        balance: U256::from(300),
+                        scaling_exponent: 0,
+                    },
+                    t1 => TokenState {
+                        balance: U256::from(400),
+                        scaling_exponent: 0,
+                    },
                 },
-            },
-            fee: BigRational::new(3.into(), 1.into()),
-            amplification_parameter: BigRational::from_integer(1.into()),
-            settlement_handling: sp_amm_handler.clone(),
-        };
-        let stable_pool_orders = hashmap! { 0 => stable_pool_order };
+                fee: BigRational::new(3.into(), 1.into()),
+                amplification_parameter: BigRational::from_integer(1.into()),
+                settlement_handling: sp_amm_handler.clone(),
+            }),
+        ];
 
         let executed_order = ExecutedOrderModel {
             exec_buy_amount: 6.into(),
@@ -320,7 +264,6 @@ mod tests {
                 }),
             }],
         };
-
         let updated_balancer_weighted = UpdatedAmmModel {
             execution: vec![ExecutedAmmModel {
                 sell_token: t1,
@@ -333,7 +276,6 @@ mod tests {
                 }),
             }],
         };
-
         let updated_balancer_stable = UpdatedAmmModel {
             execution: vec![ExecutedAmmModel {
                 sell_token: t1,
@@ -353,12 +295,7 @@ mod tests {
             prices: hashmap! { t0 => 10.into(), t1 => 11.into() },
         };
 
-        let prepared = SettlementContext {
-            limit_orders: orders,
-            constant_product_orders,
-            weighted_product_orders,
-            stable_pool_orders,
-        };
+        let prepared = SettlementContext { orders, liquidity };
 
         let settlement = convert_settlement(settled, prepared).unwrap();
         assert_eq!(
@@ -395,6 +332,7 @@ mod tests {
         let token_a = H160::from_slice(&hex!("a7d1c04faf998f9161fc9f800a99a809b84cfc9d"));
         let token_b = H160::from_slice(&hex!("c778417e063141139fce010982780140aa0cd5ab"));
         let token_c = H160::from_slice(&hex!("e4b9895e638f54c3bee2a3a78d6a297cc03e0353"));
+
         let cpo_0 = ConstantProductOrder {
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (597249810824827988770940, 225724246562756585230),
@@ -407,8 +345,8 @@ mod tests {
             fee: Ratio::new(3, 1000),
             settlement_handling: CapturingSettlementHandler::arc(),
         };
-        let constant_product_orders = hashmap! { 0usize => cpo_0.clone(), 1usize => cpo_1 };
-        let weighted_product_order = WeightedProductOrder {
+
+        let wpo = WeightedProductOrder {
             reserves: hashmap! {
                 token_c => WeightedTokenState {
                     token_state: TokenState {
@@ -428,9 +366,8 @@ mod tests {
             fee: BigRational::new(1.into(), 1000.into()),
             settlement_handling: CapturingSettlementHandler::arc(),
         };
-        let weighted_product_orders = hashmap! { 0usize => weighted_product_order.clone() };
 
-        let stable_pool_order = StablePoolOrder {
+        let spo = StablePoolOrder {
             reserves: hashmap! {
                 token_c => TokenState {
                     balance: U256::from(1234u128),
@@ -445,232 +382,204 @@ mod tests {
             amplification_parameter: BigRational::from_integer(1.into()),
             settlement_handling: CapturingSettlementHandler::arc(),
         };
-        let stable_pool_orders = hashmap! { 0usize => stable_pool_order.clone() };
 
+        let liquidity = vec![
+            Liquidity::ConstantProduct(cpo_0.clone()),
+            Liquidity::ConstantProduct(cpo_1.clone()),
+            Liquidity::BalancerWeighted(wpo.clone()),
+            Liquidity::BalancerStable(spo.clone()),
+        ];
         let solution_response = serde_json::from_str::<SettledBatchAuctionModel>(
             r#"{
-            "ref_token": "0xc778417e063141139fce010982780140aa0cd5ab",
-            "tokens": {
-                "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d": {
-                    "decimals": 18,
-                    "estimated_price": "377939419103409",
-                    "normalize_priority": "0"
-                },
-                "0xc778417e063141139fce010982780140aa0cd5ab": {
-                    "decimals": 18,
-                    "estimated_price": "1000000000000000000",
-                    "normalize_priority": "1"
-                },
-                "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": {
-                    "decimals": 18,
-                    "estimated_price": "112874952666826941",
-                    "normalize_priority": "0"
-                }
-            },
-            "prices": {
-                "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d": "379669381779741",
-                "0xc778417e063141139fce010982780140aa0cd5ab": "1000000000000000000",
-                "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": "355227837551346618"
-            },
-            "orders": {
-                "0": {
-                    "sell_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
-                    "buy_token": "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d",
-                    "sell_amount": "996570293625199060",
-                    "buy_amount": "289046068204476404625",
-                    "allow_partial_fill": false,
-                    "is_sell_order": true,
-                    "fee": {
-                        "token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
-                        "amount": "3429706374800940"
+                "ref_token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                "tokens": {
+                    "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d": {
+                        "decimals": 18,
+                        "estimated_price": "377939419103409",
+                        "normalize_priority": "0"
                     },
-                    "cost": {
-                        "token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                        "amount": "98173121900550"
+                    "0xc778417e063141139fce010982780140aa0cd5ab": {
+                        "decimals": 18,
+                        "estimated_price": "1000000000000000000",
+                        "normalize_priority": "1"
                     },
-                    "exec_sell_amount": "996570293625199060",
-                    "exec_buy_amount": "932415220613609833982"
-                }
-            },
-            "amms": {
-                "0": {
-                    "kind": "ConstantProduct",
-                    "reserves": {
-                        "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d": "597249810824827988770940",
-                        "0xc778417e063141139fce010982780140aa0cd5ab": "225724246562756585230"
-                    },
-                    "fee": "0.003",
-                    "cost": {
-                        "token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                        "amount": "140188523735120"
-                    },
-                    "execution": [
-                        {
-                            "sell_token": "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d",
-                            "buy_token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                            "exec_sell_amount": "932415220613609833982",
-                            "exec_buy_amount": "354009510372389956",
-                            "exec_plan": {
-                                "sequence": 0,
-                                "position": 1
-                            }
-                        }
-                    ]
+                    "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": {
+                        "decimals": 18,
+                        "estimated_price": "112874952666826941",
+                        "normalize_priority": "0"
+                    }
                 },
-                "1": {
-                    "execution": [
-                        {
-                            "sell_token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                            "buy_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
-                            "exec_sell_amount": "1",
-                            "exec_buy_amount": "2",
-                            "exec_plan": {
-                                "sequence": 0,
-                                "position": 2
-                            }
-                        }
-                    ]
+                "prices": {
+                    "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d": "379669381779741",
+                    "0xc778417e063141139fce010982780140aa0cd5ab": "1000000000000000000",
+                    "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": "355227837551346618"
                 },
-                "2": {
-                    "kind": "WeightedProduct",
-                    "reserves": {
-                        "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": {
-                            "balance": "1251682293173877359",
-                            "weight": "0.5"
+                "orders": {
+                    "0": {
+                        "sell_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
+                        "buy_token": "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d",
+                        "sell_amount": "996570293625199060",
+                        "buy_amount": "289046068204476404625",
+                        "allow_partial_fill": false,
+                        "is_sell_order": true,
+                        "fee": {
+                            "token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
+                            "amount": "3429706374800940"
                         },
-                        "0xc778417e063141139fce010982780140aa0cd5ab": {
-                            "balance": "799086982149629058",
-                            "weight": "0.5"
-                        }
-                    },
-                    "fee": "0.001",
-                    "cost": {
-                        "token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                        "amount": "177648716400000"
-                    },
-                    "execution": [
-                        {
-                            "sell_token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                            "buy_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
-                            "exec_sell_amount": "354009510372384890",
-                            "exec_buy_amount": "996570293625184642",
-                            "exec_plan": {
-                                "sequence": 0,
-                                "position": 0
-                            }
-                        }
-                    ]
+                        "cost": {
+                            "token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                            "amount": "98173121900550"
+                        },
+                        "exec_sell_amount": "996570293625199060",
+                        "exec_buy_amount": "932415220613609833982"
+                    }
                 },
-                "3": {
-                    "kind": "Stable",
-                    "reserves": {
-                        "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": "1234",
-                        "0xc778417e063141139fce010982780140aa0cd5ab": "5678"
-                    },
-                    "fee": "0.001",
-                    "cost": {
-                        "token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                        "amount": "1771"
-                    },
-                    "execution": [
-                        {
-                            "sell_token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                            "buy_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
-                            "exec_sell_amount": "1",
-                            "exec_buy_amount": "2",
-                            "exec_plan": {
-                                "sequence": 0,
-                                "position": 3
+                "amms": {
+                    "0": {
+                        "kind": "ConstantProduct",
+                        "reserves": {
+                            "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d": "597249810824827988770940",
+                            "0xc778417e063141139fce010982780140aa0cd5ab": "225724246562756585230"
+                        },
+                        "fee": "0.003",
+                        "cost": {
+                            "token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                            "amount": "140188523735120"
+                        },
+                        "execution": [
+                            {
+                                "sell_token": "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d",
+                                "buy_token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                                "exec_sell_amount": "932415220613609833982",
+                                "exec_buy_amount": "354009510372389956",
+                                "exec_plan": {
+                                    "sequence": 0,
+                                    "position": 1
+                                }
                             }
-                        }
-                    ]
+                        ]
+                    },
+                    "1": {
+                        "execution": [
+                            {
+                                "sell_token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                                "buy_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
+                                "exec_sell_amount": "1",
+                                "exec_buy_amount": "2",
+                                "exec_plan": {
+                                    "sequence": 0,
+                                    "position": 2
+                                }
+                            }
+                        ]
+                    },
+                    "2": {
+                        "kind": "WeightedProduct",
+                        "reserves": {
+                            "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": {
+                                "balance": "1251682293173877359",
+                                "weight": "0.5"
+                            },
+                            "0xc778417e063141139fce010982780140aa0cd5ab": {
+                                "balance": "799086982149629058",
+                                "weight": "0.5"
+                            }
+                        },
+                        "fee": "0.001",
+                        "cost": {
+                            "token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                            "amount": "177648716400000"
+                        },
+                        "execution": [
+                            {
+                                "sell_token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                                "buy_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
+                                "exec_sell_amount": "354009510372384890",
+                                "exec_buy_amount": "996570293625184642",
+                                "exec_plan": {
+                                    "sequence": 0,
+                                    "position": 0
+                                }
+                            }
+                        ]
+                    },
+                    "3": {
+                        "kind": "Stable",
+                        "reserves": {
+                            "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": "1234",
+                            "0xc778417e063141139fce010982780140aa0cd5ab": "5678"
+                        },
+                        "fee": "0.001",
+                        "cost": {
+                            "token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                            "amount": "1771"
+                        },
+                        "execution": [
+                            {
+                                "sell_token": "0xc778417e063141139fce010982780140aa0cd5ab",
+                                "buy_token": "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353",
+                                "exec_sell_amount": "3",
+                                "exec_buy_amount": "4",
+                                "exec_plan": {
+                                    "sequence": 0,
+                                    "position": 3
+                                }
+                            }
+                        ]
+                    }
+                },
+                "solver": {
+                    "name": "standard",
+                    "args": [
+                        "--write_auxiliary_files",
+                        "--solver",
+                        "SCIP",
+                        "--output_dir",
+                        "/app/results"
+                    ],
+                    "runtime": 0.0,
+                    "runtime_preprocessing": 17.097073793411255,
+                    "runtime_solving": 123.31747031211853,
+                    "runtime_ring_finding": 0.0,
+                    "runtime_validation": 0.14400219917297363,
+                    "nr_variables": 24,
+                    "nr_bool_variables": 8,
+                    "optimality_gap": null,
+                    "solver_status": "ok",
+                    "termination_condition": "optimal",
+                    "exit_status": "completed"
                 }
-            },
-            "solver": {
-                "name": "standard",
-                "args": [
-                    "--write_auxiliary_files",
-                    "--solver",
-                    "SCIP",
-                    "--output_dir",
-                    "/app/results"
-                ],
-                "runtime": 0.0,
-                "runtime_preprocessing": 17.097073793411255,
-                "runtime_solving": 123.31747031211853,
-                "runtime_ring_finding": 0.0,
-                "runtime_validation": 0.14400219917297363,
-                "nr_variables": 24,
-                "nr_bool_variables": 8,
-                "optimality_gap": null,
-                "solver_status": "ok",
-                "termination_condition": "optimal",
-                "exit_status": "completed"
-            }
-        }"#,
+            }"#,
         )
         .unwrap();
-        let matched_settlements = match_prepared_and_settled_amms(
-            constant_product_orders,
-            weighted_product_orders,
-            stable_pool_orders,
-            solution_response.amms,
-        );
-        assert!(matched_settlements.is_ok());
-        let prepared_amms = matched_settlements.unwrap();
-        let executed_cp_order: ConstantProductOrder;
-        let executed_wp_order: WeightedProductOrder;
-        let executed_sp_order: StablePoolOrder;
-        match prepared_amms[0].order.clone() {
-            ExecutedOrder::WeightedProduct(order) => {
-                executed_wp_order = order;
-            }
-            _ => {
-                panic!("Expected WeightedProductOrder!");
-            }
-        }
-        match prepared_amms[1].order.clone() {
-            ExecutedOrder::ConstantProduct(order) => {
-                executed_cp_order = order;
-            }
-            _ => {
-                panic!("Expected ConstantProductOrder!")
-            }
-        }
-        match prepared_amms[3].order.clone() {
-            ExecutedOrder::StablePool(order) => {
-                executed_sp_order = order;
-            }
-            _ => {
-                panic!("Expected StablePoolOrder!")
-            }
-        }
-        assert_eq!(executed_cp_order.tokens, cpo_0.tokens);
-        assert_eq!(executed_cp_order.reserves, cpo_0.reserves);
-        assert_eq!(executed_cp_order.fee, cpo_0.fee);
-        assert_eq!(
-            prepared_amms[1].input,
-            (token_b, U256::from(354009510372389956u128))
-        );
-        assert_eq!(
-            prepared_amms[1].output,
-            (token_a, U256::from(932415220613609833982u128))
-        );
 
-        assert_eq!(executed_wp_order.reserves, weighted_product_order.reserves);
-        assert_eq!(executed_wp_order.fee, weighted_product_order.fee);
-        assert_eq!(
-            prepared_amms[0].input,
-            (token_c, U256::from(996570293625184642u128))
-        );
-        assert_eq!(
-            prepared_amms[0].output,
-            (token_b, U256::from(354009510372384890u128))
-        );
+        let prepared_amms =
+            match_prepared_and_settled_amms(liquidity, solution_response.amms).unwrap();
 
-        assert_eq!(executed_sp_order.reserves, stable_pool_order.reserves);
-        assert_eq!(executed_sp_order.fee, stable_pool_order.fee);
-        assert_eq!(prepared_amms[2].input, (token_c, U256::from(2)));
-        assert_eq!(prepared_amms[2].output, (token_b, U256::from(1)));
+        assert_eq!(
+            prepared_amms,
+            vec![
+                ExecutedAmm {
+                    order: Liquidity::BalancerWeighted(wpo),
+                    input: (token_c, U256::from(996570293625184642u128)),
+                    output: (token_b, U256::from(354009510372384890u128)),
+                },
+                ExecutedAmm {
+                    order: Liquidity::ConstantProduct(cpo_0),
+                    input: (token_b, U256::from(354009510372389956u128)),
+                    output: (token_a, U256::from(932415220613609833982u128)),
+                },
+                ExecutedAmm {
+                    order: Liquidity::ConstantProduct(cpo_1),
+                    input: (token_c, U256::from(2)),
+                    output: (token_b, U256::from(1)),
+                },
+                ExecutedAmm {
+                    order: Liquidity::BalancerStable(spo),
+                    input: (token_c, U256::from(4)),
+                    output: (token_b, U256::from(3)),
+                },
+            ],
+        );
     }
 }


### PR DESCRIPTION
Fixed #1071

This PR refactors the `prepare_model` logic of the conversion of the solution to a settlement in the HTTP solver module.

The motivation for this refactor was to cleanup some of the complicated `shift_*` logic (which would only get more complicated as new liquidity gets added) as well as remove some of the code duplication caused by having multiple liquidity types.

Additionally, with this refactor, we now consider Balancer pools when filtering out orders without a fee connection (previously only Uniswap pools were considered), fixing #1071.

One final minor change, the batch model uses `BTreeMap`s instead of `HashMap`s. This makes it so the keys in the JSON appear in sorted (thus, deterministic) order.

### Test Plan

Adjusted unit tests for new refactor.

Run the solver connected to testing MIP and Quasimodo optimizers and make sure it finds solutions:
```
$ cargo run -p solver -- \
  --base-tokens 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2,0x6B175474E89094C44Da98b954EedeAC495271d0F,0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,0xdAC17F958D2ee523a2206206994597C13D831ec7,0xc00e94Cb662C3520282E6f5717214004A7f26888,0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2,0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599, \
  --baseline-sources Uniswap,Sushiswap,BalancerV2 \
  --orderbook-url https://protocol-mainnet.gnosis.io \
  --node-url "https://mainnet.infura.io/v3/$INFURA_PROJECT_ID" \
  --mip-solver-url "$MIP_SOLVER_URL" \
  --quasimodo-solver-url "$QUASIMODO_SOLVER_URL" \
  --solvers Mip,Quasimodo \
  --transaction-strategy DryRun
...
2021-09-21T20:04:49.256Z DEBUG solver::driver: solver Mip found solution:
...
2021-09-21T20:04:49.256Z DEBUG solver::driver: solver Quasimodo found solution:
...
```
