### PR TITLE
Add full_fee_amount column

### DIFF
--- a/database/sql/V017__add_full_fee.sql
+++ b/database/sql/V017__add_full_fee.sql
@@ -1,0 +1,11 @@
+-- 1. Add full fee column.
+-- This column is a part of order metadata. Its values are used to settle orders;
+-- they are only relevant for non-expired orders. Therefore, we can set the default
+-- to `0`, deploy an intermediate version that stores this value but never actually
+-- reads it, then wait till all the old orders are expired.
+ALTER TABLE orders
+    ADD COLUMN full_fee_amount numeric(78,0) NOT NULL DEFAULT 0;
+
+-- 2. Drop defaults.
+ALTER TABLE orders
+    ALTER COLUMN full_fee_amount DROP DEFAULT;

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -45,6 +45,7 @@ impl Default for Order {
             OrderCreation::default(),
             &DomainSeparator::default(),
             H160::default(),
+            U256::default(),
         )
         .unwrap()
     }
@@ -65,6 +66,7 @@ impl Order {
         order_creation: OrderCreation,
         domain: &DomainSeparator,
         settlement_contract: H160,
+        full_fee_amount: U256,
     ) -> Option<Self> {
         let owner = order_creation
             .signature
@@ -75,6 +77,7 @@ impl Order {
                 owner,
                 uid: order_creation.uid(domain, &owner),
                 settlement_contract,
+                full_fee_amount,
                 ..Default::default()
             },
             order_creation,
@@ -131,6 +134,11 @@ impl OrderBuilder {
 
     pub fn with_fee_amount(mut self, fee_amount: U256) -> Self {
         self.0.order_creation.fee_amount = fee_amount;
+        self
+    }
+
+    pub fn with_full_fee_amount(mut self, full_fee_amount: U256) -> Self {
+        self.0.order_meta_data.full_fee_amount = full_fee_amount;
         self
     }
 
@@ -400,6 +408,8 @@ pub struct OrderMetaData {
     pub status: OrderStatus,
     #[serde(with = "h160_hexadecimal")]
     pub settlement_contract: H160,
+    #[serde(with = "u256_decimal")]
+    pub full_fee_amount: U256,
 }
 
 impl Default for OrderMetaData {
@@ -416,6 +426,7 @@ impl Default for OrderMetaData {
             invalidated: Default::default(),
             status: OrderStatus::Open,
             settlement_contract: H160::default(),
+            full_fee_amount: U256::default(),
         }
     }
 }
@@ -608,6 +619,7 @@ mod tests {
             "validTo": 4294967295u32,
             "appData": "0x6000000000000000000000000000000000000000000000000000000000000007",
             "feeAmount": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+            "fullFeeAmount": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
             "kind": "buy",
             "partiallyFillable": false,
             "signature": "0x0200000000000000000000000000000000000000000000000000000000000003040000000000000000000000000000000000000000000000000000000000000501",
@@ -631,6 +643,7 @@ mod tests {
                 invalidated: true,
                 status: OrderStatus::Open,
                 settlement_contract: H160::from_low_u64_be(2),
+                full_fee_amount: U256::MAX,
             },
             order_creation: OrderCreation {
                 sell_token: H160::from_low_u64_be(10),

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -26,10 +26,6 @@ pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
             super::error("DuplicatedOrder", "order already exists"),
             StatusCode::BAD_REQUEST,
         ),
-        Ok(AddOrderResult::InvalidSignature) => (
-            super::error("InvalidSignature", "invalid signature"),
-            StatusCode::BAD_REQUEST,
-        ),
         Err(_) => (super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR),
     };
     warp::reply::with_status(body, status_code)

--- a/orderbook/src/api/get_fee_and_quote.rs
+++ b/orderbook/src/api/get_fee_and_quote.rs
@@ -80,11 +80,12 @@ async fn calculate_sell(
 
     // TODO: would be nice to use true sell amount after the fee but that is more complicated.
     let (fee, expiration_date) = fee_calculator
-        .min_fee(
+        .compute_unsubsidized_min_fee(
             query.sell_token,
             Some(query.buy_token),
             Some(query.sell_amount_before_fee),
             Some(OrderKind::Sell),
+            None,
         )
         .await
         .map_err(Error::PriceEstimate)?;
@@ -123,11 +124,12 @@ async fn calculate_buy(
     }
 
     let (fee, expiration_date) = fee_calculator
-        .min_fee(
+        .compute_unsubsidized_min_fee(
             query.sell_token,
             Some(query.buy_token),
             Some(query.buy_amount_after_fee),
             Some(OrderKind::Buy),
+            None,
         )
         .await
         .map_err(Error::PriceEstimate)?;
@@ -228,8 +230,8 @@ mod tests {
     fn calculate_sell_() {
         let mut fee_calculator = MockMinFeeCalculating::new();
         fee_calculator
-            .expect_min_fee()
-            .returning(|_, _, _, _| Ok((U256::from(3), Utc::now())));
+            .expect_compute_unsubsidized_min_fee()
+            .returning(|_, _, _, _, _| Ok((U256::from(3), Utc::now())));
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
             out_amount: 14.into(),
             gas: 1000.into(),
@@ -255,8 +257,8 @@ mod tests {
     fn calculate_buy_() {
         let mut fee_calculator = MockMinFeeCalculating::new();
         fee_calculator
-            .expect_min_fee()
-            .returning(|_, _, _, _| Ok((U256::from(3), Utc::now())));
+            .expect_compute_unsubsidized_min_fee()
+            .returning(|_, _, _, _, _| Ok((U256::from(3), Utc::now())));
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
             out_amount: 20.into(),
             gas: 1000.into(),

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -60,11 +60,12 @@ pub fn get_fee_info(
         async move {
             Result::<_, Infallible>::Ok(get_fee_info_response(
                 fee_calculator
-                    .min_fee(
+                    .compute_unsubsidized_min_fee(
                         query.sell_token.0,
                         Some(query.buy_token.0),
                         Some(query.amount),
                         Some(query.kind),
+                        None,
                     )
                     .await,
             ))
@@ -115,7 +116,9 @@ pub fn legacy_get_fee_info(
         let fee_calculator = fee_calculator.clone();
         async move {
             Result::<_, Infallible>::Ok(legacy_get_fee_info_response(
-                fee_calculator.min_fee(token, None, None, None).await,
+                fee_calculator
+                    .compute_unsubsidized_min_fee(token, None, None, None, None)
+                    .await,
             ))
         }
     })

--- a/orderbook/src/api/order_validation.rs
+++ b/orderbook/src/api/order_validation.rs
@@ -1,7 +1,8 @@
 use crate::{account_balances::BalanceFetching, api::WarpReplyConverting, fee::MinFeeCalculating};
 use contracts::WETH9;
 use ethcontract::{H160, U256};
-use model::order::{BuyTokenDestination, Order, SellTokenSource, BUY_ETH_ADDRESS};
+use model::order::{BuyTokenDestination, Order, OrderCreation, SellTokenSource, BUY_ETH_ADDRESS};
+use model::DomainSeparator;
 use shared::{bad_token::BadTokenDetecting, web3_traits::CodeFetching};
 use std::{sync::Arc, time::Duration};
 use warp::{http::StatusCode, reply::Json};
@@ -63,6 +64,7 @@ pub enum ValidationError {
     Partial(PartialValidationError),
     InsufficientFee,
     InsufficientFunds,
+    InvalidSignature,
     UnsupportedToken(H160),
     WrongOwner(H160),
     ZeroAmount,
@@ -92,6 +94,10 @@ impl WarpReplyConverting for ValidationError {
                     "InsufficientFunds",
                     "order owner must have funds worth at least x in his account",
                 ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::InvalidSignature => (
+                super::error("InvalidSignature", "invalid signature"),
                 StatusCode::BAD_REQUEST,
             ),
             Self::InsufficientFee => (
@@ -178,7 +184,7 @@ impl OrderValidator {
     ///     - the order validity is appropriate,
     ///     - buy_token is not the same as sell_token,
     ///     - buy and sell token destination and source are supported.
-    async fn partial_validate(&self, order: PreOrderData) -> Result<(), PartialValidationError> {
+    async fn partial_validate(&self, order: &PreOrderData) -> Result<(), PartialValidationError> {
         if self.banned_users.contains(&order.owner) {
             return Err(PartialValidationError::Forbidden);
         }
@@ -228,10 +234,35 @@ impl OrderValidator {
     /// other aspects of the order are not malformed.
     pub async fn validate(
         &self,
-        order: Order,
+        order_creation: OrderCreation,
         sender: Option<H160>,
-    ) -> Result<(), ValidationError> {
-        self.partial_validate(PreOrderData::from(order.clone()))
+        domain_separator: &DomainSeparator,
+        settlement_contract: H160,
+    ) -> Result<Order, ValidationError> {
+        let full_fee_amount = match self
+            .fee_validator
+            .get_unsubsidized_min_fee(
+                order_creation.sell_token,
+                order_creation.fee_amount,
+                Some(order_creation.app_data),
+            )
+            .await
+        {
+            Ok(full_fee_amount) => full_fee_amount,
+            Err(()) => return Err(ValidationError::InsufficientFee),
+        };
+
+        let order = match Order::from_order_creation(
+            order_creation,
+            domain_separator,
+            settlement_contract,
+            full_fee_amount,
+        ) {
+            Some(order) => order,
+            None => return Err(ValidationError::InvalidSignature),
+        };
+
+        self.partial_validate(&PreOrderData::from(order.clone()))
             .await
             .map_err(ValidationError::Partial)?;
         let order_creation = &order.order_creation;
@@ -241,17 +272,6 @@ impl OrderValidator {
         let owner = order.order_meta_data.owner;
         if matches!(sender, Some(from) if from != owner) {
             return Err(ValidationError::WrongOwner(owner));
-        }
-        if !self
-            .fee_validator
-            .is_valid_fee(
-                order_creation.sell_token,
-                order_creation.fee_amount,
-                order_creation.app_data,
-            )
-            .await
-        {
-            return Err(ValidationError::InsufficientFee);
         }
         for &token in &[order_creation.sell_token, order_creation.buy_token] {
             if !self
@@ -283,7 +303,8 @@ impl OrderValidator {
         {
             return Err(ValidationError::InsufficientFunds);
         }
-        Ok(())
+
+        Ok(order)
     }
 }
 
@@ -417,7 +438,7 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .partial_validate(PreOrderData {
+                    .partial_validate(&PreOrderData {
                         owner: H160::from_low_u64_be(1),
                         ..Default::default()
                     })
@@ -430,7 +451,7 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .partial_validate(PreOrderData {
+                    .partial_validate(&PreOrderData {
                         buy_token_balance: BuyTokenDestination::Internal,
                         ..Default::default()
                     })
@@ -443,7 +464,7 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .partial_validate(PreOrderData {
+                    .partial_validate(&PreOrderData {
                         sell_token_balance: SellTokenSource::Internal,
                         ..Default::default()
                     })
@@ -456,7 +477,7 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .partial_validate(PreOrderData {
+                    .partial_validate(&PreOrderData {
                         valid_to: 0,
                         ..Default::default()
                     })
@@ -469,7 +490,7 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .partial_validate(PreOrderData {
+                    .partial_validate(&PreOrderData {
                         valid_to: legit_valid_to,
                         buy_token: H160::from_low_u64_be(2),
                         sell_token: H160::from_low_u64_be(2),
@@ -484,7 +505,7 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .partial_validate(PreOrderData {
+                    .partial_validate(&PreOrderData {
                         valid_to: legit_valid_to,
                         buy_token: BUY_ETH_ADDRESS,
                         ..Default::default()
@@ -513,7 +534,7 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .partial_validate(PreOrderData {
+                    .partial_validate(&PreOrderData {
                         valid_to: legit_valid_to,
                         buy_token: BUY_ETH_ADDRESS,
                         ..Default::default()
@@ -538,7 +559,7 @@ mod tests {
             Arc::new(MockBalanceFetching::new()),
         );
         assert!(validator
-            .partial_validate(PreOrderData {
+            .partial_validate(&PreOrderData {
                 valid_to: shared::time::now_in_epoch_seconds()
                     + min_order_validity_period.as_secs() as u32
                     + 2,
@@ -556,12 +577,19 @@ mod tests {
         let mut bad_token_detector = MockBadTokenDetecting::new();
         let mut balance_fetcher = MockBalanceFetching::new();
         fee_calculator
-            .expect_is_valid_fee()
-            .times(1)
-            .returning(|_, _, _| false);
+            .expect_get_unsubsidized_min_fee()
+            .times(2)
+            .returning(|_, fee, _| Ok(fee));
         fee_calculator
-            .expect_is_valid_fee()
-            .returning(|_, _, _| true);
+            .expect_get_unsubsidized_min_fee()
+            .times(1)
+            .returning(|_, _, _| Err(()));
+        fee_calculator
+            .expect_get_unsubsidized_min_fee()
+            .returning(|_, fee, _| Ok(fee));
+        fee_calculator
+            .expect_get_unsubsidized_min_fee()
+            .returning(|_, fee, _| Ok(fee));
         bad_token_detector
             .expect_detect()
             .times(1)
@@ -586,67 +614,90 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let mut order = Order {
-            order_creation: OrderCreation {
-                valid_to: shared::time::now_in_epoch_seconds() + 2,
-                sell_token: H160::from_low_u64_be(1),
-                buy_token: H160::from_low_u64_be(2),
-                ..Default::default()
-            },
+        let mut order = OrderCreation {
+            valid_to: u32::MAX,
+            sell_token: H160::from_low_u64_be(1),
+            buy_token: H160::from_low_u64_be(2),
             ..Default::default()
         };
         assert_eq!(
             format!(
                 "{:?}",
-                validator.validate(order.clone(), None).await.unwrap_err()
+                validator
+                    .validate(order.clone(), None, &Default::default(), Default::default())
+                    .await
+                    .unwrap_err()
             ),
             "ZeroAmount"
         );
-        order.order_creation.buy_amount = U256::from(1);
-        order.order_creation.sell_amount = U256::from(1);
+        order.buy_amount = U256::from(1);
+        order.sell_amount = U256::from(1);
         assert_eq!(
             format!(
                 "{:?}",
                 validator
-                    .validate(order.clone(), Some(H160::from_low_u64_be(1)))
+                    .validate(
+                        order.clone(),
+                        Some(H160::from_low_u64_be(1),),
+                        &Default::default(),
+                        Default::default(),
+                    )
                     .await
                     .unwrap_err()
             ),
-            "WrongOwner(0x7e5f4552091a69125d5dfcb7b8c2659029395bdf)"
+            "WrongOwner(0x6baa5220f0e9b79b9bd1d2be31bcd641a5b283d0)"
         );
         assert_eq!(
             format!(
                 "{:?}",
-                validator.validate(order.clone(), None).await.unwrap_err()
+                validator
+                    .validate(order.clone(), None, &Default::default(), Default::default())
+                    .await
+                    .unwrap_err()
             ),
             "InsufficientFee"
         );
         assert_eq!(
             format!(
                 "{:?}",
-                validator.validate(order.clone(), None).await.unwrap_err()
+                validator
+                    .validate(order.clone(), None, &Default::default(), Default::default())
+                    .await
+                    .unwrap_err()
             ),
             "Other(failed to detect token)"
         );
         assert_eq!(
             format!(
                 "{:?}",
-                validator.validate(order.clone(), None).await.unwrap_err()
+                validator
+                    .validate(order.clone(), None, &Default::default(), Default::default())
+                    .await
+                    .unwrap_err()
             ),
             "UnsupportedToken(0x0000000000000000000000000000000000000001)"
         );
-        order.order_creation.sell_amount = U256::MAX;
-        order.order_creation.fee_amount = U256::from(1);
+        order.sell_amount = U256::MAX;
+        order.fee_amount = U256::from(1);
         assert_eq!(
             format!(
                 "{:?}",
-                validator.validate(order.clone(), None).await.unwrap_err()
+                validator
+                    .validate(order.clone(), None, &Default::default(), Default::default())
+                    .await
+                    .unwrap_err()
             ),
             "InsufficientFunds"
         );
-        order.order_creation.sell_amount = U256::from(1);
+        order.sell_amount = U256::from(1);
         assert_eq!(
-            format!("{:?}", validator.validate(order, None).await.unwrap_err()),
+            format!(
+                "{:?}",
+                validator
+                    .validate(order, None, &Default::default(), Default::default())
+                    .await
+                    .unwrap_err()
+            ),
             "InsufficientFunds"
         );
     }
@@ -657,8 +708,8 @@ mod tests {
         let mut bad_token_detector = MockBadTokenDetecting::new();
         let mut balance_fetcher = MockBalanceFetching::new();
         fee_calculator
-            .expect_is_valid_fee()
-            .returning(|_, _, _| true);
+            .expect_get_unsubsidized_min_fee()
+            .returning(|_, fee, _| Ok(fee));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -674,17 +725,21 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let order = Order {
-            order_creation: OrderCreation {
-                valid_to: shared::time::now_in_epoch_seconds() + 2,
-                sell_token: H160::from_low_u64_be(1),
-                buy_token: H160::from_low_u64_be(2),
-                buy_amount: U256::from(1),
-                sell_amount: U256::from(1),
-                ..Default::default()
-            },
+        let order = OrderCreation {
+            valid_to: shared::time::now_in_epoch_seconds() + 2,
+            sell_token: H160::from_low_u64_be(1),
+            buy_token: H160::from_low_u64_be(2),
+            buy_amount: U256::from(1),
+            sell_amount: U256::from(1),
             ..Default::default()
         };
-        assert!(validator.validate(order, None).await.is_ok());
+        let order = validator
+            .validate(order, None, &Default::default(), Default::default())
+            .await
+            .unwrap();
+        assert_eq!(
+            order.order_meta_data.full_fee_amount,
+            order.order_creation.fee_amount
+        );
     }
 }

--- a/orderbook/src/api/order_validation.rs
+++ b/orderbook/src/api/order_validation.rs
@@ -206,7 +206,7 @@ impl OrderValidator {
         {
             return Err(PartialValidationError::InsufficientValidTo);
         }
-        if has_same_buy_and_sell_token(&order, &self.native_token) {
+        if has_same_buy_and_sell_token(order, &self.native_token) {
             return Err(PartialValidationError::SameBuyAndSellToken);
         }
         if order.buy_token == BUY_ETH_ADDRESS {

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -191,8 +191,8 @@ impl From<sqlx::Error> for InsertionError {
 // current amount of data this wouldn't be better.
 const ORDERS_SELECT: &str = "\
     o.uid, o.owner, o.creation_timestamp, o.sell_token, o.buy_token, o.sell_amount, o.buy_amount, \
-    o.valid_to, o.app_data, o.fee_amount, o.kind, o.partially_fillable, o.signature, o.receiver, \
-    o.signing_scheme, o.settlement_contract, o.sell_token_balance, o.buy_token_balance, \
+    o.valid_to, o.app_data, o.fee_amount, o.full_fee_amount, o.kind, o.partially_fillable, o.signature, \
+    o.receiver, o.signing_scheme, o.settlement_contract, o.sell_token_balance, o.buy_token_balance, \
     (SELECT COALESCE(SUM(t.buy_amount), 0) FROM trades t WHERE t.order_uid = o.uid) AS sum_buy, \
     (SELECT COALESCE(SUM(t.sell_amount), 0) FROM trades t WHERE t.order_uid = o.uid) AS sum_sell, \
     (SELECT COALESCE(SUM(t.fee_amount), 0) FROM trades t WHERE t.order_uid = o.uid) AS sum_fee, \
@@ -219,8 +219,8 @@ impl OrderStoring for Postgres {
             INSERT INTO orders (
                 uid, owner, creation_timestamp, sell_token, buy_token, receiver, sell_amount, buy_amount, \
                 valid_to, app_data, fee_amount, kind, partially_fillable, signature, signing_scheme, \
-                settlement_contract, sell_token_balance, buy_token_balance) \
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18);";
+                settlement_contract, sell_token_balance, buy_token_balance, full_fee_amount) \
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19);";
         let receiver = order
             .order_creation
             .receiver
@@ -250,6 +250,7 @@ impl OrderStoring for Postgres {
             .bind(DbBuyTokenDestination::from(
                 order.order_creation.buy_token_balance,
             ))
+            .bind(u256_to_big_decimal(&order.order_meta_data.full_fee_amount))
             .execute(&self.pool)
             .await
             .map(|_| ())
@@ -406,6 +407,7 @@ struct OrdersQueryRow {
     valid_to: i64,
     app_data: Vec<u8>,
     fee_amount: BigDecimal,
+    full_fee_amount: BigDecimal,
     kind: DbOrderKind,
     partially_fillable: bool,
     signature: Vec<u8>,
@@ -473,6 +475,8 @@ impl OrdersQueryRow {
             invalidated: self.invalidated,
             status,
             settlement_contract: h160_from_vec(self.settlement_contract)?,
+            full_fee_amount: big_decimal_to_u256(&self.full_fee_amount)
+                .ok_or_else(|| anyhow!("full_fee_amount is not U256"))?,
         };
         let signing_scheme = self.signing_scheme.into();
         let order_creation = OrderCreation {
@@ -490,7 +494,7 @@ impl OrdersQueryRow {
                     .map_err(|_| anyhow!("app_data is not [u8; 32]"))?,
             ),
             fee_amount: big_decimal_to_u256(&self.fee_amount)
-                .ok_or_else(|| anyhow!("buy_amount is not U256"))?,
+                .ok_or_else(|| anyhow!("fee_amount is not U256"))?,
             kind: self.kind.into(),
             partially_fillable: self.partially_fillable,
             signature: Signature::from_bytes(signing_scheme, &self.signature)?,
@@ -549,6 +553,7 @@ mod tests {
             valid_to: valid_to_timestamp.timestamp(),
             app_data: vec![0; 32],
             fee_amount: BigDecimal::default(),
+            full_fee_amount: BigDecimal::default(),
             kind: DbOrderKind::Sell,
             partially_fillable: true,
             signature: vec![0; 65],

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -39,20 +39,28 @@ pub struct MinFeeCalculator {
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait MinFeeCalculating: Send + Sync {
-    // Returns the minimum amount of fee required to accept an order selling the specified order
-    // and an expiry date for the estimate.
-    // Returns an error if there is some estimation error and Ok(None) if no information about the given
-    // token exists
-    async fn min_fee(
+    /// Returns the minimum amount of fee required to accept an order selling the specified order
+    /// and an expiry date for the estimate.
+    /// Returns an error if there is some estimation error and Ok(None) if no information about the given
+    /// token exists
+    async fn compute_unsubsidized_min_fee(
         &self,
         sell_token: H160,
         buy_token: Option<H160>,
         amount: Option<U256>,
         kind: Option<OrderKind>,
+        app_data: Option<AppId>,
     ) -> Result<Measurement, PriceEstimationError>;
 
-    // Returns true if the fee satisfies a previous not yet expired estimate, or the fee is high enough given the current estimate.
-    async fn is_valid_fee(&self, sell_token: H160, fee: U256, app_data: AppId) -> bool;
+    /// Validates that the given subsidized fee is enough to process an order for the given token.
+    /// Returns current fee estimate (i.e., unsubsidized fee) if the given subsidized fee passes
+    /// a check. Returns `Err` if the check failed.
+    async fn get_unsubsidized_min_fee(
+        &self,
+        sell_token: H160,
+        fee: U256,
+        app_data: Option<AppId>,
+    ) -> Result<U256, ()>;
 }
 
 #[async_trait::async_trait]
@@ -128,26 +136,33 @@ impl<T> MinFeeCalculating for EthAdapter<T>
 where
     T: MinFeeCalculating + Send + Sync,
 {
-    async fn min_fee(
+    async fn compute_unsubsidized_min_fee(
         &self,
         sell_token: H160,
         buy_token: Option<H160>,
         amount: Option<U256>,
         kind: Option<OrderKind>,
+        app_data: Option<AppId>,
     ) -> Result<Measurement, PriceEstimationError> {
         self.calculator
-            .min_fee(
+            .compute_unsubsidized_min_fee(
                 sell_token,
                 buy_token.map(|token| normalize_buy_token(token, self.weth)),
                 amount,
                 kind,
+                app_data,
             )
             .await
     }
 
-    async fn is_valid_fee(&self, sell_token: H160, fee: U256, app_data: AppId) -> bool {
+    async fn get_unsubsidized_min_fee(
+        &self,
+        sell_token: H160,
+        fee: U256,
+        app_data: Option<AppId>,
+    ) -> Result<U256, ()> {
         self.calculator
-            .is_valid_fee(sell_token, fee, app_data)
+            .get_unsubsidized_min_fee(sell_token, fee, app_data)
             .await
     }
 }
@@ -177,6 +192,7 @@ impl MinFeeCalculator {
         }
     }
 
+    /// Computes unsubsidized min fee.
     async fn compute_min_fee(
         &self,
         sell_token: H160,
@@ -198,7 +214,6 @@ impl MinFeeCalculator {
                     .await?
                     .gas
                     .to_f64_lossy()
-                    * self.fee_factor
             } else {
                 GAS_PER_ORDER
             };
@@ -213,20 +228,28 @@ impl MinFeeCalculator {
         let price = estimate.price_in_sell_token_f64(&query);
         Ok(U256::from_f64_lossy(fee_in_eth * price))
     }
+
+    fn calculate_fee_factor(&self, app_data: Option<AppId>) -> f64 {
+        app_data
+            .and_then(|app_data| self.partner_additional_fee_factors.get(&app_data).cloned())
+            .unwrap_or(1.0)
+            * self.fee_factor
+    }
+
+    fn apply_fee_factor(fee: U256, factor: f64) -> U256 {
+        U256::from_f64_lossy(fee.to_f64_lossy() * factor)
+    }
 }
 
 #[async_trait::async_trait]
 impl MinFeeCalculating for MinFeeCalculator {
-    // Returns the minimum amount of fee required to accept an order selling the specified order
-    // and an expiry date for the estimate.
-    // Returns an error if there is some estimation error and Ok(None) if no information about the given
-    // token exists
-    async fn min_fee(
+    async fn compute_unsubsidized_min_fee(
         &self,
         sell_token: H160,
         buy_token: Option<H160>,
         amount: Option<U256>,
         kind: Option<OrderKind>,
+        app_data: Option<AppId>,
     ) -> Result<Measurement, PriceEstimationError> {
         ensure_token_supported(sell_token, self.bad_token_detector.as_ref()).await?;
         if let Some(buy_token) = buy_token {
@@ -260,34 +283,40 @@ impl MinFeeCalculating for MinFeeCalculator {
                 min_fee,
             )
             .await;
-        Ok((min_fee, official_valid_until))
+
+        let fee_factor = self.calculate_fee_factor(app_data);
+        Ok((
+            Self::apply_fee_factor(min_fee, fee_factor),
+            official_valid_until,
+        ))
     }
 
-    // Returns true if the fee satisfies a previous not yet expired estimate, or the fee is high enough given the current estimate.
-    async fn is_valid_fee(&self, sell_token: H160, fee: U256, app_data: AppId) -> bool {
-        let app_based_fee_factor = *self
-            .partner_additional_fee_factors
-            .get(&app_data)
-            .unwrap_or(&1.0);
+    async fn get_unsubsidized_min_fee(
+        &self,
+        sell_token: H160,
+        fee: U256,
+        app_data: Option<AppId>,
+    ) -> Result<U256, ()> {
+        let fee_factor = self.calculate_fee_factor(app_data);
 
         if let Ok(Some(past_fee)) = self
             .measurements
             .get_min_fee(sell_token, None, None, None, (self.now)())
             .await
         {
-            if fee >= apply_fee_factor(past_fee, app_based_fee_factor) {
-                return true;
+            if fee >= Self::apply_fee_factor(past_fee, fee_factor) {
+                return Ok(std::cmp::max(fee, past_fee));
             }
         }
-        if let Ok(current_fee) = self.compute_min_fee(sell_token, None, None, None).await {
-            return fee >= apply_fee_factor(current_fee, app_based_fee_factor);
-        }
-        false
-    }
-}
 
-fn apply_fee_factor(fee: U256, factor: f64) -> U256 {
-    U256::from_f64_lossy(fee.to_f64_lossy() * factor)
+        if let Ok(current_fee) = self.compute_min_fee(sell_token, None, None, None).await {
+            if fee >= Self::apply_fee_factor(current_fee, fee_factor) {
+                return Ok(std::cmp::max(fee, current_fee));
+            }
+        }
+
+        Err(())
+    }
 }
 
 struct FeeMeasurement {
@@ -373,15 +402,16 @@ mod tests {
         let token = H160([0x21; 20]);
         let mut calculator = MockMinFeeCalculating::default();
         calculator
-            .expect_min_fee()
-            .withf(move |&sell_token, &buy_token, &amount, &kind| {
+            .expect_compute_unsubsidized_min_fee()
+            .withf(move |&sell_token, &buy_token, &amount, &kind, &app_data| {
                 sell_token == token
                     && buy_token == Some(weth)
                     && amount == Some(1337.into())
                     && kind == Some(OrderKind::Sell)
+                    && app_data == None
             })
             .times(1)
-            .returning(|_, _, _, _| {
+            .returning(|_, _, _, _, _| {
                 Ok((
                     0.into(),
                     DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
@@ -390,11 +420,12 @@ mod tests {
 
         let eth_aware = EthAdapter { calculator, weth };
         assert!(eth_aware
-            .min_fee(
+            .compute_unsubsidized_min_fee(
                 token,
                 Some(BUY_ETH_ADDRESS),
                 Some(1337.into()),
-                Some(OrderKind::Sell)
+                Some(OrderKind::Sell),
+                None,
             )
             .await
             .is_ok());
@@ -406,18 +437,19 @@ mod tests {
         let token = H160([0x21; 20]);
         let mut calculator = MockMinFeeCalculating::default();
         calculator
-            .expect_is_valid_fee()
+            .expect_get_unsubsidized_min_fee()
             .withf(move |&sell_token, &fee, &app_data| {
-                sell_token == token && fee == 42.into() && app_data == AppId([0; 32])
+                sell_token == token && fee == 42.into() && app_data == Default::default()
             })
             .times(1)
-            .returning(|_, _, _| true);
+            .returning(|_, fee, _| Ok(fee));
 
         let eth_aware = EthAdapter { calculator, weth };
-        assert!(
+        assert_eq!(
             eth_aware
-                .is_valid_fee(token, 42.into(), AppId::default())
-                .await
+                .get_unsubsidized_min_fee(token, 42.into(), Default::default())
+                .await,
+            Ok(42.into())
         );
     }
 
@@ -462,20 +494,25 @@ mod tests {
 
         let token = H160::from_low_u64_be(1);
         let (fee, expiry) = fee_estimator
-            .min_fee(token, None, None, None)
+            .compute_unsubsidized_min_fee(token, None, None, None, None)
             .await
             .unwrap();
-        let app_data = AppId::default();
         // Gas price increase after measurement
         *gas_price.lock().unwrap() *= 2.0;
 
         // fee is valid before expiry
         *time.lock().unwrap() = expiry - Duration::seconds(10);
-        assert!(fee_estimator.is_valid_fee(token, fee, app_data).await);
+        assert!(fee_estimator
+            .get_unsubsidized_min_fee(token, fee, None)
+            .await
+            .is_ok());
 
         // fee is invalid for some uncached token
         let token = H160::from_low_u64_be(2);
-        assert!(!fee_estimator.is_valid_fee(token, fee, app_data).await);
+        assert!(!fee_estimator
+            .get_unsubsidized_min_fee(token, fee, None)
+            .await
+            .is_ok());
     }
 
     #[tokio::test]
@@ -496,19 +533,24 @@ mod tests {
 
         let token = H160::from_low_u64_be(1);
         let (fee, _) = fee_estimator
-            .min_fee(token, None, None, None)
+            .compute_unsubsidized_min_fee(token, None, None, None, None)
             .await
             .unwrap();
 
         dbg!(fee);
         let lower_fee = fee - U256::one();
-        let app_data = AppId::default();
         // slightly lower fee is not valid
-        assert!(!fee_estimator.is_valid_fee(token, lower_fee, app_data).await);
+        assert!(fee_estimator
+            .get_unsubsidized_min_fee(token, lower_fee, None)
+            .await
+            .is_err());
 
         // Gas price reduces, and slightly lower fee is now valid
         *gas_price.lock().unwrap() /= 2.0;
-        assert!(fee_estimator.is_valid_fee(token, lower_fee, app_data).await);
+        assert!(fee_estimator
+            .get_unsubsidized_min_fee(token, lower_fee, None)
+            .await
+            .is_ok());
     }
 
     #[tokio::test]
@@ -537,11 +579,12 @@ mod tests {
         // Selling unsupported token
         assert!(matches!(
             fee_estimator
-                .min_fee(
+                .compute_unsubsidized_min_fee(
                     unsupported_token,
                     Some(supported_token),
                     Some(100.into()),
-                    Some(OrderKind::Sell)
+                    Some(OrderKind::Sell),
+                    None,
                 )
                 .await,
             Err(PriceEstimationError::UnsupportedToken(t)) if t == unsupported_token
@@ -550,11 +593,12 @@ mod tests {
         // Buying unsupported token
         assert!(matches!(
             fee_estimator
-                .min_fee(
+                .compute_unsubsidized_min_fee(
                     supported_token,
                     Some(unsupported_token),
                     Some(100.into()),
-                    Some(OrderKind::Sell)
+                    Some(OrderKind::Sell),
+                    None,
                 )
                 .await,
             Err(PriceEstimationError::UnsupportedToken(t)) if t == unsupported_token
@@ -583,20 +627,23 @@ mod tests {
             native_token_price_estimation_amount: 1.into(),
         };
         let (fee, _) = fee_estimator
-            .min_fee(sell_token, None, None, None)
+            .compute_unsubsidized_min_fee(sell_token, None, None, None, Some(app_data))
             .await
             .unwrap();
-        let lower_fee = fee - U256::one();
-        assert!(
+        assert_eq!(
             fee_estimator
-                .is_valid_fee(sell_token, lower_fee, app_data)
-                .await
+                .get_unsubsidized_min_fee(sell_token, fee, Some(app_data))
+                .await,
+            Ok(fee * 2)
         );
-        let half_lower_fee = lower_fee / U256::from(2);
-        assert!(
-            !fee_estimator
-                .is_valid_fee(sell_token, half_lower_fee, app_data)
-                .await
-        );
+        assert!(fee_estimator
+            .get_unsubsidized_min_fee(sell_token, fee, None)
+            .await
+            .is_err());
+        let lower_fee = fee - U256::one();
+        assert!(fee_estimator
+            .get_unsubsidized_min_fee(sell_token, lower_fee, Some(app_data))
+            .await
+            .is_err());
     }
 }

--- a/solver/src/liquidity/offchain_orderbook.rs
+++ b/solver/src/liquidity/offchain_orderbook.rs
@@ -291,6 +291,7 @@ pub mod tests {
             },
             &DomainSeparator::default(),
             H160::default(),
+            U256::default(),
         )
         .unwrap();
         assert!(inflight_order_filter(
@@ -309,6 +310,7 @@ pub mod tests {
             },
             &DomainSeparator::default(),
             H160::default(),
+            U256::default(),
         )
         .unwrap();
         let adjusted_order = inflight_order_filter(


### PR DESCRIPTION
Fixes #1162

Step 1 of per-order fee computation. First, we save the original unsubsidized fee to the database, so we can use it later.

The database column is non-null, and set to be `0` for all existing orders. The idea here is to release a version that writes `full_fee_amount` but never reads it. After the release, we wait till all orders without `full_fee_amount` are either setteled or expired. Then we release a full version.

For now, the unsubsidized fee computation and validation logic is simple, we will change it later.

### Test Plan
Unit tests are in progress.
