### PR TITLE
Turn baseline solver unwrap into error

### DIFF
--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -254,7 +254,13 @@ impl Solution {
             let buy_token = amm.tokens.other(&sell_token).expect("Inconsistent path");
             let buy_amount = amm
                 .get_amount_out(buy_token, (sell_amount, sell_token))
-                .expect("Path was found, so amount must be calculable");
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "invariant violated: have path but amount was not calculatable: {}",
+                        order.id
+                    )
+                })?;
+            //.expect("Path was found, so amount must be calculable");
             let execution = AmmOrderExecution {
                 input: (sell_token, sell_amount),
                 output: (buy_token, buy_amount),


### PR DESCRIPTION
This is the same fix we made a hotfix release with for prod. The commit hasn't been included in main yet which is why I am making this PR.
I am still investigating the issue but it would be annoying to run in into the panic on staging so it makes sense to include this before we have a proper fix.
