### PR TITLE
Graceful shutdown of API

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -2,8 +2,13 @@
 # The purpose of this script is to set a log regex to forward error logs to stderr and other logs to
 # stdout. This allows us to easily configure alerts when any message goes to stderr.
 
-# The main command is run in the background so that it receives interrupt signals
+# Run both commands in the background, so that we can receive signals and forward it to the main process (for this we capture the pid).
 # The stream-split command deliberately ignores interrupts (otherwise we may lose logs on teardown). It terminates automatically
 # once the main command (stdin) terminates.
-("$@" &) | (trap '' INT; regex-stream-split '^\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z\s+(TRACE|DEBUG|INFO|WARN)' '^\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z\s+ERROR')
+( "$@" & echo $! > main_pid ) | (trap '' TERM INT; regex-stream-split '^\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z\s+(TRACE|DEBUG|INFO|WARN)' '^\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z\s+ERROR') &
 
+pid=$(cat main_pid)
+trap 'echo foo; kill -15 $pid' TERM
+trap 'echo bar; kill -2 $pid' INT
+
+wait

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -8,7 +8,7 @@
 ( "$@" & echo $! > main_pid ) | (trap '' TERM INT; regex-stream-split '^\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z\s+(TRACE|DEBUG|INFO|WARN)' '^\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z\s+ERROR') &
 
 pid=$(cat main_pid)
-trap 'echo foo; kill -15 $pid' TERM
-trap 'echo bar; kill -2 $pid' INT
+trap 'kill -15 $pid' TERM
+trap 'kill -2 $pid' INT
 
 wait

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 # The purpose of this script is to set a log regex to forward error logs to stderr and other logs to
 # stdout. This allows us to easily configure alerts when any message goes to stderr.
-"$@" | regex-stream-split "^\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z\s+(TRACE|DEBUG|INFO|WARN)" "^\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z\s+ERROR"
+
+# The main command is run in the background so that it receives interrupt signals
+# The stream-split command deliberately ignores interrupts (otherwise we may lose logs on teardown). It terminates automatically
+# once the main command (stdin) terminates.
+("$@" &) | (trap '' INT; regex-stream-split '^\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z\s+(TRACE|DEBUG|INFO|WARN)' '^\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z\s+ERROR')
+

--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -22,7 +22,7 @@ use shared::{
     Web3,
 };
 use solver::orderbook::OrderBookApi;
-use std::collections::HashMap;
+use std::{collections::HashMap, future::pending};
 use std::{num::NonZeroU64, str::FromStr, sync::Arc, time::Duration};
 
 pub const API_HOST: &str = "http://127.0.0.1:8080";
