### PR TITLE
Sunce86/flashbots tx submission3

### DIFF
--- a/solver/src/settlement_submission/flashbots_settlement.rs
+++ b/solver/src/settlement_submission/flashbots_settlement.rs
@@ -200,8 +200,6 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
 
             // create transaction
 
-            let tx_gas_cost_in_ether_wei =
-                U256::from_f64_lossy(gas_price.effective_gas_price()) * gas_estimate;
             let tx_gas_price = if let Some(eip1559) = gas_price.eip1559 {
                 (eip1559.max_fee_per_gas, 10_000_000_000.0).into()
             } else {
@@ -242,7 +240,7 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
                             err
                         );
 
-                        // if cancelation fails, we dont want to submit a new tx, rather contine and wait 
+                        // if cancelation fails, we dont want to submit a new tx, rather contine and wait
                         // for a nonce to change and end this function or a next cancelation to succeed.
                         tokio::time::sleep(UPDATE_INTERVAL).await;
                         continue;
@@ -261,9 +259,8 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
                 };
 
             tracing::info!(
-                "creating flashbots transaction with hash {:?}, tip to miner {:.3e}, gas price {:?}, gas estimate {}",
+                "creating flashbots transaction with hash {:?}, gas price {:?}, gas estimate {}",
                 hash,
-                tx_gas_cost_in_ether_wei.to_f64_lossy(),
                 gas_price,
                 gas_estimate,
             );

--- a/solver/src/settlement_submission/flashbots_settlement.rs
+++ b/solver/src/settlement_submission/flashbots_settlement.rs
@@ -231,9 +231,7 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
 
             if let Some((previous_gas_price, previous_tx)) = previous_tx.as_ref() {
                 let previous_gas_price = previous_gas_price.bump(1.125);
-                if gas_price.cap() > previous_gas_price.cap()
-                    && gas_price.tip() > previous_gas_price.tip()
-                {
+                if gas_price.cap() > previous_gas_price.cap() {
                     if let Err(err) = self.flashbots_api.cancel(previous_tx).await {
                         tracing::error!(
                             "flashbots cancellation failed, probably already completed: {:?}",


### PR DESCRIPTION
1. We suspect that we are sending too low max priority fee per gas. Hardcoded to 10gwei temporarily, before flashbots custom gas price estimator is implemented.

2. In case of tx cancellation failure, we want to skip submitting a new tx.

Todo:
1. Implement proper gas price estimator from flashbots
2. Add a deadline to avoid being stuck in case of a flashbots api fails for any reason.

Test plan
- [x] Manual tx to pass on local