### PR TITLE
Limit the number of settlements considered per solver

### DIFF
--- a/e2e/tests/eth_integration.rs
+++ b/e2e/tests/eth_integration.rs
@@ -238,6 +238,7 @@ async fn eth_integration(web3: Web3) {
             ),
         },
         1_000_000_000_000_000_000_u128.into(),
+        10,
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/onchain_settlement.rs
+++ b/e2e/tests/onchain_settlement.rs
@@ -247,6 +247,7 @@ async fn onchain_settlement(web3: Web3) {
             ),
         },
         1_000_000_000_000_000_000_u128.into(),
+        10,
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -233,6 +233,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             ),
         },
         1_000_000_000_000_000_000_u128.into(),
+        10,
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/smart_contract_orders.rs
+++ b/e2e/tests/smart_contract_orders.rs
@@ -208,6 +208,7 @@ async fn smart_contract_orders(web3: Web3) {
             ),
         },
         1_000_000_000_000_000_000_u128.into(),
+        10,
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/vault_balances.rs
+++ b/e2e/tests/vault_balances.rs
@@ -186,6 +186,7 @@ async fn vault_balances(web3: Web3) {
             ),
         },
         1_000_000_000_000_000_000_u128.into(),
+        10,
     );
     driver.single_run().await.unwrap();
 

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -20,6 +20,7 @@ use itertools::{Either, Itertools};
 use model::order::{OrderUid, BUY_ETH_ADDRESS};
 use num::BigRational;
 use primitive_types::{H160, U256};
+use rand::prelude::SliceRandom;
 use shared::{
     current_block::{self, CurrentBlockStream},
     price_estimation::{self, PriceEstimating},
@@ -54,6 +55,7 @@ pub struct Driver {
     solution_submitter: SolutionSubmitter,
     solve_id: u64,
     native_token_amount_to_estimate_prices_with: U256,
+    max_settlements_per_solver: usize,
 }
 impl Driver {
     #[allow(clippy::too_many_arguments)]
@@ -75,6 +77,7 @@ impl Driver {
         block_stream: CurrentBlockStream,
         solution_submitter: SolutionSubmitter,
         native_token_amount_to_estimate_prices_with: U256,
+        max_settlements_per_solver: usize,
     ) -> Self {
         Self {
             settlement_contract,
@@ -96,6 +99,7 @@ impl Driver {
             solution_submitter,
             solve_id: 0,
             native_token_amount_to_estimate_prices_with,
+            max_settlements_per_solver,
         }
     }
 
@@ -425,6 +429,14 @@ impl Driver {
             for settlement in &settlements {
                 tracing::debug!("solver {} found solution:\n{:?}", name, settlement);
             }
+
+            // Keep at most this many settlements. This is important in case where a solver produces
+            // a large number of settlements which would hold up the driver logic when simulating
+            // them.
+            // Shuffle first so that in the case a buggy solver keeps returning some amount of
+            // invalid settlements first we have a chance to make progress.
+            settlements.shuffle(&mut rand::thread_rng());
+            settlements.truncate(self.max_settlements_per_solver);
 
             solver_settlements::merge_settlements(
                 self.max_merged_settlements,

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -199,6 +199,10 @@ struct Arguments {
     /// likely, promoting more aggressive merging of single order settlements.
     #[structopt(long, env, default_value = "1", parse(try_from_str = shared::arguments::parse_fee_factor))]
     pub fee_objective_scaling_factor: f64,
+
+    /// The maximum number of settlements the driver considers per solver.
+    #[structopt(long, env, default_value = "20")]
+    max_settlements_per_solver: usize,
 }
 
 arg_enum! {
@@ -522,6 +526,7 @@ async fn main() {
         current_block_stream.clone(),
         solution_submitter,
         native_token_price_estimation_amount,
+        args.max_settlements_per_solver,
     );
 
     let maintainer = ServiceMaintenance {


### PR DESCRIPTION
Part of https://github.com/gnosis/gp-v2-services/issues/1157 .

This is a simple low hanging fruit fix to address the problem of a solver returning so many settlements that we cannot simulate them in a reasonable time. While the issue thread outlines some smarter ideas like estimating objective value and dropping, the solution in this PR is much simpler and still effective. We can still consider the more complex solutions in the future but they might be come invalidated when refactoring to make solvers more independent.

### Test Plan
CI
