### PR TITLE
Update to `tracing-subscriber v0.3.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,9 +1449,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
@@ -2630,6 +2630,7 @@ dependencies = [
  "serde_with",
  "structopt",
  "thiserror",
+ "time",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2993,6 +2994,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99beeb0daeac2bd1e86ac2c21caddecb244b39a093594da1a661ec2060c7aedd"
+dependencies = [
+ "itoa",
+ "libc",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,35 +3200,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+checksum = "80a4ddde70311d8da398062ecf6fc2c309337de6b0f77d6c27aff8d53f6fca52"
 dependencies = [
  "ansi_term 0.12.1",
- "chrono",
  "lazy_static",
  "matchers",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/alerter/Cargo.toml
+++ b/alerter/Cargo.toml
@@ -14,5 +14,5 @@ shared = { path = "../shared" }
 structopt = "0.3"
 tokio = { version = "1.12", features = ["macros", "time"] }
 tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 url = "2.0"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -38,10 +38,11 @@ serde_json = "1.0"
 serde_with = { version = "1.11", default-features = false }
 structopt = { version = "0.3", default-features = false }
 thiserror = "1.0"
+time = { version = "0.3", features = ["macros"] }
 tokio = { version = "1.12", features = ["macros", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.2", features = ["fmt"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "time"] }
 url = "2.2"
 warp = "0.3"
 web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev="a425fa747bca69c7aede4d2c2828f7267d79227e", default-features = false }

--- a/shared/src/sources/balancer/graph_api.rs
+++ b/shared/src/sources/balancer/graph_api.rs
@@ -60,6 +60,7 @@ impl BalancerSubgraphClient {
     ) -> Result<Vec<PoolData<T>>> {
         let mut result = Vec::new();
         let mut last_id = H256::default();
+        #[allow(clippy::blocks_in_if_conditions)]
         while {
             let page = self
                 .0

--- a/shared/src/tracing.rs
+++ b/shared/src/tracing.rs
@@ -2,17 +2,19 @@ use std::{
     panic::{self, PanicInfo},
     thread,
 };
+use time::macros::format_description;
 use tracing::level_filters::LevelFilter;
-use tracing_subscriber::fmt::{time::ChronoUtc, writer::MakeWriterExt as _};
+use tracing_subscriber::fmt::{time::UtcTime, writer::MakeWriterExt as _};
 
 /// Initializes tracing setup that is shared between the binaries.
 /// `env_filter` has similar syntax to env_logger. It is documented at
 /// https://docs.rs/tracing-subscriber/0.2.15/tracing_subscriber/filter/struct.EnvFilter.html
 pub fn initialize(env_filter: &str, stderr_threshold: LevelFilter) {
     // This is what kibana uses to separate multi line log messages.
-    let time_format_string = "%Y-%m-%dT%H:%M:%S%.3fZ";
     let subscriber_builder = tracing_subscriber::fmt::fmt()
-        .with_timer(ChronoUtc::with_format(String::from(time_format_string)))
+        .with_timer(UtcTime::new(format_description!(
+            "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:3]Z"
+        )))
         .with_env_filter(env_filter)
         .with_ansi(atty::is(atty::Stream::Stdout));
     match stderr_threshold.into_level() {

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -50,5 +50,5 @@ transaction-retry = { git = "https://github.com/gnosis/gp-transaction-retry.git"
 web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev="a425fa747bca69c7aede4d2c2828f7267d79227e", default-features = false }
 
 [dev-dependencies]
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 mockall = "0.10"


### PR DESCRIPTION
Supersedes #1293 

This PR updates the `tracing-subscriber` dependency to `v0.3.1`. Its a little more involved so I made a separate PR.

In particualr, time formatting has changed in the newer version to use the `time` crate, so the format string is specified differently. There is a built-in RFC 3339 which is almost what we need, except it uses a variable number of subsecond digits (based on trailing `0`s), so a custom format was needed.

### Test Plan

CI, no logic changes.

You can test that the formatting works by:
```
$ cargo run -p solver
2021-10-26T18:08:38.677Z  INFO solver: running solver with validated Arguments {
...
```

And then compare it to `main` to make sure its the same:
```
$ cargo run -p solver
2021-10-26T18:09:49.659Z  INFO solver: running solver with validated Arguments {
...
```