### PR TITLE
Fix quote to use sell amount after fees.

### DIFF
--- a/orderbook/src/api/post_quote.rs
+++ b/orderbook/src/api/post_quote.rs
@@ -235,38 +235,38 @@ impl OrderQuoter {
                     return Err(FeeError::PriceEstimate(PriceEstimationError::ZeroAmount));
                 }
 
-                    let (fee, expiration) = self
-                        .fee_calculator
-                        .compute_unsubsidized_min_fee(
-                            quote_request.sell_token,
-                            Some(quote_request.buy_token),
-                            Some(sell_amount_before_fee),
-                            Some(OrderKind::Sell),
-                            Some(quote_request.app_data),
-                        )
-                        .await
-                        .map_err(FeeError::PriceEstimate)?;
-                    let sell_amount_after_fee = sell_amount_before_fee
-                        .checked_sub(fee)
-                        .ok_or(FeeError::SellAmountDoesNotCoverFee)?
-                        .max(U256::one());
-                    let estimate = self
-                        .price_estimator
-                        .estimate(&price_estimation::Query {
-                            sell_token: quote_request.sell_token,
-                            buy_token: quote_request.buy_token,
-                            in_amount: sell_amount_after_fee,
-                            kind: OrderKind::Sell,
-                        })
-                        .await
-                        .map_err(FeeError::PriceEstimate)?;
-                    FeeParameters {
-                        buy_amount: estimate.out_amount,
-                        sell_amount: sell_amount_after_fee,
-                        fee_amount: fee,
-                        expiration,
+                let (fee, expiration) = self
+                    .fee_calculator
+                    .compute_unsubsidized_min_fee(
+                        quote_request.sell_token,
+                        Some(quote_request.buy_token),
+                        Some(sell_amount_before_fee),
+                        Some(OrderKind::Sell),
+                        Some(quote_request.app_data),
+                    )
+                    .await
+                    .map_err(FeeError::PriceEstimate)?;
+                let sell_amount_after_fee = sell_amount_before_fee
+                    .checked_sub(fee)
+                    .ok_or(FeeError::SellAmountDoesNotCoverFee)?
+                    .max(U256::one());
+                let estimate = self
+                    .price_estimator
+                    .estimate(&price_estimation::Query {
+                        sell_token: quote_request.sell_token,
+                        buy_token: quote_request.buy_token,
+                        in_amount: sell_amount_after_fee,
                         kind: OrderKind::Sell,
-                    }
+                    })
+                    .await
+                    .map_err(FeeError::PriceEstimate)?;
+                FeeParameters {
+                    buy_amount: estimate.out_amount,
+                    sell_amount: sell_amount_after_fee,
+                    fee_amount: fee,
+                    expiration,
+                    kind: OrderKind::Sell,
+                }
             }
             OrderQuoteSide::Sell {
                 sell_amount: SellAmount::AfterFee { .. },
@@ -283,35 +283,35 @@ impl OrderQuoter {
                     return Err(FeeError::PriceEstimate(PriceEstimationError::ZeroAmount));
                 }
 
-                    let (fee, expiration) = self
-                        .fee_calculator
-                        .compute_unsubsidized_min_fee(
-                            quote_request.sell_token,
-                            Some(quote_request.buy_token),
-                            Some(buy_amount_after_fee),
-                            Some(OrderKind::Buy),
-                            Some(quote_request.app_data),
-                        )
-                        .await
-                        .map_err(FeeError::PriceEstimate)?;
-                    let estimate = self
-                        .price_estimator
-                        .estimate(&price_estimation::Query {
-                            sell_token: quote_request.sell_token,
-                            buy_token: quote_request.buy_token,
-                            in_amount: buy_amount_after_fee,
-                            kind: OrderKind::Buy,
-                        })
-                        .await
-                        .map_err(FeeError::PriceEstimate)?;
-                    let sell_amount_after_fee = estimate.out_amount;
-                    FeeParameters {
-                        buy_amount: buy_amount_after_fee,
-                        sell_amount: sell_amount_after_fee,
-                        fee_amount: fee,
-                        expiration,
+                let (fee, expiration) = self
+                    .fee_calculator
+                    .compute_unsubsidized_min_fee(
+                        quote_request.sell_token,
+                        Some(quote_request.buy_token),
+                        Some(buy_amount_after_fee),
+                        Some(OrderKind::Buy),
+                        Some(quote_request.app_data),
+                    )
+                    .await
+                    .map_err(FeeError::PriceEstimate)?;
+                let estimate = self
+                    .price_estimator
+                    .estimate(&price_estimation::Query {
+                        sell_token: quote_request.sell_token,
+                        buy_token: quote_request.buy_token,
+                        in_amount: buy_amount_after_fee,
                         kind: OrderKind::Buy,
-                    }
+                    })
+                    .await
+                    .map_err(FeeError::PriceEstimate)?;
+                let sell_amount_after_fee = estimate.out_amount;
+                FeeParameters {
+                    buy_amount: buy_amount_after_fee,
+                    sell_amount: sell_amount_after_fee,
+                    fee_amount: fee,
+                    expiration,
+                    kind: OrderKind::Buy,
+                }
             }
         })
     }

