### PR TITLE
Use 0x quote endpoint for price estimations instead of price

### DIFF
--- a/shared/src/zeroex_api.rs
+++ b/shared/src/zeroex_api.rs
@@ -117,10 +117,9 @@ pub trait ZeroExApi {
     /// See [`/swap/v1/quote`](https://0x.org/docs/api#get-swapv1quote).
     async fn get_swap(&self, query: SwapQuery) -> Result<SwapResponse, ZeroExResponseError>;
 
-    /// Similar to `get_swap`: calculate parameters of a swap.
-    /// Does not return a transaction that can be sent to the 0x API.
-    ///
-    /// See [`/swap/v1/price`](https://0x.org/docs/api#get-swapv1price).
+    /// Pricing for RFQT liquidity.
+    /// - https://0x.org/docs/guides/rfqt-in-the-0x-api
+    /// - https://0x.org/docs/api#get-swapv1price
     async fn get_price(&self, query: SwapQuery) -> Result<PriceResponse, ZeroExResponseError>;
 }
 


### PR DESCRIPTION
The price endpoint is meant for use with RFQT and might include
liqudity sources that we cannot access until we support RFQT in the
driver. This could lead to quoting better prices or less gas use than we
will see when solving.

### Test Plan
CI
