### PR TITLE
Solver Timeout Metric

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -423,7 +423,8 @@ impl Driver {
             let mut settlements = match settlements {
                 Ok(settlement) => settlement,
                 Err(err) => {
-                    tracing::error!("solver {} error: {:?}", name, err);
+                    self.metrics.solver_time_out(name);
+                    tracing::warn!("solver {} error: {:?}", name, err);
                     continue;
                 }
             };


### PR DESCRIPTION
Rather than alert on every solver timeout like this

```
[DFUSION][GP-V2-SERVICES] Error
ERROR (pod: dfusion-v2-solver-xdai-74c4fd6c66-tdsnz):
2021-10-20T18:35:57.680Z ERROR solver::driver: solver Quasimodo error: solver timed out
```

We keep a counter of the number of each solver timeout to be displayed as a chart in grafana.
