### PR TITLE
[Easy] Update Balancer Docs

### DIFF
--- a/shared/src/sources/balancer.rs
+++ b/shared/src/sources/balancer.rs
@@ -1,15 +1,15 @@
-//! Contains event handling for maintaining in-memory storage of a
-//! `BalancerPoolRegistry` along with tools for retrieving
-//! known pools from this registry on demand.
+//! Contains event handling for maintaining in-memory storage of a `BalancerPoolRegistry` along
+//! with tools for retrieving known pools from this registry on demand.
 //!
 //! While the static information of the pools (such as `pool_id`, `address`, `tokens`) can be
 //! kept in memory as part of the registry, their dynamic information (such as current reserves)
 //! is block-dependent and must be queried from the EVM upon request.
-//! For this we provide `BalancerPoolFetcher` which is responsible for
-//! retrieving requested pools from the registry and attaching the most recent reserves to the result.
+//!
+//! For this we provide `BalancerPoolFetcher` which is responsible for retrieving requested pools
+//! from the registry and attaching the most recent reserves to the result.
 //!
 //! The module is designed to return the most recent pool info on demand.
-//! The only public facing components necessary to achieve this are
+//! The only public facing components necessary to achieve this are:
 //!
 //! 1. `BalancerPoolRegistry` which contains an event handler for each distinct Balancer Pool
 //! Factory contract and maintains its own in-memory storage of each pool and its static information.
@@ -18,18 +18,25 @@
 //! implements `WeightedPoolFetching` and thus exposes a `fetch` method
 //! which returns a collection of relevant `WeightedPools` for a given collection of `TokenPair`.
 //!
-//! For this reason, only the `event_handler` and `pool_fetching` are declared as public,
-//! while `pool_storage` and `info_fetching` merely contain internal logic regarding how
+//! 3. `WeightedPool` & `StablePool`:
+//!     This is the public facing pool structure returned by the `PoolFetcher` consisting of all
+//!     the pool's most recent information (both static and dynamic).
+//!     Essentially, this is all the relevant data from `RegisteredWeightedPool` and
+//!     `RegisteredStablePool` respectively along with the
+//!     current balances of each of the pool's tokens (aka the pool's "reserves").
+//!
+//! For this reason, only the `event_handler`, `pool_cache`, `pool_fetching` and `swap`
+//! are declared as public, others merely contain internal logic regarding how
 //! information is collected and stored.
 //!
 //! Once should think of `PoolStorage` as a type of Database for which one is not concerned
 //! with how it maintains itself.
 
 pub mod event_handler;
-pub mod graph_api;
+mod graph_api;
 mod info_fetching;
 pub mod pool_cache;
 pub mod pool_fetching;
-pub mod pool_init;
-pub mod pool_storage;
+mod pool_init;
+mod pool_storage;
 pub mod swap;

--- a/shared/src/sources/balancer/event_handler.rs
+++ b/shared/src/sources/balancer/event_handler.rs
@@ -97,8 +97,8 @@ impl BalancerPoolRegistry {
         })
     }
 
-    /// Retrieves `RegisteredPool`s from each Pool Store in the Registry and
-    /// returns the merged result.
+    /// Retrieves Registered Pools from each Pool Store in the Registry and
+    /// returns the combined pool ids.
     /// Primarily intended to be used by `BalancerPoolFetcher`.
     pub async fn get_pool_ids_containing_token_pairs(
         &self,

--- a/shared/src/sources/balancer/pool_fetching.rs
+++ b/shared/src/sources/balancer/pool_fetching.rs
@@ -1,7 +1,7 @@
 //! Pool Fetching is primarily concerned with retrieving relevant pools from the `BalancerPoolRegistry`
 //! when given a collection of `TokenPair`. Each of these pools are then queried for
-//! their `token_balances` and the `PoolFetcher` returns all up-to-date `WeightedPools`
-//! to be consumed by external users (e.g. Price Estimators and Solvers).
+//! their `token_balances` and the `PoolFetcher` returns all up-to-date `Weighted` and `Stable`
+//! pools to be consumed by external users (e.g. Price Estimators and Solvers).
 use crate::sources::balancer::pool_cache::{StablePoolReserveCache, WeightedPoolReserveCache};
 use crate::{
     current_block::CurrentBlockStream,

--- a/shared/src/sources/balancer/pool_storage.rs
+++ b/shared/src/sources/balancer/pool_storage.rs
@@ -7,9 +7,11 @@
 //!     contains only the `pool_address` as this is the only information known about the pool
 //!     at the time of event emission from the pool's factory contract.
 //!
-//! 2. `RegisteredWeightedPool`:
+//! 2. `RegisteredWeightedPool` & `RegisteredStablePool`:
 //!     contains all constant/static information about the pool (that which is not block-sensitive).
-//!     That is, `pool_id`, `address`, `tokens`, `normalized_weights`, `scaling_exponents` and `block_created`.
+//!     That is,
+//!     `pool_id`, `address`, `tokens`, `scaling_exponents`, `block_created` (i.e. `CommonPoolData`)
+//!     and `normalized_weights` (specific to weighted pools).
 //!     When the `PoolCreated` event is received by the event handler, an instance of this type is
 //!     constructed by fetching all additional information about the pool via `PoolInfoFetching`.
 //!
@@ -20,12 +22,6 @@
 //!     information in data structures that provide efficient lookup for the `PoolFetcher`.
 //!
 //!     Pool Storage implements all the CRUD methods expected of such a database.
-//!
-//! 4. `WeightedPool`:
-//!     This is the public facing pool structure returned by the `PoolFetcher` consisting of all
-//!     the pool's most recent information (both static and dynamic).
-//!     Essentially, this is all the relevant data from `RegisteredWeightedPool` along with the
-//!     current balances of each of the pool's tokens (aka the pool's "reserves").
 //!
 //! Tests included here are those pertaining to the expected functionality of `PoolStorage`
 use crate::{
@@ -93,11 +89,6 @@ impl PoolEvaluating for RegisteredStablePool {
 pub enum PoolType {
     Stable,
     Weighted,
-}
-
-pub enum RegisteredPool {
-    Weighted(RegisteredWeightedPool),
-    Stable(RegisteredStablePool),
 }
 
 #[derive(Copy, Debug, Clone, Eq, PartialEq)]


### PR DESCRIPTION
While updating the docs (to include stable pools) I found a few pub mods that didn't need to be public. Also found an unused enum `RegisteredPool`.

### Test Plan
Existing CI.
