### PR TITLE
Remove inflight trades in favor of waiting for api to see settlement

### DIFF
--- a/e2e/tests/eth_integration.rs
+++ b/e2e/tests/eth_integration.rs
@@ -205,9 +205,10 @@ async fn eth_integration(web3: Web3) {
         }),
     );
     let solver = solver::solver::naive_solver(solver_account);
+    let (orderbook_liquidity, api) = create_orderbook_liquidity(&web3, weth.address());
     let liquidity_collector = LiquidityCollector {
         uniswap_like_liquidity: vec![uniswap_liquidity],
-        orderbook_liquidity: create_orderbook_liquidity(&web3, weth.address()),
+        orderbook_liquidity,
         balancer_v2_liquidity: None,
     };
     let network_id = web3.net().version().await.unwrap();
@@ -217,7 +218,6 @@ async fn eth_integration(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
-        Duration::from_secs(30),
         weth.address(),
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),
@@ -238,6 +238,7 @@ async fn eth_integration(web3: Web3) {
             ),
         },
         1_000_000_000_000_000_000_u128.into(),
+        api,
     );
     driver.single_run().await.unwrap();
 
@@ -261,5 +262,5 @@ async fn eth_integration(web3: Web3) {
     solvable_orders_cache.update(0).await.unwrap();
 
     let orders = create_orderbook_api().get_orders().await.unwrap();
-    assert!(orders.is_empty());
+    assert!(orders.orders.is_empty());
 }

--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -57,14 +57,15 @@ pub fn create_orderbook_api() -> OrderBookApi {
     OrderBookApi::new(reqwest::Url::from_str(API_HOST).unwrap(), Client::new())
 }
 
-pub fn create_orderbook_liquidity(web3: &Web3, weth_address: H160) -> OrderbookLiquidity {
+pub fn create_orderbook_liquidity(
+    web3: &Web3,
+    weth_address: H160,
+) -> (OrderbookLiquidity, OrderBookApi) {
     let weth = WETH9::at(web3, weth_address);
-    OrderbookLiquidity::new(
-        reqwest::Url::from_str(API_HOST).unwrap(),
-        Client::new(),
-        weth,
-        Default::default(),
-        1.,
+    let api = OrderBookApi::new(reqwest::Url::from_str(API_HOST).unwrap(), Client::new());
+    (
+        OrderbookLiquidity::new(api.clone(), weth, Default::default(), 1.),
+        api,
     )
 }
 

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -192,9 +192,10 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         }),
     );
     let solver = solver::solver::naive_solver(solver_account);
+    let (orderbook_liquidity, api) = create_orderbook_liquidity(&web3, gpv2.native_token.address());
     let liquidity_collector = LiquidityCollector {
         uniswap_like_liquidity: vec![uniswap_liquidity],
-        orderbook_liquidity: create_orderbook_liquidity(&web3, gpv2.native_token.address()),
+        orderbook_liquidity,
         balancer_v2_liquidity: None,
     };
     let network_id = web3.net().version().await.unwrap();
@@ -212,7 +213,6 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
-        Duration::from_secs(30),
         gpv2.native_token.address(),
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),
@@ -233,6 +233,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             ),
         },
         1_000_000_000_000_000_000_u128.into(),
+        api,
     );
     driver.single_run().await.unwrap();
 
@@ -264,7 +265,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
     solvable_orders_cache.update(0).await.unwrap();
 
     let orders = create_orderbook_api().get_orders().await.unwrap();
-    assert!(orders.is_empty());
+    assert!(orders.orders.is_empty());
 
     // Drive again to ensure we can continue solution finding
     driver.single_run().await.unwrap();

--- a/e2e/tests/smart_contract_orders.rs
+++ b/e2e/tests/smart_contract_orders.rs
@@ -175,9 +175,10 @@ async fn smart_contract_orders(web3: Web3) {
         }),
     );
     let solver = solver::solver::naive_solver(solver_account);
+    let (orderbook_liquidity, api) = create_orderbook_liquidity(&web3, gpv2.native_token.address());
     let liquidity_collector = LiquidityCollector {
         uniswap_like_liquidity: vec![uniswap_liquidity],
-        orderbook_liquidity: create_orderbook_liquidity(&web3, gpv2.native_token.address()),
+        orderbook_liquidity,
         balancer_v2_liquidity: None,
     };
     let network_id = web3.net().version().await.unwrap();
@@ -187,7 +188,6 @@ async fn smart_contract_orders(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
-        Duration::from_secs(30),
         gpv2.native_token.address(),
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),
@@ -208,6 +208,7 @@ async fn smart_contract_orders(web3: Web3) {
             ),
         },
         1_000_000_000_000_000_000_u128.into(),
