### PR TITLE
Include Token symbol in TokenInfo model

### DIFF
--- a/shared/src/price_estimation/paraswap.rs
+++ b/shared/src/price_estimation/paraswap.rs
@@ -112,7 +112,15 @@ mod tests {
         token_info.expect_get_token_infos().returning(|tokens| {
             tokens
                 .iter()
-                .map(|token| (*token, TokenInfo { decimals: Some(18) }))
+                .map(|token| {
+                    (
+                        *token,
+                        TokenInfo {
+                            decimals: Some(18),
+                            symbol: Some("SYM".to_string()),
+                        },
+                    )
+                })
                 .collect()
         });
         let paraswap = DefaultParaswapApi {

--- a/shared/src/sources/balancer/info_fetching.rs
+++ b/shared/src/sources/balancer/info_fetching.rs
@@ -156,9 +156,9 @@ mod tests {
             .expect_get_token_infos()
             .return_once(move |_| {
                 hashmap! {
-                    tokens[0] => TokenInfo { decimals: Some(0) },
-                    tokens[1] => TokenInfo { decimals: Some(9) },
-                    tokens[2] => TokenInfo { decimals: Some(18) },
+                    tokens[0] => TokenInfo { decimals: Some(0), symbol: Some("CAT".to_string()) },
+                    tokens[1] => TokenInfo { decimals: Some(9), symbol: Some("DOG".to_string()) },
+                    tokens[2] => TokenInfo { decimals: Some(18), symbol: Some("FOX".to_string()) },
                 }
             });
 
@@ -192,8 +192,8 @@ mod tests {
             .in_sequence(&mut seq)
             .return_once(move |_| {
                 hashmap! {
-                    token => TokenInfo { decimals: None },
-                    H160::zero() => TokenInfo { decimals: Some(1) }
+                    token => TokenInfo { decimals: None, symbol: Some("GNO".to_string()) },
+                    H160::zero() => TokenInfo { decimals: Some(1), symbol: Some("WETH".to_string()) }
                 }
             });
         mock_token_info_fetcher
@@ -202,7 +202,7 @@ mod tests {
             .in_sequence(&mut seq)
             .return_once(move |_| {
                 hashmap! {
-                    token => TokenInfo { decimals: Some(19) },
+                    token => TokenInfo { decimals: Some(19), symbol: Some("BAD".to_string()) },
                 }
             });
 
@@ -260,8 +260,8 @@ mod tests {
             .expect_get_token_infos()
             .return_once(move |_| {
                 hashmap! {
-                    tokens[0] => TokenInfo { decimals: Some(18) },
-                    tokens[1] => TokenInfo { decimals: Some(17) },
+                    tokens[0] => TokenInfo { decimals: Some(18), symbol: Some("DAI".to_string()) },
+                    tokens[1] => TokenInfo { decimals: Some(17), symbol: Some("TOK".to_string()) },
                 }
             });
 
@@ -313,8 +313,8 @@ mod tests {
             .expect_get_token_infos()
             .return_once(move |_| {
                 hashmap! {
-                    tokens[0] => TokenInfo { decimals: Some(18) },
-                    tokens[1] => TokenInfo { decimals: Some(17) },
+                    tokens[0] => TokenInfo { decimals: Some(18), symbol: Some("CAT".to_string()) },
+                    tokens[1] => TokenInfo { decimals: Some(17), symbol: Some("CAT".to_string()) },
                 }
             });
 

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -373,6 +373,7 @@ fn token_models(
                 *address,
                 TokenInfoModel {
                     decimals: token_info.decimals,
+                    symbol: token_info.symbol.clone(),
                     external_price,
                     normalize_priority: Some(if &gas_model.native_token == address {
                         1
@@ -634,8 +635,8 @@ mod tests {
             .expect_get_token_infos()
             .return_once(move |_| {
                 hashmap! {
-                    buy_token => TokenInfo { decimals: Some(18)},
-                    sell_token => TokenInfo { decimals: Some(18)},
+                    buy_token => TokenInfo { decimals: Some(18), symbol: Some("CAT".to_string()) },
+                    sell_token => TokenInfo { decimals: Some(18), symbol: Some("CAT".to_string()) },
                 }
             });
         let mock_token_info_fetcher: Arc<dyn TokenInfoFetching> = Arc::new(mock_token_info_fetcher);

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -373,7 +373,7 @@ fn token_models(
                 *address,
                 TokenInfoModel {
                     decimals: token_info.decimals,
-                    symbol: token_info.symbol.clone(),
+                    alias: token_info.symbol.clone(),
                     external_price,
                     normalize_priority: Some(if &gas_model.native_token == address {
                         1

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -109,6 +109,7 @@ pub struct StablePoolParameters {
 #[derive(Clone, Debug, Serialize)]
 pub struct TokenInfoModel {
     pub decimals: Option<u8>,
+    pub symbol: Option<String>,
     pub external_price: Option<f64>,
     pub normalize_priority: Option<u64>,
     #[serde_as(as = "Option<DecimalU256>")]
@@ -339,12 +340,14 @@ mod tests {
             tokens: btreemap! {
                 buy_token => TokenInfoModel {
                     decimals: Some(6),
+                    symbol: Some("CAT".to_string()),
                     external_price: Some(1.2),
                     normalize_priority: Some(1),
                     internal_buffer: Some(U256::from(1337)),
                 },
                 sell_token => TokenInfoModel {
                     decimals: Some(18),
+                    symbol: Some("DOG".to_string()),
                     external_price: Some(2345.0),
                     normalize_priority: Some(0),
                     internal_buffer: Some(U256::from(42)),

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -370,12 +370,14 @@ mod tests {
           "tokens": {
             "0x0000000000000000000000000000000000000539": {
               "decimals": 6,
+              "symbol": "CAT",
               "external_price": 1.2,
               "normalize_priority": 1,
               "internal_buffer": "1337",
             },
             "0x000000000000000000000000000000000000a866": {
               "decimals": 18,
+              "symbol": "DOG",
               "external_price": 2345.0,
               "normalize_priority": 0,
               "internal_buffer": "42",

--- a/solver/src/solver/http_solver/model.rs
+++ b/solver/src/solver/http_solver/model.rs
@@ -109,7 +109,7 @@ pub struct StablePoolParameters {
 #[derive(Clone, Debug, Serialize)]
 pub struct TokenInfoModel {
     pub decimals: Option<u8>,
-    pub symbol: Option<String>,
+    pub alias: Option<String>,
     pub external_price: Option<f64>,
     pub normalize_priority: Option<u64>,
     #[serde_as(as = "Option<DecimalU256>")]
@@ -340,14 +340,14 @@ mod tests {
             tokens: btreemap! {
                 buy_token => TokenInfoModel {
                     decimals: Some(6),
-                    symbol: Some("CAT".to_string()),
+                    alias: Some("CAT".to_string()),
                     external_price: Some(1.2),
                     normalize_priority: Some(1),
                     internal_buffer: Some(U256::from(1337)),
                 },
                 sell_token => TokenInfoModel {
                     decimals: Some(18),
-                    symbol: Some("DOG".to_string()),
+                    alias: Some("DOG".to_string()),
                     external_price: Some(2345.0),
                     normalize_priority: Some(0),
                     internal_buffer: Some(U256::from(42)),
@@ -370,14 +370,14 @@ mod tests {
           "tokens": {
             "0x0000000000000000000000000000000000000539": {
               "decimals": 6,
-              "symbol": "CAT",
+              "alias": "CAT",
               "external_price": 1.2,
               "normalize_priority": 1,
               "internal_buffer": "1337",
             },
             "0x000000000000000000000000000000000000a866": {
               "decimals": 18,
-              "symbol": "DOG",
+              "alias": "DOG",
               "external_price": 2345.0,
               "normalize_priority": 0,
               "internal_buffer": "42",

--- a/solver/src/solver/paraswap_solver.rs
+++ b/solver/src/solver/paraswap_solver.rs
@@ -328,8 +328,8 @@ mod tests {
 
         token_info.expect_get_token_infos().returning(move |_| {
             hashmap! {
-                sell_token => TokenInfo { decimals: Some(18)},
-                buy_token => TokenInfo { decimals: Some(18)},
+                sell_token => TokenInfo { decimals: Some(18), symbol: None },
+                buy_token => TokenInfo { decimals: Some(18), symbol: None },
             }
         });
 
@@ -433,8 +433,8 @@ mod tests {
 
         token_info.expect_get_token_infos().returning(move |_| {
             hashmap! {
-                sell_token => TokenInfo { decimals: Some(18)},
-                buy_token => TokenInfo { decimals: Some(18)},
+                sell_token => TokenInfo { decimals: Some(18), symbol: None },
+                buy_token => TokenInfo { decimals: Some(18), symbol: None },
             }
         });
 
@@ -525,8 +525,8 @@ mod tests {
 
         token_info.expect_get_token_infos().returning(move |_| {
             hashmap! {
-                sell_token => TokenInfo { decimals: Some(18)},
-                buy_token => TokenInfo { decimals: Some(18)},
+                sell_token => TokenInfo { decimals: Some(18), symbol: None },
+                buy_token => TokenInfo { decimals: Some(18), symbol: None },
             }
         });
 


### PR DESCRIPTION
Closes #1105 

We now fetch token symbol along with the decimals in `TokenInfo::get_token_infos` and pass this along to http solver with `TokenInfoModel`

### Test Plan


Run the solver in dry mode with both MIP and Quasimodo solvers as

```sh
cargo run -p solver -- \
  --base-tokens 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 \
  --baseline-sources Uniswap,Sushiswap,BalancerV2 \
  --orderbook-url https://protocol-mainnet.gnosis.io \
  --node-url "https://mainnet.infura.io/v3/$INFURA_PROJECT_ID" \
  --mip-solver-url "$MIP_SOLVER_URL" \
  --quasimodo-solver-url "$QUASIMODO_SOLVER_URL" \
  --solvers Mip,Quasimodo \
  --transaction-strategy DryRun
  ```
  
  
  Place an order which is routed here
