### PR TITLE
Use POSIX signal names

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -8,7 +8,7 @@
 ( "$@" & echo $! > main_pid ) | regex-stream-split '^\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z\s+(TRACE|DEBUG|INFO|WARN)' '^\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z\s+ERROR' &
 
 # Forward signal to main pid. Sync after killing to make sure the stdout is flushed
-trap 'kill -SIGTERM $(cat main_pid); sync' SIGTERM
-trap 'kill -SIGINT $(cat main_pid); sync' SIGINT
+trap 'kill -TERM $(cat main_pid); sync' TERM
+trap 'kill -INT $(cat main_pid); sync' INT
 
 wait


### PR DESCRIPTION
This PR fixes the `trap: SIGTERM: bad trap` alerts we started seeing since #1223. This is because POSIX `trap` and `kill` only specify that signal names must be accepted without the `SIG` prefix (accepting the prefix is optional):
- [`trap`](https://man7.org/linux/man-pages/man1/trap.1p.html) (emphasis my own)
    > The condition can be EXIT, 0 (equivalent to EXIT), or a signal
    > specified using a symbolic name, **without the SIG prefix**, as
    > listed in the tables of signal names in the <signal.h> header
    > defined in the Base Definitions volume of POSIX.1‐2017, Chapter
    > 13, Headers; for example, HUP, INT, QUIT, TERM. **Implementations
    > may permit names with the SIG prefix** or ignore case in signal
    > names as an extension.
- [`kill`](https://man7.org/linux/man-pages/man1/kill.1p.html) (emphasis my own)
    > Specify the signal to send, using one of the symbolic
    > names defined in the <signal.h> header. Values of
    > signal_name shall be recognized in a case-independent
    > fashion, **without the SIG prefix**. In addition, the
    > symbolic name 0 shall be recognized, representing the
    > signal value zero. The corresponding signal shall be
    > sent instead of SIGTERM.

### Test Plan

Build the image locally and run the `orderbook`, and hit `CTRL-C`.
```
$ docker build . -f docker/Dockerfile.binary -t gnosispm/gp-v2-services
...
$ docker run -it --rm --net host -e NODE_URL -e DB_URL gnosispm/gp-v2-services orderbook 
...
^C2021-10-08T12:38:53.016Z  INFO orderbook: Gracefully shutting down API
```
