### PR TITLE
Implement 0x price estimation

### DIFF
--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -378,9 +378,7 @@ async fn main() {
                 disabled_paraswap_dexs: args.shared.disabled_paraswap_dexs.clone(),
             }) as Box<dyn PriceEstimating>,
             PriceEstimatorType::ZeroEx => Box::new(ZeroExPriceEstimator {
-                client: Arc::new(
-                    DefaultZeroExApi::with_default_url(client.clone()),
-                ),
+                client: Arc::new(DefaultZeroExApi::with_default_url(client.clone())),
                 bad_token_detector: bad_token_detector.clone(),
             }) as Box<dyn PriceEstimating>,
         })

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -19,6 +19,8 @@ use orderbook::{
     verify_deployed_contract_constants,
 };
 use primitive_types::H160;
+use shared::price_estimation::zeroex::ZeroExPriceEstimator;
+use shared::zeroex_api::DefaultZeroExApi;
 use shared::{
     bad_token::{
         cache::CachingDetector,
@@ -374,7 +376,13 @@ async fn main() {
                 token_info: token_info_fetcher.clone(),
                 bad_token_detector: bad_token_detector.clone(),
                 disabled_paraswap_dexs: args.shared.disabled_paraswap_dexs.clone(),
-            }),
+            }) as Box<dyn PriceEstimating>,
+            PriceEstimatorType::ZeroEx => Box::new(ZeroExPriceEstimator {
+                client: Arc::new(
+                    DefaultZeroExApi::new(DefaultZeroExApi::DEFAULT_URL, client.clone()).unwrap(),
+                ),
+                bad_token_detector: bad_token_detector.clone(),
+            }) as Box<dyn PriceEstimating>,
         })
         .collect::<Vec<_>>();
     let price_estimator = Arc::new(PriorityPriceEstimator::new(price_estimators));

--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -379,7 +379,7 @@ async fn main() {
             }) as Box<dyn PriceEstimating>,
             PriceEstimatorType::ZeroEx => Box::new(ZeroExPriceEstimator {
                 client: Arc::new(
-                    DefaultZeroExApi::new(DefaultZeroExApi::DEFAULT_URL, client.clone()).unwrap(),
+                    DefaultZeroExApi::with_default_url(client.clone()),
                 ),
                 bad_token_detector: bad_token_detector.clone(),
             }) as Box<dyn PriceEstimating>,

--- a/shared/src/price_estimation.rs
+++ b/shared/src/price_estimation.rs
@@ -1,5 +1,6 @@
 pub mod baseline;
 pub mod paraswap;
+pub mod zeroex;
 pub mod priority;
 
 use crate::{bad_token::BadTokenDetecting, conversions::U256Ext};
@@ -15,6 +16,7 @@ arg_enum! {
     pub enum PriceEstimatorType {
         Baseline,
         Paraswap,
+        ZeroEx,
     }
 }
 

--- a/shared/src/price_estimation.rs
+++ b/shared/src/price_estimation.rs
@@ -1,7 +1,7 @@
 pub mod baseline;
 pub mod paraswap;
-pub mod zeroex;
 pub mod priority;
+pub mod zeroex;
 
 use crate::{bad_token::BadTokenDetecting, conversions::U256Ext};
 use anyhow::Result;

--- a/shared/src/price_estimation/zeroex.rs
+++ b/shared/src/price_estimation/zeroex.rs
@@ -236,7 +236,7 @@ mod tests {
         let estimate = result.unwrap();
         println!(
             "1 eth buys {} gno, costing {} gas",
-            estimate.out_amount.to_f64_lossy() / 1e18
+            estimate.out_amount.to_f64_lossy() / 1e18,
             estimate.gas,
         );
     }

--- a/shared/src/price_estimation/zeroex.rs
+++ b/shared/src/price_estimation/zeroex.rs
@@ -235,8 +235,9 @@ mod tests {
         dbg!(&result);
         let estimate = result.unwrap();
         println!(
-            "1 eth buys {} gno",
+            "1 eth buys {} gno, costing {} gas",
             estimate.out_amount.to_f64_lossy() / 1e18
+            estimate.gas,
         );
     }
 }

