### PR TITLE
Make in flight trades keep track of block number

### DIFF
--- a/e2e/tests/eth_integration.rs
+++ b/e2e/tests/eth_integration.rs
@@ -3,7 +3,7 @@ mod ganache;
 mod services;
 
 use crate::services::{
-    create_orderbook_api, create_orderbook_liquidity, deploy_mintable_token, to_wei, GPv2,
+    create_order_converter, create_orderbook_api, deploy_mintable_token, to_wei, GPv2,
     OrderbookServices, UniswapContracts, API_HOST,
 };
 use contracts::IUniswapLikeRouter;
@@ -209,7 +209,6 @@ async fn eth_integration(web3: Web3) {
         uniswap_like_liquidity: vec![uniswap_liquidity],
         balancer_v2_liquidity: None,
     };
-    let (converter, api) = create_orderbook_liquidity(&web3, gpv2.native_token.address());
     let network_id = web3.net().version().await.unwrap();
     let mut driver = solver::driver::Driver::new(
         gpv2.settlement.clone(),
@@ -238,8 +237,8 @@ async fn eth_integration(web3: Web3) {
         },
         1_000_000_000_000_000_000_u128.into(),
         10,
-        api,
-        converter,
+        create_orderbook_api(),
+        create_order_converter(&web3, gpv2.native_token.address()),
     );
     driver.single_run().await.unwrap();
 
@@ -263,5 +262,5 @@ async fn eth_integration(web3: Web3) {
     solvable_orders_cache.update(0).await.unwrap();
 
     let orders = create_orderbook_api().get_orders().await.unwrap();
-    assert!(orders.is_empty());
+    assert!(orders.orders.is_empty());
 }

--- a/e2e/tests/services.rs
+++ b/e2e/tests/services.rs
@@ -58,18 +58,12 @@ pub fn create_orderbook_api() -> OrderBookApi {
     OrderBookApi::new(reqwest::Url::from_str(API_HOST).unwrap(), Client::new())
 }
 
