### PR TITLE
Generic convert_response for API reponse handling

### DIFF
--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -126,10 +126,10 @@ fn internal_error() -> Json {
     })
 }
 
-pub fn convert_response<T, E>(result: Result<T, E>) -> WithStatus<Json>
+pub fn convert_json_response<T, E>(result: Result<T, E>) -> WithStatus<Json>
 where
     T: Serialize,
-    E: WarpReplyConverting,
+    E: IntoWarpReply,
 {
     match result {
         Ok(response) => with_status(warp::reply::json(&response), StatusCode::OK),
@@ -137,18 +137,18 @@ where
     }
 }
 
-pub trait WarpReplyConverting {
+pub trait IntoWarpReply {
     fn into_warp_reply(self) -> WithStatus<Json>;
 }
 
-impl WarpReplyConverting for anyhowError {
+impl IntoWarpReply for anyhowError {
     fn into_warp_reply(self) -> WithStatus<Json> {
         tracing::error!(?self, "response error");
         with_status(internal_error(), StatusCode::INTERNAL_SERVER_ERROR)
     }
 }
 
-impl WarpReplyConverting for PriceEstimationError {
+impl IntoWarpReply for PriceEstimationError {
     fn into_warp_reply(self) -> WithStatus<Json> {
         match self {
             Self::UnsupportedToken(token) => with_status(

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -132,10 +132,7 @@ where
 {
     match result {
         Ok(response) => with_status(warp::reply::json(&response), StatusCode::OK),
-        Err(err) => {
-            tracing::error!(?err, "response error");
-            err.into_warp_reply()
-        }
+        Err(err) => err.into_warp_reply(),
     }
 }
 
@@ -145,6 +142,7 @@ pub trait IntoWarpReply {
 
 impl IntoWarpReply for anyhowError {
     fn into_warp_reply(self) -> WithStatus<Json> {
+        tracing::error!(?self, "response error");
         with_status(internal_error(), StatusCode::INTERNAL_SERVER_ERROR)
     }
 }

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -131,7 +131,10 @@ where
 {
     match result {
         Ok(response) => with_status(warp::reply::json(&response), StatusCode::OK),
-        Err(err) => err.into_warp_reply(),
+        Err(err) => {
+            tracing::error!(?self, "response error");
+            err.into_warp_reply()
+        },
     }
 }
 
@@ -141,7 +144,6 @@ pub trait IntoWarpReply {
 
 impl IntoWarpReply for anyhowError {
     fn into_warp_reply(self) -> WithStatus<Json> {
-        tracing::error!(?self, "response error");
         with_status(internal_error(), StatusCode::INTERNAL_SERVER_ERROR)
     }
 }

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -134,7 +134,7 @@ where
         Err(err) => {
             tracing::error!(?self, "response error");
             err.into_warp_reply()
-        },
+        }
     }
 }
 

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -19,6 +19,7 @@ use crate::{
 use anyhow::{Error as anyhowError, Result};
 use serde::{de::DeserializeOwned, Serialize};
 use shared::{metrics::get_metric_storage_registry, price_estimation::PriceEstimationError};
+use std::fmt::Debug;
 use std::{convert::Infallible, sync::Arc};
 use warp::{
     hyper::StatusCode,
@@ -127,12 +128,12 @@ fn internal_error() -> Json {
 pub fn convert_json_response<T, E>(result: Result<T, E>) -> WithStatus<Json>
 where
     T: Serialize,
-    E: IntoWarpReply,
+    E: IntoWarpReply + Debug,
 {
     match result {
         Ok(response) => with_status(warp::reply::json(&response), StatusCode::OK),
         Err(err) => {
-            tracing::error!(?self, "response error");
+            tracing::error!(?err, "response error");
             err.into_warp_reply()
         }
     }

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -126,17 +126,7 @@ fn internal_error() -> Json {
     })
 }
 
-pub fn convert_response_ok<T>(result: Result<T>) -> impl Reply
-where
-    T: WarpReplyConverting,
-{
-    match result {
-        Ok(result) => result.into_warp_reply(),
-        Err(_) => with_status(internal_error(), StatusCode::INTERNAL_SERVER_ERROR),
-    }
-}
-
-pub fn convert_response_err<T, E>(result: Result<T, E>) -> WithStatus<Json>
+pub fn convert_response<T, E>(result: Result<T, E>) -> WithStatus<Json>
 where
     T: Serialize,
     E: WarpReplyConverting,

--- a/orderbook/src/api/cancel_order.rs
+++ b/orderbook/src/api/cancel_order.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::{extract_payload, WarpReplyConverting},
+    api::{extract_payload, IntoWarpReply},
     orderbook::{OrderCancellationResult, Orderbook},
 };
 use anyhow::Result;
@@ -34,7 +34,7 @@ pub fn cancel_order_request(
         })
 }
 
-impl WarpReplyConverting for OrderCancellationResult {
+impl IntoWarpReply for OrderCancellationResult {
     fn into_warp_reply(self) -> WithStatus<Json> {
         match self {
             Self::Cancelled => with_status(warp::reply::json(&"Cancelled"), StatusCode::OK),

--- a/orderbook/src/api/cancel_order.rs
+++ b/orderbook/src/api/cancel_order.rs
@@ -1,15 +1,19 @@
-use crate::api::{convert_response_ok, extract_payload, WarpReplyConverting};
-use crate::orderbook::{OrderCancellationResult, Orderbook};
+use crate::{
+    api::{convert_response_ok, extract_payload, WarpReplyConverting},
+    orderbook::{OrderCancellationResult, Orderbook},
+};
 use anyhow::Result;
-use model::signature::EcdsaSignature;
 use model::{
     order::{OrderCancellation, OrderUid},
-    signature::EcdsaSigningScheme,
+    signature::{EcdsaSignature, EcdsaSigningScheme},
 };
 use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, sync::Arc};
-use warp::reply::{with_status, Json, WithStatus};
-use warp::{hyper::StatusCode, Filter, Rejection, Reply};
+use warp::{
+    hyper::StatusCode,
+    reply::{with_status, Json, WithStatus},
+    Filter, Rejection, Reply,
+};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/orderbook/src/api/cancel_order.rs
+++ b/orderbook/src/api/cancel_order.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::{convert_response_ok, extract_payload, WarpReplyConverting},
+    api::{extract_payload, WarpReplyConverting},
     orderbook::{OrderCancellationResult, Orderbook},
 };
 use anyhow::Result;
@@ -83,7 +83,10 @@ pub fn cancel_order(
             if let Err(err) = &result {
                 tracing::error!(?err, ?order, "cancel_order error");
             }
-            Result::<_, Infallible>::Ok(convert_response_ok(result))
+            Result::<_, Infallible>::Ok(match result {
+                Ok(result) => result.into_warp_reply(),
+                Err(_) => with_status(super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR),
+            })
         }
     })
 }

--- a/orderbook/src/api/cancel_order.rs
+++ b/orderbook/src/api/cancel_order.rs
@@ -101,7 +101,7 @@ mod tests {
                     1b",
                 "signingScheme": "eip712"
             }))
-                .unwrap(),
+            .unwrap(),
             CancellationPayload {
                 signature: EcdsaSignature {
                     r: H256(hex!(

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -27,7 +27,10 @@ pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
             super::error("DuplicatedOrder", "order already exists"),
             StatusCode::BAD_REQUEST,
         ),
-        Err(_) => with_status(super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR),
+        Err(err) => with_status(
+            super::internal_error(err.context("create_order")),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ),
     }
 }
 
@@ -39,6 +42,10 @@ pub fn create_order(
         async move {
             let order_payload_clone = order_payload.clone();
             let result = orderbook.add_order(order_payload).await;
+            // TODO - This is one place where the error log is more rich than the
+            //  generic error inside internal_error (i.e. doesn't include order_payload).
+            //  Perhaps this should be a warning and the real alert comes from the internal error.
+            //  Otherwise we should just resort to using this error logging style everywhere.
             if let Err(err) = &result {
                 tracing::error!(?err, ?order_payload_clone, "add_order error");
             }

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -1,10 +1,11 @@
 use crate::{
-    api::{extract_payload, WarpReplyConverting},
+    api::{extract_payload, IntoWarpReply},
     orderbook::{AddOrderResult, Orderbook},
 };
 use anyhow::Result;
 use model::order::OrderCreationPayload;
 use std::{convert::Infallible, sync::Arc};
+use warp::reply::with_status;
 use warp::{hyper::StatusCode, Filter, Rejection, Reply};
 
 pub fn create_order_request(
@@ -15,20 +16,19 @@ pub fn create_order_request(
 }
 
 pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
-    let (body, status_code) = match result {
-        Ok(AddOrderResult::Added(uid)) => (warp::reply::json(&uid), StatusCode::CREATED),
+    match result {
+        Ok(AddOrderResult::Added(uid)) => with_status(warp::reply::json(&uid), StatusCode::CREATED),
         Ok(AddOrderResult::OrderValidation(err)) => err.into_warp_reply(),
-        Ok(AddOrderResult::UnsupportedSignature) => (
+        Ok(AddOrderResult::UnsupportedSignature) => with_status(
             super::error("UnsupportedSignature", "signing scheme is not supported"),
             StatusCode::BAD_REQUEST,
         ),
-        Ok(AddOrderResult::DuplicatedOrder) => (
+        Ok(AddOrderResult::DuplicatedOrder) => with_status(
             super::error("DuplicatedOrder", "order already exists"),
             StatusCode::BAD_REQUEST,
         ),
-        Err(_) => (super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR),
-    };
-    warp::reply::with_status(body, status_code)
+        Err(_) => with_status(super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR),
+    }
 }
 
 pub fn create_order(

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -1,4 +1,4 @@
-use crate::api::convert_response;
+use crate::api::convert_response_ok;
 use crate::{
     api::{extract_payload, WarpReplyConverting},
     orderbook::{AddOrderResult, Orderbook},
@@ -6,7 +6,7 @@ use crate::{
 use anyhow::Result;
 use model::order::OrderCreationPayload;
 use std::{convert::Infallible, sync::Arc};
-use warp::reply::Json;
+use warp::reply::{with_status, Json, WithStatus};
 use warp::{hyper::StatusCode, Filter, Rejection, Reply};
 
 pub fn create_order_request(
@@ -17,15 +17,15 @@ pub fn create_order_request(
 }
 
 impl WarpReplyConverting for AddOrderResult {
-    fn into_warp_reply(self) -> (Json, StatusCode) {
+    fn into_warp_reply(self) -> WithStatus<Json> {
         match self {
-            AddOrderResult::Added(uid) => (warp::reply::json(&uid), StatusCode::CREATED),
+            AddOrderResult::Added(uid) => with_status(warp::reply::json(&uid), StatusCode::CREATED),
             AddOrderResult::OrderValidation(err) => err.into_warp_reply(),
-            AddOrderResult::UnsupportedSignature => (
+            AddOrderResult::UnsupportedSignature => with_status(
                 super::error("UnsupportedSignature", "signing scheme is not supported"),
                 StatusCode::BAD_REQUEST,
             ),
-            AddOrderResult::DuplicatedOrder => (
+            AddOrderResult::DuplicatedOrder => with_status(
                 super::error("DuplicatedOrder", "order already exists"),
                 StatusCode::BAD_REQUEST,
             ),
@@ -44,7 +44,7 @@ pub fn create_order(
             if let Err(err) = &result {
                 tracing::error!(?err, ?order_payload_clone, "add_order error");
             }
-            Result::<_, Infallible>::Ok(convert_response(result))
+            Result::<_, Infallible>::Ok(convert_response_ok(result))
         }
     })
 }
@@ -73,7 +73,7 @@ mod tests {
     #[tokio::test]
     async fn create_order_response_created() {
         let uid = OrderUid([1u8; 56]);
-        let response = convert_response(Ok(AddOrderResult::Added(uid))).into_response();
+        let response = convert_response_ok(Ok(AddOrderResult::Added(uid))).into_response();
         assert_eq!(response.status(), StatusCode::CREATED);
         let body = response_body(response).await;
         let body: serde_json::Value = serde_json::from_slice(body.as_slice()).unwrap();
@@ -85,7 +85,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_order_response_duplicate() {
-        let response = convert_response(Ok(AddOrderResult::DuplicatedOrder)).into_response();
+        let response = convert_response_ok(Ok(AddOrderResult::DuplicatedOrder)).into_response();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let body = response_body(response).await;
         let body: serde_json::Value = serde_json::from_slice(body.as_slice()).unwrap();

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::{extract_payload, WarpReplyConverting},
+    api::{extract_payload, IntoWarpReply},
     orderbook::{AddOrderResult, Orderbook},
 };
 use anyhow::Result;
@@ -18,7 +18,7 @@ pub fn create_order_request(
         .and(extract_payload())
 }
 
-impl WarpReplyConverting for AddOrderResult {
+impl IntoWarpReply for AddOrderResult {
     fn into_warp_reply(self) -> WithStatus<Json> {
         match self {
             AddOrderResult::Added(uid) => with_status(warp::reply::json(&uid), StatusCode::CREATED),

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -1,13 +1,15 @@
-use crate::api::convert_response_ok;
 use crate::{
-    api::{extract_payload, WarpReplyConverting},
+    api::{convert_response_ok, extract_payload, WarpReplyConverting},
     orderbook::{AddOrderResult, Orderbook},
 };
 use anyhow::Result;
 use model::order::OrderCreationPayload;
 use std::{convert::Infallible, sync::Arc};
-use warp::reply::{with_status, Json, WithStatus};
-use warp::{hyper::StatusCode, Filter, Rejection, Reply};
+use warp::{
+    hyper::StatusCode,
+    reply::{with_status, Json, WithStatus},
+    Filter, Rejection, Reply,
+};
 
 pub fn create_order_request(
 ) -> impl Filter<Extract = (OrderCreationPayload,), Error = Rejection> + Clone {

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -1,15 +1,11 @@
 use crate::{
-    api::{extract_payload, IntoWarpReply},
+    api::{extract_payload, WarpReplyConverting},
     orderbook::{AddOrderResult, Orderbook},
 };
 use anyhow::Result;
 use model::order::OrderCreationPayload;
 use std::{convert::Infallible, sync::Arc};
-use warp::{
-    hyper::StatusCode,
-    reply::{with_status, Json, WithStatus},
-    Filter, Rejection, Reply,
-};
+use warp::{hyper::StatusCode, Filter, Rejection, Reply};
 
 pub fn create_order_request(
 ) -> impl Filter<Extract = (OrderCreationPayload,), Error = Rejection> + Clone {
@@ -18,21 +14,21 @@ pub fn create_order_request(
         .and(extract_payload())
 }
 
-impl IntoWarpReply for AddOrderResult {
-    fn into_warp_reply(self) -> WithStatus<Json> {
-        match self {
-            AddOrderResult::Added(uid) => with_status(warp::reply::json(&uid), StatusCode::CREATED),
-            AddOrderResult::OrderValidation(err) => err.into_warp_reply(),
-            AddOrderResult::UnsupportedSignature => with_status(
-                super::error("UnsupportedSignature", "signing scheme is not supported"),
-                StatusCode::BAD_REQUEST,
-            ),
-            AddOrderResult::DuplicatedOrder => with_status(
-                super::error("DuplicatedOrder", "order already exists"),
-                StatusCode::BAD_REQUEST,
-            ),
-        }
-    }
+pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
+    let (body, status_code) = match result {
+        Ok(AddOrderResult::Added(uid)) => (warp::reply::json(&uid), StatusCode::CREATED),
+        Ok(AddOrderResult::OrderValidation(err)) => err.into_warp_reply(),
+        Ok(AddOrderResult::UnsupportedSignature) => (
+            super::error("UnsupportedSignature", "signing scheme is not supported"),
+            StatusCode::BAD_REQUEST,
+        ),
+        Ok(AddOrderResult::DuplicatedOrder) => (
+            super::error("DuplicatedOrder", "order already exists"),
+            StatusCode::BAD_REQUEST,
+        ),
+        Err(_) => (super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR),
+    };
+    warp::reply::with_status(body, status_code)
 }
 
 pub fn create_order(
@@ -46,10 +42,7 @@ pub fn create_order(
             if let Err(err) = &result {
                 tracing::error!(?err, ?order_payload_clone, "add_order error");
             }
-            Result::<_, Infallible>::Ok(match result {
-                Ok(result) => result.into_warp_reply(),
-                Err(_) => with_status(super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR),
-            })
+            Result::<_, Infallible>::Ok(create_order_response(result))
         }
     })
 }
@@ -78,7 +71,7 @@ mod tests {
     #[tokio::test]
     async fn create_order_response_created() {
         let uid = OrderUid([1u8; 56]);
-        let response = AddOrderResult::Added(uid).into_warp_reply().into_response();
+        let response = create_order_response(Ok(AddOrderResult::Added(uid))).into_response();
         assert_eq!(response.status(), StatusCode::CREATED);
         let body = response_body(response).await;
         let body: serde_json::Value = serde_json::from_slice(body.as_slice()).unwrap();
@@ -90,9 +83,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_order_response_duplicate() {
-        let response = AddOrderResult::DuplicatedOrder
-            .into_warp_reply()
-            .into_response();
+        let response = create_order_response(Ok(AddOrderResult::DuplicatedOrder)).into_response();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let body = response_body(response).await;
         let body: serde_json::Value = serde_json::from_slice(body.as_slice()).unwrap();

--- a/orderbook/src/api/create_order.rs
+++ b/orderbook/src/api/create_order.rs
@@ -1,3 +1,4 @@
+use crate::api::convert_response;
 use crate::{
     api::{extract_payload, WarpReplyConverting},
     orderbook::{AddOrderResult, Orderbook},
@@ -5,6 +6,7 @@ use crate::{
 use anyhow::Result;
 use model::order::OrderCreationPayload;
 use std::{convert::Infallible, sync::Arc};
+use warp::reply::Json;
 use warp::{hyper::StatusCode, Filter, Rejection, Reply};
 
 pub fn create_order_request(
@@ -14,21 +16,21 @@ pub fn create_order_request(
         .and(extract_payload())
 }
 
-pub fn create_order_response(result: Result<AddOrderResult>) -> impl Reply {
-    let (body, status_code) = match result {
-        Ok(AddOrderResult::Added(uid)) => (warp::reply::json(&uid), StatusCode::CREATED),
-        Ok(AddOrderResult::OrderValidation(err)) => err.into_warp_reply(),
-        Ok(AddOrderResult::UnsupportedSignature) => (
-            super::error("UnsupportedSignature", "signing scheme is not supported"),
-            StatusCode::BAD_REQUEST,
-        ),
-        Ok(AddOrderResult::DuplicatedOrder) => (
-            super::error("DuplicatedOrder", "order already exists"),
-            StatusCode::BAD_REQUEST,
-        ),
-        Err(_) => (super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR),
-    };
-    warp::reply::with_status(body, status_code)
+impl WarpReplyConverting for AddOrderResult {
+    fn into_warp_reply(self) -> (Json, StatusCode) {
+        match self {
+            AddOrderResult::Added(uid) => (warp::reply::json(&uid), StatusCode::CREATED),
+            AddOrderResult::OrderValidation(err) => err.into_warp_reply(),
+            AddOrderResult::UnsupportedSignature => (
+                super::error("UnsupportedSignature", "signing scheme is not supported"),
+                StatusCode::BAD_REQUEST,
+            ),
+            AddOrderResult::DuplicatedOrder => (
+                super::error("DuplicatedOrder", "order already exists"),
+                StatusCode::BAD_REQUEST,
+            ),
+        }
+    }
 }
 
 pub fn create_order(
@@ -42,7 +44,7 @@ pub fn create_order(
             if let Err(err) = &result {
                 tracing::error!(?err, ?order_payload_clone, "add_order error");
             }
-            Result::<_, Infallible>::Ok(create_order_response(result))
+            Result::<_, Infallible>::Ok(convert_response(result))
         }
     })
 }
@@ -71,7 +73,7 @@ mod tests {
     #[tokio::test]
     async fn create_order_response_created() {
         let uid = OrderUid([1u8; 56]);
-        let response = create_order_response(Ok(AddOrderResult::Added(uid))).into_response();
+        let response = convert_response(Ok(AddOrderResult::Added(uid))).into_response();
         assert_eq!(response.status(), StatusCode::CREATED);
         let body = response_body(response).await;
         let body: serde_json::Value = serde_json::from_slice(body.as_slice()).unwrap();
@@ -83,7 +85,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_order_response_duplicate() {
-        let response = create_order_response(Ok(AddOrderResult::DuplicatedOrder)).into_response();
+        let response = convert_response(Ok(AddOrderResult::DuplicatedOrder)).into_response();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let body = response_body(response).await;
         let body: serde_json::Value = serde_json::from_slice(body.as_slice()).unwrap();

--- a/orderbook/src/api/get_fee_and_quote.rs
+++ b/orderbook/src/api/get_fee_and_quote.rs
@@ -1,5 +1,5 @@
 use crate::api::{
-    convert_response,
+    convert_json_response,
     post_quote::{OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, OrderQuoter, SellAmount},
 };
 use anyhow::Result;
@@ -121,7 +121,7 @@ pub fn get_fee_and_quote_sell(
     sell_request().and_then(move |query: SellQuery| {
         let quoter = quoter.clone();
         async move {
-            Result::<_, Infallible>::Ok(convert_response(
+            Result::<_, Infallible>::Ok(convert_json_response(
                 quoter
                     .calculate_quote(&query.into())
                     .await
@@ -137,7 +137,7 @@ pub fn get_fee_and_quote_buy(
     buy_request().and_then(move |query: BuyQuery| {
         let quoter = quoter.clone();
         async move {
-            Result::<_, Infallible>::Ok(convert_response(
+            Result::<_, Infallible>::Ok(convert_json_response(
                 quoter
                     .calculate_quote(&query.into())
                     .await

--- a/orderbook/src/api/get_fee_and_quote.rs
+++ b/orderbook/src/api/get_fee_and_quote.rs
@@ -1,5 +1,5 @@
 use crate::api::{
-    convert_response_err,
+    convert_response,
     post_quote::{OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, OrderQuoter, SellAmount},
 };
 use anyhow::Result;
@@ -121,7 +121,7 @@ pub fn get_fee_and_quote_sell(
     sell_request().and_then(move |query: SellQuery| {
         let quoter = quoter.clone();
         async move {
-            Result::<_, Infallible>::Ok(convert_response_err(
+            Result::<_, Infallible>::Ok(convert_response(
                 quoter
                     .calculate_quote(&query.into())
                     .await
@@ -137,7 +137,7 @@ pub fn get_fee_and_quote_buy(
     buy_request().and_then(move |query: BuyQuery| {
         let quoter = quoter.clone();
         async move {
-            Result::<_, Infallible>::Ok(convert_response_err(
+            Result::<_, Infallible>::Ok(convert_response(
                 quoter
                     .calculate_quote(&query.into())
                     .await

--- a/orderbook/src/api/get_fee_and_quote.rs
+++ b/orderbook/src/api/get_fee_and_quote.rs
@@ -1,4 +1,7 @@
-use crate::api::{convert_response_err, post_quote::{OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, OrderQuoter, SellAmount}};
+use crate::api::{
+    convert_response_err,
+    post_quote::{OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, OrderQuoter, SellAmount},
+};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use ethcontract::{H160, U256};

--- a/orderbook/src/api/get_fee_and_quote.rs
+++ b/orderbook/src/api/get_fee_and_quote.rs
@@ -1,6 +1,4 @@
-use crate::api::post_quote::{
-    response, OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, OrderQuoter, SellAmount,
-};
+use crate::api::{convert_response_err, post_quote::{OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, OrderQuoter, SellAmount}};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use ethcontract::{H160, U256};
@@ -120,7 +118,7 @@ pub fn get_fee_and_quote_sell(
     sell_request().and_then(move |query: SellQuery| {
         let quoter = quoter.clone();
         async move {
-            Result::<_, Infallible>::Ok(response(
+            Result::<_, Infallible>::Ok(convert_response_err(
                 quoter
                     .calculate_quote(&query.into())
                     .await
@@ -136,7 +134,7 @@ pub fn get_fee_and_quote_buy(
     buy_request().and_then(move |query: BuyQuery| {
         let quoter = quoter.clone();
         async move {
-            Result::<_, Infallible>::Ok(response(
+            Result::<_, Infallible>::Ok(convert_response_err(
                 quoter
                     .calculate_quote(&query.into())
                     .await

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -1,4 +1,4 @@
-use crate::api::convert_response;
+use crate::api::convert_json_response;
 use crate::fee::MinFeeCalculating;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
@@ -48,7 +48,7 @@ pub fn get_fee_info(
                     None,
                 )
                 .await;
-            Result::<_, Infallible>::Ok(convert_response(result.map(
+            Result::<_, Infallible>::Ok(convert_json_response(result.map(
                 |(amount, expiration_date)| FeeInfo {
                     expiration_date,
                     amount,
@@ -83,7 +83,7 @@ pub fn legacy_get_fee_info(
             let result = fee_calculator
                 .compute_subsidized_min_fee(token, None, None, None, None)
                 .await;
-            Result::<_, Infallible>::Ok(convert_response(result.map(
+            Result::<_, Infallible>::Ok(convert_json_response(result.map(
                 |(minimal_fee, expiration_date)| LegacyFeeInfo {
                     expiration_date,
                     minimal_fee,

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -1,5 +1,4 @@
-use crate::api::WarpReplyConverting;
-use crate::fee::MinFeeCalculating;
+use crate::{api::WarpReplyConverting, fee::MinFeeCalculating};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use model::{order::OrderKind, u256_decimal};

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -1,4 +1,4 @@
-use crate::api::convert_response_err;
+use crate::api::convert_response;
 use crate::fee::MinFeeCalculating;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
@@ -48,7 +48,7 @@ pub fn get_fee_info(
                     None,
                 )
                 .await;
-            Result::<_, Infallible>::Ok(convert_response_err(result.map(
+            Result::<_, Infallible>::Ok(convert_response(result.map(
                 |(amount, expiration_date)| FeeInfo {
                     expiration_date,
                     amount,
@@ -83,7 +83,7 @@ pub fn legacy_get_fee_info(
             let result = fee_calculator
                 .compute_subsidized_min_fee(token, None, None, None, None)
                 .await;
-            Result::<_, Infallible>::Ok(convert_response_err(result.map(
+            Result::<_, Infallible>::Ok(convert_response(result.map(
                 |(minimal_fee, expiration_date)| LegacyFeeInfo {
                     expiration_date,
                     minimal_fee,

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -61,6 +61,10 @@ pub fn get_fee_info(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::response_body;
+    use chrono::FixedOffset;
+    use shared::price_estimation::PriceEstimationError;
+    use warp::hyper::StatusCode;
     use warp::test::request;
 
     #[tokio::test]
@@ -84,9 +88,11 @@ mod tests {
 
     #[tokio::test]
     async fn get_fee_info_response_() {
-        let response =
-            get_fee_info_response(Ok((U256::zero(), Utc::now() + FixedOffset::east(10))))
-                .into_response();
+        let result = Ok(FeeInfo {
+            expiration_date: Utc::now() + FixedOffset::east(10),
+            amount: U256::zero(),
+        });
+        let response = convert_json_response::<_, PriceEstimationError>(result).into_response();
         assert_eq!(response.status(), StatusCode::OK);
         let body = response_body(response).await;
         let body: FeeInfo = serde_json::from_slice(body.as_slice()).unwrap();

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -1,4 +1,4 @@
-use crate::api::price_estimation_error_to_warp_reply;
+use crate::api::WarpReplyConverting;
 use crate::fee::MinFeeCalculating;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
@@ -45,10 +45,7 @@ pub fn get_fee_info_response(
             };
             Ok(reply::with_status(reply::json(&fee_info), StatusCode::OK))
         }
-        Err(err) => {
-            let (json, status_code) = price_estimation_error_to_warp_reply(err);
-            Ok(reply::with_status(json, status_code))
-        }
+        Err(err) => Ok(err.into_warp_reply()),
     }
 }
 
@@ -100,10 +97,7 @@ pub fn legacy_get_fee_info_response(
             };
             Ok(reply::with_status(reply::json(&fee_info), StatusCode::OK))
         }
-        Err(err) => {
-            let (json, status_code) = price_estimation_error_to_warp_reply(err);
-            Ok(reply::with_status(json, status_code))
-        }
+        Err(err) => Ok(err.into_warp_reply()),
     }
 }
 

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -59,7 +59,7 @@ pub fn get_fee_info(
 }
 
 // TODO remove legacy fee endpoint once frontend is updated
-// TODO - This is pretty old (May 21st), I think we can remove this legacy fee endpoint.
+// Removing this in separate PR https://github.com/gnosis/gp-v2-services/pull/1295
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -1,13 +1,13 @@
-use crate::{api::WarpReplyConverting, fee::MinFeeCalculating};
+use crate::api::convert_response_err;
+use crate::fee::MinFeeCalculating;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use model::{order::OrderKind, u256_decimal};
 use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
-use shared::price_estimation::PriceEstimationError;
 use std::convert::Infallible;
 use std::sync::Arc;
-use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
+use warp::{Filter, Rejection, Reply};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -33,43 +33,33 @@ fn get_fee_info_request() -> impl Filter<Extract = (Query,), Error = Rejection> 
         .and(warp::query::<Query>())
 }
 
-pub fn get_fee_info_response(
-    result: Result<(U256, DateTime<Utc>), PriceEstimationError>,
-) -> impl Reply {
-    match result {
-        Ok((amount, expiration_date)) => {
-            let fee_info = FeeInfo {
-                expiration_date,
-                amount,
-            };
-            Ok(reply::with_status(reply::json(&fee_info), StatusCode::OK))
-        }
-        Err(err) => Ok(err.into_warp_reply()),
-    }
-}
-
 pub fn get_fee_info(
     fee_calculator: Arc<dyn MinFeeCalculating>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     get_fee_info_request().and_then(move |query: Query| {
         let fee_calculator = fee_calculator.clone();
         async move {
-            Result::<_, Infallible>::Ok(get_fee_info_response(
-                fee_calculator
-                    .compute_subsidized_min_fee(
-                        query.sell_token,
-                        Some(query.buy_token),
-                        Some(query.amount),
-                        Some(query.kind),
-                        None,
-                    )
-                    .await,
-            ))
+            let result = fee_calculator
+                .compute_subsidized_min_fee(
+                    query.sell_token,
+                    Some(query.buy_token),
+                    Some(query.amount),
+                    Some(query.kind),
+                    None,
+                )
+                .await;
+            Result::<_, Infallible>::Ok(convert_response_err(result.map(
+                |(amount, expiration_date)| FeeInfo {
+                    expiration_date,
+                    amount,
+                },
+            )))
         }
     })
 }
 
 // TODO remove legacy fee endpoint once frontend is updated
+// TODO - This is pretty old, should we remove it now?
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -84,33 +74,22 @@ pub fn legacy_get_fee_info_request() -> impl Filter<Extract = (H160,), Error = R
     warp::path!("tokens" / H160 / "fee").and(warp::get())
 }
 
-pub fn legacy_get_fee_info_response(
-    result: Result<(U256, DateTime<Utc>), PriceEstimationError>,
-) -> impl Reply {
-    match result {
-        Ok((minimal_fee, expiration_date)) => {
-            let fee_info = LegacyFeeInfo {
-                expiration_date,
-                minimal_fee,
-                fee_ratio: 0u32,
-            };
-            Ok(reply::with_status(reply::json(&fee_info), StatusCode::OK))
-        }
-        Err(err) => Ok(err.into_warp_reply()),
-    }
-}
-
 pub fn legacy_get_fee_info(
     fee_calculator: Arc<dyn MinFeeCalculating>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     legacy_get_fee_info_request().and_then(move |token| {
         let fee_calculator = fee_calculator.clone();
         async move {
-            Result::<_, Infallible>::Ok(legacy_get_fee_info_response(
-                fee_calculator
-                    .compute_subsidized_min_fee(token, None, None, None, None)
-                    .await,
-            ))
+            let result = fee_calculator
+                .compute_subsidized_min_fee(token, None, None, None, None)
+                .await;
+            Result::<_, Infallible>::Ok(convert_response_err(result.map(
+                |(minimal_fee, expiration_date)| LegacyFeeInfo {
+                    expiration_date,
+                    minimal_fee,
+                    fee_ratio: 0u32,
+                },
+            )))
         }
     })
 }
@@ -118,8 +97,6 @@ pub fn legacy_get_fee_info(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::response_body;
-    use chrono::FixedOffset;
     use warp::test::request;
 
     #[tokio::test]
@@ -142,18 +119,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_fee_info_response_() {
-        let response =
-            get_fee_info_response(Ok((U256::zero(), Utc::now() + FixedOffset::east(10))))
-                .into_response();
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_body(response).await;
-        let body: FeeInfo = serde_json::from_slice(body.as_slice()).unwrap();
-        assert_eq!(body.amount, U256::zero());
-        assert!(body.expiration_date.gt(&chrono::offset::Utc::now()))
-    }
-
-    #[tokio::test]
     async fn legacy_get_fee_info_request_ok() {
         let filter = legacy_get_fee_info_request();
         let token = String::from("0x0000000000000000000000000000000000000001");
@@ -161,18 +126,5 @@ mod tests {
         let request = request().path(&path_string).method("GET");
         let result = request.filter(&filter).await.unwrap();
         assert_eq!(result, H160::from_low_u64_be(1));
-    }
-
-    #[tokio::test]
-    async fn legacy_get_fee_info_response_() {
-        let response =
-            legacy_get_fee_info_response(Ok((U256::zero(), Utc::now() + FixedOffset::east(10))))
-                .into_response();
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_body(response).await;
-        let body: LegacyFeeInfo = serde_json::from_slice(body.as_slice()).unwrap();
-        assert_eq!(body.minimal_fee, U256::zero());
-        assert_eq!(body.fee_ratio, 0);
-        assert!(body.expiration_date.gt(&chrono::offset::Utc::now()))
     }
 }

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -59,7 +59,7 @@ pub fn get_fee_info(
 }
 
 // TODO remove legacy fee endpoint once frontend is updated
-// TODO - This is pretty old, should we remove it now?
+// TODO - This is pretty old (May 21st), I think we can remove this legacy fee endpoint.
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/orderbook/src/api/get_markets.rs
+++ b/orderbook/src/api/get_markets.rs
@@ -1,4 +1,4 @@
-use crate::api::convert_response;
+use crate::api::convert_json_response;
 use anyhow::{anyhow, Result};
 use ethcontract::{H160, U256};
 use model::order::OrderKind;
@@ -86,7 +86,7 @@ pub fn get_amount_estimate(
                     kind: query.kind,
                 })
                 .await;
-            Result::<_, Infallible>::Ok(convert_response(result.map(|estimate| {
+            Result::<_, Infallible>::Ok(convert_json_response(result.map(|estimate| {
                 AmountEstimateResult {
                     amount: estimate.out_amount,
                     token: query.market.quote_token,
@@ -144,7 +144,7 @@ mod tests {
         };
 
         // Sell Order
-        let response = convert_response::<_, PriceEstimationError>(Ok(AmountEstimateResult {
+        let response = convert_json_response::<_, PriceEstimationError>(Ok(AmountEstimateResult {
             amount: 2.into(),
             token: query.market.quote_token,
         }))
@@ -157,7 +157,7 @@ mod tests {
         assert_eq!(estimate.token, query.market.quote_token);
 
         // Buy Order
-        let response = convert_response::<_, PriceEstimationError>(Ok(AmountEstimateResult {
+        let response = convert_json_response::<_, PriceEstimationError>(Ok(AmountEstimateResult {
             amount: 2.into(),
             token: query.market.quote_token,
         }))

--- a/orderbook/src/api/get_markets.rs
+++ b/orderbook/src/api/get_markets.rs
@@ -1,4 +1,4 @@
-use crate::api::convert_response_err;
+use crate::api::convert_response;
 use anyhow::{anyhow, Result};
 use ethcontract::{H160, U256};
 use model::order::OrderKind;
@@ -86,7 +86,7 @@ pub fn get_amount_estimate(
                     kind: query.kind,
                 })
                 .await;
-            Result::<_, Infallible>::Ok(convert_response_err(result.map(|estimate| {
+            Result::<_, Infallible>::Ok(convert_response(result.map(|estimate| {
                 AmountEstimateResult {
                     amount: estimate.out_amount,
                     token: query.market.quote_token,
@@ -144,7 +144,7 @@ mod tests {
         };
 
         // Sell Order
-        let response = convert_response_err::<_, PriceEstimationError>(Ok(AmountEstimateResult {
+        let response = convert_response::<_, PriceEstimationError>(Ok(AmountEstimateResult {
             amount: 2.into(),
             token: query.market.quote_token,
         }))
@@ -157,7 +157,7 @@ mod tests {
         assert_eq!(estimate.token, query.market.quote_token);
 
         // Buy Order
-        let response = convert_response_err::<_, PriceEstimationError>(Ok(AmountEstimateResult {
+        let response = convert_response::<_, PriceEstimationError>(Ok(AmountEstimateResult {
             amount: 2.into(),
             token: query.market.quote_token,
         }))

--- a/orderbook/src/api/get_markets.rs
+++ b/orderbook/src/api/get_markets.rs
@@ -1,4 +1,4 @@
-use crate::api::price_estimation_error_to_warp_reply;
+use crate::api::WarpReplyConverting;
 use anyhow::{anyhow, Result};
 use ethcontract::{H160, U256};
 use model::order::OrderKind;
@@ -78,10 +78,7 @@ fn get_amount_estimate_response(
             }),
             StatusCode::OK,
         ),
-        Err(err) => {
-            let (json, status_code) = price_estimation_error_to_warp_reply(err);
-            reply::with_status(json, status_code)
-        }
+        Err(err) => err.into_warp_reply(),
     }
 }
 

--- a/orderbook/src/api/get_markets.rs
+++ b/orderbook/src/api/get_markets.rs
@@ -4,8 +4,7 @@ use ethcontract::{H160, U256};
 use model::order::OrderKind;
 use serde::{Deserialize, Serialize};
 use shared::price_estimation::{self, PriceEstimating, PriceEstimationError};
-use std::sync::Arc;
-use std::{convert::Infallible, str::FromStr};
+use std::{convert::Infallible, str::FromStr, sync::Arc};
 use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
 
 #[derive(Clone, Debug, PartialEq)]

--- a/orderbook/src/api/get_order_by_uid.rs
+++ b/orderbook/src/api/get_order_by_uid.rs
@@ -1,4 +1,4 @@
-use crate::{api::WarpReplyConverting, orderbook::Orderbook};
+use crate::{api::IntoWarpReply, orderbook::Orderbook};
 use anyhow::Result;
 use model::order::{Order, OrderUid};
 use std::{convert::Infallible, sync::Arc};

--- a/orderbook/src/api/get_order_by_uid.rs
+++ b/orderbook/src/api/get_order_by_uid.rs
@@ -1,5 +1,4 @@
-use crate::api::convert_get_orders_error_to_reply;
-use crate::orderbook::Orderbook;
+use crate::{api::WarpReplyConverting, orderbook::Orderbook};
 use anyhow::Result;
 use model::order::{Order, OrderUid};
 use std::{convert::Infallible, sync::Arc};
@@ -13,7 +12,7 @@ pub fn get_order_by_uid_response(result: Result<Option<Order>>) -> impl Reply {
     let order = match result {
         Ok(order) => order,
         Err(err) => {
-            return Ok(convert_get_orders_error_to_reply(err));
+            return Ok(err.into_warp_reply());
         }
     };
     Ok(match order {

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -2,7 +2,7 @@ use crate::{
     api::convert_json_response,
     {database::orders::OrderFilter, orderbook::Orderbook},
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
 use primitive_types::H160;
 use serde::Deserialize;
 use shared::time::now_in_epoch_seconds;
@@ -71,7 +71,10 @@ pub fn get_orders(
                     return Ok(warp::reply::with_status(err, StatusCode::BAD_REQUEST));
                 }
             };
-            let result = orderbook.get_orders(&order_filter).await;
+            let result = orderbook
+                .get_orders(&order_filter)
+                .await
+                .context("get_orders");
             Result::<_, Infallible>::Ok(convert_json_response(result))
         }
     })

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::convert_response_err,
+    api::convert_response,
     {database::orders::OrderFilter, orderbook::Orderbook},
 };
 use anyhow::Result;
@@ -72,7 +72,7 @@ pub fn get_orders(
                 }
             };
             let result = orderbook.get_orders(&order_filter).await;
-            Result::<_, Infallible>::Ok(convert_response_err(result))
+            Result::<_, Infallible>::Ok(convert_response(result))
         }
     })
 }

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -1,5 +1,7 @@
-use crate::api::convert_response_err;
-use crate::{database::orders::OrderFilter, orderbook::Orderbook};
+use crate::{
+    api::convert_response_err,
+    {database::orders::OrderFilter, orderbook::Orderbook},
+};
 use anyhow::Result;
 use primitive_types::H160;
 use serde::Deserialize;

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::convert_response,
+    api::convert_json_response,
     {database::orders::OrderFilter, orderbook::Orderbook},
 };
 use anyhow::Result;
@@ -72,7 +72,7 @@ pub fn get_orders(
                 }
             };
             let result = orderbook.get_orders(&order_filter).await;
-            Result::<_, Infallible>::Ok(convert_response(result))
+            Result::<_, Infallible>::Ok(convert_json_response(result))
         }
     })
 }

--- a/orderbook/src/api/get_orders_by_tx.rs
+++ b/orderbook/src/api/get_orders_by_tx.rs
@@ -1,4 +1,4 @@
-use crate::{api::convert_response, orderbook::Orderbook};
+use crate::{api::convert_json_response, orderbook::Orderbook};
 use anyhow::Result;
 use ethcontract::H256;
 use std::{convert::Infallible, sync::Arc};
@@ -15,7 +15,7 @@ pub fn get_orders_by_tx(
         let orderbook = orderbook.clone();
         async move {
             let result = orderbook.get_orders_for_tx(&hash).await;
-            Result::<_, Infallible>::Ok(convert_response(result))
+            Result::<_, Infallible>::Ok(convert_json_response(result))
         }
     })
 }

--- a/orderbook/src/api/get_orders_by_tx.rs
+++ b/orderbook/src/api/get_orders_by_tx.rs
@@ -1,22 +1,11 @@
-use crate::orderbook::Orderbook;
+use crate::{api::convert_response_err, orderbook::Orderbook};
 use anyhow::Result;
 use ethcontract::H256;
-use model::order::Order;
 use std::{convert::Infallible, sync::Arc};
-use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
+use warp::{Filter, Rejection, Reply};
 
 pub fn get_orders_by_tx_request() -> impl Filter<Extract = (H256,), Error = Rejection> + Clone {
     warp::path!("transactions" / H256 / "orders").and(warp::get())
-}
-
-pub fn get_orders_by_tx_response(result: Result<Vec<Order>>) -> impl Reply {
-    match result {
-        Ok(orders) => reply::with_status(reply::json(&orders), StatusCode::OK),
-        Err(err) => {
-            tracing::error!(?err, "get_orders_by_tx error");
-            reply::with_status(super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR)
-        }
-    }
 }
 
 pub fn get_orders_by_tx(
@@ -26,7 +15,7 @@ pub fn get_orders_by_tx(
         let orderbook = orderbook.clone();
         async move {
             let result = orderbook.get_orders_for_tx(&hash).await;
-            Result::<_, Infallible>::Ok(get_orders_by_tx_response(result))
+            Result::<_, Infallible>::Ok(convert_response_err(result))
         }
     })
 }
@@ -34,7 +23,6 @@ pub fn get_orders_by_tx(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::response_body;
     use std::str::FromStr;
 
     #[tokio::test]
@@ -47,15 +35,5 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.0, H256::from_str(hash_str).unwrap().0);
-    }
-
-    #[tokio::test]
-    async fn response_ok() {
-        let orders = vec![Order::default()];
-        let response = get_orders_by_tx_response(Ok(orders.clone())).into_response();
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_body(response).await;
-        let response_orders: Vec<Order> = serde_json::from_slice(body.as_slice()).unwrap();
-        assert_eq!(response_orders, orders);
     }
 }

--- a/orderbook/src/api/get_orders_by_tx.rs
+++ b/orderbook/src/api/get_orders_by_tx.rs
@@ -1,4 +1,4 @@
-use crate::{api::convert_response_err, orderbook::Orderbook};
+use crate::{api::convert_response, orderbook::Orderbook};
 use anyhow::Result;
 use ethcontract::H256;
 use std::{convert::Infallible, sync::Arc};
@@ -15,7 +15,7 @@ pub fn get_orders_by_tx(
         let orderbook = orderbook.clone();
         async move {
             let result = orderbook.get_orders_for_tx(&hash).await;
-            Result::<_, Infallible>::Ok(convert_response_err(result))
+            Result::<_, Infallible>::Ok(convert_response(result))
         }
     })
 }

--- a/orderbook/src/api/get_solvable_orders.rs
+++ b/orderbook/src/api/get_solvable_orders.rs
@@ -1,5 +1,5 @@
 use crate::orderbook::Orderbook;
-use crate::{api::convert_get_orders_error_to_reply, solvable_orders::SolvableOrders};
+use crate::{api::WarpReplyConverting, solvable_orders::SolvableOrders};
 use anyhow::Result;
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
@@ -14,7 +14,7 @@ fn get_solvable_orders_response(result: Result<SolvableOrders>) -> impl Reply {
             reply::json(&orders.orders),
             StatusCode::OK,
         )),
-        Err(err) => Ok(convert_get_orders_error_to_reply(err)),
+        Err(err) => Ok(err.into_warp_reply()),
     }
 }
 

--- a/orderbook/src/api/get_solvable_orders.rs
+++ b/orderbook/src/api/get_solvable_orders.rs
@@ -1,5 +1,4 @@
-use crate::orderbook::Orderbook;
-use crate::{api::WarpReplyConverting, solvable_orders::SolvableOrders};
+use crate::{api::WarpReplyConverting, orderbook::Orderbook, solvable_orders::SolvableOrders};
 use anyhow::Result;
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};

--- a/orderbook/src/api/get_solvable_orders.rs
+++ b/orderbook/src/api/get_solvable_orders.rs
@@ -1,4 +1,4 @@
-use crate::{api::convert_response_err, orderbook::Orderbook};
+use crate::{api::convert_response, orderbook::Orderbook};
 use anyhow::Result;
 use std::{convert::Infallible, sync::Arc};
 use warp::{Filter, Rejection, Reply};
@@ -14,7 +14,7 @@ pub fn get_solvable_orders(
         let orderbook = orderbook.clone();
         async move {
             let result = orderbook.get_solvable_orders().await;
-            Result::<_, Infallible>::Ok(convert_response_err(
+            Result::<_, Infallible>::Ok(convert_response(
                 result.map(|solvable_orders| solvable_orders.orders),
             ))
         }

--- a/orderbook/src/api/get_solvable_orders.rs
+++ b/orderbook/src/api/get_solvable_orders.rs
@@ -1,4 +1,4 @@
-use crate::{api::convert_response, orderbook::Orderbook};
+use crate::{api::convert_json_response, orderbook::Orderbook};
 use anyhow::Result;
 use std::{convert::Infallible, sync::Arc};
 use warp::{Filter, Rejection, Reply};
@@ -14,7 +14,7 @@ pub fn get_solvable_orders(
         let orderbook = orderbook.clone();
         async move {
             let result = orderbook.get_solvable_orders().await;
-            Result::<_, Infallible>::Ok(convert_response(
+            Result::<_, Infallible>::Ok(convert_json_response(
                 result.map(|solvable_orders| solvable_orders.orders),
             ))
         }

--- a/orderbook/src/api/get_solvable_orders_v2.rs
+++ b/orderbook/src/api/get_solvable_orders_v2.rs
@@ -1,4 +1,4 @@
-use crate::{api::convert_response_err, orderbook::Orderbook};
+use crate::{api::convert_response, orderbook::Orderbook};
 use anyhow::Result;
 use std::{convert::Infallible, sync::Arc};
 use warp::{Filter, Rejection, Reply};
@@ -14,7 +14,7 @@ pub fn get_solvable_orders(
         let orderbook = orderbook.clone();
         async move {
             let result = orderbook.get_solvable_orders().await;
-            Result::<_, Infallible>::Ok(convert_response_err(result.map(|orders| {
+            Result::<_, Infallible>::Ok(convert_response(result.map(|orders| {
                 model::SolvableOrders {
                     orders: orders.orders,
                     latest_settlement_block: orders.latest_settlement_block,
@@ -37,8 +37,7 @@ mod tests {
             orders: vec![],
             latest_settlement_block: 1,
         };
-        let response =
-            convert_response_err::<_, anyhow::Error>(Ok(solvable_orders)).into_response();
+        let response = convert_response::<_, anyhow::Error>(Ok(solvable_orders)).into_response();
         assert_eq!(response.status(), StatusCode::OK);
         let body = response_body(response).await;
         let response: model::SolvableOrders = serde_json::from_slice(body.as_slice()).unwrap();

--- a/orderbook/src/api/get_solvable_orders_v2.rs
+++ b/orderbook/src/api/get_solvable_orders_v2.rs
@@ -1,5 +1,5 @@
 use crate::orderbook::Orderbook;
-use crate::{api::convert_get_orders_error_to_reply, solvable_orders::SolvableOrders};
+use crate::{api::WarpReplyConverting, solvable_orders::SolvableOrders};
 use anyhow::Result;
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};
@@ -17,7 +17,7 @@ fn get_solvable_orders_response(result: Result<SolvableOrders>) -> impl Reply {
             }),
             StatusCode::OK,
         )),
-        Err(err) => Ok(convert_get_orders_error_to_reply(err)),
+        Err(err) => Ok(err.into_warp_reply()),
     }
 }
 

--- a/orderbook/src/api/get_solvable_orders_v2.rs
+++ b/orderbook/src/api/get_solvable_orders_v2.rs
@@ -1,5 +1,4 @@
-use crate::orderbook::Orderbook;
-use crate::{api::WarpReplyConverting, solvable_orders::SolvableOrders};
+use crate::{api::WarpReplyConverting, orderbook::Orderbook, solvable_orders::SolvableOrders};
 use anyhow::Result;
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply, Filter, Rejection, Reply};

--- a/orderbook/src/api/get_solvable_orders_v2.rs
+++ b/orderbook/src/api/get_solvable_orders_v2.rs
@@ -1,4 +1,4 @@
-use crate::{api::convert_response, orderbook::Orderbook};
+use crate::{api::convert_json_response, orderbook::Orderbook};
 use anyhow::Result;
 use std::{convert::Infallible, sync::Arc};
 use warp::{Filter, Rejection, Reply};
@@ -14,7 +14,7 @@ pub fn get_solvable_orders(
         let orderbook = orderbook.clone();
         async move {
             let result = orderbook.get_solvable_orders().await;
-            Result::<_, Infallible>::Ok(convert_response(result.map(|orders| {
+            Result::<_, Infallible>::Ok(convert_json_response(result.map(|orders| {
                 model::SolvableOrders {
                     orders: orders.orders,
                     latest_settlement_block: orders.latest_settlement_block,
@@ -37,7 +37,8 @@ mod tests {
             orders: vec![],
             latest_settlement_block: 1,
         };
-        let response = convert_response::<_, anyhow::Error>(Ok(solvable_orders)).into_response();
+        let response =
+            convert_json_response::<_, anyhow::Error>(Ok(solvable_orders)).into_response();
         assert_eq!(response.status(), StatusCode::OK);
         let body = response_body(response).await;
         let response: model::SolvableOrders = serde_json::from_slice(body.as_slice()).unwrap();

--- a/orderbook/src/api/get_trades.rs
+++ b/orderbook/src/api/get_trades.rs
@@ -2,7 +2,7 @@ use crate::{
     api::convert_json_response,
     database::trades::{TradeFilter, TradeRetrieving},
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
 use model::order::OrderUid;
 use primitive_types::H160;
 use serde::Deserialize;
@@ -55,7 +55,7 @@ pub fn get_trades(
         async move {
             match request_result {
                 Ok(trade_filter) => {
-                    let result = database.trades(&trade_filter).await;
+                    let result = database.trades(&trade_filter).await.context("get_trades");
                     Result::<_, Infallible>::Ok(convert_json_response(result))
                 }
                 Err(TradeFilterError::InvalidFilter(msg)) => {

--- a/orderbook/src/api/get_trades.rs
+++ b/orderbook/src/api/get_trades.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::convert_response,
+    api::convert_json_response,
     database::trades::{TradeFilter, TradeRetrieving},
 };
 use anyhow::Result;
@@ -56,7 +56,7 @@ pub fn get_trades(
             match request_result {
                 Ok(trade_filter) => {
                     let result = database.trades(&trade_filter).await;
-                    Result::<_, Infallible>::Ok(convert_response(result))
+                    Result::<_, Infallible>::Ok(convert_json_response(result))
                 }
                 Err(TradeFilterError::InvalidFilter(msg)) => {
                     let err = super::error("InvalidTradeFilter", msg);

--- a/orderbook/src/api/get_trades.rs
+++ b/orderbook/src/api/get_trades.rs
@@ -1,14 +1,12 @@
-use crate::api::convert_get_trades_error_to_reply;
-use crate::database::trades::TradeFilter;
-use crate::database::trades::TradeRetrieving;
+use crate::{
+    api::convert_response_err,
+    database::trades::{TradeFilter, TradeRetrieving},
+};
 use anyhow::Result;
 use model::order::OrderUid;
-use model::trade::Trade;
 use primitive_types::H160;
 use serde::Deserialize;
-use std::convert::Infallible;
-use std::sync::Arc;
-use warp::reply::{Json, WithStatus};
+use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, Filter, Rejection, Reply};
 
 #[derive(Deserialize)]
@@ -49,13 +47,6 @@ fn get_trades_request(
         .map(|query: Query| query.validate())
 }
 
-fn get_trades_response(result: Result<Vec<Trade>>) -> WithStatus<Json> {
-    match result {
-        Ok(trades) => warp::reply::with_status(warp::reply::json(&trades), StatusCode::OK),
-        Err(err) => convert_get_trades_error_to_reply(err),
-    }
-}
-
 pub fn get_trades(
     db: Arc<dyn TradeRetrieving>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
@@ -65,7 +56,7 @@ pub fn get_trades(
             match request_result {
                 Ok(trade_filter) => {
                     let result = database.trades(&trade_filter).await;
-                    Result::<_, Infallible>::Ok(get_trades_response(result))
+                    Result::<_, Infallible>::Ok(convert_response_err(result))
                 }
                 Err(TradeFilterError::InvalidFilter(msg)) => {
                     let err = super::error("InvalidTradeFilter", msg);
@@ -79,7 +70,6 @@ pub fn get_trades(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::response_body;
     use hex_literal::hex;
     use primitive_types::H160;
     use warp::test::{request, RequestBuilder};
@@ -127,15 +117,5 @@ mod tests {
         let path = "/trades";
         let result = trade_filter(request().path(path)).await.unwrap();
         assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn get_trades_response_ok() {
-        let trades = vec![Trade::default()];
-        let response = get_trades_response(Ok(trades.clone())).into_response();
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_body(response).await;
-        let response_trades: Vec<Trade> = serde_json::from_slice(body.as_slice()).unwrap();
-        assert_eq!(response_trades, trades);
     }
 }

--- a/orderbook/src/api/get_trades.rs
+++ b/orderbook/src/api/get_trades.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::convert_response_err,
+    api::convert_response,
     database::trades::{TradeFilter, TradeRetrieving},
 };
 use anyhow::Result;
@@ -56,7 +56,7 @@ pub fn get_trades(
             match request_result {
                 Ok(trade_filter) => {
                     let result = database.trades(&trade_filter).await;
-                    Result::<_, Infallible>::Ok(convert_response_err(result))
+                    Result::<_, Infallible>::Ok(convert_response(result))
                 }
                 Err(TradeFilterError::InvalidFilter(msg)) => {
                     let err = super::error("InvalidTradeFilter", msg);

--- a/orderbook/src/api/get_user_orders.rs
+++ b/orderbook/src/api/get_user_orders.rs
@@ -1,4 +1,4 @@
-use crate::{api::convert_response_err, orderbook::Orderbook};
+use crate::{api::convert_response, orderbook::Orderbook};
 use anyhow::Result;
 use primitive_types::H160;
 use serde::Deserialize;
@@ -39,7 +39,7 @@ pub fn get_user_orders(
                 ));
             }
             let result = orderbook.get_user_orders(&owner, offset, limit).await;
-            Result::<_, Infallible>::Ok(convert_response_err(result))
+            Result::<_, Infallible>::Ok(convert_response(result))
         }
     })
 }

--- a/orderbook/src/api/get_user_orders.rs
+++ b/orderbook/src/api/get_user_orders.rs
@@ -1,12 +1,11 @@
-use crate::{api::internal_error, orderbook::Orderbook};
+use crate::{api::convert_response_err, orderbook::Orderbook};
 use anyhow::Result;
-use model::order::Order;
 use primitive_types::H160;
 use serde::Deserialize;
 use std::{convert::Infallible, sync::Arc};
 use warp::{
     hyper::StatusCode,
-    reply::{self, with_status, Json, WithStatus},
+    reply::with_status,
     Filter, Rejection, Reply,
 };
 
@@ -20,16 +19,6 @@ fn request() -> impl Filter<Extract = (H160, Query), Error = Rejection> + Clone 
     warp::path!("account" / H160 / "orders")
         .and(warp::get())
         .and(warp::query::<Query>())
-}
-
-fn response(result: Result<Vec<Order>>) -> WithStatus<Json> {
-    match result {
-        Ok(orders) => reply::with_status(reply::json(&orders), StatusCode::OK),
-        Err(err) => {
-            tracing::error!(?err, "get_user_orders error");
-            with_status(internal_error(), StatusCode::INTERNAL_SERVER_ERROR)
-        }
-    }
 }
 
 pub fn get_user_orders(
@@ -54,7 +43,7 @@ pub fn get_user_orders(
                 ));
             }
             let result = orderbook.get_user_orders(&owner, offset, limit).await;
-            Result::<_, Infallible>::Ok(response(result))
+            Result::<_, Infallible>::Ok(convert_response_err(result))
         }
     })
 }
@@ -62,7 +51,6 @@ pub fn get_user_orders(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::response_body;
     use shared::addr;
 
     #[tokio::test]
@@ -87,15 +75,5 @@ mod tests {
             .unwrap();
         assert_eq!(result.1.offset, Some(1));
         assert_eq!(result.1.limit, Some(2));
-    }
-
-    #[tokio::test]
-    async fn response_ok() {
-        let orders = vec![Order::default()];
-        let response = response(Ok(orders.clone())).into_response();
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_body(response).await;
-        let response_orders: Vec<Order> = serde_json::from_slice(body.as_slice()).unwrap();
-        assert_eq!(response_orders, orders);
     }
 }

--- a/orderbook/src/api/get_user_orders.rs
+++ b/orderbook/src/api/get_user_orders.rs
@@ -1,4 +1,4 @@
-use crate::{api::convert_response, orderbook::Orderbook};
+use crate::{api::convert_json_response, orderbook::Orderbook};
 use anyhow::Result;
 use primitive_types::H160;
 use serde::Deserialize;
@@ -39,7 +39,7 @@ pub fn get_user_orders(
                 ));
             }
             let result = orderbook.get_user_orders(&owner, offset, limit).await;
-            Result::<_, Infallible>::Ok(convert_response(result))
+            Result::<_, Infallible>::Ok(convert_json_response(result))
         }
     })
 }

--- a/orderbook/src/api/get_user_orders.rs
+++ b/orderbook/src/api/get_user_orders.rs
@@ -3,11 +3,7 @@ use anyhow::Result;
 use primitive_types::H160;
 use serde::Deserialize;
 use std::{convert::Infallible, sync::Arc};
-use warp::{
-    hyper::StatusCode,
-    reply::with_status,
-    Filter, Rejection, Reply,
-};
+use warp::{hyper::StatusCode, reply::with_status, Filter, Rejection, Reply};
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 struct Query {

--- a/orderbook/src/api/order_validation.rs
+++ b/orderbook/src/api/order_validation.rs
@@ -95,9 +95,10 @@ impl IntoWarpReply for PartialValidationError {
                 ),
                 StatusCode::BAD_REQUEST,
             ),
-            Self::Other(_) => {
-                with_status(super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR)
-            }
+            Self::Other(err) => with_status(
+                super::internal_error(err.context("partial_validation")),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
         }
     }
 }
@@ -151,9 +152,10 @@ impl IntoWarpReply for ValidationError {
                 super::error("ZeroAmount", "Buy or sell amount is zero."),
                 StatusCode::BAD_REQUEST,
             ),
-            Self::Other(_) => {
-                with_status(super::internal_error(), StatusCode::INTERNAL_SERVER_ERROR)
-            }
+            Self::Other(err) => with_status(
+                super::internal_error(err.context("order_validation")),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
         }
     }
 }

--- a/orderbook/src/api/order_validation.rs
+++ b/orderbook/src/api/order_validation.rs
@@ -1,12 +1,16 @@
 use crate::{account_balances::BalanceFetching, api::WarpReplyConverting, fee::MinFeeCalculating};
 use contracts::WETH9;
 use ethcontract::{H160, U256};
-use model::order::{BuyTokenDestination, Order, OrderCreation, SellTokenSource, BUY_ETH_ADDRESS};
-use model::DomainSeparator;
+use model::{
+    order::{BuyTokenDestination, Order, OrderCreation, SellTokenSource, BUY_ETH_ADDRESS},
+    DomainSeparator,
+};
 use shared::{bad_token::BadTokenDetecting, web3_traits::CodeFetching};
 use std::{sync::Arc, time::Duration};
-use warp::reply::{with_status, WithStatus};
-use warp::{http::StatusCode, reply::Json};
+use warp::{
+    http::StatusCode,
+    reply::{with_status, Json, WithStatus},
+};
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]

--- a/orderbook/src/api/order_validation.rs
+++ b/orderbook/src/api/order_validation.rs
@@ -1,4 +1,4 @@
-use crate::{account_balances::BalanceFetching, api::WarpReplyConverting, fee::MinFeeCalculating};
+use crate::{account_balances::BalanceFetching, api::IntoWarpReply, fee::MinFeeCalculating};
 use contracts::WETH9;
 use ethcontract::{H160, U256};
 use model::{
@@ -59,7 +59,7 @@ pub enum PartialValidationError {
     Other(anyhow::Error),
 }
 
-impl WarpReplyConverting for PartialValidationError {
+impl IntoWarpReply for PartialValidationError {
     fn into_warp_reply(self) -> WithStatus<Json> {
         match self {
             Self::UnsupportedBuyTokenDestination(dest) => with_status(
@@ -114,7 +114,7 @@ pub enum ValidationError {
     Other(anyhow::Error),
 }
 
-impl WarpReplyConverting for ValidationError {
+impl IntoWarpReply for ValidationError {
     fn into_warp_reply(self) -> WithStatus<Json> {
         match self {
             ValidationError::Partial(pre) => pre.into_warp_reply(),

--- a/orderbook/src/api/post_quote.rs
+++ b/orderbook/src/api/post_quote.rs
@@ -1,6 +1,6 @@
 use crate::{
     api::{
-        self, convert_response_err,
+        self, convert_response,
         order_validation::{OrderValidating, PreOrderData, ValidationError},
         WarpReplyConverting,
     },
@@ -346,7 +346,7 @@ pub fn post_quote(
             if let Err(err) = &result {
                 tracing::warn!(?err, ?request, "post_quote error");
             }
-            Result::<_, Infallible>::Ok(convert_response_err(result))
+            Result::<_, Infallible>::Ok(convert_response(result))
         }
     })
 }
@@ -507,7 +507,7 @@ mod tests {
             from: H160::zero(),
             expiration: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
         };
-        let response = convert_response_err::<OrderQuoteResponse, OrderQuoteError>(Ok(
+        let response = convert_response::<OrderQuoteResponse, OrderQuoteError>(Ok(
             order_quote_response.clone(),
         ))
         .into_response();
@@ -520,7 +520,7 @@ mod tests {
 
     #[tokio::test]
     async fn post_quote_response_err() {
-        let response = convert_response_err::<OrderQuoteResponse, OrderQuoteError>(Err(
+        let response = convert_response::<OrderQuoteResponse, OrderQuoteError>(Err(
             OrderQuoteError::Order(ValidationError::Other(anyhow!("Uh oh - error"))),
         ))
         .into_response();

--- a/orderbook/src/api/post_quote.rs
+++ b/orderbook/src/api/post_quote.rs
@@ -2,7 +2,7 @@ use crate::{
     api::{
         self,
         order_validation::{OrderValidating, PreOrderData, ValidationError},
-        price_estimation_error_to_warp_reply, WarpReplyConverting,
+        WarpReplyConverting,
     },
     fee::MinFeeCalculating,
 };
@@ -17,11 +17,13 @@ use model::{
 use serde::{Deserialize, Serialize};
 use shared::price_estimation::{self, PriceEstimating, PriceEstimationError};
 use std::{convert::Infallible, sync::Arc};
+use warp::reply::WithStatus;
 use warp::{
     hyper::StatusCode,
-    reply::{self, Json},
+    reply::Json,
     Filter, Rejection, Reply,
 };
+use crate::api::convert_response_err;
 
 /// The order parameters to quote a price and fee for.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq)]
@@ -94,7 +96,7 @@ pub enum SellAmount {
 }
 
 /// The quoted order by the service.
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderQuote {
     pub sell_token: H160,
@@ -114,7 +116,7 @@ pub struct OrderQuote {
     pub buy_token_balance: BuyTokenDestination,
 }
 
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderQuoteResponse {
     pub quote: OrderQuote,
@@ -129,10 +131,10 @@ pub enum FeeError {
 }
 
 impl WarpReplyConverting for FeeError {
-    fn into_warp_reply(self) -> (Json, StatusCode) {
+    fn into_warp_reply(self) -> WithStatus<Json> {
         match self {
-            FeeError::PriceEstimate(err) => price_estimation_error_to_warp_reply(err),
-            FeeError::SellAmountDoesNotCoverFee => (
+            FeeError::PriceEstimate(err) => err.into_warp_reply(),
+            FeeError::SellAmountDoesNotCoverFee => warp::reply::with_status(
                 super::error(
                     "SellAmountDoesNotCoverFee",
                     "The sell amount for the sell order is lower than the fee.".to_string(),
@@ -149,8 +151,8 @@ pub enum OrderQuoteError {
     Order(ValidationError),
 }
 
-impl OrderQuoteError {
-    pub fn convert_to_reply(self) -> (Json, StatusCode) {
+impl WarpReplyConverting for OrderQuoteError {
+    fn into_warp_reply(self) -> WithStatus<Json> {
         match self {
             OrderQuoteError::Fee(err) => err.into_warp_reply(),
             OrderQuoteError::Order(err) => err.into_warp_reply(),
@@ -336,16 +338,6 @@ fn post_quote_request() -> impl Filter<Extract = (OrderQuoteRequest,), Error = R
         .and(api::extract_payload())
 }
 
-pub fn response<T: Serialize>(result: Result<T, OrderQuoteError>) -> impl Reply {
-    match result {
-        Ok(response) => reply::with_status(reply::json(&response), StatusCode::OK),
-        Err(err) => {
-            let (reply, status) = err.convert_to_reply();
-            reply::with_status(reply, status)
-        }
-    }
-}
-
 pub fn post_quote(
     quoter: Arc<OrderQuoter>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
@@ -356,7 +348,7 @@ pub fn post_quote(
             if let Err(err) = &result {
                 tracing::warn!(?err, ?request, "post_quote error");
             }
-            Result::<_, Infallible>::Ok(response(result))
+            Result::<_, Infallible>::Ok(convert_response_err(result))
         }
     })
 }
@@ -368,7 +360,7 @@ mod tests {
         api::{order_validation::MockOrderValidating, response_body},
         fee::MockMinFeeCalculating,
     };
-    use chrono::Utc;
+    use chrono::{NaiveDateTime, Utc};
     use futures::FutureExt;
     use serde_json::json;
     use shared::price_estimation::mocks::FakePriceEstimator;
@@ -498,7 +490,7 @@ mod tests {
 
     #[tokio::test]
     async fn post_quote_response_ok() {
-        let order_quote = OrderQuote {
+        let quote = OrderQuote {
             sell_token: Default::default(),
             buy_token: Default::default(),
             receiver: None,
@@ -512,17 +504,22 @@ mod tests {
             sell_token_balance: Default::default(),
             buy_token_balance: Default::default(),
         };
-        let response = response(Ok(&order_quote)).into_response();
+        let order_quote_response = OrderQuoteResponse {
+            quote,
+            from: H160::zero(),
+            expiration: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
+        };
+        let response = convert_response_err::<OrderQuoteResponse, OrderQuoteError>(Ok(order_quote_response.clone())).into_response();
         assert_eq!(response.status(), StatusCode::OK);
         let body = response_body(response).await;
         let body: serde_json::Value = serde_json::from_slice(body.as_slice()).unwrap();
-        let expected = serde_json::to_value(order_quote).unwrap();
+        let expected = serde_json::to_value(order_quote_response).unwrap();
         assert_eq!(body, expected);
     }
 
     #[tokio::test]
     async fn post_quote_response_err() {
-        let response = response::<OrderQuoteResponse>(Err(OrderQuoteError::Order(
+        let response = convert_response_err::<OrderQuoteResponse, OrderQuoteError>(Err(OrderQuoteError::Order(
             ValidationError::Other(anyhow!("Uh oh - error")),
         )))
         .into_response();

--- a/orderbook/src/orderbook.rs
+++ b/orderbook/src/orderbook.rs
@@ -3,7 +3,7 @@ use crate::{
     database::orders::{InsertionError, OrderFilter, OrderStoring},
     solvable_orders::{SolvableOrders, SolvableOrdersCache},
 };
-use anyhow::{ensure, Result};
+use anyhow::{ensure, Context, Result};
 use chrono::Utc;
 use ethcontract::H256;
 use model::{
@@ -203,7 +203,8 @@ impl Orderbook {
         let mut orders = self
             .database
             .user_orders(owner, offset, Some(limit))
-            .await?;
+            .await
+            .context("get_user_orders error")?;
         set_available_balances(orders.as_mut_slice(), &self.solvable_orders);
         Ok(orders)
     }


### PR DESCRIPTION
Based on the suggestion [here](https://github.com/gnosis/gp-v2-services/pull/1176#discussion_r721408663)

We write a generic method `convert_response` which is used in place of all the `*_response(result: Result<XXX>)` methods where appropriate.

This method expects the `Err( . )` route to implement `WarpReplyConverting`.  Additional work will have to go into generically handling the `Ok( . )` route - which is still lingering around for some reply conversions and will be addressed in a follow up PR.


### Test Plan
No logical changes - existing CI.