--- a/orderbook/src/api/post_quote.rs
+++ b/orderbook/src/api/post_quote.rs
@@ -224,7 +224,7 @@ impl OrderQuoter {
         &self,
         quote_request: &OrderQuoteRequest,
     ) -> Result<FeeParameters, FeeError> {
-        match quote_request.side {
+        Ok(match quote_request.side {
             OrderQuoteSide::Sell {
                 sell_amount:
                     SellAmount::BeforeFee {
@@ -232,8 +232,9 @@ impl OrderQuoter {
                     },
             } => {
                 if sell_amount_before_fee.is_zero() {
-                    Err(FeeError::PriceEstimate(PriceEstimationError::ZeroAmount))
-                } else {
+                    return Err(FeeError::PriceEstimate(PriceEstimationError::ZeroAmount));
+                }
+
                     let (fee, expiration) = self
                         .fee_calculator
                         .compute_unsubsidized_min_fee(
@@ -259,29 +260,29 @@ impl OrderQuoter {
                         })
                         .await
                         .map_err(FeeError::PriceEstimate)?;
-                    Ok(FeeParameters {
+                    FeeParameters {
                         buy_amount: estimate.out_amount,
-                        sell_amount: sell_amount_before_fee,
+                        sell_amount: sell_amount_after_fee,
                         fee_amount: fee,
                         expiration,
                         kind: OrderKind::Sell,
-                    })
-                }
+                    }
             }
             OrderQuoteSide::Sell {
                 sell_amount: SellAmount::AfterFee { .. },
             } => {
                 // TODO: Nice to have: true sell amount after the fee (more complicated).
-                Err(FeeError::PriceEstimate(PriceEstimationError::Other(
+                return Err(FeeError::PriceEstimate(PriceEstimationError::Other(
                     anyhow!("Currently unsupported route"),
-                )))
+                )));
             }
             OrderQuoteSide::Buy {
                 buy_amount_after_fee,
             } => {
                 if buy_amount_after_fee.is_zero() {
-                    Err(FeeError::PriceEstimate(PriceEstimationError::ZeroAmount))
-                } else {
+                    return Err(FeeError::PriceEstimate(PriceEstimationError::ZeroAmount));
+                }
+
                     let (fee, expiration) = self
                         .fee_calculator
                         .compute_unsubsidized_min_fee(
@@ -303,22 +304,16 @@ impl OrderQuoter {
                         })
                         .await
                         .map_err(FeeError::PriceEstimate)?;
-                    let sell_amount_before_fee =
-                        estimate.out_amount.checked_add(fee).ok_or_else(|| {
-                            FeeError::PriceEstimate(PriceEstimationError::Other(anyhow!(
-                                "overflow in sell_amount_before_fee"
-                            )))
-                        })?;
-                    Ok(FeeParameters {
+                    let sell_amount_after_fee = estimate.out_amount;
+                    FeeParameters {
                         buy_amount: buy_amount_after_fee,
-                        sell_amount: sell_amount_before_fee,
+                        sell_amount: sell_amount_after_fee,
                         fee_amount: fee,
                         expiration,
                         kind: OrderKind::Buy,
-                    })
-                }
+                    }
             }
-        }
+        })
     }
 }
 
