### PR TITLE
Internally use estimate_gas for settlement simulation at current block

### DIFF
--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -5,11 +5,11 @@ mod gas_price_stream;
 pub mod retry;
 pub mod rpc;
 
-use crate::{encoding::EncodedSettlement, settlement::Settlement};
+use crate::settlement::Settlement;
 use anyhow::{bail, Result};
 use archer_api::ArcherApi;
 use contracts::GPv2Settlement;
-use ethcontract::{errors::ExecutionError, Account, TransactionHash};
+use ethcontract::{Account, TransactionHash};
 use gas_estimation::GasPriceEstimating;
 use primitive_types::U256;
 use shared::Web3;
@@ -22,17 +22,6 @@ use self::archer_settlement::ArcherSolutionSubmitter;
 
 const ESTIMATE_GAS_LIMIT_FACTOR: f64 = 1.2;
 const GAS_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
-
-pub async fn estimate_gas(
-    contract: &GPv2Settlement,
-    settlement: &EncodedSettlement,
-    from: Account,
-) -> Result<U256, ExecutionError> {
-    retry::settle_method_builder(contract, settlement.clone(), from)
-        .tx
-        .estimate_gas()
-        .await
-}
 
 pub struct SolutionSubmitter {
     pub web3: Web3,

--- a/solver/src/settlement_submission/archer_settlement.rs
+++ b/solver/src/settlement_submission/archer_settlement.rs
@@ -406,13 +406,19 @@ mod tests {
         let gas_price_cap = 100e9;
 
         let settlement = Settlement::new(Default::default());
-        let gas_estimate = crate::settlement_submission::estimate_gas(
-            &contract,
-            &settlement.clone().into(),
-            account.clone(),
-        )
-        .await
-        .unwrap();
+        let gas_estimate =
+            crate::settlement_simulation::simulate_and_estimate_gas_at_current_block(
+                std::iter::once((account.clone(), settlement.clone())),
+                &contract,
+                &web3,
+                0.0,
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
 
         let submitter = ArcherSolutionSubmitter::new(
             &web3,


### PR DESCRIPTION
Estimate gas internally simulates the transaction which tells us whether
the simulation succeeded and how much gas was used in one call.

Next I will change the driver to use this function so that we do not simulate twice.

### Test Plan
Adapted the ignored test to call the new function and ran the test.