### PR TITLE
Return transaction receipt instead of just hash

### DIFF
--- a/solver/src/settlement_submission.rs
+++ b/solver/src/settlement_submission.rs
@@ -9,7 +9,7 @@ use crate::settlement::Settlement;
 use anyhow::{bail, Result};
 use archer_api::ArcherApi;
 use contracts::GPv2Settlement;
-use ethcontract::{Account, TransactionHash};
+use ethcontract::Account;
 use gas_estimation::GasPriceEstimating;
 use primitive_types::U256;
 use shared::Web3;
@@ -17,6 +17,7 @@ use std::{
     sync::Arc,
     time::{Duration, SystemTime},
 };
+use web3::types::TransactionReceipt;
 
 use self::archer_settlement::ArcherSolutionSubmitter;
 
@@ -53,7 +54,7 @@ impl SolutionSubmitter {
         settlement: Settlement,
         gas_estimate: U256,
         account: Account,
-    ) -> Result<TransactionHash> {
+    ) -> Result<TransactionReceipt> {
         match &self.transaction_strategy {
             TransactionStrategy::CustomNodes(nodes) => {
                 rpc::submit(

--- a/solver/src/settlement_submission/dry_run.rs
+++ b/solver/src/settlement_submission/dry_run.rs
@@ -4,13 +4,14 @@ use super::retry::settle_method_builder;
 use crate::{settlement::Settlement, settlement_simulation::tenderly_link};
 use anyhow::Result;
 use contracts::GPv2Settlement;
-use ethcontract::{Account, TransactionHash};
+use ethcontract::Account;
+use web3::types::TransactionReceipt;
 
 pub async fn log_settlement(
     account: Account,
     contract: &GPv2Settlement,
     settlement: Settlement,
-) -> Result<TransactionHash> {
+) -> Result<TransactionReceipt> {
     let web3 = contract.raw_instance().web3();
     let current_block = web3.eth().block_number().await?;
     let network = web3.net().version().await?;
@@ -22,7 +23,12 @@ pub async fn log_settlement(
 
     // We could technically compute a transaction hash for the settlement here,
     // but it's probably not worth the effort.
-    Ok(Default::default())
+    Ok(TransactionReceipt {
+        transaction_hash: Default::default(),
+        block_hash: Some(Default::default()),
+        block_number: Some(Default::default()),
+        ..Default::default()
+    })
 }
 
 #[cfg(test)]

--- a/solver/src/settlement_submission/rpc.rs
+++ b/solver/src/settlement_submission/rpc.rs
@@ -6,13 +6,14 @@ use super::{
 use crate::{encoding::EncodedSettlement, pending_transactions::Fee, settlement::Settlement};
 use anyhow::{Context, Result};
 use contracts::GPv2Settlement;
-use ethcontract::{Account, TransactionHash};
+use ethcontract::Account;
 use futures::stream::StreamExt;
 use gas_estimation::{EstimatedGasPrice, GasPrice1559, GasPriceEstimating};
 use primitive_types::{H160, U256};
 use shared::Web3;
 use std::time::Duration;
 use transaction_retry::RetryResult;
+use web3::types::TransactionReceipt;
 
 // Submit a settlement to the contract, updating the transaction with gas prices if they increase.
 #[allow(clippy::too_many_arguments)]
@@ -25,7 +26,7 @@ pub async fn submit(
     gas_price_cap: f64,
     settlement: Settlement,
     gas_estimate: U256,
-) -> Result<TransactionHash> {
+) -> Result<TransactionReceipt> {
     let address = account.address();
     let settlement: EncodedSettlement = settlement.into();
 


### PR DESCRIPTION
This gives us access to the block number which will be used in the fix for https://github.com/gnosis/gp-v2-services/issues/1284 .

### Test Plan
CI
