### PR TITLE
Priority price estimator

### DIFF
--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -27,7 +27,8 @@ use shared::{
     maintenance::ServiceMaintenance,
     paraswap_api::DefaultParaswapApi,
     price_estimation::{
-        baseline::BaselinePriceEstimator, paraswap::ParaswapPriceEstimator, PriceEstimating,
+        baseline::BaselinePriceEstimator, paraswap::ParaswapPriceEstimator,
+        priority::PriorityPriceEstimator, PriceEstimating,
     },
     recent_block_cache::CacheConfig,
     sources::{
@@ -156,7 +157,7 @@ async fn main() {
     let client = shared::http_client(args.shared.http_timeout);
 
     let transport = create_instrumented_transport(
-        HttpTransport::new(client.clone(), args.shared.node_url),
+        HttpTransport::new(client.clone(), args.shared.node_url.clone()),
         metrics.clone(),
     );
     let web3 = web3::Web3::new(transport);
@@ -258,10 +259,10 @@ async fn main() {
         native_token.address(),
         &args.shared.base_tokens,
     ));
-    let mut allowed_tokens = args.allowed_tokens;
+    let mut allowed_tokens = args.allowed_tokens.clone();
     allowed_tokens.extend(base_tokens.tokens().iter().copied());
     allowed_tokens.push(BUY_ETH_ADDRESS);
-    let unsupported_tokens = args.unsupported_tokens;
+    let unsupported_tokens = args.unsupported_tokens.clone();
 
     let mut finders: Vec<Arc<dyn TokenOwnerFinding>> = pair_providers
         .iter()
@@ -329,25 +330,31 @@ async fn main() {
     let token_info_fetcher = Arc::new(CachedTokenInfoFetcher::new(Box::new(TokenInfoFetcher {
         web3: web3.clone(),
     })));
-    let price_estimator = match args.shared.price_estimator {
-        PriceEstimatorType::Baseline => Arc::new(BaselinePriceEstimator::new(
-            pool_fetcher.clone(),
-            gas_price_estimator.clone(),
-            base_tokens,
-            bad_token_detector.clone(),
-            native_token.address(),
-            native_token_price_estimation_amount,
-        )) as Arc<dyn PriceEstimating>,
-        PriceEstimatorType::Paraswap => Arc::new(ParaswapPriceEstimator {
-            paraswap: Arc::new(DefaultParaswapApi {
-                client: client.clone(),
-                partner: args.shared.paraswap_partner.unwrap_or_default(),
+    let price_estimators = args
+        .shared
+        .price_estimators
+        .iter()
+        .map(|estimator| match estimator {
+            PriceEstimatorType::Baseline => Box::new(BaselinePriceEstimator::new(
+                pool_fetcher.clone(),
+                gas_price_estimator.clone(),
+                base_tokens.clone(),
+                bad_token_detector.clone(),
+                native_token.address(),
+                native_token_price_estimation_amount,
+            )) as Box<dyn PriceEstimating>,
+            PriceEstimatorType::Paraswap => Box::new(ParaswapPriceEstimator {
+                paraswap: Arc::new(DefaultParaswapApi {
+                    client: client.clone(),
+                    partner: args.shared.paraswap_partner.clone().unwrap_or_default(),
+                }),
+                token_info: token_info_fetcher.clone(),
+                bad_token_detector: bad_token_detector.clone(),
+                disabled_paraswap_dexs: args.shared.disabled_paraswap_dexs.clone(),
             }),
-            token_info: token_info_fetcher,
-            bad_token_detector: bad_token_detector.clone(),
-            disabled_paraswap_dexs: args.shared.disabled_paraswap_dexs,
-        }),
-    };
+        })
+        .collect::<Vec<_>>();
+    let price_estimator = Arc::new(PriorityPriceEstimator::new(price_estimators));
     let fee_calculator = Arc::new(EthAwareMinFeeCalculator::new(
         price_estimator.clone(),
         gas_price_estimator,

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -119,8 +119,9 @@ pub struct Arguments {
         long,
         default_value = "Baseline",
         possible_values = &PriceEstimatorType::variants(),
+        use_delimiter = true
     )]
-    pub price_estimator: PriceEstimatorType,
+    pub price_estimators: Vec<PriceEstimatorType>,
 }
 
 fn parse_fee_factor(s: &str) -> Result<f64> {

--- a/shared/src/price_estimation.rs
+++ b/shared/src/price_estimation.rs
@@ -1,5 +1,6 @@
 pub mod baseline;
 pub mod paraswap;
+pub mod priority;
 
 use crate::{bad_token::BadTokenDetecting, conversions::U256Ext};
 use anyhow::Result;
@@ -48,7 +49,7 @@ pub struct Query {
     pub kind: OrderKind,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct Estimate {
     pub out_amount: U256,
     pub gas: U256,

--- a/shared/src/price_estimation/paraswap.rs
+++ b/shared/src/price_estimation/paraswap.rs
@@ -1,7 +1,7 @@
 use super::{ensure_token_supported, Estimate, PriceEstimating, PriceEstimationError, Query};
 use crate::{
     bad_token::BadTokenDetecting,
-    paraswap_api::{ParaswapApi, PriceQuery, Side},
+    paraswap_api::{ParaswapApi, ParaswapResponseError, PriceQuery, Side},
     token_info::{TokenInfo, TokenInfoFetching},
 };
 use anyhow::{anyhow, Context, Result};
@@ -35,17 +35,16 @@ impl ParaswapPriceEstimator {
         ensure_token_supported(query.buy_token, self.bad_token_detector.as_ref()).await?;
         ensure_token_supported(query.sell_token, self.bad_token_detector.as_ref()).await?;
 
-        let (src_token, dest_token, side) = match query.kind {
-            OrderKind::Buy => (query.buy_token, query.sell_token, Side::Buy),
-            OrderKind::Sell => (query.sell_token, query.buy_token, Side::Sell),
-        };
         let price_query = PriceQuery {
-            src_token,
-            dest_token,
-            src_decimals: decimals(&src_token, token_infos)? as usize,
-            dest_decimals: decimals(&dest_token, token_infos)? as usize,
+            src_token: query.sell_token,
+            dest_token: query.buy_token,
+            src_decimals: decimals(&query.sell_token, token_infos)? as usize,
+            dest_decimals: decimals(&query.buy_token, token_infos)? as usize,
             amount: query.in_amount,
-            side,
+            side: match query.kind {
+                OrderKind::Buy => Side::Buy,
+                OrderKind::Sell => Side::Sell,
+            },
             exclude_dexs: Some(self.disabled_paraswap_dexs.clone()),
         };
 
@@ -53,10 +52,16 @@ impl ParaswapPriceEstimator {
             .paraswap
             .price(price_query)
             .await
-            .map_err(anyhow::Error::from)
+            .map_err(|err| match err {
+                ParaswapResponseError::InsufficientLiquidity => PriceEstimationError::NoLiquidity,
+                _ => PriceEstimationError::Other(err.into()),
+            })
             .context("paraswap")?;
         Ok(Estimate {
-            out_amount: response.dest_amount,
+            out_amount: match query.kind {
+                OrderKind::Buy => response.src_amount,
+                OrderKind::Sell => response.dest_amount,
+            },
             gas: response.gas_cost,
         })
     }
@@ -74,12 +79,6 @@ fn decimals(
 
 #[async_trait::async_trait]
 impl PriceEstimating for ParaswapPriceEstimator {
-    async fn estimate(&self, query: &Query) -> Result<Estimate, PriceEstimationError> {
-        let results = self.estimates(std::slice::from_ref(query)).await;
-        // Unwrap because it always returns the same number of results as queries.
-        results.into_iter().next().unwrap()
-    }
-
     async fn estimates(&self, queries: &[Query]) -> Vec<Result<Estimate, PriceEstimationError>> {
         let tokens = queries
             .iter()

--- a/shared/src/price_estimation/priority.rs
+++ b/shared/src/price_estimation/priority.rs
@@ -1,0 +1,117 @@
+use super::{Estimate, PriceEstimating, PriceEstimationError, Query};
+use anyhow::Result;
+
+/// Tries inner price estimators in order for queries failing with PriceEstimationError::Other.
+/// Successes, UnsupportedToken or NoLiquidity errors are not retried.
+pub struct PriorityPriceEstimator {
+    inner: Vec<Box<dyn PriceEstimating>>,
+}
+
+impl PriorityPriceEstimator {
+    pub fn new(inner: Vec<Box<dyn PriceEstimating>>) -> Self {
+        assert!(!inner.is_empty());
+        Self { inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl PriceEstimating for PriorityPriceEstimator {
+    async fn estimates(&self, queries: &[Query]) -> Vec<Result<Estimate, PriceEstimationError>> {
+        let mut results = self.inner[0].estimates(queries).await;
+        for inner in &self.inner[1..] {
+            let retry_indexes = results
+                .iter()
+                .enumerate()
+                .filter(|(_, result)| matches!(result, Err(PriceEstimationError::Other(_))))
+                .map(|(index, _)| index)
+                .collect::<Vec<_>>();
+            if retry_indexes.is_empty() {
+                break;
+            }
+            for index in &retry_indexes {
+                let err = match &results[*index] {
+                    Err(err) => err,
+                    _ => unreachable!(),
+                };
+                tracing::warn!(?err, "inner price estimator failed");
+            }
+            let retry_queries = retry_indexes
+                .iter()
+                .map(|index| queries[*index])
+                .collect::<Vec<_>>();
+            let retry_results = inner.estimates(&retry_queries).await;
+            for (index, result) in retry_indexes.into_iter().zip(retry_results) {
+                results[index] = result;
+            }
+        }
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::price_estimation::MockPriceEstimating;
+    use anyhow::anyhow;
+    use model::order::OrderKind;
+    use primitive_types::H160;
+
+    #[tokio::test]
+    async fn works() {
+        let queries = [
+            Query {
+                sell_token: H160::from_low_u64_le(0),
+                buy_token: H160::from_low_u64_le(1),
+                in_amount: 1.into(),
+                kind: OrderKind::Buy,
+            },
+            Query {
+                sell_token: H160::from_low_u64_le(2),
+                buy_token: H160::from_low_u64_le(3),
+                in_amount: 1.into(),
+                kind: OrderKind::Buy,
+            },
+            Query {
+                sell_token: H160::from_low_u64_le(3),
+                buy_token: H160::from_low_u64_le(4),
+                in_amount: 1.into(),
+                kind: OrderKind::Buy,
+            },
+        ];
+
+        let mut first = MockPriceEstimating::new();
+        first.expect_estimates().times(1).returning(|queries| {
+            assert_eq!(queries.len(), 3);
+            vec![
+                Err(PriceEstimationError::Other(anyhow!(""))),
+                Err(PriceEstimationError::UnsupportedToken(
+                    H160::from_low_u64_le(2),
+                )),
+                Err(PriceEstimationError::Other(anyhow!(""))),
+            ]
+        });
+        let mut second = MockPriceEstimating::new();
+        second.expect_estimates().times(1).returning(|queries| {
+            assert_eq!(queries.len(), 2);
+            assert_eq!(queries[0].sell_token, H160::from_low_u64_le(0));
+            assert_eq!(queries[1].sell_token, H160::from_low_u64_le(3));
+            vec![
+                Err(PriceEstimationError::NoLiquidity),
+                Ok(Estimate::default()),
+            ]
+        });
+        let third = MockPriceEstimating::new();
+
+        let priority =
+            PriorityPriceEstimator::new(vec![Box::new(first), Box::new(second), Box::new(third)]);
+
+        let result = priority.estimates(&queries).await;
+        assert_eq!(result.len(), 3);
+        assert!(matches!(result[0], Err(PriceEstimationError::NoLiquidity)));
+        assert!(matches!(
+            result[1],
+            Err(PriceEstimationError::UnsupportedToken(_))
+        ));
+        assert!(matches!(result[2], Ok(_)));
+    }
+}


### PR DESCRIPTION
Implements a priority price estimator that tries several inner estimators. I made this smarter than a naive implementation by only retrying unsuccessful queries and continuing to request bulk estimates.

Fixes #1139 

### Test Plan
new unit test and manual test
