### PR TITLE
Apply flat fee

### DIFF
--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -97,7 +97,11 @@ impl UnsubsidizedFee {
         app_data: AppId,
     ) -> U256 {
         let fee_in_eth = self.gas_amount * self.gas_price;
-        let discounted_fee_in_eth = (0f64).max(fee_in_eth - fee_configuration.fee_discount);
+        let mut discounted_fee_in_eth = fee_in_eth - fee_configuration.fee_discount;
+        if discounted_fee_in_eth < 0. {
+            tracing::warn!("Computed negative fee after applying fee discount: {}, capping at 0", discounted_fee_in_eth);
+            discounted_fee_in_eth = 0.;
+        }
         let factor = fee_configuration
             .partner_additional_fee_factors
             .get(&app_data)

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -90,6 +90,22 @@ impl UnsubsidizedFee {
     fn amount_in_sell_token(&self) -> f64 {
         self.gas_amount * self.gas_price * self.sell_token_price
     }
+
+    fn apply_fee_factor(
+        &self,
+        fee_configuration: &FeeSubsidyConfiguration,
+        app_data: AppId,
+    ) -> U256 {
+        let fee_in_eth = self.gas_amount * self.gas_price;
+        let discounted_fee_in_eth = (0f64).max(fee_in_eth - fee_configuration.fee_discount);
+        let factor = fee_configuration
+            .partner_additional_fee_factors
+            .get(&app_data)
+            .copied()
+            .unwrap_or(1.0)
+            * fee_configuration.fee_factor;
+        U256::from_f64_lossy(discounted_fee_in_eth * self.sell_token_price * factor)
+    }
 }
 
 #[cfg_attr(test, mockall::automock)]
@@ -225,13 +241,6 @@ impl MinFeeCalculator {
         native_token_price_estimation_amount: U256,
         fee_subsidy: FeeSubsidyConfiguration,
     ) -> Self {
-        // For now, assert we always have a fee discount of 0, since we don't
-        // support it yet.
-        assert!(
-            fee_subsidy.fee_discount == 0.,
-            "non-0 fee discount currently not supported",
-        );
-
         Self {
             price_estimator,
             gas_estimator,
@@ -283,17 +292,6 @@ impl MinFeeCalculator {
             sell_token_price,
         })
     }
-
-    fn apply_fee_factor(&self, fee: UnsubsidizedFee, app_data: AppId) -> U256 {
-        let factor = self
-            .fee_subsidy
-            .partner_additional_fee_factors
-            .get(&app_data)
-            .copied()
-            .unwrap_or(1.0)
-            * self.fee_subsidy.fee_factor;
-        U256::from_f64_lossy(fee.amount_in_sell_token() * factor)
-    }
 }
 
 #[async_trait::async_trait]
@@ -334,7 +332,7 @@ impl MinFeeCalculating for MinFeeCalculator {
             current_fee
         };
 
