### PR TITLE
Fix flaky test

### DIFF
--- a/solver/src/settlement/settlement_encoder.rs
+++ b/solver/src/settlement/settlement_encoder.rs
@@ -548,7 +548,7 @@ pub mod tests {
     fn merge_fails_because_price_is_different() {
         let prices = hashmap! { token(1) => 1.into(), token(2) => 2.into() };
         let encoder0 = SettlementEncoder::new(prices);
-        let prices = hashmap! { token(1) => 1.into(), token(2) => 3.into() };
+        let prices = hashmap! { token(1) => 1.into(), token(2) => 4.into() };
         let encoder1 = SettlementEncoder::new(prices);
         assert!(encoder0.merge(encoder1).is_err());
     }


### PR DESCRIPTION
Taken from https://github.com/gnosis/gp-v2-services/pull/1168/files so that it can be merged earlier.

> It's fixing a flaky unit test. Depending on the order we iterate over the hashset we may scale token 1 (scale factor 1, test works as expected) or scale token 2 (scale factor 3/2 which when multiplied with 1 results in 1, so the merge doesn't fail as expected).

### Test Plan
CI
