### PR TITLE
* Remove explicit env names

### DIFF
--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -69,7 +69,7 @@ struct Arguments {
     #[structopt(long)]
     skip_event_sync: bool,
 
-    /// The minimum amount of time an order has to be valid for.
+    /// The minimum amount of time in seconds an order has to be valid for.
     #[structopt(
         long,
         env,
@@ -84,7 +84,7 @@ struct Arguments {
     #[structopt(long, env, parse(try_from_str), default_value = "false")]
     skip_trace_api: bool,
 
-    /// The amount of time a classification of a token into good or bad is valid for.
+    /// The amount of time in seconds a classification of a token into good or bad is valid for.
     #[structopt(
         long,
         env,
@@ -117,8 +117,8 @@ struct Arguments {
     #[structopt(long, env, parse(try_from_str), default_value = "false")]
     pub enable_presign_orders: bool,
 
-    /// If solvable orders haven't been successfully update in this time attempting to get them
-    /// errors and our liveness check fails.
+    /// If solvable orders haven't been successfully update in this time in seconds attempting
+    /// to get them errors and our liveness check fails.
     #[structopt(
         long,
         default_value = "300",

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -58,11 +58,11 @@ struct Arguments {
     #[structopt(flatten)]
     shared: shared::arguments::Arguments,
 
-    #[structopt(long, env = "BIND_ADDRESS", default_value = "0.0.0.0:8080")]
+    #[structopt(long, env, default_value = "0.0.0.0:8080")]
     bind_address: SocketAddr,
 
     /// Url of the Postgres database. By default connects to locally running postgres.
-    #[structopt(long, env = "DB_URL", default_value = "postgresql://")]
+    #[structopt(long, env, default_value = "postgresql://")]
     db_url: Url,
 
     /// Skip syncing past events (useful for local deployments)
@@ -72,7 +72,7 @@ struct Arguments {
     /// The minimum amount of time an order has to be valid for.
     #[structopt(
         long,
-        env = "MIN_ORDER_VALIDITY_PERIOD",
+        env,
         default_value = "60",
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
@@ -81,34 +81,29 @@ struct Arguments {
     /// Don't use the trace_callMany api that only some nodes support to check whether a token
     /// should be denied.
     /// Note that if a node does not support the api we still use the less accurate call api.
-    #[structopt(
-        long,
-        env = "SKIP_TRACE_API",
-        parse(try_from_str),
-        default_value = "false"
-    )]
+    #[structopt(long, env, parse(try_from_str), default_value = "false")]
     skip_trace_api: bool,
 
     /// The amount of time a classification of a token into good or bad is valid for.
     #[structopt(
         long,
-        env = "TOKEN_QUALITY_CACHE_EXPIRY_SECONDS",
+        env,
         default_value = "600",
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
     token_quality_cache_expiry: Duration,
 
     /// List of token addresses to be ignored throughout service
-    #[structopt(long, env = "UNSUPPORTED_TOKENS", use_delimiter = true)]
+    #[structopt(long, env, use_delimiter = true)]
     pub unsupported_tokens: Vec<H160>,
 
     /// List of account addresses to be denied from order creation
-    #[structopt(long, env = "BANNED_USERS", use_delimiter = true)]
+    #[structopt(long, env, use_delimiter = true)]
     pub banned_users: Vec<H160>,
 
     /// List of token addresses that should be allowed regardless of whether the bad token detector
     /// thinks they are bad. Base tokens are automatically allowed.
-    #[structopt(long, env = "ALLOWED_TOKENS", use_delimiter = true)]
+    #[structopt(long, env, use_delimiter = true)]
     pub allowed_tokens: Vec<H160>,
 
     /// The number of pairs that are automatically updated in the pool cache.

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -25,7 +25,7 @@ pub struct Arguments {
     #[structopt(long, env, default_value = "http://localhost:8545")]
     pub node_url: Url,
 
-    /// Timeout for all http requests.
+    /// Timeout in seconds for all http requests.
     #[structopt(
             long,
             default_value = "10",
@@ -82,11 +82,11 @@ pub struct Arguments {
     #[structopt(long, env, default_value = "5")]
     pub pool_cache_maximum_retries: u32,
 
-    /// How long to sleep between retries in the pool cache.
+    /// How long to sleep in seconds between retries in the pool cache.
     #[structopt(long, env, default_value = "1", parse(try_from_str = duration_from_seconds))]
     pub pool_cache_delay_between_retries_seconds: Duration,
 
-    /// How often we poll the node to check if the current block has changed.
+    /// How often in seconds we poll the node to check if the current block has changed.
     #[structopt(
         long,
         env,

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -16,13 +16,13 @@ use url::Url;
 pub struct Arguments {
     #[structopt(
         long,
-        env = "LOG_FILTER",
+        env,
         default_value = "warn,orderbook=debug,solver=debug,shared=debug,shared::transport::http=info,archerapi=info"
     )]
     pub log_filter: String,
 
     /// The Ethereum node URL to connect to.
-    #[structopt(long, env = "NODE_URL", default_value = "http://localhost:8545")]
+    #[structopt(long, env, default_value = "http://localhost:8545")]
     pub node_url: Url,
 
     /// Timeout for all http requests.
@@ -41,7 +41,7 @@ pub struct Arguments {
     /// `Web3`: supports every network.
     #[structopt(
         long,
-        env = "GAS_ESTIMATORS",
+        env,
         default_value = "Web3",
         possible_values = &GasEstimatorType::variants(),
         case_insensitive = true,
@@ -51,7 +51,7 @@ pub struct Arguments {
 
     /// Base tokens used for finding multi-hop paths between multiple AMMs
     /// Should be the most liquid tokens of the given network.
-    #[structopt(long, env = "BASE_TOKENS", use_delimiter = true)]
+    #[structopt(long, env, use_delimiter = true)]
     pub base_tokens: Vec<H160>,
 
     /// Gas Fee Factor: 1.0 means cost is forwarded to users alteration, 0.9 means there is a 10%
@@ -62,7 +62,7 @@ pub struct Arguments {
     /// Which Liquidity sources to be used by Price Estimator.
     #[structopt(
         long,
-        env = "BASELINE_SOURCES",
+        env,
         default_value = "Uniswap,Sushiswap",
         possible_values = &BaselineSource::variants(),
         case_insensitive = true,

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -57,7 +57,7 @@ struct Arguments {
     #[structopt(short = "k", long, env, hide_env_values = true)]
     private_key: Option<PrivateKey>,
 
-    /// The target confirmation time for settlement transactions used to estimate gas price.
+    /// The target confirmation time in seconds for settlement transactions used to estimate gas price.
     #[structopt(
         long,
         env,
@@ -66,7 +66,7 @@ struct Arguments {
     )]
     target_confirm_time: Duration,
 
-    /// Every how often we should execute the driver's run loop
+    /// Every how often in seconds we should execute the driver's run loop
     #[structopt(
         long,
         env,
@@ -96,9 +96,9 @@ struct Arguments {
     )]
     solver_private_keys: Option<Vec<PrivateKey>>,
 
-    /// A settlement must contain at least one order older than this duration for it to be applied.
-    /// Larger values delay individual settlements more but have a higher coincidence of wants
-    /// chance.
+    /// A settlement must contain at least one order older than this duration in seconds for it
+    /// to be applied.  Larger values delay individual settlements more but have a higher
+    /// coincidence of wants chance.
     #[structopt(
         long,
         env,
@@ -115,7 +115,7 @@ struct Arguments {
     #[structopt(long, env, default_value = "5")]
     max_merged_settlements: usize,
 
-    /// The maximum amount of time a solver is allowed to take.
+    /// The maximum amount of time in seconds a solver is allowed to take.
     #[structopt(
         long,
         env,
@@ -149,7 +149,7 @@ struct Arguments {
     )]
     market_makable_token_list: String,
 
-    /// The maximum gas price the solver is willing to pay in a settlement
+    /// The maximum gas price in Gwei the solver is willing to pay in a settlement.
     #[structopt(
         long,
         env,
@@ -170,8 +170,8 @@ struct Arguments {
     #[structopt(long, env, default_value = "PublicMempool")]
     transaction_strategy: TransactionStrategyArg,
 
-    /// The maximum time we spend trying to settle a transaction through the archer network before
-    /// going to back to solving.
+    /// The maximum time in seconds we spend trying to settle a transaction through the archer
+    /// network before going to back to solving.
     #[structopt(
         long,
         default_value = "60",

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -42,29 +42,25 @@ struct Arguments {
     shared: shared::arguments::Arguments,
 
     /// The API endpoint to fetch the orderbook
-    #[structopt(long, env = "ORDERBOOK_URL", default_value = "http://localhost:8080")]
+    #[structopt(long, env, default_value = "http://localhost:8080")]
     orderbook_url: Url,
 
     /// The API endpoint to call the mip solver
-    #[structopt(long, env = "MIP_SOLVER_URL", default_value = "http://localhost:8000")]
+    #[structopt(long, env, default_value = "http://localhost:8000")]
     mip_solver_url: Url,
 
     /// The API endpoint to call the mip v2 solver
-    #[structopt(
-        long,
-        env = "QUASIMODO_SOLVER_URL",
-        default_value = "http://localhost:8000"
-    )]
+    #[structopt(long, env, default_value = "http://localhost:8000")]
     quasimodo_solver_url: Url,
 
     /// The private key used by the driver to sign transactions.
-    #[structopt(short = "k", long, env = "PRIVATE_KEY", hide_env_values = true)]
+    #[structopt(short = "k", long, env, hide_env_values = true)]
     private_key: Option<PrivateKey>,
 
     /// The target confirmation time for settlement transactions used to estimate gas price.
     #[structopt(
         long,
-        env = "TARGET_CONFIRM_TIME",
+        env,
         default_value = "30",
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
@@ -73,7 +69,7 @@ struct Arguments {
     /// Every how often we should execute the driver's run loop
     #[structopt(
         long,
-        env = "SETTLE_INTERVAL",
+        env,
         default_value = "10",
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
@@ -82,7 +78,7 @@ struct Arguments {
     /// Which type of solver to use
     #[structopt(
         long,
-        env = "SOLVER_TYPE",
+        env,
         default_value = "Naive,Baseline",
         possible_values = &SolverType::variants(),
         case_insensitive = true,
@@ -93,7 +89,7 @@ struct Arguments {
     /// Individual private keys for each solver
     #[structopt(
         long,
-        env = "SOLVER_PRIVATE_KEYS",
+        env,
         case_insensitive = true,
         use_delimiter = true,
         hide_env_values = true
@@ -105,29 +101,24 @@ struct Arguments {
     /// chance.
     #[structopt(
         long,
-        env = "MIN_ORDER_AGE",
+        env,
         default_value = "30",
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
     min_order_age: Duration,
 
     /// The port at which we serve our metrics
-    #[structopt(
-        long,
-        env = "METRICS_PORT",
-        default_value = "9587",
-        case_insensitive = true
-    )]
+    #[structopt(long, env, default_value = "9587", case_insensitive = true)]
     metrics_port: u16,
 
     /// The port at which we serve our metrics
-    #[structopt(long, env = "MAX_MERGED_SETTLEMENTS", default_value = "5")]
+    #[structopt(long, env, default_value = "5")]
     max_merged_settlements: usize,
 
     /// The maximum amount of time a solver is allowed to take.
     #[structopt(
         long,
-        env = "SOLVER_TIME_LIMIT",
+        env,
         default_value = "30",
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
@@ -137,7 +128,7 @@ struct Arguments {
     /// traded in order to use the 1Inch solver.
     #[structopt(
         long,
-        env = "MIN_ORDER_SIZE_ONE_INCH",
+        env,
         default_value = "5",
         parse(try_from_str = shared::arguments::wei_from_base_unit)
     )]
@@ -153,7 +144,7 @@ struct Arguments {
     /// without external liquidity
     #[structopt(
         long,
-        env = "MARKET_MAKABLE_TOKEN_LIST",
+        env,
         default_value = "https://tokens.coingecko.com/uniswap/all.json"
     )]
     market_makable_token_list: String,
@@ -161,7 +152,7 @@ struct Arguments {
     /// The maximum gas price the solver is willing to pay in a settlement
     #[structopt(
         long,
-        env = "GAS_PRICE_CAP_GWEI",
+        env,
         default_value = "1500",
         parse(try_from_str = shared::arguments::wei_from_gwei)
     )]


### PR DESCRIPTION
This PR removes the explicit env names from the command line arguments (since they take the field name in `UPPER_SNAKE_CASE` by default).

This is mostly to make sure we have consistency across all parameters (we currently had some with name, and some without). Alternatively, we can change this to use explicit naming everywhere, but I though this was easier and less prone to mistakes (for example renaming a flag but forgetting to change the environment variable name).

I also took the liberty of qualifying the units of some parameters (instead of having the parameter names reflect them).

:warning: Note that in 3 cases, the **environment variable name changed** as it did not match the parameter name. This PR therefore requires a configuration change.

### Test Plan

No logic changes. You can check that there were not parameter changes with:
```
git checkout main && cargo build && ./target/debug/orderbook --help >old.help && ./target/debug/solver --help >>old.help
git checkout remove-explicit-env-name && cargo build && ./target/debug/orderbook --help >new.help && ./target/debug/solver --help >>new.help
diff -u --color old.help new.help
rm old.help new.help
```

<details><summary>Diff result <strong>without</strong> modifications to help text</summary>

```diff
--- old.help	2021-10-07 14:30:58.270974750 +0200
+++ new.help	2021-10-07 14:31:33.074656939 +0200
@@ -107,7 +107,7 @@
             liveness check fails [default: 300]
         --token-quality-cache-expiry <token-quality-cache-expiry>
             The amount of time a classification of a token into good or bad is valid for [env:
-            TOKEN_QUALITY_CACHE_EXPIRY_SECONDS=]  [default: 600]
+            TOKEN_QUALITY_CACHE_EXPIRY=]  [default: 600]
         --unsupported-tokens <unsupported-tokens>...
             List of token addresses to be ignored throughout service [env: UNSUPPORTED_TOKENS=]
 
@@ -152,8 +152,8 @@
             `GnosisSafe`: supports mainnet and rinkeby. `Web3`: supports every network [env: GAS_ESTIMATORS=]  [default:
             Web3]  [possible values: EthGasStation, GasNow, GnosisSafe, Web3]
         --gas-price-cap <gas-price-cap>
-            The maximum gas price the solver is willing to pay in a settlement [env: GAS_PRICE_CAP_GWEI=]  [default:
-            1500]
+            The maximum gas price the solver is willing to pay in a settlement [env: GAS_PRICE_CAP=]  [default: 1500]
+
         --http-timeout <http-timeout>
             Timeout for all http requests [default: 10]
 
@@ -228,8 +228,8 @@
             The maximum amount of time a solver is allowed to take [env: SOLVER_TIME_LIMIT=]  [default: 30]
 
         --solvers <solvers>...
-            Which type of solver to use [env: SOLVER_TYPE=]  [default: Naive,Baseline]  [possible values: Naive,
-            Baseline, Mip, OneInch, Paraswap, ZeroEx, Quasimodo]
+            Which type of solver to use [env: SOLVERS=]  [default: Naive,Baseline]  [possible values: Naive, Baseline,
+            Mip, OneInch, Paraswap, ZeroEx, Quasimodo]
         --target-confirm-time <target-confirm-time>
             The target confirmation time for settlement transactions used to estimate gas price [env:
             TARGET_CONFIRM_TIME=]  [default: 30]
```

</details>

<details><summary>Full diff result <strong>with</strong> modifications to help text</summary>

```diff
--- old.help	2021-10-07 14:40:34.255637944 +0200
+++ new.help	2021-10-07 14:41:08.674314715 +0200
@@ -34,7 +34,7 @@
              [env: BIND_ADDRESS=]  [default: 0.0.0.0:8080]
 
         --block-stream-poll-interval-seconds <block-stream-poll-interval-seconds>
-            How often we poll the node to check if the current block has changed [env:
+            How often in seconds we poll the node to check if the current block has changed [env:
             BLOCK_STREAM_POLL_INTERVAL_SECONDS=]  [default: 5]
         --db-url <db-url>
             Url of the Postgres database. By default connects to locally running postgres [env: DB_URL=]  [default:
@@ -57,14 +57,14 @@
             `GnosisSafe`: supports mainnet and rinkeby. `Web3`: supports every network [env: GAS_ESTIMATORS=]  [default:
             Web3]  [possible values: EthGasStation, GasNow, GnosisSafe, Web3]
         --http-timeout <http-timeout>
-            Timeout for all http requests [default: 10]
+            Timeout in seconds for all http requests [default: 10]
 
         --log-filter <log-filter>
              [env: LOG_FILTER=]  [default:
             warn,orderbook=debug,solver=debug,shared=debug,shared::transport::http=info,archerapi=info]
         --min-order-validity-period <min-order-validity-period>
-            The minimum amount of time an order has to be valid for [env: MIN_ORDER_VALIDITY_PERIOD=]  [default: 60]
-
+            The minimum amount of time in seconds an order has to be valid for [env: MIN_ORDER_VALIDITY_PERIOD=]
+            [default: 60]
         --node-url <node-url>
             The Ethereum node URL to connect to [env: NODE_URL=]  [default: http://localhost:8545]
 
@@ -84,8 +84,8 @@
             The number of blocks kept in the pool cache [env: POOL_CACHE_BLOCKS=]  [default: 10]
 
         --pool-cache-delay-between-retries-seconds <pool-cache-delay-between-retries-seconds>
-            How long to sleep between retries in the pool cache [env: POOL_CACHE_DELAY_BETWEEN_RETRIES_SECONDS=]
-            [default: 1]
+            How long to sleep in seconds between retries in the pool cache [env:
+            POOL_CACHE_DELAY_BETWEEN_RETRIES_SECONDS=]  [default: 1]
         --pool-cache-lru-size <pool-cache-lru-size>
             The number of pairs that are automatically updated in the pool cache [env: POOL_CACHE_LRU_SIZE=]  [default:
             200]
@@ -103,11 +103,11 @@
             Note that if a node does not support the api we still use the less accurate call api [env: SKIP_TRACE_API=]
             [default: false]
         --solvable-orders-max-update-age <solvable-orders-max-update-age>
-            If solvable orders haven't been successfully update in this time attempting to get them errors and our
-            liveness check fails [default: 300]
+            If solvable orders haven't been successfully update in this time in seconds attempting to get them errors
+            and our liveness check fails [default: 300]
         --token-quality-cache-expiry <token-quality-cache-expiry>
-            The amount of time a classification of a token into good or bad is valid for [env:
-            TOKEN_QUALITY_CACHE_EXPIRY_SECONDS=]  [default: 600]
+            The amount of time in seconds a classification of a token into good or bad is valid for [env:
+            TOKEN_QUALITY_CACHE_EXPIRY=]  [default: 600]
         --unsupported-tokens <unsupported-tokens>...
             List of token addresses to be ignored throughout service [env: UNSUPPORTED_TOKENS=]
 
@@ -134,7 +134,7 @@
             Which Liquidity sources to be used by Price Estimator [env: BASELINE_SOURCES=]  [default: Uniswap,Sushiswap]
             [possible values: Uniswap, Sushiswap, BalancerV2]
         --block-stream-poll-interval-seconds <block-stream-poll-interval-seconds>
-            How often we poll the node to check if the current block has changed [env:
+            How often in seconds we poll the node to check if the current block has changed [env:
             BLOCK_STREAM_POLL_INTERVAL_SECONDS=]  [default: 5]
         --disabled-one-inch-protocols <disabled-one-inch-protocols>...
             The list of disabled 1Inch protocols. By default, the `PMM1` protocol (representing a private market maker)
@@ -152,10 +152,10 @@
             `GnosisSafe`: supports mainnet and rinkeby. `Web3`: supports every network [env: GAS_ESTIMATORS=]  [default:
             Web3]  [possible values: EthGasStation, GasNow, GnosisSafe, Web3]
         --gas-price-cap <gas-price-cap>
-            The maximum gas price the solver is willing to pay in a settlement [env: GAS_PRICE_CAP_GWEI=]  [default:
+            The maximum gas price in Gwei the solver is willing to pay in a settlement [env: GAS_PRICE_CAP=]  [default:
             1500]
         --http-timeout <http-timeout>
-            Timeout for all http requests [default: 10]
+            Timeout in seconds for all http requests [default: 10]
 
         --liquidity-order-owners <liquidity-order-owners>...
             The configured addresses whose orders should be considered liquidity and not to be included in the objective
@@ -167,8 +167,8 @@
             The list of tokens our settlement contract is willing to buy when settling trades without external liquidity
             [env: MARKET_MAKABLE_TOKEN_LIST=]  [default: https://tokens.coingecko.com/uniswap/all.json]
         --max-archer-submission-seconds <max-archer-submission-seconds>
-            The maximum time we spend trying to settle a transaction through the archer network before going to back to
-            solving [default: 60]
+            The maximum time in seconds we spend trying to settle a transaction through the archer network before going
+            to back to solving [default: 60]
         --max-merged-settlements <max-merged-settlements>
             The port at which we serve our metrics [env: MAX_MERGED_SETTLEMENTS=]  [default: 5]
 
@@ -176,9 +176,9 @@
             The port at which we serve our metrics [env: METRICS_PORT=]  [default: 9587]
 
         --min-order-age <min-order-age>
-            A settlement must contain at least one order older than this duration for it to be applied. Larger values
-            delay individual settlements more but have a higher coincidence of wants chance [env: MIN_ORDER_AGE=]
-            [default: 30]
+            A settlement must contain at least one order older than this duration in seconds for it to be applied.
+            Larger values delay individual settlements more but have a higher coincidence of wants chance [env:
+            MIN_ORDER_AGE=]  [default: 30]
         --min-order-size-one-inch <min-order-size-one-inch>
             The minimum amount of sell volume (in ETH) that needs to be traded in order to use the 1Inch solver [env:
             MIN_ORDER_SIZE_ONE_INCH=]  [default: 5]
@@ -201,8 +201,8 @@
             The number of blocks kept in the pool cache [env: POOL_CACHE_BLOCKS=]  [default: 10]
 
         --pool-cache-delay-between-retries-seconds <pool-cache-delay-between-retries-seconds>
-            How long to sleep between retries in the pool cache [env: POOL_CACHE_DELAY_BETWEEN_RETRIES_SECONDS=]
-            [default: 1]
+            How long to sleep in seconds between retries in the pool cache [env:
+            POOL_CACHE_DELAY_BETWEEN_RETRIES_SECONDS=]  [default: 1]
         --pool-cache-maximum-recent-block-age <pool-cache-maximum-recent-block-age>
             The number of pairs that are automatically updated in the pool cache [env:
             POOL_CACHE_MAXIMUM_RECENT_BLOCK_AGE=]  [default: 4]
@@ -219,19 +219,19 @@
             The API endpoint to call the mip v2 solver [env: QUASIMODO_SOLVER_URL=]  [default: http://localhost:8000]
 
         --settle-interval <settle-interval>
-            Every how often we should execute the driver's run loop [env: SETTLE_INTERVAL=]  [default: 10]
+            Every how often in seconds we should execute the driver's run loop [env: SETTLE_INTERVAL=]  [default: 10]
 
         --solver-private-keys <solver-private-keys>...
             Individual private keys for each solver [env: SOLVER_PRIVATE_KEYS]
 
         --solver-time-limit <solver-time-limit>
-            The maximum amount of time a solver is allowed to take [env: SOLVER_TIME_LIMIT=]  [default: 30]
+            The maximum amount of time in seconds a solver is allowed to take [env: SOLVER_TIME_LIMIT=]  [default: 30]
 
         --solvers <solvers>...
-            Which type of solver to use [env: SOLVER_TYPE=]  [default: Naive,Baseline]  [possible values: Naive,
-            Baseline, Mip, OneInch, Paraswap, ZeroEx, Quasimodo]
+            Which type of solver to use [env: SOLVERS=]  [default: Naive,Baseline]  [possible values: Naive, Baseline,
+            Mip, OneInch, Paraswap, ZeroEx, Quasimodo]
         --target-confirm-time <target-confirm-time>
-            The target confirmation time for settlement transactions used to estimate gas price [env:
+            The target confirmation time in seconds for settlement transactions used to estimate gas price [env:
             TARGET_CONFIRM_TIME=]  [default: 30]
         --transaction-strategy <transaction-strategy>
             How to to submit settlement transactions [env: TRANSACTION_STRATEGY=]  [default: PublicMempool]
```

</details>
