### PR TITLE
Differentiate between different solver outcomes

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -6,7 +6,7 @@ use crate::{
     in_flight_orders::InFlightOrders,
     liquidity::order_converter::OrderConverter,
     liquidity_collector::LiquidityCollector,
-    metrics::SolverMetrics,
+    metrics::{SolverMetrics, SolverRunOutcome},
     orderbook::OrderBookApi,
     settlement::Settlement,
     settlement_simulation,
@@ -14,7 +14,7 @@ use crate::{
     solver::Solver,
     solver::{Auction, SettlementWithSolver, Solvers},
 };
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use contracts::GPv2Settlement;
 use ethcontract::errors::{ExecutionError, MethodError};
 use futures::future::join_all;
@@ -126,7 +126,7 @@ impl Driver {
     async fn run_solvers(
         &self,
         auction: Auction,
-    ) -> Vec<(Arc<dyn Solver>, Result<Vec<Settlement>>)> {
+    ) -> Vec<(Arc<dyn Solver>, Result<Vec<Settlement>, SolverRunError>)> {
         join_all(self.solvers.iter().map(|solver| {
             let auction = auction.clone();
             let metrics = &self.metrics;
@@ -136,8 +136,8 @@ impl Driver {
                     match tokio::time::timeout_at(auction.deadline.into(), solver.solve(auction))
                         .await
                     {
-                        Ok(inner) => inner,
-                        Err(_timeout) => Err(anyhow!("solver timed out")),
+                        Ok(inner) => inner.map_err(SolverRunError::Solving),
+                        Err(_timeout) => Err(SolverRunError::Timeout),
                     };
                 metrics.settlement_computed(solver.name(), start_time);
                 (solver.clone(), result)
@@ -407,19 +407,30 @@ impl Driver {
             let name = solver.name();
 
             let mut settlements = match settlements {
-                Ok(settlement) => {
-                    self.metrics.solver_run_succeeded(name);
+                Ok(mut settlement) => {
+                    // Do not continue with settlements that are empty or only liquidity orders.
+                    settlement.retain(solver_settlements::has_user_order);
+                    if settlement.is_empty() {
+                        self.metrics.solver_run(name, SolverRunOutcome::Empty);
+                        continue;
+                    }
+
+                    self.metrics.solver_run(name, SolverRunOutcome::Success);
                     settlement
                 }
                 Err(err) => {
-                    self.metrics.solver_run_failed(name);
+                    match err {
+                        SolverRunError::Timeout => {
+                            self.metrics.solver_run(name, SolverRunOutcome::Timeout)
+                        }
+                        SolverRunError::Solving(_) => {
+                            self.metrics.solver_run(name, SolverRunOutcome::Failure)
+                        }
+                    }
                     tracing::warn!("solver {} error: {:?}", name, err);
                     continue;
                 }
             };
-
-            // Do not continue with settlements that are empty or only liquidity orders.
-            settlements.retain(solver_settlements::has_user_order);
 
             for settlement in &settlements {
                 tracing::debug!("solver {} found solution:\n{:?}", name, settlement);
@@ -548,6 +559,12 @@ fn print_settlements(rated_settlements: &[(Arc<dyn Solver>, RatedSettlement)]) {
             ))
             .collect::<Vec<_>>()
     );
+}
+
+#[derive(Debug)]
+enum SolverRunError {
+    Timeout,
+    Solving(anyhow::Error),
 }
 
 #[cfg(test)]

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -411,20 +411,20 @@ impl Driver {
                     // Do not continue with settlements that are empty or only liquidity orders.
                     settlement.retain(solver_settlements::has_user_order);
                     if settlement.is_empty() {
-                        self.metrics.solver_run(name, SolverRunOutcome::Empty);
+                        self.metrics.solver_run(SolverRunOutcome::Empty, name);
                         continue;
                     }
 
-                    self.metrics.solver_run(name, SolverRunOutcome::Success);
+                    self.metrics.solver_run(SolverRunOutcome::Success, name);
                     settlement
                 }
                 Err(err) => {
                     match err {
                         SolverRunError::Timeout => {
-                            self.metrics.solver_run(name, SolverRunOutcome::Timeout)
+                            self.metrics.solver_run(SolverRunOutcome::Timeout, name)
                         }
                         SolverRunError::Solving(_) => {
-                            self.metrics.solver_run(name, SolverRunOutcome::Failure)
+                            self.metrics.solver_run(SolverRunOutcome::Failure, name)
                         }
                     }
                     tracing::warn!("solver {} error: {:?}", name, err);

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -23,6 +23,19 @@ use strum::VariantNames;
 /// The maximum time between the completion of two run loops. If exceeded the service will be considered unhealthy.
 const MAX_RUNLOOP_DURATION: Duration = Duration::from_secs(7 * 60);
 
+/// The outcome of a solver run.
+pub enum SolverRunOutcome {
+    /// Computed a non-trivial settlement.
+    Success,
+    /// Run succeeded (i.e. did not error), but solver produced no settlement or
+    /// only trivial settlements.
+    Empty,
+    /// The solver timed out.
+    Timeout,
+    /// The solver returned an error.
+    Failure,
+}
+
 pub trait SolverMetrics: Send + Sync {
     fn orders_fetched(&self, orders: &[LimitOrder]);
     fn liquidity_fetched(&self, liquidity: &[Liquidity]);
@@ -30,8 +43,7 @@ pub trait SolverMetrics: Send + Sync {
     fn order_settled(&self, order: &Order, solver: &'static str);
     fn settlement_simulation_succeeded(&self, solver: &'static str);
     fn settlement_simulation_failed_on_latest(&self, solver: &'static str);
-    fn solver_run_succeeded(&self, solver: &'static str);
-    fn solver_run_failed(&self, solver: &'static str);
+    fn solver_run(&self, solver: &'static str, outcome: SolverRunOutcome);
     fn single_order_solver_succeeded(&self, solver: &'static str);
     fn single_order_solver_failed(&self, solver: &'static str);
     fn settlement_simulation_failed(&self, solver: &'static str);
@@ -260,16 +272,14 @@ impl SolverMetrics for Metrics {
             .inc()
     }
 
-    fn solver_run_succeeded(&self, solver: &'static str) {
-        self.solver_runs
-            .with_label_values(&["success", solver])
-            .inc()
-    }
-
-    fn solver_run_failed(&self, solver: &'static str) {
-        self.solver_runs
-            .with_label_values(&["failure", solver])
-            .inc()
+    fn solver_run(&self, solver: &'static str, outcome: SolverRunOutcome) {
+        let result = match outcome {
+            SolverRunOutcome::Success => "success",
+            SolverRunOutcome::Empty => "empty",
+            SolverRunOutcome::Timeout => "timeout",
+            SolverRunOutcome::Failure => "failure",
+        };
+        self.solver_runs.with_label_values(&[result, solver]).inc()
     }
 
     fn single_order_solver_succeeded(&self, solver: &'static str) {
@@ -373,8 +383,7 @@ impl SolverMetrics for NoopMetrics {
     fn order_settled(&self, _: &Order, _: &'static str) {}
     fn settlement_simulation_succeeded(&self, _: &'static str) {}
     fn settlement_simulation_failed_on_latest(&self, _: &'static str) {}
-    fn solver_run_succeeded(&self, _: &'static str) {}
-    fn solver_run_failed(&self, _: &'static str) {}
+    fn solver_run(&self, _: &'static str, _: SolverRunOutcome) {}
     fn single_order_solver_succeeded(&self, _: &'static str) {}
     fn single_order_solver_failed(&self, _: &'static str) {}
     fn settlement_simulation_failed(&self, _: &'static str) {}

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -43,7 +43,7 @@ pub trait SolverMetrics: Send + Sync {
     fn order_settled(&self, order: &Order, solver: &'static str);
     fn settlement_simulation_succeeded(&self, solver: &'static str);
     fn settlement_simulation_failed_on_latest(&self, solver: &'static str);
-    fn solver_run(&self, solver: &'static str, outcome: SolverRunOutcome);
+    fn solver_run(&self, outcome: SolverRunOutcome, solver: &'static str);
     fn single_order_solver_succeeded(&self, solver: &'static str);
     fn single_order_solver_failed(&self, solver: &'static str);
     fn settlement_simulation_failed(&self, solver: &'static str);
@@ -272,7 +272,7 @@ impl SolverMetrics for Metrics {
             .inc()
     }
 
-    fn solver_run(&self, solver: &'static str, outcome: SolverRunOutcome) {
+    fn solver_run(&self, outcome: SolverRunOutcome, solver: &'static str) {
         let result = match outcome {
             SolverRunOutcome::Success => "success",
             SolverRunOutcome::Empty => "empty",
@@ -383,7 +383,7 @@ impl SolverMetrics for NoopMetrics {
     fn order_settled(&self, _: &Order, _: &'static str) {}
     fn settlement_simulation_succeeded(&self, _: &'static str) {}
     fn settlement_simulation_failed_on_latest(&self, _: &'static str) {}
-    fn solver_run(&self, _: &'static str, _: SolverRunOutcome) {}
+    fn solver_run(&self, _: SolverRunOutcome, _: &'static str) {}
     fn single_order_solver_succeeded(&self, _: &'static str) {}
     fn single_order_solver_failed(&self, _: &'static str) {}
     fn settlement_simulation_failed(&self, _: &'static str) {}


### PR DESCRIPTION
Fixes #1280 

This PR differentiates between different solver run outcomes:
- Empty settlements
- Success
- Timeout
- Failure

I'm not entirely sure how valuable this is compared to just success/failure, and wanted to know what you all think.

### Test Plan

Observe new metrics.

<details><summary>To try out all possibilities patch the solver:</summary>

```diff
diff --git a/crates/solver/src/solver/baseline_solver.rs b/crates/solver/src/solver/baseline_solver.rs
index b1ea23f..b05f047 100644
--- a/crates/solver/src/solver/baseline_solver.rs
+++ b/crates/solver/src/solver/baseline_solver.rs
@@ -29,6 +29,7 @@ impl Solver for BaselineSolver {
             orders, liquidity, ..
         }: Auction,
     ) -> Result<Vec<Settlement>> {
+        anyhow::bail!("test error"); // Baseline always fails
         Ok(self.solve_(orders, liquidity))
     }
 
diff --git a/crates/solver/src/solver/naive_solver.rs b/crates/solver/src/solver/naive_solver.rs
index c683219..a7fa60a 100644
--- a/crates/solver/src/solver/naive_solver.rs
+++ b/crates/solver/src/solver/naive_solver.rs
@@ -28,6 +28,7 @@ impl Solver for NaiveSolver {
             orders, liquidity, ..
         }: Auction,
     ) -> Result<Vec<Settlement>> {
+        futures::future::pending::<()>().await; // Naive always times out
         let uniswaps = extract_deepest_amm_liquidity(&liquidity);
         Ok(settle(orders, uniswaps).await)
     }
diff --git a/crates/solver/src/solver/paraswap_solver.rs b/crates/solver/src/solver/paraswap_solver.rs
index 87dd59f..3d21c46 100644
--- a/crates/solver/src/solver/paraswap_solver.rs
+++ b/crates/solver/src/solver/paraswap_solver.rs
@@ -84,6 +84,7 @@ impl SingleOrderSolving for ParaswapSolver {
         &self,
         order: LimitOrder,
     ) -> Result<Option<Settlement>, SettlementError> {
+        return Ok(None); // ParaSwap always returns empty settlements
         let token_info = self
             .token_info
             .get_token_infos(&[order.sell_token, order.buy_token])
```

</details>

Then run it:
```
$ cargo run -p solver -- --solvers Baseline,Naive,ParaSwap,ZeroEx
```

And see that the metrics increase:
```
# TYPE gp_v2_solver_solver_run counter
gp_v2_solver_solver_run{result="empty",solver_type="ParaSwap"} 1
gp_v2_solver_solver_run{result="failure",solver_type="BaselineSolver"} 1
gp_v2_solver_solver_run{result="success",solver_type="0x"} 1
gp_v2_solver_solver_run{result="timeout",solver_type="NaiveSolver"} 1
```