### PR TITLE
[Trivial] Demote OrderQuoteError caused by users to WARN

### DIFF
--- a/orderbook/src/api/post_quote.rs
+++ b/orderbook/src/api/post_quote.rs
@@ -354,7 +354,16 @@ pub fn post_quote(
         async move {
             let result = quoter.calculate_quote(&request).await;
             if let Err(err) = &result {
-                tracing::error!(?err, ?request, "post_quote error");
+                match err {
+                    OrderQuoteError::Fee(FeeError::PriceEstimate(PriceEstimationError::Other(err))) => {
+                        tracing::error!(?err, ?request, "post_quote Fee error");
+                    },
+                    OrderQuoteError::Order(ValidationError::Other(err))=> {
+                        tracing::error!(?err, ?request, "post_quote Order Validation error");
+                    },
+                    _ => tracing::warn!(?err, ?request, "post_quote User error")
+                }
+
             }
             Result::<_, Infallible>::Ok(response(result))
         }

--- a/orderbook/src/api/post_quote.rs
+++ b/orderbook/src/api/post_quote.rs
@@ -355,15 +355,16 @@ pub fn post_quote(
             let result = quoter.calculate_quote(&request).await;
             if let Err(err) = &result {
                 match err {
-                    OrderQuoteError::Fee(FeeError::PriceEstimate(PriceEstimationError::Other(err))) => {
+                    OrderQuoteError::Fee(FeeError::PriceEstimate(PriceEstimationError::Other(
+                        err,
+                    ))) => {
                         tracing::error!(?err, ?request, "post_quote Fee error");
-                    },
-                    OrderQuoteError::Order(ValidationError::Other(err))=> {
+                    }
+                    OrderQuoteError::Order(ValidationError::Other(err)) => {
                         tracing::error!(?err, ?request, "post_quote Order Validation error");
-                    },
-                    _ => tracing::warn!(?err, ?request, "post_quote User error")
+                    }
+                    _ => tracing::warn!(?err, ?request, "post_quote User error"),
                 }
-
             }
             Result::<_, Infallible>::Ok(response(result))
         }

--- a/orderbook/src/api/post_quote.rs
+++ b/orderbook/src/api/post_quote.rs
@@ -354,7 +354,7 @@ pub fn post_quote(
         async move {
             let result = quoter.calculate_quote(&request).await;
             if let Err(err) = &result {
-                tracing::warn!(?err, ?request, "post_quote User error");
+                tracing::warn!(?err, ?request, "post_quote error");
             }
             Result::<_, Infallible>::Ok(response(result))
         }

--- a/orderbook/src/api/post_quote.rs
+++ b/orderbook/src/api/post_quote.rs
@@ -354,17 +354,7 @@ pub fn post_quote(
         async move {
             let result = quoter.calculate_quote(&request).await;
             if let Err(err) = &result {
-                match err {
-                    OrderQuoteError::Fee(FeeError::PriceEstimate(PriceEstimationError::Other(
-                        err,
-                    ))) => {
-                        tracing::error!(?err, ?request, "post_quote Fee error");
-                    }
-                    OrderQuoteError::Order(ValidationError::Other(err)) => {
-                        tracing::error!(?err, ?request, "post_quote Order Validation error");
-                    }
-                    _ => tracing::warn!(?err, ?request, "post_quote User error"),
-                }
+                tracing::warn!(?err, ?request, "post_quote User error");
             }
             Result::<_, Infallible>::Ok(response(result))
         }


### PR DESCRIPTION
Our new Fee & Quote service shouldn't send alerts on what are most commonly "user errors" like seen [here](https://gnosisinc.slack.com/archives/CQZBU9T5J/p1634286286003400). Specifically, this error

```
ERROR orderbook::api::post_quote: post_quote error err=Order(Partial(SameBuyAndSellToken)) request=OrderQuoteRequest
```
which don't warrant any action of any kind. 

We can use grafana to alert us of specific categories of error responses (like server error).