### PR TITLE
Flashbots tracing improvement, interval period lowered

### DIFF
--- a/solver/src/settlement_submission/flashbots_api.rs
+++ b/solver/src/settlement_submission/flashbots_api.rs
@@ -80,7 +80,7 @@ impl FlashbotsApi {
                     }
                     None => Err(anyhow!("result not a string")),
                 },
-                jsonrpc_core::Output::Failure(f) => Err(anyhow!(f.error)),
+                jsonrpc_core::Output::Failure(body) => Err(anyhow!(body.error)),
             },
             Err(err) => Err(anyhow!(err)),
         }

--- a/solver/src/settlement_submission/flashbots_api.rs
+++ b/solver/src/settlement_submission/flashbots_api.rs
@@ -32,27 +32,21 @@ impl FlashbotsApi {
         ensure!(status.is_success(), "status {}: {:?}", status, body);
 
         match serde_json::from_str::<jsonrpc_core::Output>(&body) {
-            Ok(body) => {
-                if let jsonrpc_core::Output::Success(ref x) = body {
-                    match x.result.as_str() {
-                        Some(result) => {
-                            tracing::debug!(
-                                "flashbots bundle id: {}",
-                                serde_json::to_string(&result)
-                                    .unwrap_or_else(|err| format!("error: {:?}", err)),
-                            );
-                            Ok(result.to_string())
-                        }
-                        None => Err(anyhow!("failed to submit: result not a string")),
+            Ok(body) => match body {
+                jsonrpc_core::Output::Success(body) => match body.result.as_str() {
+                    Some(result) => {
+                        tracing::debug!(
+                            "flashbots bundle id: {}",
+                            serde_json::to_string(&result)
+                                .unwrap_or_else(|err| format!("error: {:?}", err)),
+                        );
+                        Ok(result.to_string())
                     }
-                } else {
-                    Err(anyhow!("failed to submit: response not success"))
-                }
-            }
-            Err(err) => {
-                tracing::debug!("failed to submit: {}", err);
-                Err(anyhow!("failed to submit. Error: {}", err))
-            }
+                    None => Err(anyhow!("result not a string")),
+                },
+                jsonrpc_core::Output::Failure(body) => Err(anyhow!(body.error)),
+            },
+            Err(err) => Err(anyhow!(err)),
         }
     }
 
@@ -72,7 +66,24 @@ impl FlashbotsApi {
         let status = response.status();
         let body = response.text().await?;
         ensure!(status.is_success(), "status {}: {:?}", status, body);
-        Ok(())
+
+        match serde_json::from_str::<jsonrpc_core::Output>(&body) {
+            Ok(body) => match body {
+                jsonrpc_core::Output::Success(body) => match body.result.as_str() {
+                    Some(result) => {
+                        tracing::debug!(
+                            "flashbots bundle id: {}",
+                            serde_json::to_string(&result)
+                                .unwrap_or_else(|err| format!("error: {:?}", err)),
+                        );
+                        Ok(())
+                    }
+                    None => Err(anyhow!("result not a string")),
+                },
+                jsonrpc_core::Output::Failure(f) => Err(anyhow!(f.error)),
+            },
+            Err(err) => Err(anyhow!(err)),
+        }
     }
 
     /// Query status of a previously submitted transaction.

--- a/solver/src/settlement_submission/flashbots_settlement.rs
+++ b/solver/src/settlement_submission/flashbots_settlement.rs
@@ -174,7 +174,7 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
         gas_estimate: U256,
         transactions: &mut Vec<H256>,
     ) -> MethodError {
-        const UPDATE_INTERVAL: Duration = Duration::from_secs(10);
+        const UPDATE_INTERVAL: Duration = Duration::from_secs(5);
 
         // The amount of extra gas it costs to include the payment to block.coinbase interaction in
         // an existing settlement.
@@ -232,7 +232,10 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
             // If gas price has increased cancel old and submit new new transaction.
 
             if let Some((previous_gas_price, previous_tx)) = previous_tx.as_ref() {
-                if gas_price.cap() > previous_gas_price.cap() {
+                let previous_gas_price = previous_gas_price.bump(1.125);
+                if gas_price.cap() > previous_gas_price.cap()
+                    && gas_price.tip() > previous_gas_price.tip()
+                {
                     if let Err(err) = self.flashbots_api.cancel(previous_tx).await {
                         tracing::error!("flashbots cancellation failed: {:?}", err);
                     }


### PR DESCRIPTION
Improved error handling of the tx submit and cancel functions.

Interval period for simulation lowered from 10 to 5 sec.

Gas price comparison made more strict.

Test plan:
- [x] Make a manual tx on mainnet and make sure tx is mined (`https://etherscan.io/tx/0xb2556a93a97f8c785720a95fd5229f6ac7b0a9edc96d533d9e136671a7846556`)
