### PR TITLE
Fix CI for EIP-1559

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -49,8 +49,20 @@ jobs:
         # Postgres tests should not run in parallel because they use the same database.
       - run: cargo test --locked --all-features postgres -- --ignored --test-threads 1
       - run: |
-          npm install ganache-cli
-          node_modules/.bin/ganache-cli --gasLimit 10000000 --gasPrice 0 --defaultBalanceEther 1000000 &
+          npm install hardhat
+          cat > hardhat.config.js <<EOF
+          module.exports = {
+            networks: {
+              hardhat: {
+                initialBaseFeePerGas: 0,
+                accounts: {
+                  accountsBalance: "1000000000000000000000000"
+                },
+              },
+            },
+          };
+          EOF
+          node_modules/.bin/hardhat node &
       - run: cargo run --locked --all-features --bin deploy
       - run: cargo test --locked --all-features --package e2e
   openapi:

--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -35,6 +35,7 @@ macro_rules! tx_value {
         $call
             .from($acc.clone())
             .value($value)
+            .gas_price(0.into())
             .send()
             .await
             .expect(&format!("{} failed", NAME))

--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -35,7 +35,7 @@ macro_rules! tx_value {
         $call
             .from($acc.clone())
             .value($value)
-            .gas_price(0.into())
+            .gas_price(0.0.into())
             .send()
             .await
             .expect(&format!("{} failed", NAME))


### PR DESCRIPTION
This PR fixes CI for EIP-1559 compatibility. Unfortunately, Ganache doesn't support EIP-1559 (its missing certain methods and JSON fields in its RPC implementation). There is a Ganache `7.0.0-alpha.1` but it doesn't mine reverted transactions, making it very hard to debug CI failures. For this reason we settled with `hardhat node` for starting up a development node for testing and seems to work with a minor change (specifically, we manually set a gas price of 0 for transactions - this needed because `eth_gasPrice` returns 1 GWEI, and the `gasPrice` setting in the Hardhat configuration does not seem to have an effect on this).

### Test Plan

CI.
