### PR TITLE
Remove left over optionals around fee measurements

### DIFF
--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -47,7 +47,7 @@ pub fn get_fee_info(
                         amount: query.amount,
                         kind: query.kind,
                     },
-                    None,
+                    Default::default(),
                 )
                 .await;
             Result::<_, Infallible>::Ok(convert_json_response(result.map(

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -1,5 +1,5 @@
-use crate::api::convert_json_response;
 use crate::fee::MinFeeCalculating;
+use crate::{api::convert_json_response, fee::FeeData};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use model::{order::OrderKind, u256_decimal};
@@ -41,10 +41,12 @@ pub fn get_fee_info(
         async move {
             let result = fee_calculator
                 .compute_subsidized_min_fee(
-                    query.sell_token,
-                    Some(query.buy_token),
-                    Some(query.amount),
-                    Some(query.kind),
+                    FeeData {
+                        sell_token: query.sell_token,
+                        buy_token: query.buy_token,
+                        amount: query.amount,
+                        kind: query.kind,
+                    },
                     None,
                 )
                 .await;

--- a/orderbook/src/api/order_validation.rs
+++ b/orderbook/src/api/order_validation.rs
@@ -1,8 +1,14 @@
-use crate::{account_balances::BalanceFetching, api::IntoWarpReply, fee::MinFeeCalculating};
+use crate::{
+    account_balances::BalanceFetching,
+    api::IntoWarpReply,
+    fee::{FeeData, MinFeeCalculating},
+};
 use contracts::WETH9;
 use ethcontract::{H160, U256};
 use model::{
-    order::{BuyTokenDestination, Order, OrderCreation, SellTokenSource, BUY_ETH_ADDRESS},
+    order::{
+        BuyTokenDestination, Order, OrderCreation, OrderKind, SellTokenSource, BUY_ETH_ADDRESS,
+    },
     DomainSeparator,
 };
 use shared::{bad_token::BadTokenDetecting, web3_traits::CodeFetching};
@@ -270,9 +276,17 @@ impl OrderValidating for OrderValidator {
         let full_fee_amount = match self
             .fee_validator
             .get_unsubsidized_min_fee(
-                order_creation.sell_token,
-                order_creation.fee_amount,
+                FeeData {
+                    sell_token: order_creation.sell_token,
+                    buy_token: order_creation.buy_token,
+                    amount: match order_creation.kind {
+                        OrderKind::Buy => order_creation.buy_amount,
+                        OrderKind::Sell => order_creation.sell_amount,
+                    },
+                    kind: order_creation.kind,
+                },
                 Some(order_creation.app_data),
+                order_creation.fee_amount,
             )
             .await
         {
@@ -607,17 +621,17 @@ mod tests {
         fee_calculator
             .expect_get_unsubsidized_min_fee()
             .times(2)
-            .returning(|_, fee, _| Ok(fee));
+            .returning(|_, _, fee| Ok(fee));
         fee_calculator
             .expect_get_unsubsidized_min_fee()
             .times(1)
             .returning(|_, _, _| Err(()));
         fee_calculator
             .expect_get_unsubsidized_min_fee()
-            .returning(|_, fee, _| Ok(fee));
+            .returning(|_, _, fee| Ok(fee));
         fee_calculator
             .expect_get_unsubsidized_min_fee()
-            .returning(|_, fee, _| Ok(fee));
+            .returning(|_, _, fee| Ok(fee));
         bad_token_detector
             .expect_detect()
             .times(1)
@@ -767,7 +781,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         fee_calculator
             .expect_get_unsubsidized_min_fee()
-            .returning(|_, fee, _| Ok(fee));
+            .returning(|_, _, fee| Ok(fee));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));

--- a/orderbook/src/api/order_validation.rs
+++ b/orderbook/src/api/order_validation.rs
@@ -285,7 +285,7 @@ impl OrderValidating for OrderValidator {
                     },
                     kind: order_creation.kind,
                 },
-                Some(order_creation.app_data),
+                order_creation.app_data,
                 order_creation.fee_amount,
             )
             .await

--- a/orderbook/src/api/post_quote.rs
+++ b/orderbook/src/api/post_quote.rs
@@ -4,7 +4,7 @@ use crate::{
         order_validation::{OrderValidating, PreOrderData, ValidationError},
         IntoWarpReply,
     },
-    fee::MinFeeCalculating,
+    fee::{FeeData, MinFeeCalculating},
 };
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
@@ -238,10 +238,12 @@ impl OrderQuoter {
                 let (fee, expiration) = self
                     .fee_calculator
                     .compute_subsidized_min_fee(
-                        quote_request.sell_token,
-                        Some(quote_request.buy_token),
-                        Some(sell_amount_before_fee),
-                        Some(OrderKind::Sell),
+                        FeeData {
+                            sell_token: quote_request.sell_token,
+                            buy_token: quote_request.buy_token,
+                            amount: sell_amount_before_fee,
+                            kind: OrderKind::Sell,
+                        },
                         Some(quote_request.app_data),
                     )
                     .await
@@ -286,10 +288,12 @@ impl OrderQuoter {
                 let (fee, expiration) = self
                     .fee_calculator
                     .compute_subsidized_min_fee(
-                        quote_request.sell_token,
-                        Some(quote_request.buy_token),
-                        Some(buy_amount_after_fee),
-                        Some(OrderKind::Buy),
+                        FeeData {
+                            sell_token: quote_request.sell_token,
+                            buy_token: quote_request.buy_token,
+                            amount: buy_amount_after_fee,
+                            kind: OrderKind::Buy,
+                        },
                         Some(quote_request.app_data),
                     )
                     .await
@@ -539,7 +543,7 @@ mod tests {
         let expiration = Utc::now();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(move |_, _, _, _, _| Ok((U256::from(3), expiration)));
+            .returning(move |_, _| Ok((U256::from(3), expiration)));
 
         let fee_calculator = Arc::new(fee_calculator);
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
@@ -581,7 +585,7 @@ mod tests {
         let mut fee_calculator = MockMinFeeCalculating::new();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(|_, _, _, _, _| Ok((U256::from(3), Utc::now())));
+            .returning(|_, _| Ok((U256::from(3), Utc::now())));
 
         let fee_calculator = Arc::new(fee_calculator);
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
@@ -618,7 +622,7 @@ mod tests {
         let expiration = Utc::now();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(move |_, _, _, _, _| Ok((U256::from(3), expiration)));
+            .returning(move |_, _| Ok((U256::from(3), expiration)));
 
         let fee_calculator = Arc::new(fee_calculator);
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
@@ -678,7 +682,7 @@ mod tests {
         let mut fee_calculator = MockMinFeeCalculating::new();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(move |_, _, _, _, _| Ok((U256::from(3), Utc::now())));
+            .returning(move |_, _| Ok((U256::from(3), Utc::now())));
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
             out_amount: 14.into(),
             gas: 1000.into(),

--- a/orderbook/src/api/post_quote.rs
+++ b/orderbook/src/api/post_quote.rs
@@ -244,7 +244,7 @@ impl OrderQuoter {
                             amount: sell_amount_before_fee,
                             kind: OrderKind::Sell,
                         },
-                        Some(quote_request.app_data),
+                        quote_request.app_data,
                     )
                     .await
                     .map_err(FeeError::PriceEstimate)?;
@@ -294,7 +294,7 @@ impl OrderQuoter {
                             amount: buy_amount_after_fee,
                             kind: OrderKind::Buy,
                         },
-                        Some(quote_request.app_data),
+                        quote_request.app_data,
                     )
                     .await
                     .map_err(FeeError::PriceEstimate)?;

--- a/orderbook/src/database/fees.rs
+++ b/orderbook/src/database/fees.rs
@@ -1,32 +1,30 @@
 use super::{orders::DbOrderKind, Postgres};
-use crate::conversions::*;
-use crate::fee::MinFeeStoring;
+use crate::{
+    conversions::*,
+    fee::{FeeData, MinFeeStoring},
+};
 
 use anyhow::{anyhow, Context, Result};
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
-use ethcontract::{H160, U256};
-use model::order::OrderKind;
+use ethcontract::U256;
 use shared::maintenance::Maintaining;
 
 #[async_trait::async_trait]
 impl MinFeeStoring for Postgres {
     async fn save_fee_measurement(
         &self,
-        sell_token: H160,
-        buy_token: Option<H160>,
-        amount: Option<U256>,
-        kind: Option<OrderKind>,
+        fee_data: FeeData,
         expiry: DateTime<Utc>,
         min_fee: U256,
     ) -> Result<()> {
         const QUERY: &str =
             "INSERT INTO min_fee_measurements (sell_token, buy_token, amount, order_kind, expiration_timestamp, min_fee) VALUES ($1, $2, $3, $4, $5, $6);";
         sqlx::query(QUERY)
-            .bind(sell_token.as_bytes())
-            .bind(buy_token.as_ref().map(|t| t.as_bytes()))
-            .bind(amount.map(|a| u256_to_big_decimal(&a)))
-            .bind(kind.map(DbOrderKind::from))
+            .bind(fee_data.sell_token.as_bytes())
+            .bind(fee_data.buy_token.as_bytes())
+            .bind(u256_to_big_decimal(&fee_data.amount))
+            .bind(DbOrderKind::from(fee_data.kind))
             .bind(expiry)
             .bind(u256_to_big_decimal(&min_fee))
             .execute(&self.pool)
@@ -37,26 +35,23 @@ impl MinFeeStoring for Postgres {
 
     async fn read_fee_measurement(
         &self,
-        sell_token: H160,
-        buy_token: Option<H160>,
-        amount: Option<U256>,
-        kind: Option<OrderKind>,
+        fee_data: FeeData,
         min_expiry: DateTime<Utc>,
     ) -> Result<Option<U256>> {
         const QUERY: &str = "\
             SELECT MIN(min_fee) FROM min_fee_measurements \
             WHERE sell_token = $1 \
-            AND ($2 IS NULL OR buy_token = $2) \
-            AND ($3 IS NULL OR amount = $3) \
-            AND ($4 IS NULL OR order_kind = $4) \
-            AND expiration_timestamp >= $5
+            buy_token = $2 AND\
+            amount = $3 AND \
+            order_kind = $4 AND \
+            expiration_timestamp >= $5
             ";
 
         let result: Option<BigDecimal> = sqlx::query_scalar(QUERY)
-            .bind(sell_token.as_bytes())
-            .bind(buy_token.as_ref().map(|t| t.as_bytes()))
-            .bind(amount.map(|a| u256_to_big_decimal(&a)))
-            .bind(kind.map(DbOrderKind::from))
+            .bind(fee_data.sell_token.as_bytes())
+            .bind(fee_data.buy_token.as_bytes())
+            .bind(u256_to_big_decimal(&fee_data.amount))
+            .bind(DbOrderKind::from(fee_data.kind))
             .bind(min_expiry)
             .fetch_one(&self.pool)
             .await
@@ -79,7 +74,7 @@ impl Postgres {
             .bind(max_expiry)
             .execute(&self.pool)
             .await
-            .context("insert MinFeeMeasurement failed")
+            .context("remove_expired_fee_measurements failed")
             .map(|_| ())
     }
 }
@@ -97,6 +92,8 @@ impl Maintaining for Postgres {
 mod tests {
     use super::*;
     use chrono::Duration;
+    use model::order::OrderKind;
+    use primitive_types::H160;
 
     #[tokio::test]
     #[ignore]
@@ -106,45 +103,43 @@ mod tests {
 
         let now = Utc::now();
         let token_a = H160::from_low_u64_be(1);
+        let fee_data_a = FeeData {
+            sell_token: token_a,
+            buy_token: H160::from_low_u64_be(3),
+            amount: 4.into(),
+            kind: OrderKind::Sell,
+        };
         let token_b = H160::from_low_u64_be(2);
+        let fee_data_b = FeeData {
+            sell_token: token_b,
+            buy_token: token_a,
+            amount: 100.into(),
+            kind: OrderKind::Buy,
+        };
 
         // Save two measurements for token_a
-        db.save_fee_measurement(token_a, None, None, None, now, 100u32.into())
+        db.save_fee_measurement(fee_data_a, now, 100u32.into())
             .await
             .unwrap();
-        db.save_fee_measurement(
-            token_a,
-            None,
-            None,
-            None,
-            now + Duration::seconds(60),
-            200u32.into(),
-        )
-        .await
-        .unwrap();
+        db.save_fee_measurement(fee_data_a, now + Duration::seconds(60), 200u32.into())
+            .await
+            .unwrap();
 
         // Save one measurement for token_b
-        db.save_fee_measurement(
-            token_b,
-            Some(token_a),
-            Some(100.into()),
-            Some(OrderKind::Buy),
-            now,
-            10u32.into(),
-        )
-        .await
-        .unwrap();
+        db.save_fee_measurement(fee_data_b, now, 10u32.into())
+            .await
+            .unwrap();
 
         // Token A has readings valid until now and in 30s
         assert_eq!(
-            db.read_fee_measurement(token_a, None, None, None, now)
+            db.read_fee_measurement(fee_data_a, now)
                 .await
                 .unwrap()
                 .unwrap(),
             100_u32.into()
         );
         assert_eq!(
-            db.read_fee_measurement(token_a, None, None, None, now + Duration::seconds(30))
+            db.read_fee_measurement(fee_data_a, now + Duration::seconds(30))
                 .await
                 .unwrap()
                 .unwrap(),
@@ -153,55 +148,39 @@ mod tests {
 
         // Token B only has readings valid until now
         assert_eq!(
-            db.read_fee_measurement(token_b, None, None, None, now)
+            db.read_fee_measurement(fee_data_b, now)
                 .await
                 .unwrap()
                 .unwrap(),
             10u32.into()
         );
         assert_eq!(
-            db.read_fee_measurement(token_b, None, None, None, now + Duration::seconds(30))
+            db.read_fee_measurement(fee_data_b, now + Duration::seconds(30))
                 .await
                 .unwrap(),
             None
         );
 
-        // Token B has readings for right filters
+        // Token B has no reading for wrong filter
         assert_eq!(
-            db.read_fee_measurement(token_b, Some(token_a), None, None, now)
-                .await
-                .unwrap()
-                .unwrap(),
-            10u32.into()
-        );
-        assert_eq!(
-            db.read_fee_measurement(token_b, None, Some(100.into()), None, now)
-                .await
-                .unwrap()
-                .unwrap(),
-            10u32.into()
-        );
-        assert_eq!(
-            db.read_fee_measurement(token_b, None, None, Some(OrderKind::Buy), now)
-                .await
-                .unwrap()
-                .unwrap(),
-            10u32.into()
-        );
-        assert_eq!(
-            db.read_fee_measurement(token_b, None, Some(U256::zero()), None, now)
-                .await
-                .unwrap(),
+            db.read_fee_measurement(
+                FeeData {
+                    amount: 99.into(),
+                    ..fee_data_b
+                },
+                now
+            )
+            .await
+            .unwrap(),
             None
         );
 
+        // Query that previously succeeded after cleaning up expired measurements.
         db.remove_expired_fee_measurements(now + Duration::seconds(120))
             .await
             .unwrap();
         assert_eq!(
-            db.read_fee_measurement(token_b, None, None, None, now)
-                .await
-                .unwrap(),
+            db.read_fee_measurement(fee_data_b, now).await.unwrap(),
             None
         );
     }

--- a/orderbook/src/database/fees.rs
+++ b/orderbook/src/database/fees.rs
@@ -33,19 +33,20 @@ impl MinFeeStoring for Postgres {
             .map(|_| ())
     }
 
-    async fn read_fee_measurement(
+    async fn find_measurement_exact(
         &self,
         fee_data: FeeData,
         min_expiry: DateTime<Utc>,
     ) -> Result<Option<U256>> {
         const QUERY: &str = "\
             SELECT MIN(min_fee) FROM min_fee_measurements \
-            WHERE sell_token = $1 \
-            buy_token = $2 AND\
-            amount = $3 AND \
-            order_kind = $4 AND \
-            expiration_timestamp >= $5
-            ";
+            WHERE
+                sell_token = $1 AND \
+                buy_token = $2 AND \
+                amount = $3 AND \
+                order_kind = $4 AND \
+                expiration_timestamp >= $5 \
+            ;";
 
         let result: Option<BigDecimal> = sqlx::query_scalar(QUERY)
             .bind(fee_data.sell_token.as_bytes())
@@ -55,7 +56,42 @@ impl MinFeeStoring for Postgres {
             .bind(min_expiry)
             .fetch_one(&self.pool)
             .await
-            .context("load minimum fee measurement failed")?;
+            .context("find_measurement_exact")?;
+        match result {
+            Some(row) => {
+                Ok(Some(big_decimal_to_u256(&row).ok_or_else(|| {
+                    anyhow!("min fee is not an unsigned integer")
+                })?))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn find_measurement_including_larger_amount(
+        &self,
+        fee_data: FeeData,
+        min_expiry: DateTime<Utc>,
+    ) -> Result<Option<U256>> {
+        // Same as above but with `amount >=` instead of `=`.
+        const QUERY: &str = "\
+            SELECT MIN(min_fee) FROM min_fee_measurements \
+            WHERE
+                sell_token = $1 AND \
+                buy_token = $2 AND \
+                amount >= $3 AND \
+                order_kind = $4 AND \
+                expiration_timestamp >= $5 \
+            ;";
+
+        let result: Option<BigDecimal> = sqlx::query_scalar(QUERY)
+            .bind(fee_data.sell_token.as_bytes())
+            .bind(fee_data.buy_token.as_bytes())
+            .bind(u256_to_big_decimal(&fee_data.amount))
+            .bind(DbOrderKind::from(fee_data.kind))
+            .bind(min_expiry)
+            .fetch_one(&self.pool)
+            .await
+            .context("find_measurement_including_larger_amount")?;
         match result {
             Some(row) => {
                 Ok(Some(big_decimal_to_u256(&row).ok_or_else(|| {
@@ -97,7 +133,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn save_and_load_fee_measurements() {
+    async fn postgres_save_and_load_fee_measurements() {
         let db = Postgres::new("postgresql://").unwrap();
         db.clear().await.unwrap();
 
@@ -132,14 +168,14 @@ mod tests {
 
         // Token A has readings valid until now and in 30s
         assert_eq!(
-            db.read_fee_measurement(fee_data_a, now)
+            db.find_measurement_exact(fee_data_a, now)
                 .await
                 .unwrap()
                 .unwrap(),
             100_u32.into()
         );
         assert_eq!(
-            db.read_fee_measurement(fee_data_a, now + Duration::seconds(30))
+            db.find_measurement_exact(fee_data_a, now + Duration::seconds(30))
                 .await
                 .unwrap()
                 .unwrap(),
@@ -148,14 +184,14 @@ mod tests {
 
         // Token B only has readings valid until now
         assert_eq!(
-            db.read_fee_measurement(fee_data_b, now)
+            db.find_measurement_exact(fee_data_b, now)
                 .await
                 .unwrap()
                 .unwrap(),
             10u32.into()
         );
         assert_eq!(
-            db.read_fee_measurement(fee_data_b, now + Duration::seconds(30))
+            db.find_measurement_exact(fee_data_b, now + Duration::seconds(30))
                 .await
                 .unwrap(),
             None
@@ -163,7 +199,7 @@ mod tests {
 
         // Token B has no reading for wrong filter
         assert_eq!(
-            db.read_fee_measurement(
+            db.find_measurement_exact(
                 FeeData {
                     amount: 99.into(),
                     ..fee_data_b
@@ -180,7 +216,101 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            db.read_fee_measurement(fee_data_b, now).await.unwrap(),
+            db.find_measurement_exact(fee_data_b, now).await.unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_find_measurement_including_larger_amount_() {
+        let db = Postgres::new("postgresql://").unwrap();
+        db.clear().await.unwrap();
+
+        let now = Utc::now();
+        let fee_data_a = FeeData {
+            sell_token: H160::from_low_u64_be(1),
+            buy_token: H160::from_low_u64_be(3),
+            amount: 10.into(),
+            kind: OrderKind::Sell,
+        };
+
+        db.save_fee_measurement(fee_data_a, now, 100.into())
+            .await
+            .unwrap();
+        db.save_fee_measurement(
+            FeeData {
+                amount: 20.into(),
+                ..fee_data_a
+            },
+            now,
+            200.into(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            db.find_measurement_including_larger_amount(
+                FeeData {
+                    amount: 1.into(),
+                    ..fee_data_a
+                },
+                now
+            )
+            .await
+            .unwrap()
+            .unwrap(),
+            100_u32.into()
+        );
+        assert_eq!(
+            db.find_measurement_including_larger_amount(
+                FeeData {
+                    amount: 10.into(),
+                    ..fee_data_a
+                },
+                now
+            )
+            .await
+            .unwrap()
+            .unwrap(),
+            100_u32.into()
+        );
+        assert_eq!(
+            db.find_measurement_including_larger_amount(
+                FeeData {
+                    amount: 11.into(),
+                    ..fee_data_a
+                },
+                now
+            )
+            .await
+            .unwrap()
+            .unwrap(),
+            200_u32.into()
+        );
+        assert_eq!(
+            db.find_measurement_including_larger_amount(
+                FeeData {
+                    amount: 20.into(),
+                    ..fee_data_a
+                },
+                now
+            )
+            .await
+            .unwrap()
+            .unwrap(),
+            200_u32.into()
+        );
+        assert_eq!(
+            db.find_measurement_including_larger_amount(
+                FeeData {
+                    amount: 21.into(),
+                    ..fee_data_a
+                },
+                now
+            )
+            .await
+            .unwrap(),
             None
         );
     }

--- a/orderbook/src/database/instrumented.rs
+++ b/orderbook/src/database/instrumented.rs
@@ -61,10 +61,7 @@ impl EventStoring<contracts::gpv2_settlement::Event> for Instrumented {
 impl MinFeeStoring for Instrumented {
     async fn save_fee_measurement(
         &self,
-        sell_token: ethcontract::H160,
-        buy_token: Option<ethcontract::H160>,
-        amount: Option<ethcontract::U256>,
-        kind: Option<model::order::OrderKind>,
+        fee_data: crate::fee::FeeData,
         expiry: chrono::DateTime<chrono::Utc>,
         min_fee: ethcontract::U256,
     ) -> anyhow::Result<()> {
@@ -73,25 +70,20 @@ impl MinFeeStoring for Instrumented {
             .database_query_histogram("save_fee_measurement")
             .start_timer();
         self.inner
-            .save_fee_measurement(sell_token, buy_token, amount, kind, expiry, min_fee)
+            .save_fee_measurement(fee_data, expiry, min_fee)
             .await
     }
 
     async fn read_fee_measurement(
         &self,
-        sell_token: ethcontract::H160,
-        buy_token: Option<ethcontract::H160>,
-        amount: Option<ethcontract::U256>,
-        kind: Option<model::order::OrderKind>,
+        fee_data: crate::fee::FeeData,
         min_expiry: chrono::DateTime<chrono::Utc>,
     ) -> anyhow::Result<Option<ethcontract::U256>> {
         let _timer = self
             .metrics
             .database_query_histogram("read_fee_measurement")
             .start_timer();
-        self.inner
-            .read_fee_measurement(sell_token, buy_token, amount, kind, min_expiry)
-            .await
+        self.inner.read_fee_measurement(fee_data, min_expiry).await
     }
 }
 

--- a/orderbook/src/database/instrumented.rs
+++ b/orderbook/src/database/instrumented.rs
@@ -74,16 +74,32 @@ impl MinFeeStoring for Instrumented {
             .await
     }
 
-    async fn read_fee_measurement(
+    async fn find_measurement_exact(
         &self,
         fee_data: crate::fee::FeeData,
         min_expiry: chrono::DateTime<chrono::Utc>,
     ) -> anyhow::Result<Option<ethcontract::U256>> {
         let _timer = self
             .metrics
-            .database_query_histogram("read_fee_measurement")
+            .database_query_histogram("find_measurement_exact")
             .start_timer();
-        self.inner.read_fee_measurement(fee_data, min_expiry).await
+        self.inner
+            .find_measurement_exact(fee_data, min_expiry)
+            .await
+    }
+
+    async fn find_measurement_including_larger_amount(
+        &self,
+        fee_data: crate::fee::FeeData,
+        min_expiry: chrono::DateTime<chrono::Utc>,
+    ) -> anyhow::Result<Option<ethcontract::U256>> {
+        let _timer = self
+            .metrics
+            .database_query_histogram("find_measurement_including_larger_amount")
+            .start_timer();
+        self.inner
+            .find_measurement_including_larger_amount(fee_data, min_expiry)
+            .await
     }
 }
 

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -190,11 +190,6 @@ impl MinFeeCalculator {
         fee_data: FeeData,
     ) -> Result<U256, PriceEstimationError> {
         let gas_price = self.gas_estimator.estimate().await?.effective_gas_price();
-        tracing::debug!(
-            "estimated effective gas price of {:.2} Gwei",
-            gas_price / 1e9
-        );
-
         let gas_amount = self
             .price_estimator
             .estimate(&price_estimation::Query {
@@ -206,7 +201,6 @@ impl MinFeeCalculator {
             .await?
             .gas
             .to_f64_lossy();
-
         let fee_in_eth = gas_price * gas_amount;
         let query = price_estimation::Query {
             sell_token: fee_data.sell_token,
@@ -219,7 +213,7 @@ impl MinFeeCalculator {
         let fee = fee_in_eth * price;
 
         tracing::debug!(
-            ?fee_data.sell_token, ?fee_data.buy_token, ?fee_data.amount, ?fee_data.kind, %gas_price, %gas_amount, %fee_in_eth, %price, %fee,
+            ?fee_data, %gas_price, %gas_amount, %fee_in_eth, %price, %fee,
             "unsubsidized fee amount"
         );
 
@@ -250,10 +244,7 @@ impl MinFeeCalculating for MinFeeCalculator {
         let official_valid_until = now + Duration::seconds(STANDARD_VALIDITY_FOR_FEE_IN_SEC);
         let internal_valid_until = now + Duration::seconds(PERSISTED_VALIDITY_FOR_FEE_IN_SEC);
 
-        tracing::debug!(
-            ?fee_data.sell_token, ?fee_data.buy_token, ?fee_data.amount, ?fee_data.kind, ?app_data,
-            "computing subsidized fee",
-        );
+        tracing::debug!(?fee_data, ?app_data, "computing subsidized fee",);
 
         let unsubsidized_min_fee = if let Ok(Some(past_fee)) = self
             .measurements


### PR DESCRIPTION
We used to estimate fee based on sell token only so we made additional
data optional. Now we always have buy token, amount, kind so we can
clean up all the None special cases.

While most of the changes keep the logic the same we do have a
functional change. When validating a fee for a new order we previously
only took the sell token into account (see get_unsubsidized_min_fee).
This would allow someone using the api directly to get lower fee
estimates than we intended.

Fixes #1317 
Fixes #1303 

### Test Plan
CI