### PR TITLE
Write network ID in deployment script

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -50,7 +50,7 @@ jobs:
       - run: cargo test --locked --all-features postgres -- --ignored --test-threads 1
       - run: |
           npm install ganache-cli
-          node_modules/.bin/ganache-cli --networkId 5777 --gasLimit 10000000 --gasPrice 0  --defaultBalanceEther 1000000 &
+          node_modules/.bin/ganache-cli --gasLimit 10000000 --gasPrice 0 --defaultBalanceEther 1000000 &
       - run: cargo run --locked --all-features --bin deploy
       - run: cargo test --locked --all-features --package e2e
   openapi:

--- a/contracts/build.rs
+++ b/contracts/build.rs
@@ -198,15 +198,20 @@ fn generate_contract_with_config(
         .name(name)
         .load_contract_from_file(&path)
         .unwrap();
+    let network_file = paths::network_id_file();
     let address_file = paths::contract_address_file(name);
     let dest = env::var("OUT_DIR").unwrap();
 
     println!("cargo:rerun-if-changed={}", path.display());
     let mut builder = ContractBuilder::new().visibility_modifier("pub");
 
-    if let Ok(address) = fs::read_to_string(&address_file) {
+    if let (Ok(network_id), Ok(address)) = (
+        fs::read_to_string(&network_file),
+        fs::read_to_string(&address_file),
+    ) {
+        println!("cargo:rerun-if-changed={}", network_file.display());
         println!("cargo:rerun-if-changed={}", address_file.display());
-        builder = builder.add_network_str("5777", address.trim());
+        builder = builder.add_network_str(&network_id, address.trim());
     }
 
     config(builder)

--- a/contracts/src/paths.rs
+++ b/contracts/src/paths.rs
@@ -11,6 +11,15 @@ pub fn contract_address_file(name: &str) -> PathBuf {
         .join(format!("{}.addr", name))
 }
 
+/// Path to the file containing the test network ID.
+pub fn network_id_file() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("target")
+        .join("deploy")
+        .join("network")
+}
+
 /// Path to the directory containing the vendored contract artifacts.
 pub fn contract_artifacts_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("artifacts")


### PR DESCRIPTION
This PR modifies the deployment script so that it doesn't rely on a hardcoded network ID. This allows us to use more test networks that don't necessarily have an option for configuring network IDs (like Hardhat).

### Test Plan

E2E test no longer uses deterministic network ID, and should continue to pass.
