### PR TITLE
[Easy] remove AddOrderResult::MissingOrderData

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -749,7 +749,6 @@ components:
               InsufficientFunds,
               InsufficientValidTo,
               InvalidSignature,
-              MissingOrderData,
               TransferEthToContract,
               UnsupportedToken,
               WrongOwner,

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -60,13 +60,6 @@ pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
             ),
             StatusCode::BAD_REQUEST,
         ),
-        Ok(AddOrderResult::MissingOrderData) => (
-            super::error(
-                "MissingOrderData",
-                "at least 1 field of orderCreation is missing, please check the field",
-            ),
-            StatusCode::BAD_REQUEST,
-        ),
         Ok(AddOrderResult::InsufficientFunds) => (
             super::error(
                 "InsufficientFunds",

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -30,7 +30,6 @@ pub enum AddOrderResult {
     InvalidSignature,
     UnsupportedSignature,
     Forbidden,
-    MissingOrderData,
     InsufficientValidTo,
     InsufficientFunds,
     InsufficientFee,


### PR DESCRIPTION
Ever since we started using required fields in the OpenApi spec, I can't see that this route can ever be hit.

This PR removes an unnecessary enum variant from AddOrderResult, namely MissingOrderData

### Test Plan
Existing CI.