### PR TITLE
Allow missing `fullFeeAmount` field

### DIFF
--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -408,7 +408,7 @@ pub struct OrderMetaData {
     pub status: OrderStatus,
     #[serde(with = "h160_hexadecimal")]
     pub settlement_contract: H160,
-    #[serde(with = "u256_decimal")]
+    #[serde(default, with = "u256_decimal")]
     pub full_fee_amount: U256,
 }
 


### PR DESCRIPTION
This PR makes the `fullFeeAmount` field of order metadata default to 0 if missing. This allows `main` to stay compatible with the current production orderbook API.

This can be removed after the next release.

### Test Plan

CI. Trivial change.
