### PR TITLE
Store weighted pool fee as Bfp instead of BigRational

### DIFF
--- a/shared/src/baseline_solver.rs
+++ b/shared/src/baseline_solver.rs
@@ -10,6 +10,11 @@ const DEFAULT_MAX_HOPS: usize = 2;
 
 type PathCandidate = Vec<H160>;
 
+/// Note that get_amount_out and get_amount_in are not always symmetrical. That is for some AMMs it
+/// is possible that get_amount_out returns an amount for which get_amount_in returns None when
+/// trying to go the reverse direction. Or that the resulting amount is different from the original.
+/// This situation is rare and resulting amounts should usually be identical or very close but it
+/// can occur.
 pub trait BaselineSolvable {
     // Given the desired output token, the amount and token input, return the expected amount of output token.
     fn get_amount_out(&self, out_token: H160, input: (U256, H160)) -> Option<U256>;

--- a/shared/src/sources/balancer/swap.rs
+++ b/shared/src/sources/balancer/swap.rs
@@ -69,7 +69,7 @@ impl WeightedPoolRef<'_> {
             .map(|amount_without_fees| amount_without_fees.as_uint256())
     }
 
-    fn unchecked_get_amount_in(
+    fn get_amount_in_(
         &self,
         in_token: H160,
         (out_amount, out_token): (U256, H160),
@@ -94,18 +94,7 @@ impl WeightedPoolRef<'_> {
         self.add_swap_fee_amount(amount_in_before_fee).ok()
     }
 
-    fn checked_get_amount_in(
-        &self,
-        in_token: H160,
-        (out_amount, out_token): (U256, H160),
-    ) -> Option<U256> {
-        let in_amount = self.unchecked_get_amount_in(in_token, (out_amount, out_token))?;
-        // We double check that resulting amount in can symmetrically provide an amount out.
-        self.unchecked_get_amount_out(out_token, (in_amount, in_token))?;
-        Some(in_amount)
-    }
-
-    fn unchecked_get_amount_out(
+    fn get_amount_out_(
         &self,
         out_token: H160,
         (in_amount, in_token): (U256, H160),
@@ -129,26 +118,15 @@ impl WeightedPoolRef<'_> {
         .map(|bfp| out_reserves.downscale(bfp))
         .flatten()
     }
-
-    fn checked_get_amount_out(
-        &self,
-        out_token: H160,
-        (in_amount, in_token): (U256, H160),
-    ) -> Option<U256> {
-        let out_amount = self.unchecked_get_amount_out(out_token, (in_amount, in_token))?;
-        // We double check that resulting amount out can symmetrically provide an amount in.
-        self.unchecked_get_amount_in(in_token, (out_amount, out_token))?;
-        Some(out_amount)
-    }
 }
 
 impl BaselineSolvable for WeightedPoolRef<'_> {
     fn get_amount_out(&self, out_token: H160, (in_amount, in_token): (U256, H160)) -> Option<U256> {
-        self.checked_get_amount_out(out_token, (in_amount, in_token))
+        self.get_amount_out_(out_token, (in_amount, in_token))
     }
 
     fn get_amount_in(&self, in_token: H160, (out_amount, out_token): (U256, H160)) -> Option<U256> {
-        self.checked_get_amount_in(in_token, (out_amount, out_token))
+        self.get_amount_in_(in_token, (out_amount, out_token))
     }
 
     fn get_spot_price(&self, base_token: H160, quote_token: H160) -> Option<BigRational> {

--- a/solver/src/liquidity.rs
+++ b/solver/src/liquidity.rs
@@ -12,8 +12,9 @@ use model::order::Order;
 use model::{order::OrderKind, TokenPair};
 use num::{rational::Ratio, BigRational};
 use primitive_types::{H160, U256};
-use shared::sources::balancer::pool_fetching::{
-    AmplificationParameter, TokenState, WeightedTokenState,
+use shared::sources::balancer::{
+    pool_fetching::{AmplificationParameter, TokenState, WeightedTokenState},
+    swap::fixed_point::Bfp,
 };
 #[cfg(test)]
 use shared::sources::uniswap::pool_fetching::Pool;
@@ -165,7 +166,7 @@ impl From<Pool> for ConstantProductOrder {
 #[cfg_attr(test, derivative(PartialEq))]
 pub struct WeightedProductOrder {
     pub reserves: HashMap<H160, WeightedTokenState>,
-    pub fee: BigRational,
+    pub fee: Bfp,
     #[cfg_attr(test, derivative(PartialEq = "ignore"))]
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
 }
@@ -263,7 +264,7 @@ impl Default for WeightedProductOrder {
     fn default() -> Self {
         WeightedProductOrder {
             reserves: Default::default(),
-            fee: num::Zero::zero(),
+            fee: Bfp::zero(),
             settlement_handling: tests::CapturingSettlementHandler::arc(),
         }
     }

--- a/solver/src/liquidity/balancer.rs
+++ b/solver/src/liquidity/balancer.rs
@@ -86,7 +86,7 @@ impl BalancerV2Liquidity {
             .into_iter()
             .map(|pool| WeightedProductOrder {
                 reserves: pool.reserves,
-                fee: pool.common.swap_fee_percentage.into(),
+                fee: pool.common.swap_fee_percentage,
                 settlement_handling: Arc::new(SettlementHandler {
                     pool_id: pool.common.pool_id,
                     contracts: self.contracts.clone(),
@@ -350,17 +350,11 @@ mod tests {
 
         assert_eq!(
             (&weighted_orders[0].reserves, &weighted_orders[0].fee),
-            (
-                &weighted_pools[0].reserves,
-                &BigRational::new(2.into(), 1000.into())
-            ),
+            (&weighted_pools[0].reserves, &"0.002".parse().unwrap()),
         );
         assert_eq!(
             (&weighted_orders[1].reserves, &weighted_orders[1].fee),
-            (
-                &weighted_pools[1].reserves,
-                &BigRational::new(1.into(), 1000.into())
-            ),
+            (&weighted_pools[1].reserves, &"0.001".parse().unwrap()),
         );
         assert_eq!(
             (&stable_orders[0].reserves, &stable_orders[0].fee),

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -451,7 +451,7 @@ fn amm_models(liquidity: &[Liquidity], gas_model: &GasModel) -> BTreeMap<usize, 
                             })
                             .collect(),
                     }),
-                    fee: amm.fee.clone(),
+                    fee: amm.fee.into(),
                     cost: gas_model.balancer_cost(),
                     mandatory: false,
                 },

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -229,7 +229,7 @@ mod tests {
                         weight: Bfp::from(800_000_000_000_000_000),
                     }
                 },
-                fee: BigRational::new(3.into(), 1.into()),
+                fee: "0.03".parse().unwrap(),
                 settlement_handling: wp_amm_handler.clone(),
             }),
             Liquidity::BalancerStable(StablePoolOrder {
@@ -364,7 +364,7 @@ mod tests {
                     weight: Bfp::from(500_000_000_000_000_000),
                 }
             },
-            fee: BigRational::new(1.into(), 1000.into()),
+            fee: "0.001".parse().unwrap(),
             settlement_handling: CapturingSettlementHandler::arc(),
         };
 


### PR DESCRIPTION
WeightedProductOrder::fee was stored as BigRational. Now it is stored as
Bfp. This an improvement because underlying value is always a Bfp but
BigRational can store a superset of numbers so by switching to Bfp we
prevent illegal values from making their way into the value.
For example in amm_to_weighted_pool we were converting back to Bfp which
had to use try_into because it could fail. Now no failure is possible.

### Test Plan
CI
