### PR TITLE
Return block number with solvable orders from database

### DIFF
--- a/orderbook/src/api/get_solvable_orders.rs
+++ b/orderbook/src/api/get_solvable_orders.rs
@@ -1,7 +1,6 @@
-use crate::api::convert_get_orders_error_to_reply;
 use crate::orderbook::Orderbook;
+use crate::{api::convert_get_orders_error_to_reply, solvable_orders::SolvableOrders};
 use anyhow::Result;
-use model::order::Order;
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
 
@@ -9,9 +8,12 @@ fn get_solvable_orders_request() -> impl Filter<Extract = (), Error = Rejection>
     warp::path!("solvable_orders").and(warp::get())
 }
 
-fn get_solvable_orders_response(result: Result<Vec<Order>>) -> impl Reply {
+fn get_solvable_orders_response(result: Result<SolvableOrders>) -> impl Reply {
     match result {
-        Ok(orders) => Ok(reply::with_status(reply::json(&orders), StatusCode::OK)),
+        Ok(orders) => Ok(reply::with_status(
+            reply::json(&orders.orders),
+            StatusCode::OK,
+        )),
         Err(err) => Ok(convert_get_orders_error_to_reply(err)),
     }
 }

--- a/orderbook/src/database/instrumented.rs
+++ b/orderbook/src/database/instrumented.rs
@@ -150,7 +150,10 @@ impl OrderStoring for Instrumented {
         self.inner.single_order(uid).await
     }
 
-    async fn solvable_orders(&self, min_valid_to: u32) -> anyhow::Result<Vec<model::order::Order>> {
+    async fn solvable_orders(
+        &self,
+        min_valid_to: u32,
+    ) -> anyhow::Result<super::orders::SolvableOrders> {
         let _timer = self
             .metrics
             .database_query_histogram("solvable_orders")


### PR DESCRIPTION
Part of https://github.com/gnosis/gp-v2-services/issues/882

The purpose is to return the block number of the most recently observed settlement with the solvable orders in the api. Then the driver can use of this to wait until the api has seen a recently submitted settlement transaction.

This PR does not yet change the http route. I will make a v2 solvable_orders route where we return this struct instead of just a list of orders. Unless someone has a different idea. Then we can eventually deprecate the v1 route.

### Test Plan
existing tests, new postgres test
