### PR TITLE
reset estimate metrics on startup

### DIFF
--- a/orderbook/src/metrics.rs
+++ b/orderbook/src/metrics.rs
@@ -128,6 +128,14 @@ impl crate::gas_price::Metrics for Metrics {
 }
 
 impl shared::price_estimation::instrumented::Metrics for Metrics {
+    fn initialize_estimator(&self, name: &str) {
+        for result in ["success", "failure"] {
+            self.price_estimates
+                .with_label_values(&[name, result])
+                .reset();
+        }
+    }
+
     fn price_estimated(&self, name: &str, success: bool) {
         let result = if success { "success" } else { "failure" };
         self.price_estimates


### PR DESCRIPTION
This PR resets price estimator metrics on startup. This way they show up as handling 0 estimates in our dashboard.

### Test Plan

Run the orderbook and check:
```
$ curl -s http://localhost:9586/metrics | grep price_est
# HELP gp_v2_api_price_estimates Price estimator success/failure counter
# TYPE gp_v2_api_price_estimates counter
gp_v2_api_price_estimates{estimator_type="Baseline",result="failure"} 0
gp_v2_api_price_estimates{estimator_type="Baseline",result="success"} 0
gp_v2_api_price_estimates{estimator_type="ParaSwap",result="failure"} 0
gp_v2_api_price_estimates{estimator_type="ParaSwap",result="success"} 0
gp_v2_api_price_estimates{estimator_type="ZeroEx",result="failure"} 0
gp_v2_api_price_estimates{estimator_type="ZeroEx",result="success"} 0
```
