### PR TITLE
Include transport identifer in logs

### DIFF
--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -174,7 +174,7 @@ async fn main() {
     let client = shared::http_client(args.shared.http_timeout);
 
     let transport = create_instrumented_transport(
-        HttpTransport::new(client.clone(), args.shared.node_url.clone()),
+        HttpTransport::new(client.clone(), args.shared.node_url.clone(), "".to_string()),
         metrics.clone(),
     );
     let web3 = web3::Web3::new(transport);

--- a/shared/src/transport.rs
+++ b/shared/src/transport.rs
@@ -29,7 +29,11 @@ where
 
 /// Convenience method to create a transport from a URL.
 pub fn create_test_transport(url: &str) -> Web3Transport {
-    Web3Transport::new(HttpTransport::new(Client::new(), url.try_into().unwrap()))
+    Web3Transport::new(HttpTransport::new(
+        Client::new(),
+        url.try_into().unwrap(),
+        "".to_string(),
+    ))
 }
 
 /// Like above but takes url from the environment NODE_URL.

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -220,7 +220,7 @@ async fn main() {
     let client = shared::http_client(args.shared.http_timeout);
 
     let transport = create_instrumented_transport(
-        HttpTransport::new(client.clone(), args.shared.node_url),
+        HttpTransport::new(client.clone(), args.shared.node_url, "base".to_string()),
         metrics.clone(),
     );
     let web3 = web3::Web3::new(transport);
@@ -440,9 +440,10 @@ async fn main() {
                 let nodes = args
                     .transaction_submission_nodes
                     .into_iter()
-                    .map(|url| {
+                    .enumerate()
+                    .map(|(index, url)| {
                         let transport = create_instrumented_transport(
-                            HttpTransport::new(client.clone(), url),
+                            HttpTransport::new(client.clone(), url, index.to_string()),
                             metrics.clone(),
                         );
                         web3::Web3::new(transport)


### PR DESCRIPTION
In order to distinguish the messages when multiple transports are in
use. This only matters for the solver at the moment when multiple
transaction submission nodes are used. There I decided to go with a
simple index into the initial argument list. Alternatively we could pick
the base url but it is unclear what part of such urls is needed or
secret.

### Test Plan
CI