+        api,
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/vault_balances.rs
+++ b/e2e/tests/vault_balances.rs
@@ -153,9 +153,10 @@ async fn vault_balances(web3: Web3) {
         }),
     );
     let solver = solver::solver::naive_solver(solver_account);
+    let (orderbook_liquidity, api) = create_orderbook_liquidity(&web3, gpv2.native_token.address());
     let liquidity_collector = LiquidityCollector {
         uniswap_like_liquidity: vec![uniswap_liquidity],
-        orderbook_liquidity: create_orderbook_liquidity(&web3, gpv2.native_token.address()),
+        orderbook_liquidity,
         balancer_v2_liquidity: None,
     };
     let network_id = web3.net().version().await.unwrap();
@@ -165,7 +166,6 @@ async fn vault_balances(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
-        Duration::from_secs(30),
         gpv2.native_token.address(),
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),
@@ -186,6 +186,7 @@ async fn vault_balances(web3: Web3) {
             ),
         },
         1_000_000_000_000_000_000_u128.into(),
+        api,
     );
     driver.single_run().await.unwrap();
 

--- a/solver/src/liquidity_collector.rs
+++ b/solver/src/liquidity_collector.rs
@@ -6,9 +6,7 @@ use crate::{
     },
 };
 use anyhow::{Context, Result};
-use model::order::OrderUid;
 use shared::recent_block_cache::Block;
