### PR TITLE
Store all parts the the fee amount is made of separately in DB

### DIFF
--- a/database/sql/V018__decompose_fee_measurements.sql
+++ b/database/sql/V018__decompose_fee_measurements.sql
@@ -1,0 +1,12 @@
+-- Delete all existing fee measurements. Fee measurements are temporary anyway,
+-- so we aren't loosing any important information. At worst, we will cause
+-- some "insufficient fee errors" right when the migration happens.
+DELETE FROM min_fee_measurements;
+
+-- Now alter the table and instead of storing the minimum fee directly, store it
+-- as a gas amount and token gas price.
+ALTER TABLE min_fee_measurements 
+  DROP COLUMN min_fee,
+  ADD COLUMN gas_amount double precision NOT NULL,
+  ADD COLUMN gas_price double precision NOT NULL,
+  ADD COLUMN sell_token_price double precision NOT NULL;

--- a/orderbook/src/database/fees.rs
+++ b/orderbook/src/database/fees.rs
@@ -134,6 +134,17 @@ mod tests {
     use model::order::OrderKind;
     use primitive_types::H160;
 
+    // Convenience to allow using u32 in tests instead of the struct
+    impl From<u32> for UnsubsidizedFee {
+        fn from(v: u32) -> Self {
+            UnsubsidizedFee {
+                gas_amount: v as f64,
+                gas_price: 1.0,
+                sell_token_price: 1.0,
+            }
+        }
+    }
+
     #[tokio::test]
     #[ignore]
     async fn postgres_save_and_load_fee_measurements() {

--- a/orderbook/src/database/fees.rs
+++ b/orderbook/src/database/fees.rs
@@ -1,14 +1,26 @@
 use super::{orders::DbOrderKind, Postgres};
-use crate::{
-    conversions::*,
-    fee::{FeeData, MinFeeStoring},
-};
+use crate::{conversions::*, fee::{FeeData, MinFeeStoring, UnsubsidizedFee}};
 
-use anyhow::{anyhow, Context, Result};
-use bigdecimal::BigDecimal;
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
-use ethcontract::U256;
 use shared::maintenance::Maintaining;
+
+#[derive(sqlx::FromRow)]
+struct FeeRow {
+    pub gas_amount: f64,
+    pub gas_price: f64,
+    pub sell_token_price: f64,
+}
+
+impl FeeRow {
+    fn into_fee(self) -> UnsubsidizedFee {
+        UnsubsidizedFee {
+            gas_amount: self.gas_amount,
+            gas_price: self.gas_price,
+            sell_token_price: self.sell_token_price,
+        }
+    }
+}
 
 #[async_trait::async_trait]
 impl MinFeeStoring for Postgres {
@@ -16,17 +28,19 @@ impl MinFeeStoring for Postgres {
         &self,
         fee_data: FeeData,
         expiry: DateTime<Utc>,
-        min_fee: U256,
+        estimate: UnsubsidizedFee,
     ) -> Result<()> {
         const QUERY: &str =
-            "INSERT INTO min_fee_measurements (sell_token, buy_token, amount, order_kind, expiration_timestamp, min_fee) VALUES ($1, $2, $3, $4, $5, $6);";
+            "INSERT INTO min_fee_measurements (sell_token, buy_token, amount, order_kind, expiration_timestamp, gas_amount, gas_price, sell_token_price) VALUES ($1, $2, $3, $4, $5, $6, $7, $8);";
         sqlx::query(QUERY)
             .bind(fee_data.sell_token.as_bytes())
             .bind(fee_data.buy_token.as_bytes())
             .bind(u256_to_big_decimal(&fee_data.amount))
             .bind(DbOrderKind::from(fee_data.kind))
             .bind(expiry)
-            .bind(u256_to_big_decimal(&min_fee))
+            .bind(&estimate.gas_amount)
+            .bind(&estimate.gas_price)
+            .bind(&estimate.sell_token_price)
             .execute(&self.pool)
             .await
             .context("insert MinFeeMeasurement failed")
@@ -37,69 +51,58 @@ impl MinFeeStoring for Postgres {
         &self,
         fee_data: FeeData,
         min_expiry: DateTime<Utc>,
-    ) -> Result<Option<U256>> {
+    ) -> Result<Option<UnsubsidizedFee>> {
+        // Fetches the lowest fee estimate we may have for the user
         const QUERY: &str = "\
-            SELECT MIN(min_fee) FROM min_fee_measurements \
+            SELECT gas_amount, gas_price, sell_token_price FROM min_fee_measurements \
             WHERE
                 sell_token = $1 AND \
                 buy_token = $2 AND \
                 amount = $3 AND \
                 order_kind = $4 AND \
                 expiration_timestamp >= $5 \
+            ORDER BY gas_amount * gas_price * sell_token_price ASC \
             ;";
 
-        let result: Option<BigDecimal> = sqlx::query_scalar(QUERY)
+        let result: Option<FeeRow> = sqlx::query_as(QUERY)
             .bind(fee_data.sell_token.as_bytes())
             .bind(fee_data.buy_token.as_bytes())
             .bind(u256_to_big_decimal(&fee_data.amount))
             .bind(DbOrderKind::from(fee_data.kind))
             .bind(min_expiry)
-            .fetch_one(&self.pool)
+            .fetch_optional(&self.pool)
             .await
             .context("find_measurement_exact")?;
-        match result {
-            Some(row) => {
-                Ok(Some(big_decimal_to_u256(&row).ok_or_else(|| {
-                    anyhow!("min fee is not an unsigned integer")
-                })?))
-            }
-            None => Ok(None),
-        }
+        Ok(result.map(FeeRow::into_fee))
     }
 
     async fn find_measurement_including_larger_amount(
         &self,
         fee_data: FeeData,
         min_expiry: DateTime<Utc>,
-    ) -> Result<Option<U256>> {
+    ) -> Result<Option<UnsubsidizedFee>> {
         // Same as above but with `amount >=` instead of `=`.
         const QUERY: &str = "\
-            SELECT MIN(min_fee) FROM min_fee_measurements \
+            SELECT gas_amount, gas_price, sell_token_price FROM min_fee_measurements \
             WHERE
                 sell_token = $1 AND \
                 buy_token = $2 AND \
                 amount >= $3 AND \
                 order_kind = $4 AND \
                 expiration_timestamp >= $5 \
+            ORDER BY gas_amount * gas_price * sell_token_price ASC \
             ;";
 
-        let result: Option<BigDecimal> = sqlx::query_scalar(QUERY)
+        let result: Option<FeeRow> = sqlx::query_as(QUERY)
             .bind(fee_data.sell_token.as_bytes())
             .bind(fee_data.buy_token.as_bytes())
             .bind(u256_to_big_decimal(&fee_data.amount))
             .bind(DbOrderKind::from(fee_data.kind))
             .bind(min_expiry)
-            .fetch_one(&self.pool)
+            .fetch_optional(&self.pool)
             .await
             .context("find_measurement_including_larger_amount")?;
-        match result {
-            Some(row) => {
-                Ok(Some(big_decimal_to_u256(&row).ok_or_else(|| {
-                    anyhow!("min fee is not an unsigned integer")
-                })?))
-            }
-            None => Ok(None),
-        }
+        Ok(result.map(FeeRow::into_fee))
     }
 }
 

--- a/orderbook/src/database/fees.rs
+++ b/orderbook/src/database/fees.rs
@@ -10,9 +10,9 @@ use shared::maintenance::Maintaining;
 
 #[derive(sqlx::FromRow)]
 struct FeeRow {
-    pub gas_amount: f64,
-    pub gas_price: f64,
-    pub sell_token_price: f64,
+    gas_amount: f64,
+    gas_price: f64,
+    sell_token_price: f64,
 }
 
 impl FeeRow {

--- a/orderbook/src/database/fees.rs
+++ b/orderbook/src/database/fees.rs
@@ -1,5 +1,8 @@
 use super::{orders::DbOrderKind, Postgres};
-use crate::{conversions::*, fee::{FeeData, MinFeeStoring, UnsubsidizedFee}};
+use crate::{
+    conversions::*,
+    fee::{FeeData, MinFeeStoring, UnsubsidizedFee},
+};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
@@ -62,6 +65,7 @@ impl MinFeeStoring for Postgres {
                 order_kind = $4 AND \
                 expiration_timestamp >= $5 \
             ORDER BY gas_amount * gas_price * sell_token_price ASC \
+            LIMIT 1 \
             ;";
 
         let result: Option<FeeRow> = sqlx::query_as(QUERY)
@@ -91,6 +95,7 @@ impl MinFeeStoring for Postgres {
                 order_kind = $4 AND \
                 expiration_timestamp >= $5 \
             ORDER BY gas_amount * gas_price * sell_token_price ASC \
+            LIMIT 1 \
             ;";
 
         let result: Option<FeeRow> = sqlx::query_as(QUERY)

--- a/orderbook/src/database/instrumented.rs
+++ b/orderbook/src/database/instrumented.rs
@@ -1,5 +1,5 @@
 use super::{orders::OrderStoring, trades::TradeRetrieving, Postgres};
-use crate::fee::MinFeeStoring;
+use crate::fee::{MinFeeStoring, UnsubsidizedFee};
 use ethcontract::H256;
 use model::order::Order;
 use prometheus::Histogram;
@@ -63,14 +63,14 @@ impl MinFeeStoring for Instrumented {
         &self,
         fee_data: crate::fee::FeeData,
         expiry: chrono::DateTime<chrono::Utc>,
-        min_fee: ethcontract::U256,
+        estimate: UnsubsidizedFee,
     ) -> anyhow::Result<()> {
         let _timer = self
             .metrics
             .database_query_histogram("save_fee_measurement")
             .start_timer();
         self.inner
-            .save_fee_measurement(fee_data, expiry, min_fee)
+            .save_fee_measurement(fee_data, expiry, estimate)
             .await
     }
 
@@ -78,7 +78,7 @@ impl MinFeeStoring for Instrumented {
         &self,
         fee_data: crate::fee::FeeData,
         min_expiry: chrono::DateTime<chrono::Utc>,
-    ) -> anyhow::Result<Option<ethcontract::U256>> {
+    ) -> anyhow::Result<Option<UnsubsidizedFee>> {
         let _timer = self
             .metrics
             .database_query_histogram("find_measurement_exact")
@@ -92,7 +92,7 @@ impl MinFeeStoring for Instrumented {
         &self,
         fee_data: crate::fee::FeeData,
         min_expiry: chrono::DateTime<chrono::Utc>,
-    ) -> anyhow::Result<Option<ethcontract::U256>> {
+    ) -> anyhow::Result<Option<UnsubsidizedFee>> {
         let _timer = self
             .metrics
             .database_query_histogram("find_measurement_including_larger_amount")

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -10,7 +10,10 @@ use shared::{
     bad_token::BadTokenDetecting,
     price_estimation::{self, ensure_token_supported, PriceEstimating, PriceEstimationError},
 };
-use std::{collections::HashMap, sync::{Arc, Mutex}};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 pub type Measurement = (U256, DateTime<Utc>);
 
@@ -362,13 +365,19 @@ impl MinFeeCalculating for MinFeeCalculator {
             .await
         {
             if subsidized_fee >= self.apply_fee_factor(past_fee, app_data) {
-                return Ok(std::cmp::max(subsidized_fee, U256::from_f64_lossy(past_fee.amount_in_sell_token())));
+                return Ok(std::cmp::max(
+                    subsidized_fee,
+                    U256::from_f64_lossy(past_fee.amount_in_sell_token()),
+                ));
             }
         }
 
         if let Ok(current_fee) = self.compute_unsubsidized_min_fee(fee_data).await {
             if subsidized_fee >= self.apply_fee_factor(current_fee, app_data) {
-                return Ok(std::cmp::max(subsidized_fee, U256::from_f64_lossy(current_fee.amount_in_sell_token())));
+                return Ok(std::cmp::max(
+                    subsidized_fee,
+                    U256::from_f64_lossy(current_fee.amount_in_sell_token()),
+                ));
             }
         }
 
@@ -788,7 +797,7 @@ mod tests {
         let unsubsidized_min_fee = UnsubsidizedFee {
             gas_amount: 1337.,
             sell_token_price,
-            gas_price: gas_estimate
+            gas_price: gas_estimate,
         };
 
         let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -76,7 +76,7 @@ pub struct FeeData {
 }
 
 /// Everything required to compute the fee amount in sell token
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct UnsubsidizedFee {
     pub gas_amount: f64,
     pub gas_price: f64,
@@ -785,7 +785,11 @@ mod tests {
         let sell_token_price = 1.25;
         let gas_estimate = 42.;
 
-        let unsubsidized_min_fee = U256::from_f64_lossy(1337. * sell_token_price * gas_estimate);
+        let unsubsidized_min_fee = UnsubsidizedFee {
+            gas_amount: 1337.,
+            sell_token_price,
+            gas_price: gas_estimate
+        };
 
         let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(
             EstimatedGasPrice {
@@ -845,7 +849,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             fee,
-            U256::from_f64_lossy(unsubsidized_min_fee.to_f64_lossy() * 0.8 * 0.5)
+            U256::from_f64_lossy(unsubsidized_min_fee.amount_in_sell_token() * 0.8 * 0.5)
         );
 
         let (fee, _) = fee_estimator
@@ -854,7 +858,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             fee,
-            U256::from_f64_lossy(unsubsidized_min_fee.to_f64_lossy() * 0.8)
+            U256::from_f64_lossy(unsubsidized_min_fee.amount_in_sell_token() * 0.8)
         );
     }
 }


### PR DESCRIPTION
Part of #1333 (other side of #1348)

This PR changes the fee measurement table in a way that allows us to recover the amount of eth that the estimate was based on (by storing gas price as well as gas amount).

This allows us to not only apply a subsidy factor, but also a concrete subsidy in fixed eth (or even just gas units if we wanted to).

**Note about a sneaky change:** While debugging this, I noticed that we swallow DB errors in the fee estimation silently and just keep re-querying fee estimates in case of DB errors. I found this dangerous (as it's easy to commit a faulty SQL query without getting errors) and therefor changed the logic to error on DB query errors.

### Test Plan
Existing unit tests (when they are fixed) + made sure that I can locally quote and place orders (checking logs that measurements are read correctly)