@@ -575,7 +570,7 @@ mod tests {
             result,
             FeeParameters {
                 buy_amount: 14.into(),
-                sell_amount: 10.into(),
+                sell_amount: 7.into(),
                 fee_amount: 3.into(),
                 expiration,
                 kind: OrderKind::Sell
@@ -655,7 +650,7 @@ mod tests {
             result,
             FeeParameters {
                 buy_amount: 10.into(),
-                sell_amount: 23.into(),
+                sell_amount: 20.into(),
                 fee_amount: 3.into(),
                 expiration,
                 kind: OrderKind::Buy
@@ -705,7 +700,7 @@ mod tests {
             sell_token: H160::from_low_u64_be(1),
             buy_token: H160::from_low_u64_be(2),
             receiver: None,
-            sell_amount: 17.into(), // TODO - verify that this is indeed correct.
+            sell_amount: 14.into(),
             kind: OrderKind::Buy,
             partially_fillable: false,
             sell_token_balance: Default::default(),


### PR DESCRIPTION
This PR fixes the price estimation to use sell amounts after fees instead of before fees in the order being returned by the quote. It appears that this was also an issue with the previous `feeAndQuote` route, but because the FE never used it we just never noticed.

As with anything price related, please double check my logic :stuck_out_tongue:.

### Logic behind the issue

<details><summary>Sell order</summary>

Consider the following quote:
```
$ curl -s 'hcurl -s 'https://protocol-mainnet.dev.gnosisdev.com/api/v1/quote' \
  -X POST -H 'Content-Type: application/json' \
  --data '@-' <<EOF | jq '.quote'
{
  "sellToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
  "buyToken": "0x6810e776880c02933d47db1b9fc05908e5386b96",
  "receiver": "0x9008D19f58AAbD9eD0D60971565AA8510560ab41",
  "validTo": 1642933600,
  "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
  "partiallyFillable": false,
  "sellTokenBalance": "erc20",
  "buyTokenBalance": "erc20",
  "from": "0x9008D19f58AAbD9eD0D60971565AA8510560ab41",
  "kind": "sell",
  "sellAmountBeforeFee": "99999999999999999999"
}
EOF
{
  "sellToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
  "buyToken": "0x6810e776880c02933d47db1b9fc05908e5386b96",
  "receiver": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
  "sellAmount": "99999999999999999999",
  "buyAmount": "1130670041002376308447",
  "validTo": 1642933600,
  "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
  "feeAmount": "19457353360933336",
  "kind": "sell",
  "partiallyFillable": false,
  "sellTokenBalance": "erc20",
  "buyTokenBalance": "erc20"
}
```

Notice how the resulting total amount being transferred out would be `sellAmount + feeAmount != sellAmountBeforeFee`. We can also check that the buy amount estimate is off:

```
$ curl -s 'https://protocol-mainnet.dev.gnosisdev.com/api/v1/markets/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2-0x6810e776880c02933d47db1b9fc05908e5386b96/sell/99999999999999999999' | jq
{
  "amount": "1130887745446190225918",
  "token": "0x6810e776880c02933d47db1b9fc05908e5386b96"
}
$ curl -s 'https://protocol-mainnet.dev.gnosisdev.com/api/v1/markets/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2-0x6810e776880c02933d47db1b9fc05908e5386b96/sell/99980542646639066663' | jq
{
  "amount": "1130670041002376308447",
  "token": "0x6810e776880c02933d47db1b9fc05908e5386b96"
}
```

Noticing that the quoted `buyAmount` is for that of the sell amount **after** fees (i.e. `sellAmountBeforeFee - feeAmount`.

</details>

<details><summary>Buy Order</summary>

The same applies for buy orders:

```
$ curl -s 'hcurl -s 'https://protocol-mainnet.dev.gnosisdev.com/api/v1/quote' \
  -X POST -H 'Content-Type: application/json' \
  --data '@-' <<EOF | jq '.quote'
{
  "sellToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
  "buyToken": "0x6810e776880c02933d47db1b9fc05908e5386b96",
  "receiver": "0x9008D19f58AAbD9eD0D60971565AA8510560ab41",
  "validTo": 1642933600,
  "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
  "partiallyFillable": false,
  "sellTokenBalance": "erc20",
  "buyTokenBalance": "erc20",
  "from": "0x9008D19f58AAbD9eD0D60971565AA8510560ab41",
  "kind": "buy",
  "buyAmountAfterFee": "1000000000000000000"
}
EOF
{
  "sellToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
  "buyToken": "0x6810e776880c02933d47db1b9fc05908e5386b96",
  "receiver": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
  "sellAmount": "99263306172383937",
  "buyAmount": "1000000000000000000",
  "validTo": 1642933600,
  "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
  "feeAmount": "11513335111283690",
  "kind": "buy",
  "partiallyFillable": false,
  "sellTokenBalance": "erc20",
  "buyTokenBalance": "erc20"
}
$ curl -s 'https://protocol-mainnet.dev.gnosisdev.com/api/v1/markets/0x6810e776880c02933d47db1b9fc05908e5386b96-0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/buy/1000000000000000000' | jq
{
  "amount": "87749971061100247",
  "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
}
$ python -c 'print(87749971061100247 + 11513335111283690)'
99263306172383937
```

Notice how the quoted sell amount is higher than what it actually needs to be in order to buy `1000000000000000000` of a token by exactly `feeAmount`.

</details>

### Test Plan

Updated unit tests, running the commands :point_up: produces the expected results.

### Note to reviewers

I moved the code around a little (used early return to get rid of some right-ward drift) which caused an indentation change. In order to make the PR easier to review I split it into two commits. The commit with the actual changes is https://github.com/gnosis/gp-v2-services/pull/1256/commits/6991f344e28db8c59f2a299663d26ad21b28ffbf, while the second commit is just the result of `cargo fmt`. **I suggest using the link above to make reviewing easier**.