### PR TITLE
Fix handling of buy order edge case in baseline solver

### DIFF
--- a/shared/src/baseline_solver.rs
+++ b/shared/src/baseline_solver.rs
@@ -10,6 +10,11 @@ const DEFAULT_MAX_HOPS: usize = 2;
 
 type PathCandidate = Vec<H160>;
 
+/// Note that get_amount_out and get_amount_in are not always symmetrical. That is for some AMMs it
+/// is possible that get_amount_out returns an amount for which get_amount_in returns None when
+/// trying to go the reverse direction. Or that the resulting amount is different from the original.
+/// This situation is rare and resulting amounts should usually be identical or very close but it
+/// can occur.
 pub trait BaselineSolvable {
     // Given the desired output token, the amount and token input, return the expected amount of output token.
     fn get_amount_out(&self, out_token: H160, input: (U256, H160)) -> Option<U256>;

--- a/shared/src/sources/balancer/swap.rs
+++ b/shared/src/sources/balancer/swap.rs
@@ -69,7 +69,7 @@ impl WeightedPoolRef<'_> {
             .map(|amount_without_fees| amount_without_fees.as_uint256())
     }
 
-    fn unchecked_get_amount_in(
+    fn get_amount_in_(
         &self,
         in_token: H160,
         (out_amount, out_token): (U256, H160),
@@ -94,18 +94,7 @@ impl WeightedPoolRef<'_> {
         self.add_swap_fee_amount(amount_in_before_fee).ok()
     }
 
-    fn checked_get_amount_in(
-        &self,
-        in_token: H160,
-        (out_amount, out_token): (U256, H160),
-    ) -> Option<U256> {
-        let in_amount = self.unchecked_get_amount_in(in_token, (out_amount, out_token))?;
-        // We double check that resulting amount in can symmetrically provide an amount out.
-        self.unchecked_get_amount_out(out_token, (in_amount, in_token))?;
-        Some(in_amount)
-    }
-
-    fn unchecked_get_amount_out(
+    fn get_amount_out_(
         &self,
         out_token: H160,
         (in_amount, in_token): (U256, H160),
@@ -129,26 +118,15 @@ impl WeightedPoolRef<'_> {
         .map(|bfp| out_reserves.downscale(bfp))
         .flatten()
     }
-
-    fn checked_get_amount_out(
-        &self,
-        out_token: H160,
-        (in_amount, in_token): (U256, H160),
-    ) -> Option<U256> {
-        let out_amount = self.unchecked_get_amount_out(out_token, (in_amount, in_token))?;
-        // We double check that resulting amount out can symmetrically provide an amount in.
-        self.unchecked_get_amount_in(in_token, (out_amount, out_token))?;
-        Some(out_amount)
-    }
 }
 
 impl BaselineSolvable for WeightedPoolRef<'_> {
     fn get_amount_out(&self, out_token: H160, (in_amount, in_token): (U256, H160)) -> Option<U256> {
-        self.checked_get_amount_out(out_token, (in_amount, in_token))
+        self.get_amount_out_(out_token, (in_amount, in_token))
     }
 
     fn get_amount_in(&self, in_token: H160, (out_amount, out_token): (U256, H160)) -> Option<U256> {
-        self.checked_get_amount_in(in_token, (out_amount, out_token))
+        self.get_amount_in_(in_token, (out_amount, out_token))
     }
 
     fn get_spot_price(&self, base_token: H160, quote_token: H160) -> Option<BigRational> {

--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -30,7 +30,7 @@ impl Solver for BaselineSolver {
             orders, liquidity, ..
         }: Auction,
     ) -> Result<Vec<Settlement>> {
-        Ok(self.solve(orders, liquidity))
+        Ok(self.solve_(orders, liquidity))
     }
 
     fn account(&self) -> &Account {
@@ -130,7 +130,7 @@ impl BaselineSolver {
         }
     }
 
-    fn solve(&self, user_orders: Vec<LimitOrder>, liquidity: Vec<Liquidity>) -> Vec<Settlement> {
+    fn solve_(&self, user_orders: Vec<LimitOrder>, liquidity: Vec<Liquidity>) -> Vec<Settlement> {
         let amm_map =
             liquidity
                 .into_iter()
@@ -169,15 +169,10 @@ impl BaselineSolver {
                 None => continue,
             };
 
-            // Check limit price
-            if solution.executed_buy_amount >= order.buy_amount
-                && solution.executed_sell_amount <= order.sell_amount
-            {
-                match solution.into_settlement(&order) {
-                    Ok(settlement) => settlements.push(settlement),
-                    Err(err) => {
-                        tracing::error!("baseline_solver failed to create settlement: {:?}", err)
-                    }
+            match solution.into_settlement(&order) {
+                Ok(settlement) => settlements.push(settlement),
+                Err(err) => {
+                    tracing::error!("baseline_solver failed to create settlement: {:?}", err)
                 }
             }
         }
@@ -199,6 +194,20 @@ impl BaselineSolver {
                 let best = candidates
                     .iter()
                     .filter_map(|path| estimate_sell_amount(order.buy_amount, path, amms))
+                    .filter(|estimate| estimate.value <= order.sell_amount)
+                    // For buy orders we find the best path starting at the buy token ending at the
+                    // sell token. When we turn this into a settlement however we need to go from
+                    // the sell token to the buy token. This reversing of the direction can fail or
+                    // yield different amounts as explained in the BaselineSolvable trait.
+                    .filter(|estimate| {
+                        matches!(
+                            traverse_path_forward(
+                                order.sell_token,
+                                estimate.value,
+                                &estimate.path,
+                            ), Some(amount) if amount >= order.buy_amount
+                        )
+                    })
                     .min_by_key(|estimate| estimate.value)?;
                 (best.path, best.value, order.buy_amount)
             }
@@ -206,6 +215,7 @@ impl BaselineSolver {
                 let best = candidates
                     .iter()
                     .filter_map(|path| estimate_buy_amount(order.sell_amount, path, amms))
+                    .filter(|estimate| estimate.value >= order.buy_amount)
                     .max_by_key(|estimate| estimate.value)?;
                 (best.path, order.sell_amount, best.value)
             }
@@ -219,10 +229,25 @@ impl BaselineSolver {
 
     #[cfg(test)]
     fn must_solve(&self, orders: Vec<LimitOrder>, liquidity: Vec<Liquidity>) -> Settlement {
-        self.solve(orders, liquidity).into_iter().next().unwrap()
+        self.solve_(orders, liquidity).into_iter().next().unwrap()
     }
 }
 
+fn traverse_path_forward(
+    mut sell_token: H160,
+    mut sell_amount: U256,
+    path: &[&Amm],
+) -> Option<U256> {
+    for amm in path {
+        let buy_token = amm.tokens.other(&sell_token).expect("Inconsistent path");
+        let buy_amount = amm.get_amount_out(buy_token, (sell_amount, sell_token))?;
+        sell_token = buy_token;
+        sell_amount = buy_amount;
+    }
+    Some(sell_amount)
+}
+
+#[derive(Debug)]
 struct Solution {
     path: Vec<Amm>,
     executed_sell_amount: U256,
@@ -243,13 +268,7 @@ impl Solution {
             let buy_token = amm.tokens.other(&sell_token).expect("Inconsistent path");
             let buy_amount = amm
                 .get_amount_out(buy_token, (sell_amount, sell_token))
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "invariant violated: have path but amount was not calculatable: {}",
-                        order.id
-                    )
-                })?;
-            //.expect("Path was found, so amount must be calculable");
+                .expect("Path was found, so amount must be calculable");
             let execution = AmmOrderExecution {
                 input: (sell_token, sell_amount),
                 output: (buy_token, buy_amount),
@@ -290,6 +309,7 @@ mod tests {
     use crate::test::account;
     use model::order::OrderKind;
     use num::rational::Ratio;
+    use shared::sources::balancer::swap::fixed_point::Bfp;
     use shared::{
         addr,
         sources::balancer::pool_fetching::{TokenState, WeightedTokenState},
@@ -545,7 +565,7 @@ mod tests {
 
         let base_tokens = Arc::new(BaseTokens::new(H160::zero(), &[]));
         let solver = BaselineSolver::new(account(), base_tokens);
-        assert_eq!(solver.solve(orders, liquidity).len(), 1);
+        assert_eq!(solver.solve_(orders, liquidity).len(), 1);
     }
 
     #[test]
@@ -601,6 +621,86 @@ mod tests {
             &[],
         ));
         let solver = BaselineSolver::new(account(), base_tokens);
-        assert_eq!(solver.solve(vec![order], liquidity).len(), 0);
+        assert_eq!(solver.solve_(vec![order], liquidity).len(), 0);
+    }
+
+    #[test]
+    fn does_not_panic_for_asymmetrical_pool() {
+        let tokens: Vec<H160> = (0..3).map(H160::from_low_u64_be).collect();
+        let order = LimitOrder {
+            id: "".to_string(),
+            sell_token: tokens[0],
+            buy_token: tokens[2],
+            sell_amount: 7999613.into(),
+            buy_amount: 1.into(),
+            kind: OrderKind::Buy,
+            partially_fillable: false,
+            fee_amount: 0.into(),
+            is_liquidity_order: false,
+            settlement_handling: CapturingSettlementHandler::arc(),
+        };
+        let pool_0 = ConstantProductOrder {
+            tokens: TokenPair::new(tokens[1], tokens[2]).unwrap(),
+            reserves: (10, 12),
+            fee: Ratio::new(0, 1),
+            settlement_handling: CapturingSettlementHandler::arc(),
+        };
+        let pool_1 = WeightedProductOrder {
+            reserves: [
+                (
+                    tokens[0],
+                    WeightedTokenState {
+                        token_state: TokenState {
+                            balance: 4294966784u64.into(),
+                            scaling_exponent: 0,
+                        },
+                        weight: 255.into(),
+                    },
+                ),
+                (
+                    tokens[1],
+                    WeightedTokenState {
+                        token_state: TokenState {
+                            balance: 4278190173u64.into(),
+                            scaling_exponent: 0,
+                        },
+                        weight: 2030043135usize.into(),
+                    },
+                ),
+            ]
+            .iter()
+            .cloned()
+            .collect(),
+            fee: Bfp::zero(),
+            settlement_handling: CapturingSettlementHandler::arc(),
+        };
+        // When baseline solver goes from the buy token to the sell token it sees that a path with
+        // a sell amount of 7999613.
+        assert_eq!(
+            pool_0.get_amount_in(tokens[1], (1.into(), tokens[2])),
+            Some(1.into())
+        );
+        assert_eq!(
+            pool_1.get_amount_in(tokens[0], (1.into(), tokens[1])),
+            Some(7999613.into())
+        );
+        // But then when it goes from the sell token to the buy token to construct the settlement
+        // it encounters the asymmetry of the weighted pool. With the same in amount the out amount
+        // has changed from 1 to 0.
+        assert_eq!(
+            pool_1.get_amount_out(tokens[1], (7999613.into(), tokens[0])),
+            Some(0.into()),
+        );
+        // This makes using the second pool fail.
+        assert_eq!(pool_0.get_amount_in(tokens[2], (0.into(), tokens[1])), None);
+
+        let liquidity = vec![
+            Liquidity::ConstantProduct(pool_0),
+            Liquidity::BalancerWeighted(pool_1),
+        ];
+        let base_tokens = Arc::new(BaseTokens::new(tokens[0], &tokens));
+        let solver = BaselineSolver::new(account(), base_tokens);
+        let settlements = solver.solve_(vec![order], liquidity);
+        assert!(settlements.is_empty());
     }
 }


### PR DESCRIPTION
To find the optimal path for buy orders we start at the buy token and
use get_amount_in repeatedly until we arrive at the sell token. However
when creating a settlement the path has to be traversed in the sell
direction because that is what the user has balance in.
This is problematic when an amm is not symmetrical: using the result of
get_amount_in in get_amount_out returns a (usually slightly) different
value. This can cause further amm interactions to fail.
This commit fixes this by enforcing the forward (sell) direction of the
resulting paths for buy orders. Sell orders do not need to be fixed as
they are already in the correct direction.
Additionally I have moved order limit checks into settle_order because
it felt more natural there with the forward path check.

Closes #1140

### Test Plan
Existing tests. I would have like to add a test for the panic case too but was unable to do so because the way the types are specified in the baseline solver I cannot easily pass in my own `impl BaselineSolvable` that has the behavior I want. So I would have to craft a pool that showcases this behavior by hand which was too time consuming.
