### PR TITLE
Significantly improve orderbook compile times

### DIFF
--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -142,11 +142,11 @@ where
 }
 
 pub trait IntoWarpReply {
-    fn into_warp_reply(self) -> WithStatus<Json>;
+    fn into_warp_reply(self) -> ApiReply;
 }
 
 impl IntoWarpReply for anyhowError {
-    fn into_warp_reply(self) -> WithStatus<Json> {
+    fn into_warp_reply(self) -> ApiReply {
         with_status(internal_error(self), StatusCode::INTERNAL_SERVER_ERROR)
     }
 }

--- a/orderbook/src/api.rs
+++ b/orderbook/src/api.rs
@@ -32,20 +32,22 @@ pub fn handle_all_routes(
     orderbook: Arc<Orderbook>,
     quoter: Arc<OrderQuoter>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    let create_order = create_order::create_order(orderbook.clone());
-    let get_orders = get_orders::get_orders(orderbook.clone());
-    let fee_info = get_fee_info::get_fee_info(quoter.fee_calculator.clone());
-    let get_order = get_order_by_uid::get_order_by_uid(orderbook.clone());
-    let get_solvable_orders = get_solvable_orders::get_solvable_orders(orderbook.clone());
-    let get_solvable_orders_v2 = get_solvable_orders_v2::get_solvable_orders(orderbook.clone());
-    let get_trades = get_trades::get_trades(database);
-    let cancel_order = cancel_order::cancel_order(orderbook.clone());
-    let get_amount_estimate = get_markets::get_amount_estimate(quoter.price_estimator.clone());
-    let get_fee_and_quote_sell = get_fee_and_quote::get_fee_and_quote_sell(quoter.clone());
-    let get_fee_and_quote_buy = get_fee_and_quote::get_fee_and_quote_buy(quoter.clone());
-    let get_user_orders = get_user_orders::get_user_orders(orderbook.clone());
-    let get_orders_by_tx = get_orders_by_tx::get_orders_by_tx(orderbook);
-    let post_quote = post_quote::post_quote(quoter);
+    let create_order = create_order::create_order(orderbook.clone()).boxed();
+    let get_orders = get_orders::get_orders(orderbook.clone()).boxed();
+    let fee_info = get_fee_info::get_fee_info(quoter.fee_calculator.clone()).boxed();
+    let get_order = get_order_by_uid::get_order_by_uid(orderbook.clone()).boxed();
+    let get_solvable_orders = get_solvable_orders::get_solvable_orders(orderbook.clone()).boxed();
+    let get_solvable_orders_v2 =
+        get_solvable_orders_v2::get_solvable_orders(orderbook.clone()).boxed();
+    let get_trades = get_trades::get_trades(database).boxed();
+    let cancel_order = cancel_order::cancel_order(orderbook.clone()).boxed();
+    let get_amount_estimate =
+        get_markets::get_amount_estimate(quoter.price_estimator.clone()).boxed();
+    let get_fee_and_quote_sell = get_fee_and_quote::get_fee_and_quote_sell(quoter.clone()).boxed();
+    let get_fee_and_quote_buy = get_fee_and_quote::get_fee_and_quote_buy(quoter.clone()).boxed();
+    let get_user_orders = get_user_orders::get_user_orders(orderbook.clone()).boxed();
+    let get_orders_by_tx = get_orders_by_tx::get_orders_by_tx(orderbook).boxed();
+    let post_quote = post_quote::post_quote(quoter).boxed();
     let cors = warp::cors()
         .allow_any_origin()
         .allow_methods(vec!["GET", "POST", "DELETE", "OPTIONS", "PUT", "PATCH"])
@@ -73,6 +75,8 @@ pub fn handle_all_routes(
 
     routes_with_labels.recover(handle_rejection).with(cors)
 }
+
+pub type ApiReply = warp::reply::WithStatus<warp::reply::Json>;
 
 // We turn Rejection into Reply to workaround warp not setting CORS headers on rejections.
 async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {

--- a/orderbook/src/api/cancel_order.rs
+++ b/orderbook/src/api/cancel_order.rs
@@ -8,7 +8,7 @@ use model::{
 };
 use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, sync::Arc};
-use warp::{hyper::StatusCode, Filter, Rejection, Reply};
+use warp::{hyper::StatusCode, Filter, Rejection};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -29,7 +29,7 @@ pub fn cancel_order_request(
         })
 }
 
