### PR TITLE
Update Paraswap Solver Errors

### DIFF
--- a/shared/src/paraswap_api.rs
+++ b/shared/src/paraswap_api.rs
@@ -57,6 +57,8 @@ impl ParaswapApi for DefaultParaswapApi {
                 "ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT" => {
                     Err(ParaswapResponseError::TooMuchSlippageOnQuote)
                 }
+                "Server is too busy" => Err(ParaswapResponseError::ServerBusy),
+                "Bad USD price" => Err(ParaswapResponseError::ComputePrice(message)),
                 _ => Err(ParaswapResponseError::UnknownParaswapError(format!(
                     "uncatalogued Price Query error message {}",
                     message
@@ -119,6 +121,9 @@ pub enum ParaswapResponseError {
     #[error("Error getParaSwapPool - From Price Route {0}")]
     GetParaswapPool(String),
 
+    #[error("Server is too busy")]
+    ServerBusy,
+
     // Connectivity or non-response error
     #[error("Failed on send")]
     Send(reqwest::Error),
@@ -153,6 +158,10 @@ fn parse_paraswap_response_text(
             "Error getParaSwapPool" => Err(ParaswapResponseError::GetParaswapPool(
                 query_str.parse().unwrap(),
             )),
+            "Unable to process the transaction" => {
+                Err(ParaswapResponseError::BuildingTransaction(message))
+            }
+            "Server is too busy" => Err(ParaswapResponseError::ServerBusy),
             _ => Err(ParaswapResponseError::UnknownParaswapError(format!(
                 "uncatalogued error message {}",
                 message

--- a/solver/src/solver/paraswap_solver.rs
+++ b/solver/src/solver/paraswap_solver.rs
@@ -77,7 +77,9 @@ impl From<ParaswapResponseError> for SettlementError {
                 err,
                 ParaswapResponseError::PriceChange
                     | ParaswapResponseError::BuildingTransaction(_)
-                    | ParaswapResponseError::GetParaswapPool(_),
+                    | ParaswapResponseError::GetParaswapPool(_)
+                    | ParaswapResponseError::ServerBusy
+                    | ParaswapResponseError::Send(_),
             ),
         }
     }


### PR DESCRIPTION
We are seeing a lot of uncatalogued Paraswap errors (likely coming from the upgrade to v5). In this PR I went through all error alerts of last week and catalogued them.

I decided to make ServerBusy retryable (not sure if that's a good idea given that they are already encountering a lot of load in that case, but likely our single request won't make things worse).

Also, we should retry Send errors (as they may stem from timeouts or other intermittent network issues)

### Test Plan
Existing unit tests
