### PR TITLE
Allow price estimator argument to be env var

### DIFF
--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -117,6 +117,7 @@ pub struct Arguments {
 
     #[structopt(
         long,
+        env,
         default_value = "Baseline",
         possible_values = &PriceEstimatorType::variants(),
         use_delimiter = true


### PR DESCRIPTION
Forgot to make this env before.

### Test Plan
manually ran
