### PR TITLE
Fix price estimation metric counting all errors as unsuccessful

### DIFF
--- a/shared/src/price_estimation/instrumented.rs
+++ b/shared/src/price_estimation/instrumented.rs
@@ -35,7 +35,8 @@ where
     ) -> Vec<anyhow::Result<Estimate, PriceEstimationError>> {
         let results = self.inner.estimates(queries).await;
         for result in &results {
-            self.metrics.price_estimated(&self.name, result.is_ok());
+            let success = !matches!(result, Err(PriceEstimationError::Other(_)));
+            self.metrics.price_estimated(&self.name, success);
         }
         results
     }


### PR DESCRIPTION
The PriceEstimationError enum has several cases that should not be
counted as errors for the purposes of this m,etric. I decided to only
count `Other` as error as this means we were not able to get a
successful response from the estimator. The other errors should all be
presented as errors to api users but are not errors in terms of the
price estimator.

### Test Plan
CI, change so small does not need unit test