-        let subsidized_min_fee = self.apply_fee_factor(unsubsidized_min_fee, app_data);
+        let subsidized_min_fee = unsubsidized_min_fee.apply_fee_factor(&self.fee_subsidy, app_data);
         tracing::debug!(
             "computed subsidized fee of {:?}",
             (subsidized_min_fee, fee_data.sell_token),
@@ -364,7 +362,7 @@ impl MinFeeCalculating for MinFeeCalculator {
             .find_measurement_including_larger_amount(fee_data, (self.now)())
             .await
         {
-            if subsidized_fee >= self.apply_fee_factor(past_fee, app_data) {
+            if subsidized_fee >= past_fee.apply_fee_factor(&self.fee_subsidy, app_data) {
                 return Ok(std::cmp::max(
                     subsidized_fee,
                     U256::from_f64_lossy(past_fee.amount_in_sell_token()),
@@ -373,7 +371,7 @@ impl MinFeeCalculating for MinFeeCalculator {
         }
 
         if let Ok(current_fee) = self.compute_unsubsidized_min_fee(fee_data).await {
-            if subsidized_fee >= self.apply_fee_factor(current_fee, app_data) {
+            if subsidized_fee >= current_fee.apply_fee_factor(&self.fee_subsidy, app_data) {
                 return Ok(std::cmp::max(
                     subsidized_fee,
                     U256::from_f64_lossy(current_fee.amount_in_sell_token()),
@@ -868,6 +866,55 @@ mod tests {
         assert_eq!(
             fee,
             U256::from_f64_lossy(unsubsidized_min_fee.amount_in_sell_token() * 0.8)
+        );
+    }
+
+    #[test]
+    fn test_apply_fee_factor_capped_at_zero() {
+        let unsubsidized = UnsubsidizedFee {
+            gas_amount: 100_000_f64,
+            gas_price: 1_000_000_000_f64,
+            sell_token_price: 1.,
+        };
+
+        let fee_configuration = FeeSubsidyConfiguration {
+            fee_discount: 500_000_000_000_000_f64,
+            fee_factor: 0.5,
+            partner_additional_fee_factors: HashMap::new(),
+        };
+
+        assert_eq!(
+            unsubsidized.apply_fee_factor(&fee_configuration, Default::default()),
+            U256::zero()
+        );
+    }
+
+    #[test]
+    fn test_apply_fee_factor_order() {
+        let unsubsidized = UnsubsidizedFee {
+            gas_amount: 100_000_f64,
+            gas_price: 1_000_000_000_f64,
+            sell_token_price: 1.,
+        };
+
+        let app_id = AppId([1u8; 32]);
+        let fee_configuration = FeeSubsidyConfiguration {
+            fee_discount: 50_000_000_000_000_f64,
+            fee_factor: 0.5,
+            partner_additional_fee_factors: maplit::hashmap! {
+                app_id => 0.1,
+            },
+        };
+
+        // (100G - 50G) * 0.5
+        assert_eq!(
+            unsubsidized.apply_fee_factor(&fee_configuration, Default::default()),
+            25_000_000_000_000u128.into()
+        );
+        // Additionally multiply with 0.1 if partner app id is used
+        assert_eq!(
+            unsubsidized.apply_fee_factor(&fee_configuration, app_id),
+            2_500_000_000_000u128.into()
         );
     }
 }

--- a/orderbook/src/fee.rs
+++ b/orderbook/src/fee.rs
@@ -99,7 +99,10 @@ impl UnsubsidizedFee {
         let fee_in_eth = self.gas_amount * self.gas_price;
         let mut discounted_fee_in_eth = fee_in_eth - fee_configuration.fee_discount;
         if discounted_fee_in_eth < 0. {
-            tracing::warn!("Computed negative fee after applying fee discount: {}, capping at 0", discounted_fee_in_eth);
+            tracing::warn!(
+                "Computed negative fee after applying fee discount: {}, capping at 0",
+                discounted_fee_in_eth
+            );
             discounted_fee_in_eth = 0.;
         }
         let factor = fee_configuration


### PR DESCRIPTION
Closes #1333 

This PR connects #1348 and #1349 together by applying the flat fee discount (in native token) to the unsubsidised fee estimate.

### Test Plan
Added unit test for the application logic + running locally and making sure the math checks out + I can place orders.


```
cargo run --bin orderbook --  --skip-event-sync --skip-trace-api --baseline-sources Uniswap,Sushiswap,BalancerV2 --price-estimators ZeroEx,Paraswap --fee-discount 20000000000000000
```

> 2021-11-05T09:54:31.047Z DEBUG orderbook::fee: unsubsidized fee amount fee_data=FeeData { sell_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, buy_token: 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48, amount: 1000000000000000000, kind: Sell } gas_price=108057518796 gas_amount=249391 fee_in_eth=26948572670053236 sell_token_price=1 fee=26948572670053236
2021-11-05T09:54:31.062Z DEBUG orderbook::fee: using new fee measurement UnsubsidizedFee { gas_amount: 249391.0, gas_price: 108057518796.0, sell_token_price: 1.0 }