-pub fn create_orderbook_liquidity(
-    web3: &Web3,
-    weth_address: H160,
-) -> (OrderConverter, OrderBookApi) {
-    (
-        OrderConverter {
-            native_token: WETH9::at(web3, weth_address),
-            liquidity_order_owners: Default::default(),
-            fee_objective_scaling_factor: 1.,
-        },
-        OrderBookApi::new(API_HOST.parse().unwrap(), Client::new()),
-    )
+pub fn create_order_converter(web3: &Web3, weth_address: H160) -> OrderConverter {
+    OrderConverter {
+        native_token: WETH9::at(web3, weth_address),
+        liquidity_order_owners: Default::default(),
+        fee_objective_scaling_factor: 1.,
+    }
 }
 
 pub struct GPv2 {

--- a/e2e/tests/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/settlement_without_onchain_liquidity.rs
@@ -24,7 +24,7 @@ mod ganache;
 #[macro_use]
 mod services;
 use crate::services::{
-    create_orderbook_api, create_orderbook_liquidity, deploy_mintable_token, to_wei, GPv2,
+    create_order_converter, create_orderbook_api, deploy_mintable_token, to_wei, GPv2,
     OrderbookServices, UniswapContracts, API_HOST,
 };
 use shared::maintenance::Maintaining;
@@ -196,7 +196,6 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         uniswap_like_liquidity: vec![uniswap_liquidity],
         balancer_v2_liquidity: None,
     };
-    let (converter, api) = create_orderbook_liquidity(&web3, gpv2.native_token.address());
     let network_id = web3.net().version().await.unwrap();
     let market_makable_token_list = TokenList::new(maplit::hashmap! {
         token_a.address() => Token {
@@ -233,8 +232,8 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         },
         1_000_000_000_000_000_000_u128.into(),
         10,
-        api,
-        converter,
+        create_orderbook_api(),
+        create_order_converter(&web3, gpv2.native_token.address()),
     );
     driver.single_run().await.unwrap();
 
@@ -266,7 +265,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
     solvable_orders_cache.update(0).await.unwrap();
 
     let orders = create_orderbook_api().get_orders().await.unwrap();
-    assert!(orders.is_empty());
+    assert!(orders.orders.is_empty());
 
     // Drive again to ensure we can continue solution finding
     driver.single_run().await.unwrap();

--- a/e2e/tests/smart_contract_orders.rs
+++ b/e2e/tests/smart_contract_orders.rs
@@ -3,8 +3,8 @@ mod ganache;
 mod services;
 
 use crate::services::{
-    create_orderbook_liquidity, deploy_mintable_token, to_wei, GPv2, OrderbookServices,
-    UniswapContracts, API_HOST,
+    create_order_converter, create_orderbook_api, deploy_mintable_token, to_wei, GPv2,
+    OrderbookServices, UniswapContracts, API_HOST,
 };
 use contracts::IUniswapLikeRouter;
 use ethcontract::prelude::{Account, Address, Bytes, PrivateKey, U256};
@@ -179,7 +179,6 @@ async fn smart_contract_orders(web3: Web3) {
         uniswap_like_liquidity: vec![uniswap_liquidity],
         balancer_v2_liquidity: None,
     };
-    let (converter, api) = create_orderbook_liquidity(&web3, gpv2.native_token.address());
     let network_id = web3.net().version().await.unwrap();
     let mut driver = solver::driver::Driver::new(
         gpv2.settlement.clone(),
@@ -208,8 +207,8 @@ async fn smart_contract_orders(web3: Web3) {
         },
         1_000_000_000_000_000_000_u128.into(),
         10,
-        api,
-        converter,
+        create_orderbook_api(),
+        create_order_converter(&web3, gpv2.native_token.address()),
     );
     driver.single_run().await.unwrap();
 

--- a/e2e/tests/vault_balances.rs
+++ b/e2e/tests/vault_balances.rs
@@ -22,8 +22,8 @@ mod ganache;
 #[macro_use]
 mod services;
 use crate::services::{
-    create_orderbook_liquidity, deploy_mintable_token, to_wei, GPv2, OrderbookServices,
-    UniswapContracts, API_HOST,
+    create_order_converter, create_orderbook_api, deploy_mintable_token, to_wei, GPv2,
+    OrderbookServices, UniswapContracts, API_HOST,
 };
 
 const TRADER: [u8; 32] = [1; 32];
@@ -157,7 +157,6 @@ async fn vault_balances(web3: Web3) {
         uniswap_like_liquidity: vec![uniswap_liquidity],
         balancer_v2_liquidity: None,
     };
-    let (converter, api) = create_orderbook_liquidity(&web3, gpv2.native_token.address());
     let network_id = web3.net().version().await.unwrap();
     let mut driver = solver::driver::Driver::new(
         gpv2.settlement.clone(),
@@ -186,8 +185,8 @@ async fn vault_balances(web3: Web3) {
         },
         1_000_000_000_000_000_000_u128.into(),
         10,
-        api,
-        converter,
+        create_orderbook_api(),
+        create_order_converter(&web3, gpv2.native_token.address()),
     );
     driver.single_run().await.unwrap();
 

--- a/solver/src/in_flight_orders.rs
+++ b/solver/src/in_flight_orders.rs
@@ -1,0 +1,73 @@
+use model::{
+    order::{Order, OrderUid},
+    SolvableOrders,
+};
+use std::collections::{BTreeMap, HashSet};
+
+/// After a settlement transaction we need to keep track of in flight orders until the api has
+/// seen the tx. Otherwise we would attempt to solve already matched orders again leading to
+/// failures.
+#[derive(Default)]
+pub struct InFlightOrders {
+    /// Maps block to orders settled in that block.
+    in_flight: BTreeMap<u64, Vec<OrderUid>>,
+}
+
+impl InFlightOrders {
+    /// Takes note of the new set of solvable orders and returns the ones that aren't in flight.
+    pub fn update_and_filter(&mut self, new: SolvableOrders) -> Vec<Order> {
+        // If api has seen block X then trades starting at X + 1 are still in flight.
+        self.in_flight = self.in_flight.split_off(&(new.latest_settlement_block + 1));
+        let mut orders = new.orders;
+        // TODO - could model inflight_trades as HashMap<OrderUid, Vec<Trade>>
+        // https://github.com/gnosis/gp-v2-services/issues/673
+        // Note that this will result in simulation error "GPv2: order filled" if the
+        // next solver run loop tries to match the order again beyond its remaining amount.
+        let in_flight = self
+            .in_flight
+            .values()
+            .flatten()
+            .copied()
+            .collect::<HashSet<_>>();
+        orders.retain(|order| {
+            order.order_creation.partially_fillable
+                || !in_flight.contains(&order.order_meta_data.uid)
+        });
+        orders
+    }
+
+    pub fn mark_settled_orders(&mut self, block: u64, orders: impl Iterator<Item = OrderUid>) {
+        self.in_flight.entry(block).or_default().extend(orders);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test() {
+        let mut inflight = InFlightOrders::default();
+        inflight.mark_settled_orders(1, std::array::IntoIter::new([OrderUid::from_integer(0)]));
+        let mut order0 = Order::default();
+        order0.order_meta_data.uid = OrderUid::from_integer(0);
+        order0.order_creation.partially_fillable = true;
+        let mut order1 = Order::default();
+        order1.order_meta_data.uid = OrderUid::from_integer(1);
+        let mut solvable_orders = SolvableOrders {
+            orders: vec![order0, order1],
+            latest_settlement_block: 0,
+        };
+
+        let filtered = inflight.update_and_filter(solvable_orders.clone());
+        assert_eq!(filtered.len(), 2);
+
+        solvable_orders.orders[0].order_creation.partially_fillable = false;
+        let filtered = inflight.update_and_filter(solvable_orders.clone());
+        assert_eq!(filtered.len(), 1);
+
+        solvable_orders.latest_settlement_block = 1;
+        let filtered = inflight.update_and_filter(solvable_orders.clone());
+        assert_eq!(filtered.len(), 2);
+    }
+}

--- a/solver/src/lib.rs
+++ b/solver/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod driver;
 pub mod encoding;
+pub mod in_flight_orders;
 pub mod interactions;
 pub mod liquidity;
 pub mod liquidity_collector;

--- a/solver/src/orderbook.rs
+++ b/solver/src/orderbook.rs
@@ -1,4 +1,4 @@
-use model::order::Order;
+use model::SolvableOrders;
 use reqwest::{Client, Url};
 
 pub struct OrderBookApi {
@@ -12,8 +12,8 @@ impl OrderBookApi {
         Self { base, client }
     }
 
-    pub async fn get_orders(&self) -> reqwest::Result<Vec<Order>> {
-        const PATH: &str = "/api/v1/solvable_orders";
+    pub async fn get_orders(&self) -> reqwest::Result<SolvableOrders> {
+        const PATH: &str = "/api/v2/solvable_orders";
         let mut url = self.base.clone();
         url.set_path(PATH);
         self.client.get(url).send().await?.json().await


### PR DESCRIPTION
and refactor into standalone component.

We keep track of the block number so that in flight trades stay alive until the api sees the block of the new settlement which we verify using the v2 solvable orders route. Previously we would always delete in flight trades in the next run loop which was no longer enough with the recent run loop speed ups.

Fixes https://github.com/gnosis/gp-v2-services/issues/1284 .
Supersedes https://github.com/gnosis/gp-v2-services/pull/1250 .

### Test Plan
CI and adapted unit test for in flight trades.
