### PR TITLE
V2 solvable orders route

### DIFF
--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -131,6 +131,13 @@ impl DomainSeparator {
     }
 }
 
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SolvableOrders {
+    pub orders: Vec<order::Order>,
+    pub latest_settlement_block: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -240,6 +240,27 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Order"
+  /api/v2/solvable_orders:
+    get:
+      summary: Get solvable orders.
+      description: |
+        The set of orders that solvers should be solving right now. These orders are determined to
+        be valid at the time of the request.
+      responses:
+        200:
+          description: the orders
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  orders:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Order"
+                  latestSettlementBlock:
+                    type: integer
+                    description: The block number in which the most recent settlement was observed.
   /api/v1/fee:
     get:
       description: |

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -7,6 +7,7 @@ mod get_order_by_uid;
 mod get_orders;
 mod get_orders_by_tx;
 mod get_solvable_orders;
+mod get_solvable_orders_v2;
 mod get_trades;
 mod get_user_orders;
 pub mod order_validation;
@@ -39,6 +40,7 @@ pub fn handle_all_routes(
     let fee_info = get_fee_info::get_fee_info(fee_calculator.clone());
     let get_order = get_order_by_uid::get_order_by_uid(orderbook.clone());
     let get_solvable_orders = get_solvable_orders::get_solvable_orders(orderbook.clone());
+    let get_solvable_orders_v2 = get_solvable_orders_v2::get_solvable_orders(orderbook.clone());
     let get_trades = get_trades::get_trades(database);
     let cancel_order = cancel_order::cancel_order(orderbook.clone());
     let get_amount_estimate = get_markets::get_amount_estimate(price_estimator.clone());
@@ -53,22 +55,27 @@ pub fn handle_all_routes(
         .allow_any_origin()
         .allow_methods(vec!["GET", "POST", "DELETE", "OPTIONS", "PUT", "PATCH"])
         .allow_headers(vec!["Origin", "Content-Type", "X-Auth-Token", "X-AppId"]);
-    let routes_with_labels = warp::path!("api" / "v1" / ..).and(
-        (create_order.with(handle_metrics("create_order")))
-            .or(get_orders.with(handle_metrics("get_orders")))
-            .or(fee_info.with(handle_metrics("fee_info")))
-            .or(legacy_fee_info.with(handle_metrics("legacy_fee_info")))
-            .or(get_order.with(handle_metrics("get_order")))
-            .or(get_solvable_orders.with(handle_metrics("get_solvable_orders")))
-            .or(get_trades.with(handle_metrics("get_trades")))
-            .or(cancel_order.with(handle_metrics("cancel_order")))
-            .or(get_amount_estimate.with(handle_metrics("get_amount_estimate")))
-            .or(get_fee_and_quote_sell.with(handle_metrics("get_fee_and_quote_sell")))
-            .or(get_fee_and_quote_buy.with(handle_metrics("get_fee_and_quote_buy")))
-            .or(get_user_orders.with(handle_metrics("get_user_orders")))
-            .or(get_orders_by_tx.with(handle_metrics("get_orders_by_tx")))
-            .or(post_quote.with(handle_metrics("get_user_orders"))),
-    );
+    let routes_with_labels = (warp::path!("api" / "v1" / ..)
+        .and(create_order.with(handle_metrics("create_order"))))
+    .or(warp::path!("api" / "v1" / ..).and(get_orders.with(handle_metrics("get_orders"))))
+    .or(warp::path!("api" / "v1" / ..).and(fee_info.with(handle_metrics("fee_info"))))
+    .or(warp::path!("api" / "v1" / ..).and(legacy_fee_info.with(handle_metrics("legacy_fee_info"))))
+    .or(warp::path!("api" / "v1" / ..).and(get_order.with(handle_metrics("get_order"))))
+    .or(warp::path!("api" / "v1" / ..)
+        .and(get_solvable_orders.with(handle_metrics("get_solvable_orders"))))
+    .or(warp::path!("api" / "v2" / ..)
+        .and(get_solvable_orders_v2.with(handle_metrics("get_solvable_orders"))))
+    .or(warp::path!("api" / "v1" / ..).and(get_trades.with(handle_metrics("get_trades"))))
+    .or(warp::path!("api" / "v1" / ..).and(cancel_order.with(handle_metrics("cancel_order"))))
+    .or(warp::path!("api" / "v1" / ..)
+        .and(get_amount_estimate.with(handle_metrics("get_amount_estimate"))))
+    .or(warp::path!("api" / "v1" / ..)
+        .and(get_fee_and_quote_sell.with(handle_metrics("get_fee_and_quote_sell"))))
+    .or(warp::path!("api" / "v1" / ..)
+        .and(get_fee_and_quote_buy.with(handle_metrics("get_fee_and_quote_buy"))))
+    .or(warp::path!("api" / "v1" / ..).and(get_user_orders.with(handle_metrics("get_user_orders"))))
+    .or(warp::path!("api" / "v1" / ..).and(get_orders_by_tx.with(handle_metrics("get_user_by_tx"))))
+    .or(warp::path!("api" / "v1" / ..).and(post_quote.with(handle_metrics("get_user_orders"))));
 
     routes_with_labels.recover(handle_rejection).with(cors)
 }

--- a/orderbook/src/api/get_solvable_orders_v2.rs
+++ b/orderbook/src/api/get_solvable_orders_v2.rs
@@ -1,0 +1,55 @@
+use crate::orderbook::Orderbook;
+use crate::{api::convert_get_orders_error_to_reply, solvable_orders::SolvableOrders};
+use anyhow::Result;
+use std::{convert::Infallible, sync::Arc};
+use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
+
+fn get_solvable_orders_request() -> impl Filter<Extract = (), Error = Rejection> + Clone {
+    warp::path!("solvable_orders").and(warp::get())
+}
+
+fn get_solvable_orders_response(result: Result<SolvableOrders>) -> impl Reply {
+    match result {
+        Ok(orders) => Ok(reply::with_status(
+            reply::json(&model::SolvableOrders {
+                orders: orders.orders,
+                latest_settlement_block: orders.latest_settlement_block,
+            }),
+            StatusCode::OK,
+        )),
+        Err(err) => Ok(convert_get_orders_error_to_reply(err)),
+    }
+}
+
+pub fn get_solvable_orders(
+    orderbook: Arc<Orderbook>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    get_solvable_orders_request().and_then(move || {
+        let orderbook = orderbook.clone();
+        async move {
+            let result = orderbook.get_solvable_orders().await;
+            Result::<_, Infallible>::Ok(get_solvable_orders_response(result))
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::response_body;
+    use std::time::Instant;
+
+    #[tokio::test]
+    async fn serialize_response() {
+        let orders = SolvableOrders {
+            orders: vec![],
+            update_time: Instant::now(),
+            latest_settlement_block: 1,
+        };
+        let response = get_solvable_orders_response(Ok(orders)).into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body(response).await;
+        let response: model::SolvableOrders = serde_json::from_slice(body.as_slice()).unwrap();
+        assert_eq!(response.latest_settlement_block, 1);
+    }
+}

--- a/orderbook/src/solvable_orders.rs
+++ b/orderbook/src/solvable_orders.rs
@@ -44,7 +44,7 @@ struct Inner {
 pub struct SolvableOrders {
     pub orders: Vec<Order>,
     pub update_time: Instant,
-    pub newest_settlement_block: u64,
+    pub latest_settlement_block: u64,
 }
 
 impl SolvableOrdersCache {
@@ -65,7 +65,7 @@ impl SolvableOrdersCache {
                 orders: SolvableOrders {
                     orders: Vec::new(),
                     update_time: Instant::now(),
-                    newest_settlement_block: 0,
+                    latest_settlement_block: 0,
                 },
                 balances: Default::default(),
                 block: 0,
@@ -137,7 +137,7 @@ impl SolvableOrdersCache {
             orders: SolvableOrders {
                 orders,
                 update_time: Instant::now(),
-                newest_settlement_block: db_solvable_orders.latest_settlement_block,
+                latest_settlement_block: db_solvable_orders.latest_settlement_block,
             },
             balances: new_balances,
             block,


### PR DESCRIPTION
Adds a new route that includes the settlement block information. The route is the same except that the returned json is now an object with an extra field for the block.

Had to adjust api.rs code so that it doesn't assume all paths share the same prefix.

### Test Plan
will do manual test
