### PR TITLE
Use Muslrust with OpenSSL 1.1

### DIFF
--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -6,21 +6,17 @@ COPY . .
 RUN env CARGO_PROFILE_RELEASE_DEBUG=1 cargo build --target x86_64-unknown-linux-musl --release
 
 RUN \
-  cd .. && \
-  git clone https://github.com/gnosis/regex-stream-split.git && \
-  cd regex-stream-split && \
-  git checkout edc88224612b9e151c334fa6d3a7d20575d83836 && \
-  cargo build --target x86_64-unknown-linux-musl --release
+    cd .. && \
+    git clone https://github.com/gnosis/regex-stream-split.git && \
+    cd regex-stream-split && \
+    git checkout edc88224612b9e151c334fa6d3a7d20575d83836 && \
+    cargo build --target x86_64-unknown-linux-musl --release
 
 # Extract Binary
 FROM docker.io/alpine:latest
 
 # Handle signal handlers properly
-RUN apk add --no-cache tini ca-certificates && update-ca-certificates
-
-# Remove outdated certificates
-RUN rm etc/ssl/certs/ca-certificates.crt etc/ssl/certs/ca-cert-DST_Root_CA_X3.pem
-
+RUN apk add --no-cache tini
 COPY --from=cargo-build /usr/src/regex-stream-split/target/x86_64-unknown-linux-musl/release/regex-stream-split /usr/local/bin/regex-stream-split
 COPY --from=cargo-build /usr/src/oba-services/target/x86_64-unknown-linux-musl/release/orderbook /usr/local/bin/orderbook
 COPY --from=cargo-build /usr/src/oba-services/target/x86_64-unknown-linux-musl/release/solver /usr/local/bin/solver

--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -1,4 +1,4 @@
-FROM docker.io/clux/muslrust:stable as cargo-build
+FROM docker.io/clux/muslrust:1.55.0-openssl11 as cargo-build
 WORKDIR /usr/src/oba-services
 
 # Copy and Build Code


### PR DESCRIPTION
This PR changes our docker image to build with OpenSSL > 1.1.

This should resolve the DST certificate expiry issues that we have been seeing. Additionally, this reverts the manual certificate update that was previously done.

### Test Plan

1. Build the new image:
    ```
    docker build . -f docker/Dockerfile.binary -t gnosispm/gp-v2-services
    ```
2. Run the image with 0x and ParaSwap solvers to check that `reqwest` can make HTTPS requests
    ```
    podman run -it --rm gnosispm/gp-v2-services solver \
      --node-url "https://mainnet.infura.io/v3/$INFURA_PROJECT_ID" \
      --private-key $PRIVATE_KEY \
      --orderbook-url https://protocol-mainnet.gnosis.io \
      --solvers Paraswap,ZeroEx \
      --transaction-strategy DryRun
    ```
3. See that they both find solutions:
    ```
    2021-10-01T08:15:33.936Z DEBUG solver::driver: solver ParaSwap found solution:
    ...
    2021-10-01T08:15:33.937Z DEBUG solver::driver: solver 0x found solution:
    ...
    ```
