### PR TITLE
Add full_fee_amount column: post-commit review fixes

### DIFF
--- a/orderbook/src/api/order_validation.rs
+++ b/orderbook/src/api/order_validation.rs
@@ -624,7 +624,12 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .validate_and_construct_order(order.clone(), None, &Default::default(), Default::default())
+                    .validate_and_construct_order(
+                        order.clone(),
+                        None,
+                        &Default::default(),
+                        Default::default()
+                    )
                     .await
                     .unwrap_err()
             ),
@@ -651,7 +656,12 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .validate_and_construct_order(order.clone(), None, &Default::default(), Default::default())
+                    .validate_and_construct_order(
+                        order.clone(),
+                        None,
+                        &Default::default(),
+                        Default::default()
+                    )
                     .await
                     .unwrap_err()
             ),
@@ -661,7 +671,12 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .validate_and_construct_order(order.clone(), None, &Default::default(), Default::default())
+                    .validate_and_construct_order(
+                        order.clone(),
+                        None,
+                        &Default::default(),
+                        Default::default()
+                    )
                     .await
                     .unwrap_err()
             ),
@@ -671,7 +686,12 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .validate_and_construct_order(order.clone(), None, &Default::default(), Default::default())
+                    .validate_and_construct_order(
+                        order.clone(),
+                        None,
+                        &Default::default(),
+                        Default::default()
+                    )
                     .await
                     .unwrap_err()
             ),
@@ -683,7 +703,12 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .validate_and_construct_order(order.clone(), None, &Default::default(), Default::default())
+                    .validate_and_construct_order(
+                        order.clone(),
+                        None,
+                        &Default::default(),
+                        Default::default()
+                    )
                     .await
                     .unwrap_err()
             ),
@@ -694,7 +719,12 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .validate_and_construct_order(order, None, &Default::default(), Default::default())
+                    .validate_and_construct_order(
+                        order,
+                        None,
+                        &Default::default(),
+                        Default::default()
+                    )
                     .await
                     .unwrap_err()
             ),

--- a/orderbook/src/api/order_validation.rs
+++ b/orderbook/src/api/order_validation.rs
@@ -232,7 +232,7 @@ impl OrderValidator {
     ///
     /// Furthermore, full order validation also calls partial_validate to ensure that
     /// other aspects of the order are not malformed.
-    pub async fn validate(
+    pub async fn validate_and_construct_order(
         &self,
         order_creation: OrderCreation,
         sender: Option<H160>,
@@ -624,7 +624,7 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .validate(order.clone(), None, &Default::default(), Default::default())
+                    .validate_and_construct_order(order.clone(), None, &Default::default(), Default::default())
                     .await
                     .unwrap_err()
             ),
@@ -636,7 +636,7 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .validate(
+                    .validate_and_construct_order(
                         order.clone(),
                         Some(H160::from_low_u64_be(1),),
                         &Default::default(),
@@ -651,7 +651,7 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .validate(order.clone(), None, &Default::default(), Default::default())
+                    .validate_and_construct_order(order.clone(), None, &Default::default(), Default::default())
                     .await
                     .unwrap_err()
             ),
@@ -661,7 +661,7 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .validate(order.clone(), None, &Default::default(), Default::default())
+                    .validate_and_construct_order(order.clone(), None, &Default::default(), Default::default())
                     .await
                     .unwrap_err()
             ),
@@ -671,7 +671,7 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .validate(order.clone(), None, &Default::default(), Default::default())
+                    .validate_and_construct_order(order.clone(), None, &Default::default(), Default::default())
                     .await
                     .unwrap_err()
             ),
@@ -683,7 +683,7 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .validate(order.clone(), None, &Default::default(), Default::default())
+                    .validate_and_construct_order(order.clone(), None, &Default::default(), Default::default())
                     .await
                     .unwrap_err()
             ),
@@ -694,7 +694,7 @@ mod tests {
             format!(
                 "{:?}",
                 validator
-                    .validate(order, None, &Default::default(), Default::default())
+                    .validate_and_construct_order(order, None, &Default::default(), Default::default())
                     .await
                     .unwrap_err()
             ),
@@ -734,7 +734,7 @@ mod tests {
             ..Default::default()
         };
         let order = validator
-            .validate(order, None, &Default::default(), Default::default())
+            .validate_and_construct_order(order, None, &Default::default(), Default::default())
             .await
             .unwrap();
         assert_eq!(

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -84,7 +84,7 @@ impl Orderbook {
 
         let order = match self
             .order_validator
-            .validate(
+            .validate_and_construct_order(
                 order_creation,
                 payload.from,
                 &self.domain_separator,


### PR DESCRIPTION
This is a follow up for the prematurely merged PR #1173. Please, review changes related to `Orderbook::add_order` and `OrderValidator::validate` there, and I'll address all comments in this PR.

For now, this PR just changes naming to be consistent.