### PR TITLE
Remove redundant empty batch check

### DIFF
--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -392,9 +392,6 @@ impl Driver {
         .await;
         tracing::debug!("estimated prices: {:?}", estimated_prices);
         let orders = orders_with_price_estimates(orders, &estimated_prices);
-        if !has_at_least_one_user_order(&orders) {
-            return Ok(());
-        }
 
         self.metrics.orders_fetched(&orders);
         self.metrics.liquidity_fetched(&liquidity);


### PR DESCRIPTION
This PR just removes a redundant empty batch check that must have slipped in #1306 

I chose to remove the first check based on https://github.com/gnosis/gp-v2-services/pull/1306#issuecomment-952932177:

> Actually on second thought I will move it below the metrics because getting price estimates for a few potential PMM orders is no big deal.

### Test Plan

:pray: 
