### PR TITLE
Add metric to track gas price estimate

### DIFF
--- a/orderbook/src/gas_price.rs
+++ b/orderbook/src/gas_price.rs
@@ -1,0 +1,51 @@
+//! Module defining an instrumented Ethereum gas price estimator.
+//!
+//! This allows us to keep track of historic gas prices in Grafana and do things
+//! like alert when gas prices get too high as well as detect spikes and other
+//! anomalies.
+
+use anyhow::Result;
+use gas_estimation::{EstimatedGasPrice, GasPriceEstimating};
+use std::{sync::Arc, time::Duration};
+
+/// An instrumented gas price estimator that wraps an inner one.
+pub struct InstrumentedGasEstimator<T> {
+    inner: T,
+    metrics: Arc<dyn Metrics>,
+}
+
+impl<T> InstrumentedGasEstimator<T>
+where
+    T: GasPriceEstimating,
+{
+    pub fn new(inner: T, metrics: Arc<dyn Metrics>) -> Self {
+        Self { inner, metrics }
+    }
+}
+
+#[async_trait::async_trait]
+impl<T> GasPriceEstimating for InstrumentedGasEstimator<T>
+where
+    T: GasPriceEstimating,
+{
+    async fn estimate_with_limits(
+        &self,
+        gas_limit: f64,
+        time_limit: Duration,
+    ) -> Result<EstimatedGasPrice> {
+        // Instrumenting gas estimates with limits is hard. Since we don't use
+        // it in the orderbook, lets leave this out for now.
+        self.inner.estimate_with_limits(gas_limit, time_limit).await
+    }
+
+    async fn estimate(&self) -> Result<EstimatedGasPrice> {
+        let estimate = self.inner.estimate().await?;
+        self.metrics.gas_price(estimate);
+        Ok(estimate)
+    }
+}
+
+/// Gas estimator metrics.
+pub trait Metrics: Send + Sync + 'static {
+    fn gas_price(&self, estimate: EstimatedGasPrice);
+}

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -4,6 +4,7 @@ pub mod conversions;
 pub mod database;
 pub mod event_updater;
 pub mod fee;
+pub mod gas_price;
 pub mod metrics;
 pub mod orderbook;
 pub mod solvable_orders;

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -11,6 +11,7 @@ use orderbook::{
     database::{self, orders::OrderFilter, Postgres},
     event_updater::EventUpdater,
     fee::EthAwareMinFeeCalculator,
+    gas_price::InstrumentedGasEstimator,
     metrics::Metrics,
     orderbook::Orderbook,
     serve_api,
@@ -259,7 +260,7 @@ async fn main() {
         settlement_contract.address(),
     ));
 
-    let gas_price_estimator = Arc::new(
+    let gas_price_estimator = Arc::new(InstrumentedGasEstimator::new(
         shared::gas_price_estimation::create_priority_estimator(
             client.clone(),
             &web3,
@@ -268,7 +269,8 @@ async fn main() {
         )
         .await
         .expect("failed to create gas price estimator"),
-    );
+        metrics.clone(),
+    ));
 
     let pair_providers = sources::pair_providers(&args.shared.baseline_sources, chain_id, &web3)
         .await


### PR DESCRIPTION
This PR adds an instrumented gas price estimator that records sampled gas prices as a metric.

In terms of Prometheus things... I used a `Gauge`. My understanding is that this allows us to set a single value that will get sample over time, allowing us to plot a nice graph of 
```
          ^         
          |  --    __
gas_price |/    \/
          |      
          +---------->
              time
```

### Test Plan

Start the orderbook and check metrics at:
```
$ curl -s http://localhost:9586/metrics | grep gas_price
# HELP gp_v2_api_gas_price Gas price estimate over time.
# TYPE gp_v2_api_gas_price gauge
gp_v2_api_gas_price 140.321906696
```
