### PR TITLE
Allow using private 0x api

### DIFF
--- a/orderbook/src/main.rs
+++ b/orderbook/src/main.rs
@@ -356,6 +356,17 @@ async fn main() {
     let token_info_fetcher = Arc::new(CachedTokenInfoFetcher::new(Box::new(TokenInfoFetcher {
         web3: web3.clone(),
     })));
+    let zeroex_api = Arc::new(
+        DefaultZeroExApi::new(
+            args.shared
+                .zeroex_url
+                .as_deref()
+                .unwrap_or(DefaultZeroExApi::DEFAULT_URL),
+            args.shared.zeroex_api_key.clone(),
+            client.clone(),
+        )
+        .unwrap(),
+    );
     let price_estimators = args
         .shared
         .price_estimators
@@ -389,7 +400,7 @@ async fn main() {
                 )),
                 PriceEstimatorType::ZeroEx => Box::new(InstrumentedPriceEstimator::new(
                     ZeroExPriceEstimator {
-                        client: Arc::new(DefaultZeroExApi::with_default_url(client.clone())),
+                        api: zeroex_api.clone(),
                         bad_token_detector: bad_token_detector.clone(),
                     },
                     "ZeroEx",

--- a/shared/src/arguments.rs
+++ b/shared/src/arguments.rs
@@ -126,6 +126,12 @@ pub struct Arguments {
         use_delimiter = true
     )]
     pub price_estimators: Vec<PriceEstimatorType>,
+
+    #[structopt(long, env)]
+    pub zeroex_url: Option<String>,
+
+    #[structopt(long, env)]
+    pub zeroex_api_key: Option<String>,
 }
 
 pub fn parse_fee_factor(s: &str) -> Result<f64> {

--- a/shared/src/price_estimation/zeroex.rs
+++ b/shared/src/price_estimation/zeroex.rs
@@ -11,7 +11,7 @@ use primitive_types::U256;
 use std::sync::Arc;
 
 pub struct ZeroExPriceEstimator {
-    pub client: Arc<dyn ZeroExApi + Send + Sync>,
+    pub api: Arc<dyn ZeroExApi>,
     pub bad_token_detector: Arc<dyn BadTokenDetecting>,
 }
 
@@ -33,14 +33,13 @@ impl ZeroExPriceEstimator {
         };
 
         let swap = self
-            .client
+            .api
             .get_swap(SwapQuery {
                 sell_token: query.sell_token,
                 buy_token: query.buy_token,
                 sell_amount,
                 buy_amount,
                 slippage_percentage: Default::default(),
-                skip_validation: Some(true),
             })
             .await
             .map_err(|err| PriceEstimationError::Other(err.into()))?;
@@ -107,7 +106,7 @@ mod tests {
         let gno = addr!("6810e776880c02933d47db1b9fc05908e5386b96");
 
         let estimator = ZeroExPriceEstimator {
-            client: Arc::new(zeroex_api),
+            api: Arc::new(zeroex_api),
             bad_token_detector: Arc::new(ListBasedDetector::deny_list(Vec::new())),
         };
 
@@ -153,7 +152,7 @@ mod tests {
         let gno = addr!("6810e776880c02933d47db1b9fc05908e5386b96");
 
         let estimator = ZeroExPriceEstimator {
-            client: Arc::new(zeroex_api),
+            api: Arc::new(zeroex_api),
             bad_token_detector: Arc::new(ListBasedDetector::deny_list(Vec::new())),
         };
 
@@ -174,7 +173,7 @@ mod tests {
     #[tokio::test]
     async fn same_token() {
         let estimator = ZeroExPriceEstimator {
-            client: Arc::new(MockZeroExApi::new()),
+            api: Arc::new(MockZeroExApi::new()),
             bad_token_detector: Arc::new(ListBasedDetector::deny_list(Vec::new())),
         };
 
@@ -200,7 +199,7 @@ mod tests {
         let gno = addr!("6810e776880c02933d47db1b9fc05908e5386b96");
 
         let estimator = ZeroExPriceEstimator {
-            client: Arc::new(MockZeroExApi::new()),
+            api: Arc::new(MockZeroExApi::new()),
             // we don't support this shady token -_-
             bad_token_detector: Arc::new(ListBasedDetector::deny_list(vec![gno])),
         };
@@ -229,7 +228,7 @@ mod tests {
         let gno = addr!("6810e776880c02933d47db1b9fc05908e5386b96");
 
         let estimator = ZeroExPriceEstimator {
-            client: Arc::new(DefaultZeroExApi::with_default_url(Client::new())),
+            api: Arc::new(DefaultZeroExApi::with_default_url(Client::new())),
             bad_token_detector: Arc::new(ListBasedDetector::deny_list(Vec::new())),
         };
 

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -23,6 +23,7 @@ use shared::{
     token_info::{CachedTokenInfoFetcher, TokenInfoFetcher},
     token_list::TokenList,
     transport::{create_instrumented_transport, http::HttpTransport},
+    zeroex_api::DefaultZeroExApi,
 };
 use solver::{
     driver::Driver,
@@ -413,6 +414,18 @@ async fn main() {
         }
     };
 
+    let zeroex_api = Arc::new(
+        DefaultZeroExApi::new(
+            args.shared
+                .zeroex_url
+                .as_deref()
+                .unwrap_or(DefaultZeroExApi::DEFAULT_URL),
+            args.shared.zeroex_api_key,
+            client.clone(),
+        )
+        .unwrap(),
+    );
+
     let solver = solver::solver::create(
         web3.clone(),
         solvers,
@@ -433,6 +446,7 @@ async fn main() {
         client.clone(),
         native_token_price_estimation_amount,
         metrics.clone(),
+        zeroex_api,
     )
     .expect("failure creating solvers");
     let liquidity_collector = LiquidityCollector {

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -13,6 +13,7 @@ use num::BigRational;
 use oneinch_solver::OneInchSolver;
 use paraswap_solver::ParaswapSolver;
 use reqwest::{Client, Url};
+use shared::zeroex_api::ZeroExApi;
 use shared::{
     baseline_solver::BaseTokens, conversions::U256Ext, price_estimation::PriceEstimating,
     token_info::TokenInfoFetching, Web3,
@@ -154,6 +155,7 @@ pub fn create(
     client: Client,
     native_token_amount_to_estimate_prices_with: U256,
     solver_metrics: Arc<dyn SolverMetrics>,
+    zeroex_api: Arc<dyn ZeroExApi>,
 ) -> Result<Solvers> {
     // Tiny helper function to help out with type inference. Otherwise, all
     // `Box::new(...)` expressions would have to be cast `as Box<dyn Solver>`.
@@ -236,7 +238,7 @@ pub fn create(
                         web3.clone(),
                         settlement_contract.clone(),
                         chain_id,
-                        client.clone(),
+                        zeroex_api.clone(),
                     )
                     .unwrap();
                     shared(SingleOrderSolver::new(


### PR DESCRIPTION
This helps us not run into rate limits and eventually use their RFQT liquidity.

I added the values we want to use to 1password.

### Test Plan
new ignored test that I ran