### PR TITLE
Remove legacy fee from API

### DIFF
--- a/orderbook/openapi.yml
+++ b/orderbook/openapi.yml
@@ -179,27 +179,6 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Order"
-  /api/v1/tokens/{sellToken}/fee:
-    get:
-      description: |
-        The fee that is charged for placing an order.
-        The fee is described by a minimum fee - in order to cover the gas costs for onchain settling - and
-        a feeRatio charged to the users for using the service.
-      parameters:
-        - name: sellToken
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Address"
-      responses:
-        200:
-          description: the fee
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyFeeInformation"
-        404:
-          description: sellToken non-existent
   /api/v1/trades:
     get:
       summary: Get existing Trades.
@@ -527,29 +506,6 @@ components:
       required:
         - expirationDate
         - amount
-    LegacyFeeInformation:
-      description: |
-        Provides the information to calculate the fees.
-      type: object
-      properties:
-        expirationDate:
-          description: |
-            Expiration date of the offered fee. Order service might not accept
-            the fee after this expiration date. Encoded as ISO 8601 UTC.
-          type: string
-          example: "2020-12-03T18:35:18.814523Z"
-        minimalFee:
-          description: Absolute amount of minimal fee charged per order in specified sellToken
-          $ref: "#/components/schemas/TokenAmount"
-        feeRatio:
-          description: The fee ratio charged on a sellAmount. Denoted in basis points
-          example: 10
-          type: number
-          format: int32
-      required:
-        - expirationDate
-        - minimalFee
-        - feeRatio
     OrderType:
       description: Is this a buy order or sell order?
       type: string

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -33,7 +33,6 @@ pub fn handle_all_routes(
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     let create_order = create_order::create_order(orderbook.clone());
     let get_orders = get_orders::get_orders(orderbook.clone());
-    let legacy_fee_info = get_fee_info::legacy_get_fee_info(quoter.fee_calculator.clone());
     let fee_info = get_fee_info::get_fee_info(quoter.fee_calculator.clone());
     let get_order = get_order_by_uid::get_order_by_uid(orderbook.clone());
     let get_solvable_orders = get_solvable_orders::get_solvable_orders(orderbook.clone());
@@ -54,7 +53,6 @@ pub fn handle_all_routes(
         .and(create_order.with(handle_metrics("create_order"))))
     .or(warp::path!("api" / "v1" / ..).and(get_orders.with(handle_metrics("get_orders"))))
     .or(warp::path!("api" / "v1" / ..).and(fee_info.with(handle_metrics("fee_info"))))
-    .or(warp::path!("api" / "v1" / ..).and(legacy_fee_info.with(handle_metrics("legacy_fee_info"))))
     .or(warp::path!("api" / "v1" / ..).and(get_order.with(handle_metrics("get_order"))))
     .or(warp::path!("api" / "v1" / ..)
         .and(get_solvable_orders.with(handle_metrics("get_solvable_orders"))))

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -73,55 +73,6 @@ pub fn get_fee_info(
     })
 }
 
-// TODO remove legacy fee endpoint once frontend is updated
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct LegacyFeeInfo {
-    pub expiration_date: DateTime<Utc>,
-    #[serde(with = "u256_decimal")]
-    pub minimal_fee: U256,
-    pub fee_ratio: u32,
-}
-
-pub fn legacy_get_fee_info_request() -> impl Filter<Extract = (H160,), Error = Rejection> + Clone {
-    warp::path!("tokens" / H160 / "fee").and(warp::get())
-}
-
-pub fn legacy_get_fee_info_response(
-    result: Result<(U256, DateTime<Utc>), PriceEstimationError>,
-) -> impl Reply {
-    match result {
-        Ok((minimal_fee, expiration_date)) => {
-            let fee_info = LegacyFeeInfo {
-                expiration_date,
-                minimal_fee,
-                fee_ratio: 0u32,
-            };
-            Ok(reply::with_status(reply::json(&fee_info), StatusCode::OK))
-        }
-        Err(err) => {
-            let (json, status_code) = price_estimation_error_to_warp_reply(err);
-            Ok(reply::with_status(json, status_code))
-        }
-    }
-}
-
-pub fn legacy_get_fee_info(
-    fee_calculator: Arc<dyn MinFeeCalculating>,
-) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    legacy_get_fee_info_request().and_then(move |token| {
-        let fee_calculator = fee_calculator.clone();
-        async move {
-            Result::<_, Infallible>::Ok(legacy_get_fee_info_response(
-                fee_calculator
-                    .compute_subsidized_min_fee(token, None, None, None, None)
-                    .await,
-            ))
-        }
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -157,29 +108,6 @@ mod tests {
         let body = response_body(response).await;
         let body: FeeInfo = serde_json::from_slice(body.as_slice()).unwrap();
         assert_eq!(body.amount, U256::zero());
-        assert!(body.expiration_date.gt(&chrono::offset::Utc::now()))
-    }
-
-    #[tokio::test]
-    async fn legacy_get_fee_info_request_ok() {
-        let filter = legacy_get_fee_info_request();
-        let token = String::from("0x0000000000000000000000000000000000000001");
-        let path_string = format!("/tokens/{}/fee", token);
-        let request = request().path(&path_string).method("GET");
-        let result = request.filter(&filter).await.unwrap();
-        assert_eq!(result, H160::from_low_u64_be(1));
-    }
-
-    #[tokio::test]
-    async fn legacy_get_fee_info_response_() {
-        let response =
-            legacy_get_fee_info_response(Ok((U256::zero(), Utc::now() + FixedOffset::east(10))))
-                .into_response();
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_body(response).await;
-        let body: LegacyFeeInfo = serde_json::from_slice(body.as_slice()).unwrap();
-        assert_eq!(body.minimal_fee, U256::zero());
-        assert_eq!(body.fee_ratio, 0);
         assert!(body.expiration_date.gt(&chrono::offset::Utc::now()))
     }
 }


### PR DESCRIPTION
While working on #1292, I stumbled upon a section of code with a `TODO - remove this` from back in May. I think it is safe to assume that the front end no longer depends on this. Tagging @anxolin , @alfetopito and @W3stside to double check.

This Legacy fee endpoint has been deprecated since #574 (May 10, 2021)

According to Grafana this endpoint is not really being used. Anything that is using is has only ever been getting 404 responses for as long as the graph has history (October 10, 2021) - see [here](https://dashboard-projects.gnosis.io/d/3Z-RJHuGz/gpv2?viewPanel=39&orgId=2&refresh=30s&from=now-90d&to=now)