### PR TITLE
[Trivial] Fix uncatalogued Paraswap Error

### DIFF
--- a/shared/src/paraswap_api.rs
+++ b/shared/src/paraswap_api.rs
@@ -161,7 +161,7 @@ fn parse_paraswap_response_text(
             "Unable to process the transaction" => {
                 Err(ParaswapResponseError::BuildingTransaction(message))
             }
-            "Server is too busy" => Err(ParaswapResponseError::ServerBusy),
+            "Server too busy" => Err(ParaswapResponseError::ServerBusy),
             _ => Err(ParaswapResponseError::UnknownParaswapError(format!(
                 "uncatalogued error message {}",
                 message


### PR DESCRIPTION
Even though this was a well-known error, we were getting several alerts like [this](https://gnosisinc.slack.com/archives/CUD4MUCUF/p1634221398029700) one that it was uncatalogued. This is because either they changed the text of their error message or we added a word to it during refactoring.

After a bit of digging a bit into [slack alerts](https://gnosisinc.slack.com/archives/CUD4MUCUF/p1634044732096200), and [this PR](https://github.com/gnosis/gp-v2-services/pull/1184/files). It appears this text change was made in the Paraswap API on October 12, 2021.
