### PR TITLE
[OnCall] Don't error when estimating price for zero amounts

### DIFF
--- a/shared/src/price_estimation/baseline.rs
+++ b/shared/src/price_estimation/baseline.rs
@@ -137,7 +137,7 @@ impl BaselinePriceEstimator {
             return Ok((Vec::new(), query.in_amount));
         }
         if query.in_amount.is_zero() {
-            return Ok((Vec::new(), U256::zero()));
+            return Err(PriceEstimationError::ZeroAmount);
         }
         match query.kind {
             OrderKind::Buy => {

--- a/shared/src/price_estimation/baseline.rs
+++ b/shared/src/price_estimation/baseline.rs
@@ -5,7 +5,7 @@ use crate::{
     recent_block_cache::Block,
     sources::uniswap::pool_fetching::{Pool, PoolFetching},
 };
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use ethcontract::{H160, U256};
 use gas_estimation::GasPriceEstimating;
 use model::{order::OrderKind, TokenPair};
@@ -137,7 +137,7 @@ impl BaselinePriceEstimator {
             return Ok((Vec::new(), query.in_amount));
         }
         if query.in_amount.is_zero() {
-            return Err(anyhow!("Attempt to estimate price of a trade with zero amount.").into());
+            return Ok((Vec::new(), U256::zero()));
         }
         match query.kind {
             OrderKind::Buy => {


### PR DESCRIPTION
We are getting a lot of alerts like https://gnosisinc.slack.com/archives/CQZBU9T5J/p1633190571003100. I assume that these queries are coming from our trading bot (in particular when doing the reverse checked added in https://github.com/gnosis/gp-v2-trading-bot/pull/31

Since we don't control what clients request from us, we should probably not error when a clients wants to get an estimate for a zero amount.

Arguably we could also filter these kind of requests at a higher layer and not even forward them into the price estimator (happy to change to that if that's preferred).

### Test Plan
Existing unit tests (should I add one for this branch?)

Access:

- http://localhost:8080/api/v1/fee?sellToken=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&buyToken=0x8798249c2e607446efb7ad49ec89dd1865ff4272&amount=0&kind=buy
- http://localhost:8080/api/v1/markets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48-0xdAC17F958D2ee523a2206206994597C13D831ec7/buy/0
- http://localhost:8080/api/v1/markets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48-0xdAC17F958D2ee523a2206206994597C13D831ec7/sell/0

For all of them expect:

> {"errorType":"InvalidAmount","description":"invalid trade amount"}

and no error logs in console
