### PR TITLE
Remove driver wait interval

### DIFF
--- a/e2e/tests/eth_integration.rs
+++ b/e2e/tests/eth_integration.rs
@@ -217,7 +217,6 @@ async fn eth_integration(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
-        Duration::from_secs(30),
         weth.address(),
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),

--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -226,7 +226,6 @@ async fn onchain_settlement(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
-        Duration::from_secs(30),
         gpv2.native_token.address(),
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -212,7 +212,6 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
-        Duration::from_secs(30),
         gpv2.native_token.address(),
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),

--- a/e2e/tests/smart_contract_orders.rs
+++ b/e2e/tests/smart_contract_orders.rs
@@ -187,7 +187,6 @@ async fn smart_contract_orders(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
-        Duration::from_secs(30),
         gpv2.native_token.address(),
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),

--- a/e2e/tests/vault_balances.rs
+++ b/e2e/tests/vault_balances.rs
@@ -165,7 +165,6 @@ async fn vault_balances(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
-        Duration::from_secs(30),
         gpv2.native_token.address(),
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -40,7 +40,6 @@ pub struct Driver {
     price_estimator: Arc<dyn PriceEstimating>,
     solvers: Solvers,
     gas_price_estimator: Arc<dyn GasPriceEstimating>,
-    settle_interval: Duration,
     native_token: H160,
     min_order_age: Duration,
     metrics: Arc<dyn SolverMetrics>,
@@ -63,7 +62,6 @@ impl Driver {
         price_estimator: Arc<dyn PriceEstimating>,
         solvers: Solvers,
         gas_price_estimator: Arc<dyn GasPriceEstimating>,
-        settle_interval: Duration,
         native_token: H160,
         min_order_age: Duration,
         metrics: Arc<dyn SolverMetrics>,
@@ -82,7 +80,6 @@ impl Driver {
             price_estimator,
             solvers,
             gas_price_estimator,
-            settle_interval,
             native_token,
             min_order_age,
             metrics,
@@ -106,7 +103,7 @@ impl Driver {
                 Err(err) => tracing::error!("single run errored: {:?}", err),
             }
             self.metrics.runloop_completed();
-            tokio::time::sleep(self.settle_interval).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
     }
 

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -70,15 +70,6 @@ struct Arguments {
     )]
     target_confirm_time: Duration,
 
-    /// Every how often in seconds we should execute the driver's run loop
-    #[structopt(
-        long,
-        env,
-        default_value = "10",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
-    )]
-    settle_interval: Duration,
-
     /// Which type of solver to use
     #[structopt(
         long,
@@ -510,7 +501,6 @@ async fn main() {
         price_estimator,
         solver,
         gas_price_estimator,
-        args.settle_interval,
         native_token_contract.address(),
         args.min_order_age,
         metrics.clone(),


### PR DESCRIPTION
This has become obsolete by the inflight trade logic but never removed.
Originally we needed this to make it more like that the api had seen our
settlement transaction but this is no longer needed.
We keep the 1 second sleep to prevent busy looping in case the run loop
returns an error immediately.
This should improve throughput of settlements.

This part has been extracted from https://github.com/gnosis/gp-v2-services/pull/1250 .

### Test Plan
CI
