### PR TITLE
API - Remove defaults in order data fields

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -569,10 +569,8 @@ components:
           type: boolean
         sellTokenBalance:
           $ref: "#/components/schemas/SellTokenSource"
-          default: "erc20"
         buyTokenBalance:
           $ref: "#/components/schemas/BuyTokenDestination"
-          default: "erc20"
       required:
         - sellToken
         - buyToken
@@ -583,6 +581,8 @@ components:
         - feeAmount
         - kind
         - partiallyFillable
+        - sellTokenBalance
+        - buyTokenBalance
     OrderCreation:
       description: Data a user provides when creating a new order.
       allOf:
@@ -882,16 +882,16 @@ components:
               type: boolean
             sellTokenBalance:
               $ref: "#/components/schemas/SellTokenSource"
-              default: "erc20"
             buyTokenBalance:
               $ref: "#/components/schemas/BuyTokenDestination"
-              default: "erc20"
           required:
             - sellToken
             - buyToken
             - validTo
             - appData
             - partiallyFillable
+            - sellTokenBalance
+            - buyTokenBalance
     OrderQuote:
       description: |
         An order quoted by the back end that can be directly signed and


### PR DESCRIPTION
Based on the discussion [here](https://github.com/gnosis/gp-v2-services/pull/1155#discussion_r720090959)

We remove all defaults for order request data and make the fields required by the API. This means that front ends, if not already, will have to start specifying sell and buy token source and destination.


cc @alfetopito, @W3stside  & @anxolin  (in case this affects cowswap interface).
