### PR TITLE
Do not settle liquidity orders in single order solver and baseline

### DIFF
--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -130,7 +130,12 @@ impl BaselineSolver {
         }
     }
 
-    fn solve_(&self, user_orders: Vec<LimitOrder>, liquidity: Vec<Liquidity>) -> Vec<Settlement> {
+    fn solve_(
+        &self,
+        mut user_orders: Vec<LimitOrder>,
+        liquidity: Vec<Liquidity>,
+    ) -> Vec<Settlement> {
+        user_orders.retain(|order| !order.is_liquidity_order);
         let amm_map =
             liquidity
                 .into_iter()

--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -132,10 +132,11 @@ impl BaselineSolver {
 
     fn solve_(
         &self,
-        mut user_orders: Vec<LimitOrder>,
+        mut limit_orders: Vec<LimitOrder>,
         liquidity: Vec<Liquidity>,
     ) -> Vec<Settlement> {
-        user_orders.retain(|order| !order.is_liquidity_order);
+        limit_orders.retain(|order| !order.is_liquidity_order);
+        let user_orders = limit_orders;
         let amm_map =
             liquidity
                 .into_iter()

--- a/solver/src/solver/single_order_solver.rs
+++ b/solver/src/solver/single_order_solver.rs
@@ -52,7 +52,10 @@ impl<I: SingleOrderSolving + Send + Sync + 'static> Solver for SingleOrderSolver
         // Randomize which orders we start with to prevent us getting stuck on bad orders.
         orders.shuffle(&mut rand::thread_rng());
 
-        let mut orders = orders.into_iter().collect::<VecDeque<_>>();
+        let mut orders = orders
+            .into_iter()
+            .filter(|order| !order.is_liquidity_order)
+            .collect::<VecDeque<_>>();
         let mut settlements = Vec::new();
         let settle = async {
             while let Some(order) = orders.pop_front() {


### PR DESCRIPTION
These solvers settle orders one by one without making use of liquidity
orders. Without this check they would treat them as user orders even
though we do not want these orders to be settled on their own.

Part of #1307 

### Test Plan
CI, existing tests make sure non liquidity orders are still being considered