### PR TITLE
Count solver run failures

### DIFF
--- a/solver/src/settlement_simulation.rs
+++ b/solver/src/settlement_simulation.rs
@@ -84,7 +84,7 @@ pub async fn simulate_and_error_with_tenderly_link(
     gas_price: EstimatedGasPrice,
     network_id: &str,
     block: u64,
-) -> Result<Vec<Result<()>>> {
+) -> Vec<Result<()>> {
     let mut batch = CallBatch::new(web3.transport());
     let futures = settlements
         .map(|(account, settlement)| {
@@ -103,14 +103,14 @@ pub async fn simulate_and_error_with_tenderly_link(
         .collect::<Vec<_>>();
     batch.execute_all(SIMULATE_BATCH_SIZE).await;
 
-    Ok(futures
+    futures
         .into_iter()
         .map(|(future, transaction_builder)| {
             future.now_or_never().unwrap().map(|_| ()).map_err(|err| {
                 Error::new(err).context(tenderly_link(block, network_id, transaction_builder))
             })
         })
-        .collect())
+        .collect()
 }
 
 fn settle_method(
@@ -183,8 +183,7 @@ mod tests {
             network_id.as_str(),
             block,
         )
-        .await
-        .unwrap();
+        .await;
         let _ = dbg!(result);
 
         let result = simulate_and_estimate_gas_at_current_block(


### PR DESCRIPTION
Supersedes #1278 

This PR counts solver run success and failures. This allows us to setup alerts on solver failures if the rate gets too high.

Additionally, I removed a path to a `tracing::error!` that could never get hit. It just makes it easier to identify what we can actually alert on by searching for `tracing::error`.

### Test Plan

Run the solver with MIP and Quasimodo, one with incorrect authentication, and check metric values:
```
$ cargo run -p solver -- \
  --orderbook-url https://protocol-mainnet.gnosis.io \
  --node-url "https://mainnet.infura.io/v3/$INFURA_PROJECT_ID" \
  --mip-solver-url "https://invalid_user:invalid_password@$MIP_SOLVER_HOSTNAME" \
  --quasimodo-solver-url "$QUASIMODO_SOLVER_URL" \
  --solver-account 0xa6DDBD0dE6B310819b49f680F65871beE85f517e \
  --solvers Mip,Quasimodo \
  --transaction-strategy DryRun
...
2021-10-21T07:36:51.392Z  WARN solver::driver: solver Mip error: solver response is not success: ...
...
$ curl -s http://localhost:9587/metrics | grep solver_run
# HELP gp_v2_solver_solver_run Success/Failure counts
# TYPE gp_v2_solver_solver_run counter
gp_v2_solver_solver_run{result="failure",solver_type="Mip"} 9
gp_v2_solver_solver_run{result="success",solver_type="Quasimodo"} 9
```