--- a/shared/src/price_estimation/zeroex.rs
+++ b/shared/src/price_estimation/zeroex.rs
@@ -1,0 +1,242 @@
+use crate::bad_token::BadTokenDetecting;
+use crate::price_estimation::{
+    ensure_token_supported, Estimate, PriceEstimating, PriceEstimationError, Query,
+};
+use crate::zeroex_api::{SwapQuery, ZeroExApi};
+use model::order::OrderKind;
+use std::sync::Arc;
+
+pub struct ZeroExPriceEstimator {
+    pub client: Arc<dyn ZeroExApi + Send + Sync>,
+    pub bad_token_detector: Arc<dyn BadTokenDetecting>,
+}
+
+impl ZeroExPriceEstimator {
+    async fn estimate(&self, query: &Query) -> Result<Estimate, PriceEstimationError> {
+        if query.buy_token == query.sell_token {
+            return Ok(Estimate {
+                out_amount: query.in_amount,
+                gas: 0.into(),
+            });
+        }
+
+        ensure_token_supported(query.buy_token, self.bad_token_detector.as_ref()).await?;
+        ensure_token_supported(query.sell_token, self.bad_token_detector.as_ref()).await?;
+
+        let (sell_amount, buy_amount) = match query.kind {
+            OrderKind::Buy => (None, Some(query.in_amount)),
+            OrderKind::Sell => (Some(query.in_amount), None),
+        };
+
+        let swap = self
+            .client
+            .get_price(SwapQuery {
+                sell_token: query.sell_token,
+                buy_token: query.buy_token,
+                sell_amount,
+                buy_amount,
+                slippage_percentage: Default::default(),
+                skip_validation: None,
+            })
+            .await
+            .map_err(|err| PriceEstimationError::Other(err.into()))?;
+
+        Ok(Estimate {
+            out_amount: match query.kind {
+                OrderKind::Buy => swap.sell_amount,
+                OrderKind::Sell => swap.buy_amount,
+            },
+            gas: swap.estimated_gas,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl PriceEstimating for ZeroExPriceEstimator {
+    async fn estimates(
+        &self,
+        queries: &[Query],
+    ) -> Vec<anyhow::Result<Estimate, PriceEstimationError>> {
+        let mut results = Vec::with_capacity(queries.len());
+
+        for query in queries {
+            results.push(self.estimate(query).await);
+        }
+
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bad_token::list_based::ListBasedDetector;
+    use crate::zeroex_api::MockZeroExApi;
+    use crate::zeroex_api::{DefaultZeroExApi, PriceResponse};
+    use reqwest::Client;
+
+    #[tokio::test]
+    async fn estimate_sell() {
+        let mut zeroex_api = MockZeroExApi::new();
+
+        // Response was generated with:
+        //
+        // curl "https://api.0x.org/swap/v1/price?\
+        //     sellToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&\
+        //     buyToken=0x6810e776880c02933d47db1b9fc05908e5386b96&\
+        //     slippagePercentage=0&\
+        //     sellAmount=100000000000000000"
+        zeroex_api.expect_get_price().return_once(|_| {
+            Ok(PriceResponse {
+                sell_amount: 100000000000000000u64.into(),
+                buy_amount: 1110165823572443613u64.into(),
+                allowance_target: addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
+                price: 11.101_658_235_724_436,
+                estimated_gas: 111000.into(),
+            })
+        });
+
+        let weth = addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+        let gno = addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+
+        let estimator = ZeroExPriceEstimator {
+            client: Arc::new(zeroex_api),
+            bad_token_detector: Arc::new(ListBasedDetector::deny_list(Vec::new())),
+        };
+
+        let est = estimator
+            .estimate(&Query {
+                sell_token: weth,
+                buy_token: gno,
+                in_amount: 100000000000000000u64.into(),
+                kind: OrderKind::Sell,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(est.out_amount, 1110165823572443613u64.into());
+        assert_eq!(est.gas, 111000.into());
+    }
+
+    #[tokio::test]
+    async fn estimate_buy() {
+        let mut zeroex_api = MockZeroExApi::new();
+
+        // Response was generated with:
+        //
+        // curl "https://api.0x.org/swap/v1/price?\
+        //     sellToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&\
+        //     buyToken=0x6810e776880c02933d47db1b9fc05908e5386b96&\
+        //     slippagePercentage=0&\
+        //     buyAmount=100000000000000000"
+        zeroex_api.expect_get_price().return_once(|_| {
+            Ok(PriceResponse {
+                sell_amount: 8986186353137488u64.into(),
+                buy_amount: 100000000000000000u64.into(),
+                allowance_target: addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
+                price: 0.089_861_863_531_374_87,
+                estimated_gas: 111000.into(),
+            })
+        });
+
+        let weth = addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+        let gno = addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+
+        let estimator = ZeroExPriceEstimator {
+            client: Arc::new(zeroex_api),
+            bad_token_detector: Arc::new(ListBasedDetector::deny_list(Vec::new())),
+        };
+
+        let est = estimator
+            .estimate(&Query {
+                sell_token: weth,
+                buy_token: gno,
+                in_amount: 100000000000000000u64.into(),
+                kind: OrderKind::Buy,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(est.out_amount, 8986186353137488u64.into());
+        assert_eq!(est.gas, 111000.into());
+    }
+
+    #[tokio::test]
+    async fn same_token() {
+        let estimator = ZeroExPriceEstimator {
+            client: Arc::new(MockZeroExApi::new()),
+            bad_token_detector: Arc::new(ListBasedDetector::deny_list(Vec::new())),
+        };
+
+        let weth = addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+
+        let est = estimator
+            .estimate(&Query {
+                sell_token: weth,
+                buy_token: weth,
+                in_amount: 100000000000000000u64.into(),
+                kind: OrderKind::Buy,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(est.out_amount, 100000000000000000u64.into());
+        assert_eq!(est.gas, 0.into());
+    }
+
+    #[tokio::test]
+    async fn unsupported_token() {
+        let weth = addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+        let gno = addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+
+        let estimator = ZeroExPriceEstimator {
+            client: Arc::new(MockZeroExApi::new()),
+            // we don't support this shady token -_-
+            bad_token_detector: Arc::new(ListBasedDetector::deny_list(vec![gno])),
+        };
+
+        let err = estimator
+            .estimate(&Query {
+                sell_token: weth,
+                buy_token: gno,
+                in_amount: 100000000000000000u64.into(),
+                kind: OrderKind::Buy,
+            })
+            .await
+            .unwrap_err();
+
+        if let PriceEstimationError::UnsupportedToken(token) = err {
+            assert_eq!(token, gno);
+        } else {
+            panic!("unexpected error: {:?}", err);
+        }
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn real_estimate() {
+        let weth = addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+        let gno = addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+
+        let estimator = ZeroExPriceEstimator {
+            client: Arc::new(DefaultZeroExApi::with_default_url(Client::new())),
+            bad_token_detector: Arc::new(ListBasedDetector::deny_list(Vec::new())),
+        };
+
+        let result = estimator
+            .estimate(&Query {
+                sell_token: weth,
+                buy_token: gno,
+                in_amount: 100000000000000000u64.into(),
+                kind: OrderKind::Sell,
+            })
+            .await;
+
+        dbg!(&result);
+        let estimate = result.unwrap();
+        println!(
+            "1 eth buys {} gno",
+            estimate.out_amount.to_f64_lossy() / 1e18
+        );
+    }
+}

--- a/shared/src/price_estimation/zeroex.rs
+++ b/shared/src/price_estimation/zeroex.rs
@@ -36,7 +36,7 @@ impl ZeroExPriceEstimator {
                 sell_amount,
                 buy_amount,
                 slippage_percentage: Default::default(),
-                skip_validation: None,
+                skip_validation: Some(true),
             })
             .await
             .map_err(|err| PriceEstimationError::Other(err.into()))?;

--- a/shared/src/zeroex_api.rs
+++ b/shared/src/zeroex_api.rs
@@ -100,7 +100,7 @@ pub struct PriceResponse {
 #[serde(rename_all = "camelCase")]
 pub struct SwapResponse {
     #[serde(flatten)]
-    pub header: PriceResponse,
+    pub price: PriceResponse,
     pub to: H160,
     #[derivative(Debug(format_with = "debug_bytes"))]
     pub data: Bytes,
@@ -300,7 +300,7 @@ mod tests {
         assert_eq!(
                 swap,
                 SwapResponse {
-                    header: PriceResponse {
+                    price: PriceResponse {
                         sell_amount: U256::from_dec_str("100000000000000000").unwrap(),
                         buy_amount: U256::from_dec_str("1312100257517027783").unwrap(),
                         allowance_target: crate::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),

--- a/shared/src/zeroex_api.rs
+++ b/shared/src/zeroex_api.rs
@@ -40,8 +40,8 @@ pub struct SwapQuery {
 }
 
 impl SwapQuery {
-    /// Encodes the swap query as
-    fn into_url(self, base_url: &Url) -> Url {
+    /// Encodes the swap query as a url with get parameters.
+    fn format_url(&self, base_url: &Url, endpoint: &str) -> Url {
         // The `Display` implementation for `H160` unfortunately does not print
         // the full address and instead uses ellipsis (e.g. "0xeeee…eeee"). This
         // helper just works around that.
@@ -50,7 +50,9 @@ impl SwapQuery {
         }
 
         let mut url = base_url
-            .join("/swap/v1/quote?")
+            .join("/swap/v1/")
+            .expect("unexpectedly invalid URL segment")
+            .join(endpoint)
             .expect("unexpectedly invalid URL segment");
         url.query_pairs_mut()
             .append_pair("sellToken", &addr2str(self.sell_token))
@@ -76,11 +78,11 @@ impl SwapQuery {
     }
 }
 
-/// A Ox API swap response.
+/// A Ox API `price` response.
 #[derive(Clone, Default, Derivative, Deserialize, PartialEq)]
 #[derivative(Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct SwapResponse {
+pub struct PriceResponse {
     #[serde(with = "u256_decimal")]
     pub sell_amount: U256,
     #[serde(with = "u256_decimal")]
@@ -88,6 +90,17 @@ pub struct SwapResponse {
     pub allowance_target: H160,
     #[serde(deserialize_with = "deserialize_decimal_f64")]
     pub price: f64,
+    #[serde(with = "u256_decimal")]
+    pub estimated_gas: U256,
+}
+
+/// A Ox API `swap` response.
+#[derive(Clone, Default, Derivative, Deserialize, PartialEq)]
+#[derivative(Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapResponse {
+    #[serde(flatten)]
+    pub header: PriceResponse,
     pub to: H160,
     #[derivative(Debug(format_with = "debug_bytes"))]
     pub data: Bytes,
@@ -95,11 +108,20 @@ pub struct SwapResponse {
     pub value: U256,
 }
 
-/// Mockable implementation of the API for unit test
+/// Abstract 0x API. Provides a mockable implementation.
 #[mockall::automock]
 #[async_trait::async_trait]
 pub trait ZeroExApi {
+    /// Retrieve a swap for the specified parameters from the 1Inch API.
+    ///
+    /// See [`/swap/v1/quote`](https://0x.org/docs/api#get-swapv1quote).
     async fn get_swap(&self, query: SwapQuery) -> Result<SwapResponse, ZeroExResponseError>;
+
+    /// Similar to `get_swap`: calculate parameters of a swap.
+    /// Does not return a transaction that can be sent to the 0x API.
+    ///
+    /// See [`/swap/v1/price`](https://0x.org/docs/api#get-swapv1price).
+    async fn get_price(&self, query: SwapQuery) -> Result<PriceResponse, ZeroExResponseError>;
 }
 
 /// 0x API Client implementation.
@@ -110,14 +132,20 @@ pub struct DefaultZeroExApi {
 }
 
 impl DefaultZeroExApi {
+    /// Default 0x API URL.
     pub const DEFAULT_URL: &'static str = "https://api.0x.org/";
 
-    /// Create a new 1Inch HTTP API client with the specified base URL.
+    /// Create a new 0x HTTP API client with the specified base URL.
     pub fn new(base_url: impl IntoUrl, client: Client) -> Result<Self> {
         Ok(Self {
             client,
             base_url: base_url.into_url()?,
         })
+    }
+
+    /// Create a new 0x HTTP API client using the default URL.
+    pub fn with_default_url(client: Client) -> Self {
+        Self::new(Self::DEFAULT_URL, client).unwrap()
     }
 }
 
@@ -150,36 +178,42 @@ pub enum ZeroExResponseError {
 
 #[async_trait::async_trait]
 impl ZeroExApi for DefaultZeroExApi {
-    /// Retrieves a swap for the specified parameters from the 1Inch API.
     async fn get_swap(&self, query: SwapQuery) -> Result<SwapResponse, ZeroExResponseError> {
-        let query_str = format!("{:?}", &query);
+        self.swap_like_request_impl("swap", query).await
+    }
+
+    async fn get_price(&self, query: SwapQuery) -> Result<PriceResponse, ZeroExResponseError> {
+        self.swap_like_request_impl("price", query).await
+    }
+}
+
+impl DefaultZeroExApi {
+    async fn swap_like_request_impl<T: for <'a> serde::Deserialize<'a>>(
+        &self,
+        endpoint: &str,
+        query: SwapQuery,
+    ) -> Result<T, ZeroExResponseError> {
         let response_text = self
             .client
-            .get(query.into_url(&self.base_url))
+            .get(query.format_url(&self.base_url, endpoint))
             .send()
             .await
             .map_err(ZeroExResponseError::Send)?
             .text()
             .await
             .map_err(ZeroExResponseError::TextFetch)?;
-        parse_zeroex_response_text(&response_text, &query_str)
-    }
-}
 
-fn parse_zeroex_response_text(
-    response_text: &str,
-    query: &str,
-) -> Result<SwapResponse, ZeroExResponseError> {
-    match serde_json::from_str::<RawResponse<SwapResponse>>(response_text) {
-        Ok(RawResponse::ResponseOk(response)) => Ok(response),
-        Ok(RawResponse::ResponseErr { reason: message }) => match &message[..] {
-            "Server Error" => Err(ZeroExResponseError::ServerError(format!("{:?}", query))),
-            _ => Err(ZeroExResponseError::UnknownZeroExError(message)),
-        },
-        Err(err) => Err(ZeroExResponseError::DeserializeError(
-            err,
-            response_text.parse().unwrap(),
-        )),
+        match serde_json::from_str::<RawResponse<T>>(&response_text) {
+            Ok(RawResponse::ResponseOk(response)) => Ok(response),
+            Ok(RawResponse::ResponseErr { reason: message }) => match &message[..] {
+                "Server Error" => Err(ZeroExResponseError::ServerError(format!("{:?}", query))),
+                _ => Err(ZeroExResponseError::UnknownZeroExError(message)),
+            },
+            Err(err) => Err(ZeroExResponseError::DeserializeError(
+                err,
+                response_text.parse().unwrap(),
+            )),
+        }
     }
 }
 
@@ -218,7 +252,7 @@ mod tests {
             slippage_percentage: Slippage::number_from_basis_points(30).unwrap(),
             skip_validation: None,
         }
-        .into_url(&base_url);
+        .format_url(&base_url, "quote");
 
         assert_eq!(
             url.as_str(),
@@ -242,7 +276,7 @@ mod tests {
             slippage_percentage: Slippage::number_from_basis_points(30).unwrap(),
             skip_validation: Some(true),
         }
-        .into_url(&base_url);
+        .format_url(&base_url, "quote");
 
         assert_eq!(
             url.as_str(),
@@ -266,10 +300,13 @@ mod tests {
         assert_eq!(
                 swap,
                 SwapResponse {
-                    sell_amount: U256::from_dec_str("100000000000000000").unwrap(),
-                     buy_amount: U256::from_dec_str("1312100257517027783").unwrap(),
-                     allowance_target: crate::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
-                    price: 13.121_002_575_170_278_f64,
+                    header: PriceResponse {
+                        sell_amount: U256::from_dec_str("100000000000000000").unwrap(),
+                        buy_amount: U256::from_dec_str("1312100257517027783").unwrap(),
+                        allowance_target: crate::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
+                        price: 13.121_002_575_170_278_f64,
+                        estimated_gas: 111000.into(),
+                    },
                     to: crate::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
                     data: Bytes(hex::decode(
                         "d9627aa40000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000016345785d8a00000000000000000000000000000000000000000000000000001206e6c0056936e100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000006810e776880c02933d47db1b9fc05908e5386b96869584cd0000000000000000000000001000000000000000000000000000000000000011000000000000000000000000000000000000000000000092415e982f60d431ba"

--- a/shared/src/zeroex_api.rs
+++ b/shared/src/zeroex_api.rs
@@ -188,7 +188,7 @@ impl ZeroExApi for DefaultZeroExApi {
 }
 
 impl DefaultZeroExApi {
-    async fn swap_like_request_impl<T: for <'a> serde::Deserialize<'a>>(
+    async fn swap_like_request_impl<T: for<'a> serde::Deserialize<'a>>(
         &self,
         endpoint: &str,
         query: SwapQuery,


### PR DESCRIPTION
Fixes #1249.

Adds a 0x price estimator to the orderbook API for estimating token price and trade prices.

### Test Plan
New unit tests, inclusing a test with a real 0x API