@@ -226,12 +226,13 @@ impl OrderbookServices {
         let maintenance = ServiceMaintenance {
             maintainers: vec![db.clone(), event_updater],
         };
-        orderbook::serve_task(
+        orderbook::serve_api(
             db.clone(),
             orderbook,
             fee_calculator,
             price_estimator.clone(),
             API_HOST[7..].parse().expect("Couldn't parse API address"),
+            pending::<()>(),
         );
 
         Self {

--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -232,7 +232,7 @@ impl OrderbookServices {
             fee_calculator,
             price_estimator.clone(),
             API_HOST[7..].parse().expect("Couldn't parse API address"),
-            pending::<()>(),
+            pending(),
         );
 
         Self {

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -42,7 +42,7 @@ shared= { path = "../shared" }
 sqlx = { version = "0.5", default-features = false, features = ["bigdecimal", "chrono", "macros", "runtime-tokio-native-tls", "postgres"] }
 structopt = "0.3"
 thiserror = "1.0"
-tokio = { version = "1.12", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.12", features = ["macros", "rt-multi-thread", "sync", "time", "signal"] }
 tracing = "0.1"
 url = "2.2"
 warp = "0.3"

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -29,9 +29,7 @@ pub fn serve_api(
 ) -> JoinHandle<()> {
     let filter = api::handle_all_routes(database, orderbook, fee_calculator, price_estimator);
     tracing::info!(%address, "serving order book");
-    let (_, server) = warp::serve(filter).bind_with_graceful_shutdown(address, async {
-        shutdown_receiver.await;
-    });
+    let (_, server) = warp::serve(filter).bind_with_graceful_shutdown(address, shutdown_receiver);
     task::spawn(server)
 }
 

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -19,13 +19,13 @@ use shared::price_estimation::PriceEstimating;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::{task, task::JoinHandle};
 
-pub fn serve_api<T>(
+pub fn serve_api(
     database: Arc<dyn TradeRetrieving>,
     orderbook: Arc<Orderbook>,
     fee_calculator: Arc<EthAwareMinFeeCalculator>,
     price_estimator: Arc<dyn PriceEstimating>,
     address: SocketAddr,
-    shutdown_receiver: impl Future<Output = T> + Send + 'static,
+    shutdown_receiver: impl Future<Output = ()> + Send + 'static,
 ) -> JoinHandle<()> {
     let filter = api::handle_all_routes(database, orderbook, fee_calculator, price_estimator);
     tracing::info!(%address, "serving order book");

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -13,30 +13,26 @@ use anyhow::{anyhow, Context as _, Result};
 use contracts::GPv2Settlement;
 use database::trades::TradeRetrieving;
 use fee::EthAwareMinFeeCalculator;
+use futures::Future;
 use model::DomainSeparator;
-use shared::{
-    metrics::{serve_metrics, DEFAULT_METRICS_PORT},
-    price_estimation::PriceEstimating,
-};
+use shared::price_estimation::PriceEstimating;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::{task, task::JoinHandle};
 
-pub fn serve_task(
+pub fn serve_api<T>(
     database: Arc<dyn TradeRetrieving>,
     orderbook: Arc<Orderbook>,
     fee_calculator: Arc<EthAwareMinFeeCalculator>,
     price_estimator: Arc<dyn PriceEstimating>,
     address: SocketAddr,
+    shutdown_receiver: impl Future<Output = T> + Send + 'static,
 ) -> JoinHandle<()> {
-    let filter =
-        api::handle_all_routes(database, orderbook.clone(), fee_calculator, price_estimator);
-    let mut metrics_address = address;
+    let filter = api::handle_all_routes(database, orderbook, fee_calculator, price_estimator);
     tracing::info!(%address, "serving order book");
-    task::spawn(warp::serve(filter).bind(address));
-
-    tracing::info!(%metrics_address, "serving metrics");
-    metrics_address.set_port(DEFAULT_METRICS_PORT);
-    serve_metrics(orderbook, metrics_address)
+    let (_, server) = warp::serve(filter).bind_with_graceful_shutdown(address, async {
+        shutdown_receiver.await;
+    });
+    task::spawn(server)
 }
 
 /**

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Context, Result};
 use contracts::{BalancerV2Vault, GPv2Settlement, WETH9};
-use futures::future;
 use model::{
     app_id::AppId,
     order::{OrderUid, BUY_ETH_ADDRESS},
@@ -50,10 +49,7 @@ use shared::{
 };
 use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 use structopt::StructOpt;
-use tokio::{
-    signal::unix::{signal, SignalKind},
-    task,
-};
+use tokio::task;
 use url::Url;
 
 #[derive(Debug, StructOpt)]
@@ -439,23 +435,13 @@ async fn main() {
     tracing::info!(%metrics_address, "serving metrics");
     let metrics_task = serve_metrics(orderbook, metrics_address);
 
-    // Intercept main signals for graceful shutdown
-    // Kubernetes sends sigterm, whereas locally sigint (ctrl-c) is most common
-    let sigterm = async { signal(SignalKind::terminate()).unwrap().recv().await };
-    let sigint = async {
-        signal(SignalKind::interrupt()).unwrap().recv().await;
-    };
-    futures::pin_mut!(sigint);
-    futures::pin_mut!(sigterm);
-    let shutdown = future::select(sigterm, sigint);
-
     futures::pin_mut!(serve_api);
     tokio::select! {
         result = &mut serve_api => tracing::error!(?result, "API task exited"),
         result = maintenance_task => tracing::error!(?result, "maintenance task exited"),
         result = db_metrics_task => tracing::error!(?result, "database metrics task exited"),
         result = metrics_task => tracing::error!(?result, "metrics task exited"),
-        _ = shutdown => {
+        _ = shutdown_signal() => {
             tracing::info!("Gracefully shutting down API");
             shutdown_sender.send(()).expect("failed to send shutdown signal");
             match tokio::time::timeout(Duration::from_secs(10), serve_api).await {
@@ -464,6 +450,33 @@ async fn main() {
             }
         }
     };
+}
+
+#[cfg(unix)]
+async fn shutdown_signal() {
+    // Intercept main signals for graceful shutdown
+    // Kubernetes sends sigterm, whereas locally sigint (ctrl-c) is most common
+    let sigterm = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .unwrap()
+            .recv()
+            .await
+    };
+    let sigint = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+            .unwrap()
+            .recv()
+            .await;
+    };
+    futures::pin_mut!(sigint);
+    futures::pin_mut!(sigterm);
+    futures::future::select(sigterm, sigint).await;
+}
+
+#[cfg(windows)]
+async fn shutdown_signal() {
+    // We don't support signal handling on windows
+    std::future::pending().await
 }
 
 async fn check_database_connection(orderbook: &Orderbook) {

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -422,7 +422,9 @@ async fn main() {
         fee_calculator,
         price_estimator,
         args.bind_address,
-        shutdown_receiver,
+        async {
+            let _ = shutdown_receiver.await;
+        }
     );
     let maintenance_task =
         task::spawn(service_maintainer.run_maintenance_on_new_block(current_block_stream));

--- a/solver/src/settlement/settlement_encoder.rs
+++ b/solver/src/settlement/settlement_encoder.rs
@@ -548,7 +548,7 @@ pub mod tests {
     fn merge_fails_because_price_is_different() {
         let prices = hashmap! { token(1) => 1.into(), token(2) => 2.into() };
         let encoder0 = SettlementEncoder::new(prices);
-        let prices = hashmap! { token(1) => 1.into(), token(2) => 3.into() };
+        let prices = hashmap! { token(1) => 1.into(), token(2) => 4.into() };
         let encoder1 = SettlementEncoder::new(prices);
         assert!(encoder0.merge(encoder1).is_err());
     }


### PR DESCRIPTION
Fixes #576

We are from time to time seeing alerts for error messages like (mostly in staging):

> ERROR (pod: dev-dfusion-v2-solver-mainnet-6459f9677f-gx4zg):
2021-09-28T07:03:22.630Z ERROR solver::driver: single run errored: failed to get orderbook liquidity
Caused by:
   0: failed to get orderbook
   1: error sending request for url (http://...dfusion.svc.cluster.local/api/v1/solvable_orders): error trying to connect: tcp connect error: Connection refused (os error 111)
   2: error trying to connect: tcp connect error: Connection refused (os error 111)
   3: tcp connect error: Connection refused (os error 111)
   4: Connection refused (os error 111)

This is likely due to the API receiving a sigterm signal while a request is inflight (in which case the tcp connection may be refused). This PR makes it so that we intercept the sigterm signal and use it to gracefully shut down the server (which will finish serving in flight requests).

### Test Plan
Set a sleep of 10s in one the get endpoints. Query the path and before the 10s is up send a sigterm to the orderbook process. Before this PR the inflight request would error. Now, the shutdown will wait until the sleep is up and the request is served before tearing down the process.
