### PR TITLE
Filter settlements without user orders

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -437,7 +437,8 @@ impl Driver {
                 }
             };
 
-            solver_settlements::filter_empty_settlements(&mut settlements);
+            // Do not continue with settlements that are empty or only liquidity orders.
+            settlements.retain(solver_settlements::has_user_order);
 
             for settlement in &settlements {
                 tracing::debug!("solver {} found solution:\n{:?}", name, settlement);

--- a/solver/src/solver/baseline_solver.rs
+++ b/solver/src/solver/baseline_solver.rs
@@ -130,7 +130,13 @@ impl BaselineSolver {
         }
     }
 
-    fn solve_(&self, user_orders: Vec<LimitOrder>, liquidity: Vec<Liquidity>) -> Vec<Settlement> {
+    fn solve_(
+        &self,
+        mut limit_orders: Vec<LimitOrder>,
+        liquidity: Vec<Liquidity>,
+    ) -> Vec<Settlement> {
+        limit_orders.retain(|order| !order.is_liquidity_order);
+        let user_orders = limit_orders;
         let amm_map =
             liquidity
                 .into_iter()

--- a/solver/src/solver/single_order_solver.rs
+++ b/solver/src/solver/single_order_solver.rs
@@ -52,7 +52,10 @@ impl<I: SingleOrderSolving + Send + Sync + 'static> Solver for SingleOrderSolver
         // Randomize which orders we start with to prevent us getting stuck on bad orders.
         orders.shuffle(&mut rand::thread_rng());
 
-        let mut orders = orders.into_iter().collect::<VecDeque<_>>();
+        let mut orders = orders
+            .into_iter()
+            .filter(|order| !order.is_liquidity_order)
+            .collect::<VecDeque<_>>();
         let mut settlements = Vec::new();
         let settle = async {
             while let Some(order) = orders.pop_front() {


### PR DESCRIPTION
Part of #1307

As an additional check to #1315 for all solvers. Even with this, 1315 still makes sense because we save time in the single order solvers by skipping liquidity orders.

### Test Plan
CI and new unit test