### PR TITLE
Make some logs less verbose

### DIFF
--- a/shared/src/bad_token/trace_call.rs
+++ b/shared/src/bad_token/trace_call.rs
@@ -86,7 +86,7 @@ pub struct TraceCallDetector {
 impl BadTokenDetecting for TraceCallDetector {
     async fn detect(&self, token: H160) -> Result<TokenQuality> {
         let quality = self.detect_impl(token).await?;
-        tracing::info!("token {:?} quality {:?}", token, quality);
+        tracing::debug!("token {:?} quality {:?}", token, quality);
         Ok(quality)
     }
 }

--- a/shared/src/sources/balancer/event_handler.rs
+++ b/shared/src/sources/balancer/event_handler.rs
@@ -178,7 +178,7 @@ impl EventStoring<WeightedPoolFactoryEvent> for PoolStorage {
         &mut self,
         events: Vec<EthContractEvent<WeightedPoolFactoryEvent>>,
     ) -> Result<()> {
-        tracing::info!(
+        tracing::debug!(
             "inserting {} Balancer Weighted Pools from events",
             events.len()
         );
@@ -209,7 +209,7 @@ impl EventStoring<WeightedPool2TokensFactoryEvent> for PoolStorage {
         &mut self,
         events: Vec<EthContractEvent<WeightedPool2TokensFactoryEvent>>,
     ) -> Result<()> {
-        tracing::info!(
+        tracing::debug!(
             "Inserting {} Balancer Weighted 2-Token Pools from events",
             events.len()
         );
@@ -237,7 +237,7 @@ impl EventStoring<StablePoolFactoryEvent> for PoolStorage {
         &mut self,
         events: Vec<EthContractEvent<StablePoolFactoryEvent>>,
     ) -> Result<()> {
-        tracing::info!(
+        tracing::debug!(
             "Inserting {} Balancer Stable Pools from events",
             events.len()
         );

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -335,7 +335,7 @@ impl Driver {
                 gas_estimate,
                 gas_price: gas_price_normalized.clone(),
             };
-            tracing::info!(
+            tracing::debug!(
                 "Objective value for solver {} is {}: surplus={}, gas_estimate={}, gas_price={}",
                 solver,
                 rated_settlement.objective_value(),
@@ -493,7 +493,7 @@ impl Driver {
                 .unwrap_or(false)
             {
                 settlement.settlement = settlement.settlement.without_onchain_liquidity();
-                tracing::info!("settlement without onchain liquidity");
+                tracing::debug!("settlement without onchain liquidity");
             }
 
             tracing::info!("winning settlement: {:?}", settlement);

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -320,7 +320,7 @@ impl Solver for SellVolumeFilteringSolver {
         auction.orders = self
             .filter_orders(auction.orders, &auction.price_estimates)
             .await;
-        tracing::info!(
+        tracing::debug!(
             "Filtered {} orders because on insufficient volume",
             original_length - auction.orders.len()
         );

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -241,7 +241,7 @@ impl HttpSolver {
         url.set_path("/solve");
 
         let instance_name = self.generate_instance_name();
-        tracing::info!("http solver instance name is {}", instance_name);
+        tracing::debug!("http solver instance name is {}", instance_name);
         url.query_pairs_mut()
             .append_pair("instance_name", &instance_name)
             .append_pair("time_limit", &timeout.as_secs().to_string());

--- a/solver/src/solver/naive_solver.rs
+++ b/solver/src/solver/naive_solver.rs
@@ -61,7 +61,7 @@ fn settle_pair(
     let uniswap = match uniswaps.get(&pair) {
         Some(uniswap) => uniswap,
         None => {
-            tracing::warn!("No AMM for: {:?}", pair);
+            tracing::debug!("No AMM for: {:?}", pair);
             return None;
         }
     };


### PR DESCRIPTION
by converting them from info to debug

My motivation is to to make looking at the Kibana logs easier when excluding logs at lower level than info (debug, trace). I'd like all info logs to not be too spammy and be useful to tell from a high level what the application is doing at the moment. Then we something needs to be investigated in more detail debug logs can be included in the filter.

### Test Plan
CI
