### PR TITLE
Still merge settlements if prices are scalable

### DIFF
--- a/solver/src/driver/solver_settlements.rs
+++ b/solver/src/driver/solver_settlements.rs
@@ -172,15 +172,15 @@ mod tests {
     fn merge_continues_on_error() {
         let token0 = H160::from_low_u64_be(0);
         let token1 = H160::from_low_u64_be(1);
-        let settlement0 = Settlement::new(hashmap! {token0 => 0.into()});
-        let settlement1 = Settlement::new(hashmap! {token0 => 2.into()});
-        let settlement2 = Settlement::new(hashmap! {token0 => 0.into(), token1 => 1.into()});
+        let settlement0 = Settlement::new(hashmap! {token0 => 1.into(), token1 => 2.into()});
+        let settlement1 = Settlement::new(hashmap! {token0 => 2.into(), token1 => 2.into()});
+        let settlement2 = Settlement::new(hashmap! {token0 => 1.into(), token1 => 2.into()});
         let settlements = vec![settlement0, settlement1, settlement2];
 
-        // Can't merge 0 with 1 because token0 clearing prices is different.
+        // Can't merge 0 with 1 because token0 and token1 clearing prices are different.
         let merged = merge_at_most_settlements(2, settlements.into_iter()).unwrap();
-        assert_eq!(merged.clearing_price(token0), Some(0.into()));
-        assert_eq!(merged.clearing_price(token1), Some(1.into()));
+        assert_eq!(merged.clearing_price(token0), Some(1.into()));
+        assert_eq!(merged.clearing_price(token1), Some(2.into()));
     }
 
     #[test]

--- a/solver/src/settlement/settlement_encoder.rs
+++ b/solver/src/settlement/settlement_encoder.rs
@@ -4,9 +4,9 @@ use anyhow::{bail, ensure, Context as _, Result};
 use model::order::{Order, OrderKind};
 use num::{BigRational, Zero};
 use primitive_types::{H160, U256};
-use shared::conversions::U256Ext;
+use shared::conversions::{big_rational_to_u256, U256Ext};
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{hash_map::Entry, HashMap, HashSet},
     iter,
     sync::Arc,
 };
@@ -259,13 +259,20 @@ impl SettlementEncoder {
 
     // Merge other into self so that the result contains both settlements.
     // Fails if the settlements cannot be merged for example because the same limit order is used in
-    // both or the same token has different clearing prices.
+    // both or more than one token has a different clearing prices (a single token difference is scaled)
     pub fn merge(mut self, mut other: Self) -> Result<Self> {
+        let scaling_factor = self.price_scaling_factor(&other);
         for (key, value) in other.clearing_prices {
+            let scaled_price =
+                big_rational_to_u256(&(value.to_big_rational() * scaling_factor.clone()))
+                    .context("Invalid price scaling factor")?;
             match self.clearing_prices.entry(key) {
-                Entry::Occupied(entry) => ensure!(*entry.get() == value, "different price"),
+                Entry::Occupied(entry) => ensure!(
+                    *entry.get() == scaled_price,
+                    "different price after scaling"
+                ),
                 Entry::Vacant(entry) => {
-                    entry.insert(value);
+                    entry.insert(scaled_price);
                     self.tokens.push(key);
                 }
             }
@@ -290,6 +297,28 @@ impl SettlementEncoder {
         }
 
         Ok(self)
+    }
+
+    fn price_scaling_factor(&self, other: &Self) -> BigRational {
+        let self_keys: HashSet<_> = self.clearing_prices().keys().collect();
+        let other_keys: HashSet<_> = other.clearing_prices().keys().collect();
+        let common_tokens: Vec<_> = self_keys.intersection(&other_keys).collect();
+        match common_tokens.first() {
+            Some(token) => {
+                let price_in_self = self
+                    .clearing_prices
+                    .get(token)
+                    .expect("common token should be present")
+                    .to_big_rational();
+                let price_in_other = other
+                    .clearing_prices
+                    .get(token)
+                    .expect("common token should be present")
+                    .to_big_rational();
+                price_in_self / price_in_other
+            }
+            None => U256::one().to_big_rational(),
+        }
     }
 }
 
@@ -514,11 +543,27 @@ pub mod tests {
 
     #[test]
     fn merge_fails_because_price_is_different() {
-        let prices = hashmap! { token(1) => 1.into() };
+        let prices = hashmap! { token(1) => 1.into(), token(2) => 2.into() };
         let encoder0 = SettlementEncoder::new(prices);
-        let prices = hashmap! { token(1) => 2.into() };
+        let prices = hashmap! { token(1) => 1.into(), token(2) => 3.into() };
         let encoder1 = SettlementEncoder::new(prices);
         assert!(encoder0.merge(encoder1).is_err());
+    }
+
+    #[test]
+    fn merge_scales_prices_if_only_one_token_used_twice() {
+        let prices = hashmap! { token(1) => 2.into(), token(2) => 2.into() };
+        let encoder0 = SettlementEncoder::new(prices);
+        let prices = hashmap! { token(1) => 1.into(), token(3) => 3.into() };
+        let encoder1 = SettlementEncoder::new(prices);
+
+        let merged = encoder0.merge(encoder1).unwrap();
+        let prices = hashmap! {
+            token(1) => 2.into(),
+            token(2) => 2.into(),
+            token(3) => 6.into(),
+        };
+        assert_eq!(merged.clearing_prices, prices);
     }
 
     #[test]

--- a/solver/src/settlement/settlement_encoder.rs
+++ b/solver/src/settlement/settlement_encoder.rs
@@ -263,9 +263,8 @@ impl SettlementEncoder {
     pub fn merge(mut self, mut other: Self) -> Result<Self> {
         let scaling_factor = self.price_scaling_factor(&other);
         for (key, value) in other.clearing_prices {
-            let scaled_price =
-                big_rational_to_u256(&(value.to_big_rational() * scaling_factor.clone()))
-                    .context("Invalid price scaling factor")?;
+            let scaled_price = big_rational_to_u256(&(value.to_big_rational() * &scaling_factor))
+                .context("Invalid price scaling factor")?;
             match self.clearing_prices.entry(key) {
                 Entry::Occupied(entry) => ensure!(
                     *entry.get() == scaled_price,


### PR DESCRIPTION
Fixes issue describe [here on slack](https://gnosisinc.slack.com/archives/CC3C5SMB5/p1632135697012100?thread_ts=1632086177.005000&cid=CC3C5SMB5)

We currently don't merge settlements as soon as two settlements differ on a single token. This is overly harsh, because e.g. a settlement matching a USDC -> WETH trade and another solution settling and USDT -> WETH trade could still be merged, even if WETH had a different reference price in both solutions (the price of WETH in solution 2 could e.g. be "scaled" to the same price as in solution 1, the same scaling would then have to apply to the USDT).

This PR makes it so that we extract the scaling factor of the two price vectors (based on the first common token, 1 if no token is in common) and then try to scale all prices accordingly. I'm hoping that with the use of BigRationals I'm avoiding rounding errors (although we could likely live with a rounding error of up to 1bip due to buffers)

### Test Plan
Added a unit test
