### PR TITLE
[Fix] Merge-Scaling solutions needs to always scale prices upwards

### DIFF
--- a/solver/src/settlement/settlement_encoder.rs
+++ b/solver/src/settlement/settlement_encoder.rs
@@ -2,7 +2,7 @@ use super::{Interaction, Trade, TradeExecution};
 use crate::{encoding::EncodedSettlement, interactions::UnwrapWethInteraction};
 use anyhow::{bail, ensure, Context as _, Result};
 use model::order::{Order, OrderKind};
-use num::{BigRational, Zero};
+use num::{BigRational, One, Zero};
 use primitive_types::{H160, U256};
 use shared::conversions::{big_rational_to_u256, U256Ext};
 use std::{
@@ -263,7 +263,7 @@ impl SettlementEncoder {
     pub fn merge(mut self, mut other: Self) -> Result<Self> {
         let scaling_factor = self.price_scaling_factor(&other);
         // Make sure we always scale prices up to avoid precision issues
-        if scaling_factor < BigRational::from_integer(1.into()) {
+        if scaling_factor < BigRational::one() {
             return other.merge(self);
         }
         for (key, value) in other.clearing_prices {

--- a/solver/src/settlement/settlement_encoder.rs
+++ b/solver/src/settlement/settlement_encoder.rs
@@ -262,6 +262,10 @@ impl SettlementEncoder {
     // both or more than one token has a different clearing prices (a single token difference is scaled)
     pub fn merge(mut self, mut other: Self) -> Result<Self> {
         let scaling_factor = self.price_scaling_factor(&other);
+        // Make sure we always scale prices up to avoid precision issues
+        if scaling_factor < BigRational::from_integer(1.into()) {
+            return other.merge(self);
+        }
         for (key, value) in other.clearing_prices {
             let scaled_price = big_rational_to_u256(&(value.to_big_rational() * &scaling_factor))
                 .context("Invalid price scaling factor")?;
@@ -563,6 +567,24 @@ pub mod tests {
             token(3) => 6.into(),
         };
         assert_eq!(merged.clearing_prices, prices);
+    }
+
+    #[test]
+    fn merge_always_scales_smaller_price_up() {
+        let prices = hashmap! { token(1) => 1.into(), token(2) => 1_000_000.into() };
+        let encoder0 = SettlementEncoder::new(prices);
+        let prices = hashmap! { token(1) => 1_000_000.into(), token(3) => 900_000.into() };
+        let encoder1 = SettlementEncoder::new(prices);
+
+        let merge01 = encoder0.clone().merge(encoder1.clone()).unwrap();
+        let merge10 = encoder1.merge(encoder0).unwrap();
+        assert_eq!(merge10.clearing_prices, merge01.clearing_prices);
+
+        // If scaled down 900k would have become 0
+        assert_eq!(
+            *merge10.clearing_prices.get(&token(3)).unwrap(),
+            900_000.into()
+        );
     }
 
     #[test]


### PR DESCRIPTION
During our Kafeekränzchen, we merged a bunch of 0x settlements leading to a simulation failure: https://logs.gnosisdev.com/app/kibana#/discover/doc/de1f5360-a9ae-11ea-acbb-9d2e3cb124ca/logstash-2021.09.24?id=BpLmF3wBRkP_oNi3DbT5

> 1: contract call reverted with message: Some("GPv2: limit price not respected")

The problem seems to be that the price vector (including some 6 decimal tokens) has been scaled down leading to very imprecise values for 18 decimal tokens:

```
clearing_prices: {
            0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee: 17,
            0x16980b3b4a3f9d89e33311b5aa8f80303e5ca4f8: 2973186314,
            0x6810e776880c02933d47db1b9fc05908e5386b96: 1,
            0xdac17f958d2ee523a2206206994597c13d831ec7: 6231023909,
            0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48: 6059645869,
            0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2: 17,
        },
```

This PR therefore changes the scaling logic in a way that will make the numbers always larger (to avoid precision loss)

### Test Plan
Added a unit test demonstrating the problem.

Also I recreated the merge from the example above (a lot of manual work) and with the new code this would now lead to a successful simulation: https://dashboard.tenderly.co/gp-v2/staging/simulator/9a2a6939-44db-4b86-b6a4-7147b4aec016
