### PR TITLE
Pre-Order Validation

### DIFF
--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -9,6 +9,7 @@ mod get_solvable_orders;
 mod get_trades;
 mod get_user_orders;
 mod post_quote;
+pub mod validation;
 
 use crate::{
     database::trades::TradeRetrieving, fee::EthAwareMinFeeCalculator, orderbook::Orderbook,

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -15,14 +15,7 @@ pub fn create_order_request(
 pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
     let (body, status_code) = match result {
         Ok(AddOrderResult::Added(uid)) => (warp::reply::json(&uid), StatusCode::CREATED),
-        Ok(AddOrderResult::UnsupportedBuyTokenDestination(dest)) => (
-            super::error("UnsupportedBuyTokenDestination", format!("Type {:?}", dest)),
-            StatusCode::BAD_REQUEST,
-        ),
-        Ok(AddOrderResult::UnsupportedSellTokenSource(source)) => (
-            super::error("UnsupportedSellTokenSource", format!("Type {:?}", source)),
-            StatusCode::BAD_REQUEST,
-        ),
+        Ok(AddOrderResult::PreValidationError(err)) => err.to_warp_reply(),
         Ok(AddOrderResult::UnsupportedToken(token)) => (
             super::error("UnsupportedToken", format!("Token address {}", token)),
             StatusCode::BAD_REQUEST,
@@ -49,17 +42,6 @@ pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
             super::error("UnsupportedSignature", "signing scheme is not supported"),
             StatusCode::BAD_REQUEST,
         ),
-        Ok(AddOrderResult::Forbidden) => (
-            super::error("Forbidden", "Forbidden, your account is deny-listed"),
-            StatusCode::FORBIDDEN,
-        ),
-        Ok(AddOrderResult::InsufficientValidTo) => (
-            super::error(
-                "InsufficientValidTo",
-                "validTo is not far enough in the future",
-            ),
-            StatusCode::BAD_REQUEST,
-        ),
         Ok(AddOrderResult::MissingOrderData) => (
             super::error(
                 "MissingOrderData",
@@ -76,21 +58,6 @@ pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
         ),
         Ok(AddOrderResult::InsufficientFee) => (
             super::error("InsufficientFee", "Order does not include sufficient fee"),
-            StatusCode::BAD_REQUEST,
-        ),
-        Ok(AddOrderResult::TransferEthToContract) => (
-            super::error(
-                "TransferEthToContract",
-                "Sending Ether to a smart contract wallets is currently not \
-                 supported",
-            ),
-            StatusCode::BAD_REQUEST,
-        ),
-        Ok(AddOrderResult::SameBuyAndSellToken) => (
-            super::error(
-                "SameBuyAndSellToken",
-                "Buy token is the same as the sell token.",
-            ),
             StatusCode::BAD_REQUEST,
         ),
         Ok(AddOrderResult::ZeroAmount) => (

--- a/orderbook/src/api/validation.rs
+++ b/orderbook/src/api/validation.rs
@@ -1,0 +1,353 @@
+use contracts::WETH9;
+use ethcontract::H160;
+use model::order::{BuyTokenDestination, Order, SellTokenSource, BUY_ETH_ADDRESS};
+use shared::web3_traits::CodeFetching;
+use std::time::Duration;
+use warp::{http::StatusCode, reply::Json};
+
+#[derive(Debug)]
+pub enum ValidationError {
+    Forbidden,
+    InsufficientValidTo,
+    TransferEthToContract,
+    SameBuyAndSellToken,
+    UnsupportedBuyTokenDestination(BuyTokenDestination),
+    UnsupportedSellTokenSource(SellTokenSource),
+    Other(anyhow::Error),
+}
+
+impl ValidationError {
+    pub fn to_warp_reply(&self) -> (Json, StatusCode) {
+        match self {
+            Self::UnsupportedBuyTokenDestination(dest) => (
+                super::error("UnsupportedBuyTokenDestination", format!("Type {:?}", dest)),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::UnsupportedSellTokenSource(src) => (
+                super::error("UnsupportedSellTokenSource", format!("Type {:?}", src)),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::Forbidden => (
+                super::error("Forbidden", "Forbidden, your account is deny-listed"),
+                StatusCode::FORBIDDEN,
+            ),
+            Self::InsufficientValidTo => (
+                super::error(
+                    "InsufficientValidTo",
+                    "validTo is not far enough in the future",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::TransferEthToContract => (
+                super::error(
+                    "TransferEthToContract",
+                    "Sending Ether to smart contract wallets is currently not supported",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::SameBuyAndSellToken => (
+                super::error(
+                    "SameBuyAndSellToken",
+                    "Buy token is the same as the sell token.",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::Other(_) => (super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR),
+        }
+    }
+}
+
+pub struct PreOrderValidator {
+    code_fetcher: Box<dyn CodeFetching>,
+    native_token: WETH9,
+    banned_users: Vec<H160>,
+    min_order_validity_period: Duration,
+}
+
+#[derive(Default)]
+pub struct PreOrderData {
+    owner: H160,
+    sell_token: H160,
+    buy_token: H160,
+    receiver: H160,
+    valid_to: u32,
+    buy_token_balance: BuyTokenDestination,
+    sell_token_balance: SellTokenSource,
+}
+
+impl From<Order> for PreOrderData {
+    fn from(order: Order) -> Self {
+        Self {
+            owner: order.order_meta_data.owner,
+            sell_token: order.order_creation.sell_token,
+            buy_token: order.order_creation.buy_token,
+            receiver: order.actual_receiver(),
+            valid_to: order.order_creation.valid_to,
+            buy_token_balance: order.order_creation.buy_token_balance,
+            sell_token_balance: order.order_creation.sell_token_balance,
+        }
+    }
+}
+
+impl PreOrderValidator {
+    pub fn new(
+        code_fetcher: Box<dyn CodeFetching>,
+        native_token: WETH9,
+        banned_users: Vec<H160>,
+        min_order_validity_period: Duration,
+    ) -> Self {
+        Self {
+            code_fetcher,
+            native_token,
+            banned_users,
+            min_order_validity_period,
+        }
+    }
+
+    pub async fn validate_partial_order(&self, order: PreOrderData) -> Result<(), ValidationError> {
+        if self.banned_users.contains(&order.owner) {
+            return Err(ValidationError::Forbidden);
+        }
+        if order.buy_token_balance != BuyTokenDestination::Erc20 {
+            return Err(ValidationError::UnsupportedBuyTokenDestination(
+                order.buy_token_balance,
+            ));
+        }
+        if !matches!(
+            order.sell_token_balance,
+            SellTokenSource::Erc20 | SellTokenSource::External
+        ) {
+            return Err(ValidationError::UnsupportedSellTokenSource(
+                order.sell_token_balance,
+            ));
+        }
+
+        if order.valid_to
+            < shared::time::now_in_epoch_seconds() + self.min_order_validity_period.as_secs() as u32
+        {
+            return Err(ValidationError::InsufficientValidTo);
+        }
+
+        if has_same_buy_and_sell_token(&order, &self.native_token) {
+            return Err(ValidationError::SameBuyAndSellToken);
+        }
+
+        if order.buy_token == BUY_ETH_ADDRESS {
+            let code_size = self
+                .code_fetcher
+                .code_size(order.receiver)
+                .await
+                .map_err(ValidationError::Other)?;
+            if code_size != 0 {
+                return Err(ValidationError::TransferEthToContract);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Returns true if the orders have same buy and sell tokens.
+///
+/// This also checks for orders selling wrapped native token for native token.
+fn has_same_buy_and_sell_token(order: &PreOrderData, native_token: &WETH9) -> bool {
+    order.sell_token == order.buy_token
+        || (order.sell_token == native_token.address() && order.buy_token == BUY_ETH_ADDRESS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::anyhow;
+    use shared::dummy_contract;
+    use shared::web3_traits::MockCodeFetching;
+
+    #[test]
+    fn detects_orders_with_same_buy_and_sell_token() {
+        let native_token = dummy_contract!(WETH9, [0xef; 20]);
+        assert!(has_same_buy_and_sell_token(
+            &PreOrderData {
+                sell_token: H160([0x01; 20]),
+                buy_token: H160([0x01; 20]),
+                ..Default::default()
+            },
+            &native_token,
+        ));
+        assert!(has_same_buy_and_sell_token(
+            &PreOrderData {
+                sell_token: native_token.address(),
+                buy_token: BUY_ETH_ADDRESS,
+                ..Default::default()
+            },
+            &native_token,
+        ));
+
+        assert!(!has_same_buy_and_sell_token(
+            &PreOrderData {
+                sell_token: H160([0x01; 20]),
+                buy_token: H160([0x02; 20]),
+                ..Default::default()
+            },
+            &native_token,
+        ));
+        // Sell token set to 0xeee...eee has no special meaning, so it isn't
+        // considered buying and selling the same token.
+        assert!(!has_same_buy_and_sell_token(
+            &PreOrderData {
+                sell_token: BUY_ETH_ADDRESS,
+                buy_token: native_token.address(),
+                ..Default::default()
+            },
+            &native_token,
+        ));
+    }
+
+    #[tokio::test]
+    async fn validate_partial_order_err() {
+        let mut code_fetcher = Box::new(MockCodeFetching::new());
+        let native_token = dummy_contract!(WETH9, [0xef; 20]);
+        let min_order_validity_period = Duration::from_secs(1);
+        let banned_users = vec![H160::from_low_u64_be(1)];
+        let legit_valid_to =
+            shared::time::now_in_epoch_seconds() + min_order_validity_period.as_secs() as u32 + 2;
+        code_fetcher
+            .expect_code_size()
+            .times(1)
+            .return_once(|_| Ok(1));
+        let validator = PreOrderValidator {
+            code_fetcher,
+            native_token,
+            banned_users,
+            min_order_validity_period,
+        };
+        assert_eq!(
+            format!(
+                "{:?}",
+                validator
+                    .validate_partial_order(PreOrderData {
+                        owner: H160::from_low_u64_be(1),
+                        ..Default::default()
+                    })
+                    .await
+                    .unwrap_err()
+            ),
+            "Forbidden"
+        );
+        assert_eq!(
+            format!(
+                "{:?}",
+                validator
+                    .validate_partial_order(PreOrderData {
+                        buy_token_balance: BuyTokenDestination::Internal,
+                        ..Default::default()
+                    })
+                    .await
+                    .unwrap_err()
+            ),
+            "UnsupportedBuyTokenDestination(Internal)"
+        );
+        assert_eq!(
+            format!(
+                "{:?}",
+                validator
+                    .validate_partial_order(PreOrderData {
+                        sell_token_balance: SellTokenSource::Internal,
+                        ..Default::default()
+                    })
+                    .await
+                    .unwrap_err()
+            ),
+            "UnsupportedSellTokenSource(Internal)"
+        );
+        assert_eq!(
+            format!(
+                "{:?}",
+                validator
+                    .validate_partial_order(PreOrderData {
+                        valid_to: 0,
+                        ..Default::default()
+                    })
+                    .await
+                    .unwrap_err()
+            ),
+            "InsufficientValidTo"
+        );
+        assert_eq!(
+            format!(
+                "{:?}",
+                validator
+                    .validate_partial_order(PreOrderData {
+                        valid_to: legit_valid_to,
+                        buy_token: H160::from_low_u64_be(2),
+                        sell_token: H160::from_low_u64_be(2),
+                        ..Default::default()
+                    })
+                    .await
+                    .unwrap_err()
+            ),
+            "SameBuyAndSellToken"
+        );
+        assert_eq!(
+            format!(
+                "{:?}",
+                validator
+                    .validate_partial_order(PreOrderData {
+                        valid_to: legit_valid_to,
+                        buy_token: BUY_ETH_ADDRESS,
+                        ..Default::default()
+                    })
+                    .await
+                    .unwrap_err()
+            ),
+            "TransferEthToContract"
+        );
+
+        let mut code_fetcher = Box::new(MockCodeFetching::new());
+        code_fetcher
+            .expect_code_size()
+            .times(1)
+            .return_once(|_| Err(anyhow!("Failed to fetch Code Size!")));
+        let validator = PreOrderValidator {
+            code_fetcher,
+            native_token: dummy_contract!(WETH9, [0xef; 20]),
+            banned_users: vec![],
+            min_order_validity_period: Duration::from_secs(1),
+        };
+        assert_eq!(
+            format!(
+                "{:?}",
+                validator
+                    .validate_partial_order(PreOrderData {
+                        valid_to: legit_valid_to,
+                        buy_token: BUY_ETH_ADDRESS,
+                        ..Default::default()
+                    })
+                    .await
+                    .unwrap_err()
+            ),
+            "Other(Failed to fetch Code Size!)"
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_partial_order_ok() {
+        let code_fetcher = Box::new(MockCodeFetching::new());
+        let min_order_validity_period = Duration::from_secs(1);
+        let validator = PreOrderValidator {
+            code_fetcher,
+            native_token: dummy_contract!(WETH9, [0xef; 20]),
+            banned_users: vec![],
+            min_order_validity_period: Duration::from_secs(1),
+        };
+        assert!(validator
+            .validate_partial_order(PreOrderData {
+                valid_to: shared::time::now_in_epoch_seconds()
+                    + min_order_validity_period.as_secs() as u32
+                    + 2,
+                sell_token: H160::from_low_u64_be(1),
+                buy_token: H160::from_low_u64_be(2),
+                ..Default::default()
+            })
+            .await
+            .is_ok());
+    }
+}

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -1,45 +1,34 @@
 use crate::{
     account_balances::BalanceFetching,
+    api::validation::{PreOrderValidator, ValidationError},
     database::orders::{InsertionError, OrderFilter, OrderStoring},
     fee::{EthAwareMinFeeCalculator, MinFeeCalculating},
     solvable_orders::SolvableOrdersCache,
 };
 use anyhow::{ensure, Result};
 use chrono::Utc;
-use contracts::WETH9;
 use model::{
-    order::{
-        BuyTokenDestination, OrderCancellation, OrderCreation, OrderCreationPayload,
-        SellTokenSource,
-    },
+    order::{Order, OrderCancellation, OrderCreationPayload, OrderStatus, OrderUid},
     signature::SigningScheme,
-};
-use model::{
-    order::{Order, OrderStatus, OrderUid, BUY_ETH_ADDRESS},
     DomainSeparator,
 };
 use primitive_types::{H160, U256};
-use shared::{bad_token::BadTokenDetecting, metrics::LivenessChecking, web3_traits::CodeFetching};
+use shared::{bad_token::BadTokenDetecting, metrics::LivenessChecking};
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub enum AddOrderResult {
     Added(OrderUid),
     WrongOwner(H160),
     DuplicatedOrder,
     InvalidSignature,
     UnsupportedSignature,
-    Forbidden,
     MissingOrderData,
-    InsufficientValidTo,
     InsufficientFunds,
     InsufficientFee,
     UnsupportedToken(H160),
-    TransferEthToContract,
-    SameBuyAndSellToken,
-    UnsupportedBuyTokenDestination(BuyTokenDestination),
-    UnsupportedSellTokenSource(SellTokenSource),
     ZeroAmount,
+    PreValidationError(ValidationError),
 }
 
 #[derive(Debug)]
@@ -60,14 +49,11 @@ pub struct Orderbook {
     database: Arc<dyn OrderStoring>,
     balance_fetcher: Arc<dyn BalanceFetching>,
     fee_validator: Arc<EthAwareMinFeeCalculator>,
-    min_order_validity_period: Duration,
     bad_token_detector: Arc<dyn BadTokenDetecting>,
-    code_fetcher: Box<dyn CodeFetching>,
-    native_token: WETH9,
-    banned_users: Vec<H160>,
     enable_presign_orders: bool,
     solvable_orders: Arc<SolvableOrdersCache>,
     solvable_orders_max_update_age: Duration,
+    pre_order_validator: Arc<PreOrderValidator>,
 }
 
 impl Orderbook {
@@ -78,14 +64,11 @@ impl Orderbook {
         database: Arc<dyn OrderStoring>,
         balance_fetcher: Arc<dyn BalanceFetching>,
         fee_validator: Arc<EthAwareMinFeeCalculator>,
-        min_order_validity_period: Duration,
         bad_token_detector: Arc<dyn BadTokenDetecting>,
-        code_fetcher: Box<dyn CodeFetching>,
-        native_token: WETH9,
-        banned_users: Vec<H160>,
         enable_presign_orders: bool,
         solvable_orders: Arc<SolvableOrdersCache>,
         solvable_orders_max_update_age: Duration,
+        pre_order_validator: Arc<PreOrderValidator>,
     ) -> Self {
         Self {
             domain_separator,
@@ -93,61 +76,44 @@ impl Orderbook {
             database,
             balance_fetcher,
             fee_validator,
-            min_order_validity_period,
             bad_token_detector,
-            code_fetcher,
-            native_token,
-            banned_users,
             enable_presign_orders,
             solvable_orders,
             solvable_orders_max_update_age,
+            pre_order_validator,
         }
     }
 
     pub async fn add_order(&self, payload: OrderCreationPayload) -> Result<AddOrderResult> {
-        let order = payload.order_creation;
-
-        // Temporary - reject new order types until last stage of balancer integration
-        if order.buy_token_balance != BuyTokenDestination::Erc20 {
-            return Ok(AddOrderResult::UnsupportedBuyTokenDestination(
-                order.buy_token_balance,
-            ));
-        }
+        let order_creation = payload.order_creation;
         if !matches!(
-            order.sell_token_balance,
-            SellTokenSource::Erc20 | SellTokenSource::External
-        ) {
-            return Ok(AddOrderResult::UnsupportedSellTokenSource(
-                order.sell_token_balance,
-            ));
-        }
-        if !matches!(
-            (order.signature.scheme(), self.enable_presign_orders),
+            (
+                order_creation.signature.scheme(),
+                self.enable_presign_orders
+            ),
             (SigningScheme::Eip712 | SigningScheme::EthSign, _) | (SigningScheme::PreSign, true)
         ) {
             return Ok(AddOrderResult::UnsupportedSignature);
         }
-        if has_same_buy_and_sell_token(&order, &self.native_token) {
-            return Ok(AddOrderResult::SameBuyAndSellToken);
-        }
-        if order.buy_amount.is_zero() || order.sell_amount.is_zero() {
+
+        if order_creation.buy_amount.is_zero() || order_creation.sell_amount.is_zero() {
             return Ok(AddOrderResult::ZeroAmount);
         }
 
-        if order.valid_to
-            < shared::time::now_in_epoch_seconds() + self.min_order_validity_period.as_secs() as u32
-        {
-            return Ok(AddOrderResult::InsufficientValidTo);
-        }
         if !self
             .fee_validator
-            .is_valid_fee(order.sell_token, order.fee_amount, order.app_data)
+            .is_valid_fee(
+                order_creation.sell_token,
+                order_creation.fee_amount,
+                order_creation.app_data,
+            )
             .await
         {
             return Ok(AddOrderResult::InsufficientFee);
         }
+
         let order = match Order::from_order_creation(
-            order,
+            order_creation,
             &self.domain_separator,
             self.settlement_contract,
         ) {
@@ -156,8 +122,15 @@ impl Orderbook {
         };
 
         let owner = order.order_meta_data.owner;
-        if self.banned_users.contains(&owner) {
-            return Ok(AddOrderResult::Forbidden);
+
+        let pre_validation = self
+            .pre_order_validator
+            .validate_partial_order(order.clone().into())
+            .await;
+        if pre_validation.is_err() {
+            return Ok(AddOrderResult::PreValidationError(
+                pre_validation.unwrap_err(),
+            ));
         }
 
         if matches!(payload.from, Some(from) if from != owner) {
@@ -189,13 +162,6 @@ impl Orderbook {
             .unwrap_or(false)
         {
             return Ok(AddOrderResult::InsufficientFunds);
-        }
-
-        if order.order_creation.buy_token == BUY_ETH_ADDRESS {
-            let code_size = self.code_fetcher.code_size(order.actual_receiver()).await?;
-            if code_size != 0 {
-                return Ok(AddOrderResult::TransferEthToContract);
-            }
         }
 
         match self.database.insert_order(&order).await {
@@ -337,7 +303,7 @@ fn set_available_balances(orders: &mut [Order], cache: &SolvableOrdersCache) {
     }
 }
 
-// Mininum balance user must have in sell token for order to be accepted. None if no balance is
+// Minimum balance user must have in sell token for order to be accepted. None if no balance is
 // sufficient.
 fn minimum_balance(order: &Order) -> Option<U256> {
     if order.order_creation.partially_fillable {
@@ -350,21 +316,13 @@ fn minimum_balance(order: &Order) -> Option<U256> {
     }
 }
 
-/// Returns true if the orders have same buy and sell tokens.
-///
-/// This also checks for orders selling wrapped native token for native token.
-fn has_same_buy_and_sell_token(order: &OrderCreation, native_token: &WETH9) -> bool {
-    order.sell_token == order.buy_token
-        || (order.sell_token == native_token.address() && order.buy_token == BUY_ETH_ADDRESS)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use ethcontract::H160;
     use futures::FutureExt;
-    use model::order::{OrderBuilder, OrderCreation};
-    use shared::{bad_token::list_based::ListBasedDetector, dummy_contract};
+    use model::order::OrderBuilder;
+    use shared::bad_token::list_based::ListBasedDetector;
 
     #[test]
     fn filter_unsupported_tokens_() {
@@ -391,45 +349,5 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(result, &orders[1..2]);
-    }
-
-    #[test]
-    fn detects_orders_with_same_buy_and_sell_token() {
-        let native_token = dummy_contract!(WETH9, [0xef; 20]);
-        assert!(has_same_buy_and_sell_token(
-            &OrderCreation {
-                sell_token: H160([0x01; 20]),
-                buy_token: H160([0x01; 20]),
-                ..Default::default()
-            },
-            &native_token,
-        ));
-        assert!(has_same_buy_and_sell_token(
-            &OrderCreation {
-                sell_token: native_token.address(),
-                buy_token: BUY_ETH_ADDRESS,
-                ..Default::default()
-            },
-            &native_token,
-        ));
-
-        assert!(!has_same_buy_and_sell_token(
-            &OrderCreation {
-                sell_token: H160([0x01; 20]),
-                buy_token: H160([0x02; 20]),
-                ..Default::default()
-            },
-            &native_token,
-        ));
-        // Sell token set to 0xeee...eee has no special meaning, so it isn't
-        // considered buying and selling the same token.
-        assert!(!has_same_buy_and_sell_token(
-            &OrderCreation {
-                sell_token: BUY_ETH_ADDRESS,
-                buy_token: native_token.address(),
-                ..Default::default()
-            },
-            &native_token,
-        ));
     }
 }


### PR DESCRIPTION
In Preparation for the new Fee and Quote endpoint (cf #1155) we shift some of the order validation into its own file (to be shared among both `Orderbook.add_order` and the `QuoteRequest` endpoint). More specifically, we move all order validations pertaining to the buy/sell tokens, order validity, balance sources and destinations, banned users, and transfer eth to contract into their own `PreOrderValidator`. Any order validations regarding balance or fee sufficiency and signature validity remain in the `Orderbook.add_order` method.

### Test Plan
This is a refactor although I have added some tests to the new method `validate_partial_order`
