### PR TITLE
Exclude Cost Calculation for PMM Orders

### DIFF
--- a/solver/src/settlement.rs
+++ b/solver/src/settlement.rs
@@ -229,11 +229,8 @@ impl Settlement {
         self.encoder
             .trades()
             .iter()
+            .filter(|trade| !trade.is_liquidity_order)
             .filter_map(|trade| {
-                if trade.is_liquidity_order {
-                    // Exclude cost for liquidity orders.
-                    return None;
-                }
                 let fee_token_price =
                     external_prices.get(&trade.order.order_creation.sell_token)?;
                 Some(trade.executed_scaled_unsubsidized_fee()?.to_big_rational() * fee_token_price)


### PR DESCRIPTION
Based on a [discussion in slack](https://gnosisinc.slack.com/archives/C022S0FM1GW/p1635239843006100) we have forgotten to exclude cost of liquidity orders in #1267.


TODO - include test demonstrating that this does what we expect.
