### PR TITLE
[Trivial] Log Improvement

### DIFF
--- a/shared/src/sources/balancer/pool_init.rs
+++ b/shared/src/sources/balancer/pool_init.rs
@@ -88,8 +88,12 @@ impl PoolInitializing for DefaultPoolInitializer {
             DefaultPoolInitializer::Subgraph(inner) => inner.initialize_pools().await,
             DefaultPoolInitializer::Fetched(inner) => inner.initialize_pools().await,
         }?;
-
-        tracing::debug!("initialized registered pools {:?}", registered_pools);
+        tracing::debug!(
+            "initialized registered pools ({} Stable, {} Weighted & {} TwoTokenWeighted)",
+            registered_pools.stable_pools.len(),
+            registered_pools.weighted_pools.len(),
+            registered_pools.weighted_2token_pools.len()
+        );
         Ok(registered_pools)
     }
 }

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -365,7 +365,9 @@ async fn main() {
         if let Some(private_keys) = args.solver_private_keys {
             assert!(
                 private_keys.len() == args.solvers.len(),
-                "number of solver does not match the number of private keys"
+                "number of solvers {} does not match the number of private keys {}",
+                args.solvers.len(),
+                private_keys.len()
             );
 
             private_keys


### PR DESCRIPTION
1. When number of private keys doesn't match number of solvers we show how many of each there are.
2. When initializing Balancer pools instead of printing them all out we now just show this:
```
DEBUG shared::sources::balancer::pool_init: initialized registered pools (3 Stable, 60 Weighted & 70 TwoTokenWeighted)
```

### Test Plan
No logical changes.
