### PR TITLE
Gas calculation modifications

### DIFF
--- a/shared/src/price_estimation/gas.rs
+++ b/shared/src/price_estimation/gas.rs
@@ -1,9 +1,12 @@
 ///! constants to estimate gas use in GPv2
 
+/// gas for initialization
+pub const INITIALIZATION_COST: u64 =
+    // initial tx gas
+    32_000;
+
 /// minimum gas every settlement takes
 pub const SETTLEMENT: u64 =
-    // initial tx gas
-    32_000 +
     // isSolver
     7365;
 
@@ -22,5 +25,13 @@ pub const TRADE: u64 =
 /// of the 90% most traded tokens by volume in the month of Oct. 2021.
 pub const ERC20_TRANSFER: u64 = 27_513;
 
+/// lower bound for gas refunds
+/// this number was derived from some empiric observations
+pub const GAS_REFUNDS: u64 = 13_000;
+
 /// a settlement that contains one trade
-pub const SETTLEMENT_SINGLE_TRADE: u64 = SETTLEMENT + TRADE + 2 * ERC20_TRANSFER;
+pub const SETTLEMENT_SINGLE_TRADE: u64 =
+    INITIALIZATION_COST + SETTLEMENT + TRADE + 2 * ERC20_TRANSFER - GAS_REFUNDS;
+
+/// settlement overhead for one trade
+pub const SETTLEMENT_OVERHEAD: u64 = SETTLEMENT + TRADE + 2 * ERC20_TRANSFER;

--- a/shared/src/price_estimation/paraswap.rs
+++ b/shared/src/price_estimation/paraswap.rs
@@ -64,7 +64,7 @@ impl ParaswapPriceEstimator {
                 OrderKind::Buy => response.src_amount,
                 OrderKind::Sell => response.dest_amount,
             },
-            gas: U256::from(gas::SETTLEMENT_SINGLE_TRADE) + response.gas_cost,
+            gas: U256::from(gas::SETTLEMENT_OVERHEAD) + response.gas_cost,
         })
     }
 }

--- a/shared/src/price_estimation/zeroex.rs
+++ b/shared/src/price_estimation/zeroex.rs
@@ -49,7 +49,7 @@ impl ZeroExPriceEstimator {
                 OrderKind::Buy => swap.price.sell_amount,
                 OrderKind::Sell => swap.price.buy_amount,
             },
-            gas: U256::from(gas::SETTLEMENT_SINGLE_TRADE) + swap.price.estimated_gas,
+            gas: U256::from(gas::SETTLEMENT_OVERHEAD) + swap.price.estimated_gas,
         })
     }
 }


### PR DESCRIPTION
This PR reduces gas costs in two cases:

**paraswap and zeroEx estimates:** Before the PR, the gas costs calculations contained the initialisation_gas costs of a tx 2-times, once in our SETTLEMENT_SINGLE_TRADE and in the estimate from the dex-ags.
Hence, we are switching to only the SETTLEMENT_OVERHEAD, not containing the gas costs of the intilziation.

**Baseline Estimates:** Usually, we have gas-refunds and they were not considered. I added them into the SETTLEMENT_SINGLE_TRADE estimate and hence our baseline estimator should result in lower estimates.


### Test Plan
no tests, just making sure that the logic is correct.
