### PR TITLE
[Trivial] Readd print about what orders are part of the current run loop

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -377,6 +377,8 @@ impl Driver {
             .into_iter()
             .map(|order| self.order_converter.normalize_limit_order(order))
             .collect::<Vec<_>>();
+        tracing::info!("got {} orders: {:?}", orders.len(), orders);
+        
         let liquidity = self
             .liquidity_collector
             .get_liquidity_for_orders(&orders, Block::Number(current_block_during_liquidity_fetch))

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -378,7 +378,7 @@ impl Driver {
             .map(|order| self.order_converter.normalize_limit_order(order))
             .collect::<Vec<_>>();
         tracing::info!("got {} orders: {:?}", orders.len(), orders);
-        
+
         let liquidity = self
             .liquidity_collector
             .get_liquidity_for_orders(&orders, Block::Number(current_block_during_liquidity_fetch))

--- a/solver/src/in_flight_orders.rs
+++ b/solver/src/in_flight_orders.rs
@@ -67,7 +67,7 @@ mod tests {
         assert_eq!(filtered.len(), 1);
 
         solvable_orders.latest_settlement_block = 1;
-        let filtered = inflight.update_and_filter(solvable_orders.clone());
+        let filtered = inflight.update_and_filter(solvable_orders);
         assert_eq!(filtered.len(), 2);
     }
 }

--- a/solver/src/liquidity_collector.rs
+++ b/solver/src/liquidity_collector.rs
@@ -22,6 +22,7 @@ impl LiquidityCollector {
             .filter(|order| !order.is_liquidity_order)
             .cloned()
             .collect::<Vec<_>>();
+        tracing::info!("got {} user orders: {:?}", user_orders.len(), user_orders);
         for liquidity in &self.uniswap_like_liquidity {
             amms.extend(
                 liquidity

--- a/solver/src/liquidity_collector.rs
+++ b/solver/src/liquidity_collector.rs
@@ -22,7 +22,6 @@ impl LiquidityCollector {
             .filter(|order| !order.is_liquidity_order)
             .cloned()
             .collect::<Vec<_>>();
-        tracing::info!("got {} user orders: {:?}", user_orders.len(), user_orders);
         for liquidity in &self.uniswap_like_liquidity {
             amms.extend(
                 liquidity


### PR DESCRIPTION
It was removed in #1287, please let me know if this was on purpose (I found this statement extremely useful when debugging runloops)

### Test Plan
🤷 
