### PR TITLE
Remove orderbook dependency from solver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2718,7 +2718,6 @@ dependencies = [
  "mockall",
  "model",
  "num",
- "orderbook",
  "primitive-types",
  "prometheus",
  "rand",

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -33,7 +33,6 @@ lazy_static = "1.4"
 maplit = "1.0"
 model = { path = "../model" }
 num = "0.4"
-orderbook= { path = "../orderbook" }
 primitive-types = { version = "0.9", features = ["fp-conversion"] }
 prometheus = "0.12"
 rand = "0.8"


### PR DESCRIPTION
This is never used. Removing it should improve compile times a little as orderbook and solver crate now be compiled in paralle.

### Test Plan
CI