### PR TITLE
Use stable `muslrust` again

### DIFF
--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -1,4 +1,4 @@
-FROM docker.io/clux/muslrust:1.55.0-openssl11 as cargo-build
+FROM docker.io/clux/muslrust:stable as cargo-build
 WORKDIR /usr/src/oba-services
 
 # Copy and Build Code


### PR DESCRIPTION
The OpenSSL to v1.1 change is now in the `muslrust:stable` image, so no need to use the temporary "testing" label anymore.

### Test Plan

Check that indeed the new OpenSSL version is v1.1 in the image:
```
$ docker run -it --rm --pull docker.io/clux/muslrust:stable sh -c 'pkg-config openssl --modversion'                                 
1.1.1i
```

Compare this with the [previous stable image](https://github.com/gnosis/gp-v2-services/runs/3759739998#step:3:75) used to build https://github.com/gnosis/gp-v2-services/commit/0bcce3851b96af62ff01a7a1d21cef9e04d79f80:
```
$ docker run -it --rm docker.io/clux/muslrust@sha256:7bd4ca1375e1a5e871922516b7cdbc02562ed9701970a0b3c21ad251a954f03b sh -c 'pkg-config openssl --modversion'
1.0.2u
```
