### PR TITLE
Drop old transport metrics

### DIFF
--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use contracts::{BalancerV2Vault, GPv2Settlement, WETH9};
+use ethcontract::dyns::DynTransport;
 use model::{
     app_id::AppId,
     order::{OrderUid, BUY_ETH_ADDRESS},
@@ -49,7 +50,6 @@ use shared::{
         PoolAggregator,
     },
     token_info::{CachedTokenInfoFetcher, TokenInfoFetcher},
-    transport::create_instrumented_transport,
     transport::http::HttpTransport,
 };
 use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
@@ -180,10 +180,11 @@ async fn main() {
 
     let client = shared::http_client(args.shared.http_timeout);
 
-    let transport = create_instrumented_transport(
-        HttpTransport::new(client.clone(), args.shared.node_url.clone(), "".to_string()),
-        metrics.clone(),
-    );
+    let transport = DynTransport::new(HttpTransport::new(
+        client.clone(),
+        args.shared.node_url.clone(),
+        "".to_string(),
+    ));
     let web3 = web3::Web3::new(transport);
     let settlement_contract = GPv2Settlement::deployed(&web3)
         .await

--- a/shared/src/transport.rs
+++ b/shared/src/transport.rs
@@ -1,31 +1,13 @@
 pub mod dummy;
 pub mod http;
-pub mod instrumented;
 pub mod mock;
 
-use self::{
-    http::HttpTransport,
-    instrumented::{MetricTransport, TransportMetrics},
-};
+use self::http::HttpTransport;
 use crate::Web3Transport;
 use reqwest::Client;
-use std::{convert::TryInto as _, sync::Arc};
-use web3::BatchTransport;
+use std::convert::TryInto as _;
 
 pub const MAX_BATCH_SIZE: usize = 100;
-
-/// Convenience method to create our standard instrumented transport.
-pub fn create_instrumented_transport<T>(
-    transport: T,
-    metrics: Arc<dyn TransportMetrics>,
-) -> Web3Transport
-where
-    T: BatchTransport + Send + Sync + 'static,
-    T::Out: Send + 'static,
-    T::Batch: Send + 'static,
-{
-    Web3Transport::new(MetricTransport::new(transport, metrics))
-}
 
 /// Convenience method to create a transport from a URL.
 pub fn create_test_transport(url: &str) -> Web3Transport {

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::anyhow;
 use contracts::{IUniswapLikeRouter, WETH9};
+use ethcontract::dyns::DynTransport;
 use ethcontract::{Account, PrivateKey, H160, U256};
 use reqwest::Url;
 use shared::{
@@ -22,7 +23,7 @@ use shared::{
     },
     token_info::{CachedTokenInfoFetcher, TokenInfoFetcher},
     token_list::TokenList,
-    transport::{create_instrumented_transport, http::HttpTransport},
+    transport::http::HttpTransport,
 };
 use solver::{
     driver::Driver,
@@ -254,10 +255,11 @@ async fn main() {
 
     let client = shared::http_client(args.shared.http_timeout);
 
-    let transport = create_instrumented_transport(
-        HttpTransport::new(client.clone(), args.shared.node_url, "base".to_string()),
-        metrics.clone(),
-    );
+    let transport = DynTransport::new(HttpTransport::new(
+        client.clone(),
+        args.shared.node_url,
+        "base".to_string(),
+    ));
     let web3 = web3::Web3::new(transport);
     let chain_id = web3
         .eth()
@@ -472,10 +474,11 @@ async fn main() {
                     .into_iter()
                     .enumerate()
                     .map(|(index, url)| {
-                        let transport = create_instrumented_transport(
-                            HttpTransport::new(client.clone(), url, index.to_string()),
-                            metrics.clone(),
-                        );
+                        let transport = DynTransport::new(HttpTransport::new(
+                            client.clone(),
+                            url,
+                            index.to_string(),
+                        ));
                         web3::Web3::new(transport)
                     })
                     .collect::<Vec<_>>();


### PR DESCRIPTION
Part of metrics refactoring. Removing instrumented transport because HTTP transport now exports its own metrics.

Note that I'm working in a separate branch, so these changes won't appear in `main` for a while.