### PR TITLE
Log more fee information

### DIFF
--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -234,15 +234,14 @@ impl MinFeeCalculator {
         };
         let estimate = self.price_estimator.estimate(&query).await?;
         let price = estimate.price_in_sell_token_f64(&query);
+        let fee = fee_in_eth * price;
 
         tracing::debug!(
-            "computed unsubsidized fee amount of {} ETH at a price of {} ETH/{:?}",
-            fee_in_eth,
-            price,
-            sell_token,
+            ?sell_token, ?buy_token, ?amount, ?kind, %gas_price, %gas_amount, %fee_in_eth, %price, %fee,
+            "unsubsidized fee amount"
         );
 
-        Ok(U256::from_f64_lossy(fee_in_eth * price))
+        Ok(U256::from_f64_lossy(fee))
     }
 
     fn apply_fee_factor(&self, fee: U256, app_data: Option<AppId>) -> U256 {


### PR DESCRIPTION

### Test Plan
Manually ran and looked at log.

2021-10-28T11:28:03.381Z DEBUG orderbook::fee: unsubsidized fee amount sell_token=0xdac17f958d2ee523a2206206994597c13d831ec7 buy_token=Some(0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) amount=Some(1000000) kind=Some(Sell) gas_price=140800745777 gas_amount=111000 fee_in_eth=15628882781247000 price=0.000000004126744675 fee=64496408.79371024

