### PR TITLE
Apply fee factor to stored computed fees and not just new ones

### DIFF
--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -60,7 +60,7 @@ pub fn get_fee_info(
         async move {
             Result::<_, Infallible>::Ok(get_fee_info_response(
                 fee_calculator
-                    .compute_unsubsidized_min_fee(
+                    .compute_subsidized_min_fee(
                         query.sell_token,
                         Some(query.buy_token),
                         Some(query.amount),
@@ -115,7 +115,7 @@ pub fn legacy_get_fee_info(
         async move {
             Result::<_, Infallible>::Ok(legacy_get_fee_info_response(
                 fee_calculator
-                    .compute_unsubsidized_min_fee(token, None, None, None, None)
+                    .compute_subsidized_min_fee(token, None, None, None, None)
                     .await,
             ))
         }

--- a/orderbook/src/api/post_quote.rs
+++ b/orderbook/src/api/post_quote.rs
@@ -237,7 +237,7 @@ impl OrderQuoter {
 
                 let (fee, expiration) = self
                     .fee_calculator
-                    .compute_unsubsidized_min_fee(
+                    .compute_subsidized_min_fee(
                         quote_request.sell_token,
                         Some(quote_request.buy_token),
                         Some(sell_amount_before_fee),
@@ -285,7 +285,7 @@ impl OrderQuoter {
 
                 let (fee, expiration) = self
                     .fee_calculator
-                    .compute_unsubsidized_min_fee(
+                    .compute_subsidized_min_fee(
                         quote_request.sell_token,
                         Some(quote_request.buy_token),
                         Some(buy_amount_after_fee),
@@ -540,7 +540,7 @@ mod tests {
 
         let expiration = Utc::now();
         fee_calculator
-            .expect_compute_unsubsidized_min_fee()
+            .expect_compute_subsidized_min_fee()
             .returning(move |_, _, _, _, _| Ok((U256::from(3), expiration)));
 
         let fee_calculator = Arc::new(fee_calculator);
@@ -582,7 +582,7 @@ mod tests {
     fn calculate_fee_sell_after_fees_quote_request() {
         let mut fee_calculator = MockMinFeeCalculating::new();
         fee_calculator
-            .expect_compute_unsubsidized_min_fee()
+            .expect_compute_subsidized_min_fee()
             .returning(|_, _, _, _, _| Ok((U256::from(3), Utc::now())));
 
         let fee_calculator = Arc::new(fee_calculator);
@@ -619,7 +619,7 @@ mod tests {
         let mut fee_calculator = MockMinFeeCalculating::new();
         let expiration = Utc::now();
         fee_calculator
-            .expect_compute_unsubsidized_min_fee()
+            .expect_compute_subsidized_min_fee()
             .returning(move |_, _, _, _, _| Ok((U256::from(3), expiration)));
 
         let fee_calculator = Arc::new(fee_calculator);
@@ -679,7 +679,7 @@ mod tests {
 
         let mut fee_calculator = MockMinFeeCalculating::new();
         fee_calculator
-            .expect_compute_unsubsidized_min_fee()
+            .expect_compute_subsidized_min_fee()
             .returning(move |_, _, _, _, _| Ok((U256::from(3), Utc::now())));
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
             out_amount: 14.into(),

--- a/orderbook/src/database/fees.rs
+++ b/orderbook/src/database/fees.rs
@@ -35,7 +35,7 @@ impl MinFeeStoring for Postgres {
             .map(|_| ())
     }
 
-    async fn get_min_fee(
+    async fn read_fee_measurement(
         &self,
         sell_token: H160,
         buy_token: Option<H160>,
@@ -137,14 +137,14 @@ mod tests {
 
         // Token A has readings valid until now and in 30s
         assert_eq!(
-            db.get_min_fee(token_a, None, None, None, now)
+            db.read_fee_measurement(token_a, None, None, None, now)
                 .await
                 .unwrap()
                 .unwrap(),
             100_u32.into()
         );
         assert_eq!(
-            db.get_min_fee(token_a, None, None, None, now + Duration::seconds(30))
+            db.read_fee_measurement(token_a, None, None, None, now + Duration::seconds(30))
                 .await
                 .unwrap()
                 .unwrap(),
@@ -153,14 +153,14 @@ mod tests {
 
         // Token B only has readings valid until now
         assert_eq!(
-            db.get_min_fee(token_b, None, None, None, now)
+            db.read_fee_measurement(token_b, None, None, None, now)
                 .await
                 .unwrap()
                 .unwrap(),
             10u32.into()
         );
         assert_eq!(
-            db.get_min_fee(token_b, None, None, None, now + Duration::seconds(30))
+            db.read_fee_measurement(token_b, None, None, None, now + Duration::seconds(30))
                 .await
                 .unwrap(),
             None
@@ -168,28 +168,28 @@ mod tests {
 
         // Token B has readings for right filters
         assert_eq!(
-            db.get_min_fee(token_b, Some(token_a), None, None, now)
+            db.read_fee_measurement(token_b, Some(token_a), None, None, now)
                 .await
                 .unwrap()
                 .unwrap(),
             10u32.into()
         );
         assert_eq!(
-            db.get_min_fee(token_b, None, Some(100.into()), None, now)
+            db.read_fee_measurement(token_b, None, Some(100.into()), None, now)
                 .await
                 .unwrap()
                 .unwrap(),
             10u32.into()
         );
         assert_eq!(
-            db.get_min_fee(token_b, None, None, Some(OrderKind::Buy), now)
+            db.read_fee_measurement(token_b, None, None, Some(OrderKind::Buy), now)
                 .await
                 .unwrap()
                 .unwrap(),
             10u32.into()
         );
         assert_eq!(
-            db.get_min_fee(token_b, None, Some(U256::zero()), None, now)
+            db.read_fee_measurement(token_b, None, Some(U256::zero()), None, now)
                 .await
                 .unwrap(),
             None
@@ -199,7 +199,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            db.get_min_fee(token_b, None, None, None, now)
+            db.read_fee_measurement(token_b, None, None, None, now)
                 .await
                 .unwrap(),
             None

--- a/orderbook/src/database/instrumented.rs
+++ b/orderbook/src/database/instrumented.rs
@@ -77,7 +77,7 @@ impl MinFeeStoring for Instrumented {
             .await
     }
 
-    async fn get_min_fee(
+    async fn read_fee_measurement(
         &self,
         sell_token: ethcontract::H160,
         buy_token: Option<ethcontract::H160>,
@@ -87,10 +87,10 @@ impl MinFeeStoring for Instrumented {
     ) -> anyhow::Result<Option<ethcontract::U256>> {
         let _timer = self
             .metrics
-            .database_query_histogram("get_min_fee")
+            .database_query_histogram("read_fee_measurement")
             .start_timer();
         self.inner
-            .get_min_fee(sell_token, buy_token, amount, kind, min_expiry)
+            .read_fee_measurement(sell_token, buy_token, amount, kind, min_expiry)
             .await
     }
 }

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -39,11 +39,13 @@ pub struct MinFeeCalculator {
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait MinFeeCalculating: Send + Sync {
-    /// Returns the minimum amount of fee required to accept an order selling the specified order
-    /// and an expiry date for the estimate.
-    /// Returns an error if there is some estimation error and Ok(None) if no information about the given
-    /// token exists
-    async fn compute_unsubsidized_min_fee(
+    /// Returns the minimum amount of fee required to accept an order selling
+    /// the specified order and an expiry date for the estimate. The returned
+    /// amount applies configured "fee factors" for subsidizing user trades.
+    ///
+    /// Returns an error if there is some estimation error and `Ok(None)` if no
+    /// information about the given token exists
+    async fn compute_subsidized_min_fee(
         &self,
         sell_token: H160,
         buy_token: Option<H160>,
@@ -63,6 +65,7 @@ pub trait MinFeeCalculating: Send + Sync {
     ) -> Result<U256, ()>;
 }
 
+#[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait MinFeeStoring: Send + Sync {
     // Stores the given measurement. Returns an error if this fails
@@ -78,7 +81,7 @@ pub trait MinFeeStoring: Send + Sync {
 
     // Return a vector of previously stored measurements for the given token that have an expiry >= min expiry
     // If buy_token or sell_amount is not specified, it will return the lowest estimate matching the values provided.
-    async fn get_min_fee(
+    async fn read_fee_measurement(
         &self,
         sell_token: H160,
         buy_token: Option<H160>,
@@ -88,7 +91,7 @@ pub trait MinFeeStoring: Send + Sync {
     ) -> Result<Option<U256>>;
 }
 
-const GAS_PER_ORDER: f64 = 100_000.0;
+const GAS_PER_ORDER: f64 = 200_000.0;
 
 // We use a longer validity internally for persistence to avoid writing a value to storage on every request
 // This way we can serve a previous estimate if the same token is queried again shortly after
@@ -136,7 +139,7 @@ impl<T> MinFeeCalculating for EthAdapter<T>
 where
     T: MinFeeCalculating + Send + Sync,
 {
-    async fn compute_unsubsidized_min_fee(
+    async fn compute_subsidized_min_fee(
         &self,
         sell_token: H160,
         buy_token: Option<H160>,
@@ -145,7 +148,7 @@ where
         app_data: Option<AppId>,
     ) -> Result<Measurement, PriceEstimationError> {
         self.calculator
-            .compute_unsubsidized_min_fee(
+            .compute_subsidized_min_fee(
                 sell_token,
                 buy_token.map(|token| normalize_buy_token(token, self.weth)),
                 amount,
@@ -193,7 +196,7 @@ impl MinFeeCalculator {
     }
 
     /// Computes unsubsidized min fee.
-    async fn compute_min_fee(
+    async fn compute_unsubsidized_min_fee(
         &self,
         sell_token: H160,
         buy_token: Option<H160>,
@@ -201,10 +204,15 @@ impl MinFeeCalculator {
         kind: Option<OrderKind>,
     ) -> Result<U256, PriceEstimationError> {
         let gas_price = self.gas_estimator.estimate().await?.effective_gas_price();
+        tracing::debug!(
+            "estimated effective gas price of {:.2} Gwei",
+            gas_price / 1e9
+        );
+
         let gas_amount =
             if let (Some(buy_token), Some(amount), Some(kind)) = (buy_token, amount, kind) {
-                // We only apply the discount to the more sophisticated fee estimation, as the legacy one is already very favorable to the user in most cases
-                self.price_estimator
+                let gas_estimate = self
+                    .price_estimator
                     .estimate(&price_estimation::Query {
                         sell_token,
                         buy_token,
@@ -213,10 +221,35 @@ impl MinFeeCalculator {
                     })
                     .await?
                     .gas
-                    .to_f64_lossy()
+                    .to_f64_lossy();
+
+                match kind {
+                    OrderKind::Sell => {
+                        tracing::debug!(
+                            "estimated {} gas for order selling {} {:?} for {:?}",
+                            gas_estimate,
+                            amount,
+                            sell_token,
+                            buy_token
+                        );
+                    }
+                    OrderKind::Buy => {
+                        tracing::debug!(
+                            "estimated {} gas for order buying {} {:?} for {:?}",
+                            gas_estimate,
+                            amount,
+                            buy_token,
+                            sell_token
+                        );
+                    }
+                }
+
+                gas_estimate
             } else {
+                tracing::debug!("using default {} gas per order", GAS_PER_ORDER);
                 GAS_PER_ORDER
             };
+
         let fee_in_eth = gas_price * gas_amount;
         let query = price_estimation::Query {
             sell_token,
@@ -226,24 +259,30 @@ impl MinFeeCalculator {
         };
         let estimate = self.price_estimator.estimate(&query).await?;
         let price = estimate.price_in_sell_token_f64(&query);
+
+        tracing::debug!(
+            "computed unsubsidized fee amount of {} ETH at a price of {} ETH/{:?}",
+            fee_in_eth,
+            price,
+            sell_token,
+        );
+
         Ok(U256::from_f64_lossy(fee_in_eth * price))
     }
 
-    fn calculate_fee_factor(&self, app_data: Option<AppId>) -> f64 {
-        app_data
-            .and_then(|app_data| self.partner_additional_fee_factors.get(&app_data).cloned())
+    fn apply_fee_factor(&self, fee: U256, app_data: Option<AppId>) -> U256 {
+        let factor = app_data
+            .and_then(|app_data| self.partner_additional_fee_factors.get(&app_data))
+            .copied()
             .unwrap_or(1.0)
-            * self.fee_factor
-    }
-
-    fn apply_fee_factor(fee: U256, factor: f64) -> U256 {
+            * self.fee_factor;
         U256::from_f64_lossy(fee.to_f64_lossy() * factor)
     }
 }
 
 #[async_trait::async_trait]
 impl MinFeeCalculating for MinFeeCalculator {
-    async fn compute_unsubsidized_min_fee(
+    async fn compute_subsidized_min_fee(
         &self,
         sell_token: H160,
         buy_token: Option<H160>,
@@ -260,33 +299,34 @@ impl MinFeeCalculating for MinFeeCalculator {
         let official_valid_until = now + Duration::seconds(STANDARD_VALIDITY_FOR_FEE_IN_SEC);
         let internal_valid_until = now + Duration::seconds(PERSISTED_VALIDITY_FOR_FEE_IN_SEC);
 
-        if let Ok(Some(past_fee)) = self
+        let unsubsidized_min_fee = if let Ok(Some(past_fee)) = self
             .measurements
-            .get_min_fee(sell_token, buy_token, amount, kind, official_valid_until)
+            .read_fee_measurement(sell_token, buy_token, amount, kind, official_valid_until)
             .await
         {
-            return Ok((past_fee, official_valid_until));
-        }
+            past_fee
+        } else {
+            let current_fee = self
+                .compute_unsubsidized_min_fee(sell_token, buy_token, amount, kind)
+                .await?;
 
-        let min_fee = self
-            .compute_min_fee(sell_token, buy_token, amount, kind)
-            .await?;
+            let _ = self
+                .measurements
+                .save_fee_measurement(
+                    sell_token,
+                    buy_token,
+                    amount,
+                    kind,
+                    internal_valid_until,
+                    current_fee,
+                )
+                .await;
 
-        let _ = self
-            .measurements
-            .save_fee_measurement(
-                sell_token,
-                buy_token,
-                amount,
-                kind,
-                internal_valid_until,
-                min_fee,
-            )
-            .await;
+            current_fee
+        };
 
-        let fee_factor = self.calculate_fee_factor(app_data);
         Ok((
-            Self::apply_fee_factor(min_fee, fee_factor),
+            self.apply_fee_factor(unsubsidized_min_fee, app_data),
             official_valid_until,
         ))
     }
@@ -297,20 +337,21 @@ impl MinFeeCalculating for MinFeeCalculator {
         fee: U256,
         app_data: Option<AppId>,
     ) -> Result<U256, ()> {
-        let fee_factor = self.calculate_fee_factor(app_data);
-
         if let Ok(Some(past_fee)) = self
             .measurements
-            .get_min_fee(sell_token, None, None, None, (self.now)())
+            .read_fee_measurement(sell_token, None, None, None, (self.now)())
             .await
         {
-            if fee >= Self::apply_fee_factor(past_fee, fee_factor) {
+            if fee >= self.apply_fee_factor(past_fee, app_data) {
                 return Ok(std::cmp::max(fee, past_fee));
             }
         }
 
-        if let Ok(current_fee) = self.compute_min_fee(sell_token, None, None, None).await {
-            if fee >= Self::apply_fee_factor(current_fee, fee_factor) {
+        if let Ok(current_fee) = self
+            .compute_unsubsidized_min_fee(sell_token, None, None, None)
+            .await
+        {
+            if fee >= self.apply_fee_factor(current_fee, app_data) {
                 return Ok(std::cmp::max(fee, current_fee));
             }
         }
@@ -329,6 +370,7 @@ struct FeeMeasurement {
 
 #[derive(Default)]
 struct InMemoryFeeStore(Mutex<HashMap<H160, Vec<FeeMeasurement>>>);
+
 #[async_trait::async_trait]
 impl MinFeeStoring for InMemoryFeeStore {
     async fn save_fee_measurement(
@@ -355,7 +397,7 @@ impl MinFeeStoring for InMemoryFeeStore {
         Ok(())
     }
 
-    async fn get_min_fee(
+    async fn read_fee_measurement(
         &self,
         sell_token: H160,
         buy_token: Option<H160>,
@@ -389,6 +431,7 @@ mod tests {
     use chrono::{Duration, NaiveDateTime};
     use gas_estimation::{gas_price::EstimatedGasPrice, GasPrice1559};
     use maplit::hashmap;
+    use mockall::{predicate::*, Sequence};
     use shared::{
         bad_token::list_based::ListBasedDetector, gas_price_estimation::FakeGasPriceEstimator,
         price_estimation::mocks::FakePriceEstimator,
@@ -403,7 +446,7 @@ mod tests {
         let token = H160([0x21; 20]);
         let mut calculator = MockMinFeeCalculating::default();
         calculator
-            .expect_compute_unsubsidized_min_fee()
+            .expect_compute_subsidized_min_fee()
             .withf(move |&sell_token, &buy_token, &amount, &kind, &app_data| {
                 sell_token == token
                     && buy_token == Some(weth)
@@ -421,7 +464,7 @@ mod tests {
 
         let eth_aware = EthAdapter { calculator, weth };
         assert!(eth_aware
-            .compute_unsubsidized_min_fee(
+            .compute_subsidized_min_fee(
                 token,
                 Some(BUY_ETH_ADDRESS),
                 Some(1337.into()),
@@ -502,7 +545,7 @@ mod tests {
 
         let token = H160::from_low_u64_be(1);
         let (fee, expiry) = fee_estimator
-            .compute_unsubsidized_min_fee(token, None, None, None, None)
+            .compute_subsidized_min_fee(token, None, None, None, None)
             .await
             .unwrap();
         // Gas price increase after measurement
@@ -549,7 +592,7 @@ mod tests {
 
         let token = H160::from_low_u64_be(1);
         let (fee, _) = fee_estimator
-            .compute_unsubsidized_min_fee(token, None, None, None, None)
+            .compute_subsidized_min_fee(token, None, None, None, None)
             .await
             .unwrap();
 
@@ -605,7 +648,7 @@ mod tests {
         // Selling unsupported token
         assert!(matches!(
             fee_estimator
-                .compute_unsubsidized_min_fee(
+                .compute_subsidized_min_fee(
                     unsupported_token,
                     Some(supported_token),
                     Some(100.into()),
@@ -619,7 +662,7 @@ mod tests {
         // Buying unsupported token
         assert!(matches!(
             fee_estimator
-                .compute_unsubsidized_min_fee(
+                .compute_subsidized_min_fee(
                     supported_token,
                     Some(unsupported_token),
                     Some(100.into()),
@@ -662,7 +705,7 @@ mod tests {
             native_token_price_estimation_amount: 1.into(),
         };
         let (fee, _) = fee_estimator
-            .compute_unsubsidized_min_fee(sell_token, None, None, None, Some(app_data))
+            .compute_subsidized_min_fee(sell_token, None, None, None, Some(app_data))
             .await
             .unwrap();
         assert_eq!(
@@ -680,5 +723,90 @@ mod tests {
             .get_unsubsidized_min_fee(sell_token, lower_fee, Some(app_data))
             .await
             .is_err());
+    }
+
+    #[tokio::test]
+    async fn applies_fee_factor_to_past_and_new_fees() {
+        let sell_token = H160::from_low_u64_be(1);
+        let native_token_price_estimation_amount = 100.;
+        let sell_token_price = 1.25;
+        let gas_estimate = 42.;
+
+        let unsubsidized_min_fee =
+            U256::from_f64_lossy(GAS_PER_ORDER * sell_token_price * gas_estimate);
+
+        let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(
+            EstimatedGasPrice {
+                legacy: 42.,
+                ..Default::default()
+            },
+        ))));
+        let price_estimator = Arc::new(FakePriceEstimator(price_estimation::Estimate {
+            out_amount: U256::from_f64_lossy(
+                native_token_price_estimation_amount * sell_token_price,
+            ),
+            gas: 1337.into(),
+        }));
+
+        let mut measurements = MockMinFeeStoring::new();
+        let mut seq = Sequence::new();
+        measurements
+            .expect_read_fee_measurement()
+            .times(1)
+            .in_sequence(&mut seq)
+            .with(eq(sell_token), eq(None), eq(None), eq(None), always())
+            .returning(|_, _, _, _, _| Ok(None));
+        measurements
+            .expect_save_fee_measurement()
+            .times(1)
+            .in_sequence(&mut seq)
+            .with(
+                eq(sell_token),
+                eq(None),
+                eq(None),
+                eq(None),
+                always(),
+                eq(unsubsidized_min_fee),
+            )
+            .returning(|_, _, _, _, _, _| Ok(()));
+        measurements
+            .expect_read_fee_measurement()
+            .times(1)
+            .in_sequence(&mut seq)
+            .with(eq(sell_token), eq(None), eq(None), eq(None), always())
+            .returning(move |_, _, _, _, _| Ok(Some(unsubsidized_min_fee)));
+
+        let app_data = AppId([1u8; 32]);
+        let fee_estimator = MinFeeCalculator {
+            price_estimator,
+            gas_estimator,
+            native_token: Default::default(),
+            measurements: Arc::new(measurements),
+            now: Box::new(Utc::now),
+            fee_factor: 0.8,
+            bad_token_detector: Arc::new(ListBasedDetector::deny_list(vec![])),
+            partner_additional_fee_factors: hashmap! { app_data => 0.5 },
+            native_token_price_estimation_amount: U256::from_f64_lossy(
+                native_token_price_estimation_amount,
+            ),
+        };
+
+        let (fee, _) = fee_estimator
+            .compute_subsidized_min_fee(sell_token, None, None, None, Some(app_data))
+            .await
+            .unwrap();
+        assert_eq!(
+            fee,
+            U256::from_f64_lossy(unsubsidized_min_fee.to_f64_lossy() * 0.8 * 0.5)
+        );
+
+        let (fee, _) = fee_estimator
+            .compute_subsidized_min_fee(sell_token, None, None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            fee,
+            U256::from_f64_lossy(unsubsidized_min_fee.to_f64_lossy() * 0.8)
+        );
     }
 }

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -310,7 +310,7 @@ impl MinFeeCalculating for MinFeeCalculator {
                 .compute_unsubsidized_min_fee(sell_token, buy_token, amount, kind)
                 .await?;
 
-            let _ = self
+            if let Err(err) = self
                 .measurements
                 .save_fee_measurement(
                     sell_token,
@@ -320,7 +320,10 @@ impl MinFeeCalculating for MinFeeCalculator {
                     internal_valid_until,
                     current_fee,
                 )
-                .await;
+                .await
+            {
+                tracing::warn!(?err, "error saving fee measurement");
+            }
 
             current_fee
         };


### PR DESCRIPTION
This PR applies changes the `MinFeeCalculator` logic so that it applies factors to past fees as well as new fees.

With the change of storing full fee amounts for orders, we needed to start storing the unsubsidized fee amount into the Postgres database. There was an early exit when the fee was stored in the database that didn't apply the fee factor.

Additionally, I added some more logging so that we get more details about how fees are being computed making it easier to diagnose failures in the future.

One **sneaky** change I through in was to increase the `ORDER_GAS_AMOUNT` to 200k. This was done because previously, we would not subsidize min-fees that were computed with this "legacy" method. Now, with the refactor, we subsidize this amount as well, so it was increased to offset that subsidy by a bit. I can revert this change if people are uncomfortable with it.

### Test Plan

Added a new unit test to make sure fee factor is applied in both places.