-use std::collections::HashSet;
 
 pub struct LiquidityCollector {
     pub orderbook_liquidity: OrderbookLiquidity,
@@ -17,10 +15,10 @@ pub struct LiquidityCollector {
 }
 
 impl LiquidityCollector {
-    pub async fn get_orders(&self, inflight_trades: &HashSet<OrderUid>) -> Result<Vec<LimitOrder>> {
+    pub async fn get_orders(&self) -> Result<Vec<LimitOrder>> {
         let limit_orders = self
             .orderbook_liquidity
-            .get_liquidity(inflight_trades)
+            .get_liquidity()
             .await
             .context("failed to get orderbook liquidity")?;
         tracing::info!("got {} orders: {:?}", limit_orders.len(), limit_orders);

--- a/solver/src/orderbook.rs
+++ b/solver/src/orderbook.rs
@@ -1,6 +1,7 @@
-use model::order::Order;
+use model::SolvableOrders;
 use reqwest::{Client, Url};
 
+#[derive(Clone)]
 pub struct OrderBookApi {
     base: Url,
     client: Client,
@@ -12,8 +13,8 @@ impl OrderBookApi {
         Self { base, client }
     }
 
-    pub async fn get_orders(&self) -> reqwest::Result<Vec<Order>> {
-        const PATH: &str = "/api/v1/solvable_orders";
+    pub async fn get_orders(&self) -> reqwest::Result<SolvableOrders> {
+        const PATH: &str = "/api/v2/solvable_orders";
         let mut url = self.base.clone();
         url.set_path(PATH);
         self.client.get(url).send().await?.json().await

--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -9,7 +9,7 @@ use crate::settlement::Settlement;
 use anyhow::{bail, Result};
 use archer_api::ArcherApi;
 use contracts::GPv2Settlement;
-use ethcontract::{Account, TransactionHash};
+use ethcontract::Account;
 use gas_estimation::GasPriceEstimating;
 use primitive_types::U256;
 use shared::Web3;
@@ -17,6 +17,7 @@ use std::{
     sync::Arc,
     time::{Duration, SystemTime},
 };
+use web3::types::TransactionReceipt;
 
 use self::archer_settlement::ArcherSolutionSubmitter;
 
@@ -53,7 +54,7 @@ impl SolutionSubmitter {
         settlement: Settlement,
         gas_estimate: U256,
         account: Account,
-    ) -> Result<TransactionHash> {
+    ) -> Result<TransactionReceipt> {
         match &self.transaction_strategy {
             TransactionStrategy::CustomNodes(nodes) => {
                 rpc::submit(

--- a/solver/src/settlement_submission/archer_settlement.rs
+++ b/solver/src/settlement_submission/archer_settlement.rs
@@ -37,7 +37,7 @@ use gas_estimation::GasPriceEstimating;
 use primitive_types::{H256, U256};
 use shared::Web3;
 use std::time::{Duration, Instant, SystemTime};
-use web3::types::TransactionId;
+use web3::types::TransactionReceipt;
 
 pub struct ArcherSolutionSubmitter<'a> {
     web3: &'a Web3,
@@ -89,7 +89,7 @@ impl<'a> ArcherSolutionSubmitter<'a> {
         deadline: SystemTime,
         settlement: Settlement,
         gas_estimate: U256,
-    ) -> Result<Option<H256>> {
+    ) -> Result<Option<TransactionReceipt>> {
         let nonce = self.nonce().await?;
 
         tracing::info!(
@@ -136,9 +136,9 @@ impl<'a> ArcherSolutionSubmitter<'a> {
             );
 
             loop {
-                if let Some(hash) = find_mined_transaction(self.web3, &transactions).await {
-                    tracing::info!("found mined transaction {}", hash);
-                    return Ok(Some(hash));
+                if let Some(receipt) = find_mined_transaction(self.web3, &transactions).await {
+                    tracing::info!("found mined transaction {}", receipt.transaction_hash);
+                    return Ok(Some(receipt));
                 }
                 if Instant::now() + MINED_TX_CHECK_INTERVAL > tx_to_propagate_deadline {
                     break;
@@ -305,13 +305,13 @@ impl<'a> ArcherSolutionSubmitter<'a> {
 }
 
 /// From a list of potential hashes find one that was mined.
-async fn find_mined_transaction(web3: &Web3, hashes: &[H256]) -> Option<H256> {
+async fn find_mined_transaction(web3: &Web3, hashes: &[H256]) -> Option<TransactionReceipt> {
     // It would be nice to use the nonce and account address to find the transaction hash but there
     // is no way to do this in ethrpc api so we have to check the candidates one by one.
     let web3 = web3::Web3::new(web3::transports::Batch::new(web3.transport()));
     let futures = hashes
         .iter()
-        .map(|&hash| web3.eth().transaction(TransactionId::Hash(hash)))
+        .map(|&hash| web3.eth().transaction_receipt(hash))
         .collect::<Vec<_>>();
     if let Err(err) = web3.transport().submit_batch().await {
         tracing::error!("mined transaction batch failed: {:?}", err);
@@ -322,9 +322,7 @@ async fn find_mined_transaction(web3: &Web3, hashes: &[H256]) -> Option<H256> {
             Err(err) => {
                 tracing::error!("mined transaction individual failed: {:?}", err);
             }
-            Ok(Some(transaction)) if transaction.block_hash.is_some() => {
-                return Some(transaction.hash)
-            }
+            Ok(Some(transaction)) if transaction.block_hash.is_some() => return Some(transaction),
             Ok(_) => (),
         }
     }
@@ -379,7 +377,13 @@ mod tests {
                 "b9752d57ea49d8055bf50a1361f066691d7b4f2abd555e71896370d1eccda526"
             )),
         ];
-        assert_eq!(find_mined_transaction(&web3, hashes).await, Some(hashes[1]));
+        assert_eq!(
+            find_mined_transaction(&web3, hashes)
+                .await
+                .unwrap()
+                .transaction_hash,
+            hashes[1]
+        );
     }
 
     // env NODE_URL=... PRIVATE_KEY=... ARCHER_AUTHORIZATION=... cargo test -p solver mainnet_settlement -- --ignored --nocapture

--- a/solver/src/settlement_submission/dry_run.rs
+++ b/solver/src/settlement_submission/dry_run.rs
@@ -4,13 +4,14 @@ use super::retry::settle_method_builder;
 use crate::{settlement::Settlement, settlement_simulation::tenderly_link};
 use anyhow::Result;
 use contracts::GPv2Settlement;
-use ethcontract::{Account, TransactionHash};
+use ethcontract::Account;
+use web3::types::TransactionReceipt;
 
 pub async fn log_settlement(
     account: Account,
     contract: &GPv2Settlement,
     settlement: Settlement,
-) -> Result<TransactionHash> {
+) -> Result<TransactionReceipt> {
     let web3 = contract.raw_instance().web3();
     let current_block = web3.eth().block_number().await?;
     let network = web3.net().version().await?;

--- a/solver/src/settlement_submission/rpc.rs
+++ b/solver/src/settlement_submission/rpc.rs
@@ -6,13 +6,14 @@ use super::{
 use crate::{encoding::EncodedSettlement, pending_transactions::Fee, settlement::Settlement};
 use anyhow::{Context, Result};
 use contracts::GPv2Settlement;
-use ethcontract::{Account, TransactionHash};
+use ethcontract::Account;
 use futures::stream::StreamExt;
 use gas_estimation::GasPriceEstimating;
 use primitive_types::{H160, U256};
 use shared::Web3;
 use std::time::Duration;
 use transaction_retry::RetryResult;
+use web3::types::TransactionReceipt;
 
 // Submit a settlement to the contract, updating the transaction with gas prices if they increase.
 #[allow(clippy::too_many_arguments)]
@@ -25,7 +26,7 @@ pub async fn submit(
     gas_price_cap: f64,
     settlement: Settlement,
     gas_estimate: U256,
-) -> Result<TransactionHash> {
+) -> Result<TransactionReceipt> {
     let address = account.address();
     let settlement: EncodedSettlement = settlement.into();
 


### PR DESCRIPTION
Because the code is simpler. Also gets rid of the driver run loop
interval because it no longer serves any purpose. This should improve
throughput.

### Test Plan
CI and I'm going to observe logs on staging after merging
