### PR TITLE
Use Debian slim image for services binary

### DIFF
--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -1,27 +1,27 @@
-FROM docker.io/clux/muslrust:stable as cargo-build
-WORKDIR /usr/src/oba-services
+FROM docker.io/rust:1-slim-bullseye as cargo-build
+WORKDIR /usr/local/src/gp-v2-services
 
 # Copy and Build Code
 COPY . .
-RUN env CARGO_PROFILE_RELEASE_DEBUG=1 cargo build --target x86_64-unknown-linux-musl --release
+RUN CARGO_PROFILE_RELEASE_DEBUG=1 cargo build --release
 
 RUN \
     cd .. && \
     git clone https://github.com/gnosis/regex-stream-split.git && \
     cd regex-stream-split && \
     git checkout edc88224612b9e151c334fa6d3a7d20575d83836 && \
-    cargo build --target x86_64-unknown-linux-musl --release
+    cargo build --release
 
 # Extract Binary
-FROM docker.io/alpine:latest
+FROM docker.io/debian:bullseye-slim
 
 # Handle signal handlers properly
-RUN apk add --no-cache tini
-COPY --from=cargo-build /usr/src/regex-stream-split/target/x86_64-unknown-linux-musl/release/regex-stream-split /usr/local/bin/regex-stream-split
-COPY --from=cargo-build /usr/src/oba-services/target/x86_64-unknown-linux-musl/release/orderbook /usr/local/bin/orderbook
-COPY --from=cargo-build /usr/src/oba-services/target/x86_64-unknown-linux-musl/release/solver /usr/local/bin/solver
-COPY --from=cargo-build /usr/src/oba-services/target/x86_64-unknown-linux-musl/release/alerter /usr/local/bin/alerter
+RUN apt-get update && apt-get install tini && apt-get clean
+COPY --from=cargo-build /usr/src/regex-stream-split/target/release/regex-stream-split /usr/local/bin/regex-stream-split
+COPY --from=cargo-build /usr/src/oba-services/target/release/orderbook /usr/local/bin/orderbook
+COPY --from=cargo-build /usr/src/oba-services/target/release/solver /usr/local/bin/solver
+COPY --from=cargo-build /usr/src/oba-services/target/release/alerter /usr/local/bin/alerter
 COPY docker/startup.sh /usr/local/bin/startup.sh
 
 CMD echo "Specify binary - either solver or orderbook"
-ENTRYPOINT ["/sbin/tini", "--", "startup.sh"]
+ENTRYPOINT ["/usr/bin/tini", "--", "startup.sh"]

--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -1,6 +1,9 @@
 FROM docker.io/rust:1-slim-bullseye as cargo-build
 WORKDIR /usr/local/src/gp-v2-services
 
+# Install dependencies
+RUN apt-get update && apt-get install -y git libssl-dev pkg-config
+
 # Copy and Build Code
 COPY . .
 RUN CARGO_PROFILE_RELEASE_DEBUG=1 cargo build --release
@@ -16,11 +19,11 @@ RUN \
 FROM docker.io/debian:bullseye-slim
 
 # Handle signal handlers properly
-RUN apt-get update && apt-get install tini && apt-get clean
-COPY --from=cargo-build /usr/src/regex-stream-split/target/release/regex-stream-split /usr/local/bin/regex-stream-split
-COPY --from=cargo-build /usr/src/oba-services/target/release/orderbook /usr/local/bin/orderbook
-COPY --from=cargo-build /usr/src/oba-services/target/release/solver /usr/local/bin/solver
-COPY --from=cargo-build /usr/src/oba-services/target/release/alerter /usr/local/bin/alerter
+RUN apt-get update && apt-get install -y ca-certificates tini && apt-get clean
+COPY --from=cargo-build /usr/local/src/regex-stream-split/target/release/regex-stream-split /usr/local/bin/regex-stream-split
+COPY --from=cargo-build /usr/local/src/gp-v2-services/target/release/orderbook /usr/local/bin/orderbook
+COPY --from=cargo-build /usr/local/src/gp-v2-services/target/release/solver /usr/local/bin/solver
+COPY --from=cargo-build /usr/local/src/gp-v2-services/target/release/alerter /usr/local/bin/alerter
 COPY docker/startup.sh /usr/local/bin/startup.sh
 
 CMD echo "Specify binary - either solver or orderbook"


### PR DESCRIPTION
This PR modifies services to use the Debian slim official Rust image to build our services binaries. This way we:
- Use the official Rust image
- Make debugging certain issues (like outdated OpenSSL) easier
- More "standard" build and distribution
- Faster builds (7 minutes for me vs 21 before)

### Test Plan

Build and run the image:
```
$ docker build . -f docker/Dockerfile.binary -t gnosispm/gp-v2-services
... # Takes a while, get a coffee :P
   Compiling shared v0.1.0 (/usr/local/src/gp-v2-services/shared)
   Compiling solver v0.1.0 (/usr/local/src/gp-v2-services/solver)
   Compiling orderbook v0.1.0 (/usr/local/src/gp-v2-services/orderbook)
   Compiling alerter v0.1.0 (/usr/local/src/gp-v2-services/alerter)
    Finished release [optimized + debuginfo] target(s) in 7m 22s
...
$ docker run -it --rm gnosispm/gp-v2-services solver \
  --base-tokens 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 \
  --baseline-sources Uniswap,Sushiswap,BalancerV2 \
  --orderbook-url https://protocol-mainnet.gnosis.io \
  --node-url "https://mainnet.infura.io/v3/$INFURA_PROJECT_ID" \
  --mip-solver-url "$MIP_SOLVER_URL" \
  --quasimodo-solver-url "$QUASIMODO_SOLVER_URL" \
  --solvers Mip,Quasimodo,ParaSwap,ZeroEx \
  --solver-account 0xa6DDBD0dE6B310819b49f680F65871beE85f517e \
  --transaction-strategy DryRun
...
2021-10-08T10:30:08.242Z DEBUG solver::driver: single run finished ok
```
