### PR TITLE
Include GP gas use in price estimations

### DIFF
--- a/shared/src/price_estimation.rs
+++ b/shared/src/price_estimation.rs
@@ -1,4 +1,5 @@
 pub mod baseline;
+pub mod gas;
 pub mod instrumented;
 pub mod paraswap;
 pub mod priority;
@@ -59,6 +60,7 @@ pub struct Query {
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Estimate {
     pub out_amount: U256,
+    /// full gas cost when settling this order alone on gp
     pub gas: U256,
 }
 

--- a/shared/src/price_estimation/gas.rs
+++ b/shared/src/price_estimation/gas.rs
@@ -18,7 +18,7 @@ pub const TRADE: u64 =
 
 /// lower bound for an erc20 transfer
 /// TODO: Use an average or median?
-pub const ERC20_TRANSFER: u64 = 20_000;
+pub const ERC20_TRANSFER: u64 = 25_551;
 
 /// a settlement that contains one trade
 pub const SETTLEMENT_SINGLE_TRADE: u64 = SETTLEMENT + TRADE + 2 * ERC20_TRANSFER;

--- a/shared/src/price_estimation/gas.rs
+++ b/shared/src/price_estimation/gas.rs
@@ -1,0 +1,24 @@
+///! constants to estimate gas use in GPv2
+
+/// minimum gas every settlement takes
+pub const SETTLEMENT: u64 =
+    // initial tx gas
+    32_000 +
+    // isSolver
+    7365;
+
+/// gas per trade excluding c20 transfer
+pub const TRADE: u64 =
+    // computeTradeExecutions
+    35_000 +
+    // transferFromAccounts and transferToAccount overhead
+    2 * 3000 +
+    // overhead of one interaction
+    3000;
+
+/// lower bound for an erc20 transfer
+/// TODO: Use an average or median?
+pub const ERC20_TRANSFER: u64 = 20_000;
+
+/// a settlement that contains one trade
+pub const SETTLEMENT_SINGLE_TRADE: u64 = SETTLEMENT + TRADE + 2 * ERC20_TRANSFER;

--- a/shared/src/price_estimation/paraswap.rs
+++ b/shared/src/price_estimation/paraswap.rs
@@ -1,4 +1,4 @@
-use super::{ensure_token_supported, Estimate, PriceEstimating, PriceEstimationError, Query};
+use super::{ensure_token_supported, gas, Estimate, PriceEstimating, PriceEstimationError, Query};
 use crate::{
     bad_token::BadTokenDetecting,
     paraswap_api::{ParaswapApi, ParaswapResponseError, PriceQuery, Side},
@@ -6,7 +6,7 @@ use crate::{
 };
 use anyhow::{anyhow, Context, Result};
 use model::order::OrderKind;
-use primitive_types::H160;
+use primitive_types::{H160, U256};
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -64,7 +64,7 @@ impl ParaswapPriceEstimator {
                 OrderKind::Buy => response.src_amount,
                 OrderKind::Sell => response.dest_amount,
             },
-            gas: response.gas_cost,
+            gas: U256::from(gas::SETTLEMENT_SINGLE_TRADE) + response.gas_cost,
         })
     }
 }

--- a/shared/src/price_estimation/zeroex.rs
+++ b/shared/src/price_estimation/zeroex.rs
@@ -1,9 +1,13 @@
-use crate::bad_token::BadTokenDetecting;
-use crate::price_estimation::{
-    ensure_token_supported, Estimate, PriceEstimating, PriceEstimationError, Query,
+use super::gas;
+use crate::{
+    bad_token::BadTokenDetecting,
+    price_estimation::{
+        ensure_token_supported, Estimate, PriceEstimating, PriceEstimationError, Query,
+    },
+    zeroex_api::{SwapQuery, ZeroExApi},
 };
-use crate::zeroex_api::{SwapQuery, ZeroExApi};
 use model::order::OrderKind;
+use primitive_types::U256;
 use std::sync::Arc;
 
 pub struct ZeroExPriceEstimator {
@@ -46,7 +50,7 @@ impl ZeroExPriceEstimator {
                 OrderKind::Buy => swap.sell_amount,
                 OrderKind::Sell => swap.buy_amount,
             },
-            gas: swap.estimated_gas,
+            gas: U256::from(gas::SETTLEMENT_SINGLE_TRADE) + swap.estimated_gas,
         })
     }
 }
@@ -115,7 +119,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(est.out_amount, 1110165823572443613u64.into());
-        assert_eq!(est.gas, 111000.into());
+        assert!(est.gas > 111000.into());
     }
 
     #[tokio::test]
@@ -158,7 +162,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(est.out_amount, 8986186353137488u64.into());
-        assert_eq!(est.gas, 111000.into());
+        assert!(est.gas > 111000.into());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes https://github.com/gnosis/gp-v2-services/issues/1325

I estimated the constants by looking at a few transactions in Tenderly. Maybe people more familiar with the smart contracts like @fedgiac and @nlordell have more insight on the right values.

Also changes the baseline gas estimate to use the new constants.

| hops | before | now |
| - | - | - |
| 1 | 200000 | 203365 |
| 2 | 260000 | 283365 |
| 3 | 320000 | 363365 |

### Test Plan
CI