-pub fn cancel_order_response(result: Result<OrderCancellationResult>) -> impl Reply {
+pub fn cancel_order_response(result: Result<OrderCancellationResult>) -> super::ApiReply {
     let (body, status_code) = match result {
         Ok(OrderCancellationResult::Cancelled) => (warp::reply::json(&"Cancelled"), StatusCode::OK),
         Ok(OrderCancellationResult::InvalidSignature) => (
@@ -73,7 +73,7 @@ pub fn cancel_order_response(result: Result<OrderCancellationResult>) -> impl Re
 
 pub fn cancel_order(
     orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
     cancel_order_request().and_then(move |order| {
         let orderbook = orderbook.clone();
         async move {
@@ -89,7 +89,7 @@ mod tests {
     use ethcontract::H256;
     use hex_literal::hex;
     use serde_json::json;
-    use warp::test::request;
+    use warp::{test::request, Reply};
 
     #[test]
     fn cancellation_payload_deserialization() {

--- a/orderbook/src/api/get_fee_and_quote.rs
+++ b/orderbook/src/api/get_fee_and_quote.rs
@@ -8,7 +8,7 @@ use ethcontract::{H160, U256};
 use model::u256_decimal;
 use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, sync::Arc};
-use warp::{Filter, Rejection, Reply};
+use warp::{Filter, Rejection};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -117,7 +117,7 @@ fn buy_request() -> impl Filter<Extract = (BuyQuery,), Error = Rejection> + Clon
 
 pub fn get_fee_and_quote_sell(
     quoter: Arc<OrderQuoter>,
-) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
     sell_request().and_then(move |query: SellQuery| {
         let quoter = quoter.clone();
         async move {
@@ -133,7 +133,7 @@ pub fn get_fee_and_quote_sell(
 
 pub fn get_fee_and_quote_buy(
     quoter: Arc<OrderQuoter>,
-) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
     buy_request().and_then(move |query: BuyQuery| {
         let quoter = quoter.clone();
         async move {

--- a/orderbook/src/api/get_fee_info.rs
+++ b/orderbook/src/api/get_fee_info.rs
@@ -7,7 +7,7 @@ use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
 use std::sync::Arc;
-use warp::{Filter, Rejection, Reply};
+use warp::{Filter, Rejection};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -35,7 +35,7 @@ fn get_fee_info_request() -> impl Filter<Extract = (Query,), Error = Rejection> 
 
 pub fn get_fee_info(
     fee_calculator: Arc<dyn MinFeeCalculating>,
-) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
     get_fee_info_request().and_then(move |query: Query| {
         let fee_calculator = fee_calculator.clone();
         async move {
@@ -67,7 +67,7 @@ mod tests {
     use chrono::FixedOffset;
     use shared::price_estimation::PriceEstimationError;
     use warp::hyper::StatusCode;
-    use warp::test::request;
+    use warp::{test::request, Reply};
 
     #[tokio::test]
     async fn get_fee_info_request_ok() {

--- a/orderbook/src/api/get_markets.rs
+++ b/orderbook/src/api/get_markets.rs
@@ -5,7 +5,7 @@ use model::order::OrderKind;
 use serde::{Deserialize, Serialize};
 use shared::price_estimation::{self, PriceEstimating};
 use std::{convert::Infallible, str::FromStr, sync::Arc};
-use warp::{Filter, Rejection, Reply};
+use warp::{Filter, Rejection};
 
 #[derive(Clone, Debug, PartialEq)]
 struct AmountEstimateQuery {
@@ -67,7 +67,7 @@ fn get_amount_estimate_request(
 
 pub fn get_amount_estimate(
     price_estimator: Arc<dyn PriceEstimating>,
-) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
     get_amount_estimate_request().and_then(move |query: AmountEstimateQuery| {
         let price_estimator = price_estimator.clone();
         async move {
@@ -103,7 +103,7 @@ mod tests {
     use hex_literal::hex;
     use shared::price_estimation::PriceEstimationError;
     use warp::hyper::StatusCode;
-    use warp::test::request;
+    use warp::{test::request, Reply};
 
     #[tokio::test]
     async fn test_get_amount_estimate_request() {

--- a/orderbook/src/api/get_orders.rs
+++ b/orderbook/src/api/get_orders.rs
@@ -7,7 +7,7 @@ use primitive_types::H160;
 use serde::Deserialize;
 use shared::time::now_in_epoch_seconds;
 use std::{convert::Infallible, sync::Arc};
-use warp::{hyper::StatusCode, Filter, Rejection, Reply};
+use warp::{hyper::StatusCode, Filter, Rejection};
 
 // The default values create a filter that only includes valid orders.
 #[derive(Default, Deserialize)]
@@ -60,7 +60,7 @@ pub fn get_orders_request(
 
 pub fn get_orders(
     orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
     get_orders_request().and_then(move |order_filter| {
         let orderbook = orderbook.clone();
         async move {

--- a/orderbook/src/api/get_orders_by_tx.rs
+++ b/orderbook/src/api/get_orders_by_tx.rs
@@ -2,7 +2,7 @@ use crate::{api::convert_json_response, orderbook::Orderbook};
 use anyhow::Result;
 use ethcontract::H256;
 use std::{convert::Infallible, sync::Arc};
-use warp::{Filter, Rejection, Reply};
+use warp::{Filter, Rejection};
 
 pub fn get_orders_by_tx_request() -> impl Filter<Extract = (H256,), Error = Rejection> + Clone {
     warp::path!("transactions" / H256 / "orders").and(warp::get())
@@ -10,7 +10,7 @@ pub fn get_orders_by_tx_request() -> impl Filter<Extract = (H256,), Error = Reje
 
 pub fn get_orders_by_tx(
     orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
     get_orders_by_tx_request().and_then(move |hash: H256| {
         let orderbook = orderbook.clone();
         async move {

--- a/orderbook/src/api/get_solvable_orders.rs
+++ b/orderbook/src/api/get_solvable_orders.rs
@@ -1,7 +1,7 @@
 use crate::{api::convert_json_response, orderbook::Orderbook};
 use anyhow::Result;
 use std::{convert::Infallible, sync::Arc};
-use warp::{Filter, Rejection, Reply};
+use warp::{Filter, Rejection};
 
 fn get_solvable_orders_request() -> impl Filter<Extract = (), Error = Rejection> + Clone {
     warp::path!("solvable_orders").and(warp::get())
@@ -9,7 +9,7 @@ fn get_solvable_orders_request() -> impl Filter<Extract = (), Error = Rejection>
 
 pub fn get_solvable_orders(
     orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
     get_solvable_orders_request().and_then(move || {
         let orderbook = orderbook.clone();
         async move {

--- a/orderbook/src/api/get_solvable_orders_v2.rs
+++ b/orderbook/src/api/get_solvable_orders_v2.rs
@@ -1,7 +1,7 @@
 use crate::{api::convert_json_response, orderbook::Orderbook};
 use anyhow::Result;
 use std::{convert::Infallible, sync::Arc};
-use warp::{Filter, Rejection, Reply};
+use warp::{Filter, Rejection};
 
 fn get_solvable_orders_request() -> impl Filter<Extract = (), Error = Rejection> + Clone {
     warp::path!("solvable_orders").and(warp::get())
@@ -9,7 +9,7 @@ fn get_solvable_orders_request() -> impl Filter<Extract = (), Error = Rejection>
 
 pub fn get_solvable_orders(
     orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
     get_solvable_orders_request().and_then(move || {
         let orderbook = orderbook.clone();
         async move {
@@ -29,7 +29,7 @@ mod tests {
     use super::*;
     use crate::api::response_body;
     use model::SolvableOrders;
-    use warp::hyper::StatusCode;
+    use warp::{hyper::StatusCode, Reply};
 
     #[tokio::test]
     async fn serialize_response() {

--- a/orderbook/src/api/get_trades.rs
+++ b/orderbook/src/api/get_trades.rs
@@ -7,7 +7,7 @@ use model::order::OrderUid;
 use primitive_types::H160;
 use serde::Deserialize;
 use std::{convert::Infallible, sync::Arc};
-use warp::{hyper::StatusCode, Filter, Rejection, Reply};
+use warp::{hyper::StatusCode, Filter, Rejection};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -49,7 +49,7 @@ fn get_trades_request(
 
 pub fn get_trades(
     db: Arc<dyn TradeRetrieving>,
-) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
     get_trades_request().and_then(move |request_result| {
         let database = db.clone();
         async move {

--- a/orderbook/src/api/get_user_orders.rs
+++ b/orderbook/src/api/get_user_orders.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use primitive_types::H160;
 use serde::Deserialize;
 use std::{convert::Infallible, sync::Arc};
-use warp::{hyper::StatusCode, reply::with_status, Filter, Rejection, Reply};
+use warp::{hyper::StatusCode, reply::with_status, Filter, Rejection};
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 struct Query {
@@ -19,7 +19,7 @@ fn request() -> impl Filter<Extract = (H160, Query), Error = Rejection> + Clone 
 
 pub fn get_user_orders(
     orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
     request().and_then(move |owner: H160, query: Query| {
         let orderbook = orderbook.clone();
         async move {

--- a/orderbook/src/api/order_validation.rs
+++ b/orderbook/src/api/order_validation.rs
@@ -13,10 +13,7 @@ use model::{
 };
 use shared::{bad_token::BadTokenDetecting, web3_traits::CodeFetching};
 use std::{sync::Arc, time::Duration};
-use warp::{
-    http::StatusCode,
-    reply::{with_status, Json, WithStatus},
-};
+use warp::{http::StatusCode, reply::with_status};
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
@@ -66,7 +63,7 @@ pub enum PartialValidationError {
 }
 
 impl IntoWarpReply for PartialValidationError {
-    fn into_warp_reply(self) -> WithStatus<Json> {
+    fn into_warp_reply(self) -> super::ApiReply {
         match self {
             Self::UnsupportedBuyTokenDestination(dest) => with_status(
                 super::error("UnsupportedBuyTokenDestination", format!("Type {:?}", dest)),
@@ -122,7 +119,7 @@ pub enum ValidationError {
 }
 
 impl IntoWarpReply for ValidationError {
-    fn into_warp_reply(self) -> WithStatus<Json> {
+    fn into_warp_reply(self) -> super::ApiReply {
         match self {
             ValidationError::Partial(pre) => pre.into_warp_reply(),
             Self::UnsupportedToken(token) => with_status(

--- a/orderbook/src/api/post_quote.rs
+++ b/orderbook/src/api/post_quote.rs
@@ -20,7 +20,7 @@ use std::{convert::Infallible, sync::Arc};
 use warp::{
     hyper::StatusCode,
     reply::{Json, WithStatus},
-    Filter, Rejection, Reply,
+    Filter, Rejection,
 };
 
 /// The order parameters to quote a price and fee for.
@@ -342,7 +342,7 @@ fn post_quote_request() -> impl Filter<Extract = (OrderQuoteRequest,), Error = R
 
 pub fn post_quote(
     quoter: Arc<OrderQuoter>,
-) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
     post_quote_request().and_then(move |request: OrderQuoteRequest| {
         let quoter = quoter.clone();
         async move {
@@ -366,7 +366,7 @@ mod tests {
     use futures::FutureExt;
     use serde_json::json;
     use shared::price_estimation::mocks::FakePriceEstimator;
-    use warp::test::request;
+    use warp::{test::request, Reply};
 
     #[test]
     fn deserializes_sell_after_fees_quote_request() {

--- a/orderbook/src/api/post_quote.rs
+++ b/orderbook/src/api/post_quote.rs
@@ -17,11 +17,7 @@ use model::{
 use serde::{Deserialize, Serialize};
 use shared::price_estimation::{self, PriceEstimating, PriceEstimationError};
 use std::{convert::Infallible, sync::Arc};
-use warp::{
-    hyper::StatusCode,
-    reply::{Json, WithStatus},
-    Filter, Rejection,
-};
+use warp::{hyper::StatusCode, Filter, Rejection};
 
 /// The order parameters to quote a price and fee for.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq)]
@@ -129,7 +125,7 @@ pub enum FeeError {
 }
 
 impl IntoWarpReply for FeeError {
-    fn into_warp_reply(self) -> WithStatus<Json> {
+    fn into_warp_reply(self) -> super::ApiReply {
         match self {
             FeeError::PriceEstimate(err) => err.into_warp_reply(),
             FeeError::SellAmountDoesNotCoverFee => warp::reply::with_status(
@@ -150,7 +146,7 @@ pub enum OrderQuoteError {
 }
 
 impl IntoWarpReply for OrderQuoteError {
-    fn into_warp_reply(self) -> WithStatus<Json> {
+    fn into_warp_reply(self) -> super::ApiReply {
         match self {
             OrderQuoteError::Fee(err) => err.into_warp_reply(),
             OrderQuoteError::Order(err) => err.into_warp_reply(),

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -17,6 +17,7 @@ use futures::Future;
 use model::DomainSeparator;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::{task, task::JoinHandle};
+use warp::Filter;
 
 pub fn serve_api(
     database: Arc<dyn TradeRetrieving>,
@@ -25,7 +26,7 @@ pub fn serve_api(
     address: SocketAddr,
     shutdown_receiver: impl Future<Output = ()> + Send + 'static,
 ) -> JoinHandle<()> {
-    let filter = api::handle_all_routes(database, orderbook, quoter);
+    let filter = api::handle_all_routes(database, orderbook, quoter).boxed();
     tracing::info!(%address, "serving order book");
     let (_, server) = warp::serve(filter).bind_with_graceful_shutdown(address, shutdown_receiver);
     task::spawn(server)


### PR DESCRIPTION
This appears to be a regression in Rust 1.56 where complicated types like what we create with Warp here take a long time to compile when having their trait bounds checked. Workaround is to box them. This has negligible performance impact.

To measure compilation time I ran

```
touch orderbook/src/api.rs && time cargo build --bin orderbook
```

multiple times. With this change I get 4s and without this change 26 s.

### Test Plan
CI
