### PR TITLE
Fix panic with weighted token state scaling factor

### DIFF
--- a/shared/src/sources/balancer/swap.rs
+++ b/shared/src/sources/balancer/swap.rs
@@ -25,11 +25,15 @@ impl WeightedTokenState {
         self.upscale(self.token_state.balance)
     }
 
+    fn scaling_exponent_as_factor(&self) -> Option<U256> {
+        U256::from(10).checked_pow(self.token_state.scaling_exponent.into())
+    }
+
     /// Scales the input token amount to the value that is used by the Balancer
     /// contract to execute math operations.
     fn upscale(&self, amount: U256) -> Option<Bfp> {
         amount
-            .checked_mul(U256::exp10(self.token_state.scaling_exponent as usize))
+            .checked_mul(self.scaling_exponent_as_factor()?)
             .map(Bfp::from_wei)
     }
 
@@ -38,7 +42,7 @@ impl WeightedTokenState {
     fn downscale(&self, amount: Bfp) -> Option<U256> {
         amount
             .as_uint256()
-            .checked_div(U256::exp10(self.token_state.scaling_exponent as usize))
+            .checked_div(self.scaling_exponent_as_factor()?)
     }
 }
 


### PR DESCRIPTION
U256::exp10 panics if result would overflow.

### Test Plan
I do have a test that constructs a full WeightedPool to trigger this but don't think it is useful to include since the code change is obvious enough.