### PR TITLE
[OnCall] Don't alert well catalogued (and somewhat expected) errors

### DIFF
--- a/shared/src/paraswap_api.rs
+++ b/shared/src/paraswap_api.rs
@@ -57,6 +57,8 @@ impl ParaswapApi for DefaultParaswapApi {
                 "ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT" => {
                     Err(ParaswapResponseError::TooMuchSlippageOnQuote)
                 }
+                "Server is too busy" => Err(ParaswapResponseError::ServerBusy),
+                "Bad USD price" => Err(ParaswapResponseError::ComputePrice(message)),
                 _ => Err(ParaswapResponseError::UnknownParaswapError(format!(
                     "uncatalogued Price Query error message {}",
                     message
@@ -119,6 +121,9 @@ pub enum ParaswapResponseError {
     #[error("Error getParaSwapPool - From Price Route {0}")]
     GetParaswapPool(String),
 
+    #[error("Server is too busy")]
+    ServerBusy,
+
     // Connectivity or non-response error
     #[error("Failed on send")]
     Send(reqwest::Error),
@@ -153,6 +158,10 @@ fn parse_paraswap_response_text(
             "Error getParaSwapPool" => Err(ParaswapResponseError::GetParaswapPool(
                 query_str.parse().unwrap(),
             )),
+            "Unable to process the transaction" => {
+                Err(ParaswapResponseError::BuildingTransaction(message))
+            }
+            "Server is too busy" => Err(ParaswapResponseError::ServerBusy),
             _ => Err(ParaswapResponseError::UnknownParaswapError(format!(
                 "uncatalogued error message {}",
                 message

--- a/solver/src/solver/oneinch_solver/api.rs
+++ b/solver/src/solver/oneinch_solver/api.rs
@@ -143,6 +143,7 @@ impl From<SwapResponseError> for SettlementError {
         SettlementError {
             inner: anyhow!(error.message),
             retryable: matches!(error.status_code, 500),
+            should_alert: true,
         }
     }
 }

--- a/solver/src/solver/paraswap_solver.rs
+++ b/solver/src/solver/paraswap_solver.rs
@@ -81,6 +81,15 @@ impl From<ParaswapResponseError> for SettlementError {
                     | ParaswapResponseError::ServerBusy
                     | ParaswapResponseError::Send(_),
             ),
+            should_alert: !matches!(
+                err,
+                ParaswapResponseError::PriceChange
+                    | ParaswapResponseError::BuildingTransaction(_)
+                    | ParaswapResponseError::ComputePrice(_)
+                    | ParaswapResponseError::InsufficientLiquidity
+                    | ParaswapResponseError::TooMuchSlippageOnQuote
+                    | ParaswapResponseError::ServerBusy,
+            ),
         }
     }
 }

--- a/solver/src/solver/paraswap_solver.rs
+++ b/solver/src/solver/paraswap_solver.rs
@@ -77,7 +77,9 @@ impl From<ParaswapResponseError> for SettlementError {
                 err,
                 ParaswapResponseError::PriceChange
                     | ParaswapResponseError::BuildingTransaction(_)
-                    | ParaswapResponseError::GetParaswapPool(_),
+                    | ParaswapResponseError::GetParaswapPool(_)
+                    | ParaswapResponseError::ServerBusy
+                    | ParaswapResponseError::Send(_),
             ),
         }
     }

--- a/solver/src/solver/paraswap_solver.rs
+++ b/solver/src/solver/paraswap_solver.rs
@@ -80,6 +80,7 @@ impl From<ParaswapResponseError> for SettlementError {
                     | ParaswapResponseError::GetParaswapPool(_)
                     | ParaswapResponseError::ServerBusy
                     | ParaswapResponseError::Send(_),
+            ),
             should_alert: !matches!(
                 err,
                 ParaswapResponseError::PriceChange

--- a/solver/src/solver/single_order_solver.rs
+++ b/solver/src/solver/single_order_solver.rs
@@ -86,6 +86,8 @@ impl<I: SingleOrderSolving + Send + Sync + 'static> Solver for SingleOrderSolver
 pub struct SettlementError {
     pub inner: anyhow::Error,
     pub retryable: bool,
+    // Whether or not this error should be logged as an error
+    pub should_alert: bool,
 }
 
 impl From<anyhow::Error> for SettlementError {
@@ -93,6 +95,7 @@ impl From<anyhow::Error> for SettlementError {
         SettlementError {
             inner: err,
             retryable: false,
+            should_alert: true,
         }
     }
 }
@@ -161,6 +164,7 @@ mod tests {
                     0 => Err(SettlementError {
                         inner: anyhow!(""),
                         retryable: true,
+                        should_alert: true,
                     }),
                     1 => Ok(None),
                     _ => unreachable!(),
@@ -200,6 +204,7 @@ mod tests {
             Err(SettlementError {
                 inner: anyhow!(""),
                 retryable: false,
+                should_alert: true,
             })
         });
 

--- a/solver/src/solver/single_order_solver.rs
+++ b/solver/src/solver/single_order_solver.rs
@@ -58,10 +58,12 @@ impl<I: SingleOrderSolving + Send + Sync + 'static> Solver for SingleOrderSolver
                     Err(err) => {
                         let name = self.inner.name();
                         if err.retryable {
-                            tracing::warn!("Solver {} benign error: {:?}", name, &err);
+                            tracing::warn!("Solver {} retryable error: {:?}", name, &err);
                             orders.push_back(order);
-                        } else {
+                        } else if err.should_alert {
                             tracing::error!("Solver {} hard error: {:?}", name, &err);
+                        } else {
+                            tracing::warn!("Solver {} soft error: {:?}", name, &err);
                         }
                     }
                 }

--- a/solver/src/solver/zeroex_solver.rs
+++ b/solver/src/solver/zeroex_solver.rs
@@ -137,6 +137,7 @@ impl From<ZeroExResponseError> for SettlementError {
         SettlementError {
             inner: anyhow!("0x Response Error {:?}", err),
             retryable: matches!(err, ZeroExResponseError::ServerError(_)),
+            should_alert: true,
         }
     }
 }


### PR DESCRIPTION
Purpose of this PR is to control some of the most noisy alerts we are seeing (e.g. "Server too busy"). Those are well understood and catalogued yet they may still happen. While we may still want to alert if they happen more often than usual, it's currently not helpful to have these alerts in our channel.

### Test Plan
Existing CI
