### PR TITLE
Update ERC20 `transfer()` gas cost.

### DIFF
--- a/shared/src/price_estimation/gas.rs
+++ b/shared/src/price_estimation/gas.rs
@@ -16,9 +16,11 @@ pub const TRADE: u64 =
     // overhead of one interaction
     3000;
 
-/// lower bound for an erc20 transfer
-/// TODO: Use an average or median?
-pub const ERC20_TRANSFER: u64 = 25_551;
+/// lower bound for an erc20 transfer.
+///
+/// Value was computed by taking 52 percentile median of `transfer()` costs
+/// of the 90% most traded tokens by volume in the month of Oct. 2021.
+pub const ERC20_TRANSFER: u64 = 27_513;
 
 /// a settlement that contains one trade
 pub const SETTLEMENT_SINGLE_TRADE: u64 = SETTLEMENT + TRADE + 2 * ERC20_TRANSFER;


### PR DESCRIPTION
This PR fixes the ERC20 `transfer()` gas cost because of issues in the Dune query.

It turns out `position(X in Y)` is 1-offset based (i.e. `Y starts with X <=> position(X in Y) = 1`).

<details><summary>Query</summary>

```sql
with
buy_tokens AS (
    SELECT distinct("buyToken") as token, count(*) as ct 
    FROM gnosis_protocol_v2."GPv2Settlement_evt_Trade"
    GROUP BY token
),

sell_tokens as (
    SELECT distinct("sellToken") as token, count(*) as ct 
    FROM gnosis_protocol_v2."GPv2Settlement_evt_Trade"
    GROUP BY token
),

all_tokens as (
    select * from buy_tokens
    union
    select * from sell_tokens
),

token_counter as (
    SELECT
        token,
        sum(ct) as popularity
    FROM all_tokens
    GROUP BY token
    ORDER BY popularity desc
),

top_ninty_percent as (
    select token from token_counter
    limit (select 9 * count(*) / 10 from token_counter)
),

transfer_costs as (
    select 
        max(gas_used) maximum, 
        min(gas_used) minimum,
        PERCENTILE_CONT(0.50) WITHIN GROUP(ORDER BY gas_used) median_average,
        avg(gas_used) mean_average,
        count(*) sample_size
    from top_ninty_percent
    inner join ethereum.transactions
    on "to" = token
    -- where "to" = '\x6810e776880c02933d47db1b9fc05908e5386b96'
    where block_time > TO_DATE('2021/10/01', 'YYYY/MM/DD') -- restrict the date.
    and success = true
    and position('\xa9059cbb' in data) = 1
)

select * from transfer_costs
```

</details>

<details><summary>Result</summary>


maximum | minimum | median_average | mean_average | sample_size
-- | -- | -- | -- | --
467848 | 21560 | 48513 | 49910.18072783892 | 7929282


</details>