### PR TITLE
Cleanup dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,17 @@ dependencies = [
  "num-bigint 0.3.3",
  "num-integer",
  "num-traits",
- "serde",
+]
+
+[[package]]
+name = "bigdecimal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
+dependencies = [
+ "num-bigint 0.4.2",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -215,16 +225,6 @@ dependencies = [
  "memchr",
  "regex-automata",
  "serde",
-]
-
-[[package]]
-name = "buf_redux"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
-dependencies = [
- "memchr",
- "safemem",
 ]
 
 [[package]]
@@ -1038,7 +1038,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
- "tokio-tungstenite 0.15.0",
+ "tokio-tungstenite",
  "tracing",
  "url",
  "web3",
@@ -1322,15 +1322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "input_buffer"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
-dependencies = [
- "bytes",
-]
-
-[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,7 +1565,7 @@ name = "model"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bigdecimal",
+ "bigdecimal 0.3.0",
  "chrono",
  "derivative",
  "enum-utils",
@@ -1584,31 +1575,12 @@ dependencies = [
  "lazy_static",
  "maplit",
  "num",
- "num-bigint 0.3.3",
  "primitive-types",
  "secp256k1",
  "serde",
  "serde_json",
  "serde_with",
  "web3",
-]
-
-[[package]]
-name = "multipart"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
-dependencies = [
- "buf_redux",
- "httparse",
- "log",
- "mime",
- "mime_guess",
- "quick-error",
- "rand",
- "safemem",
- "tempfile",
- "twoway",
 ]
 
 [[package]]
@@ -1819,7 +1791,7 @@ dependencies = [
  "anyhow",
  "assert_approx_eq",
  "async-trait",
- "bigdecimal",
+ "bigdecimal 0.2.2",
  "chrono",
  "const_format",
  "contracts",
@@ -1832,7 +1804,6 @@ dependencies = [
  "mockall",
  "model",
  "num",
- "num-bigint 0.3.3",
  "primitive-types",
  "prometheus",
  "prometheus-metric-storage",
@@ -2131,12 +2102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23129d50f2c9355ced935fce8a08bd706ee2e7ce2b3b33bf61dace0e379ac63a"
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2356,12 +2321,6 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -2692,7 +2651,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bigdecimal",
  "chrono",
  "contracts",
  "derivative",
@@ -2758,7 +2716,7 @@ dependencies = [
  "ahash",
  "atoi",
  "base64",
- "bigdecimal",
+ "bigdecimal 0.2.2",
  "bitflags",
  "byteorder",
  "bytes",
@@ -3099,19 +3057,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e96bb520beab540ab664bd5a9cfeaa1fcd846fa68c830b42e2c8963071251d2"
-dependencies = [
- "futures-util",
- "log",
- "pin-project",
- "tokio",
- "tungstenite 0.13.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
@@ -3122,7 +3067,7 @@ dependencies = [
  "pin-project",
  "tokio",
  "tokio-native-tls",
- "tungstenite 0.14.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -3236,26 +3181,6 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8dada8c1a3aeca77d6b51a4f1314e0f4b8e438b7b1b71e3ddaca8080e4093"
-dependencies = [
- "base64",
- "byteorder",
- "bytes",
- "http",
- "httparse",
- "input_buffer",
- "log",
- "rand",
- "sha-1",
- "thiserror",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
@@ -3272,15 +3197,6 @@ dependencies = [
  "thiserror",
  "url",
  "utf-8",
-]
-
-[[package]]
-name = "twoway"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3425,7 +3341,6 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "multipart",
  "percent-encoding",
  "pin-project",
  "scoped-tls",
@@ -3434,7 +3349,6 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.14.0",
  "tokio-util",
  "tower-service",
  "tracing",

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
-bigdecimal = "0.2"
+bigdecimal = "0.3"
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 derivative = "2.2"
 ethabi = "15.0"
@@ -17,7 +17,6 @@ hex-literal = "0.3"
 lazy_static = "1.4"
 maplit = "1.0"
 num = "0.4"
-num-bigint = "0.3"
 primitive-types = { version = "0.10" }
 secp256k1 = "0.20"
 serde = { version = "1.0", features = ["derive"] }

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -9,11 +9,10 @@ use crate::{
 use chrono::{offset::Utc, DateTime, NaiveDateTime};
 use derivative::Derivative;
 use hex_literal::hex;
-use num_bigint::BigUint;
+use num::BigUint;
 use primitive_types::{H160, H256, U256};
 use secp256k1::key::ONE_KEY;
-use serde::{de, Deserialize, Serialize};
-use serde::{Deserializer, Serializer};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::serde_as;
 use std::{
     collections::HashSet,

--- a/model/src/trade.rs
+++ b/model/src/trade.rs
@@ -1,7 +1,7 @@
 //! Contains the Trade type as described by the specification with serialization as described by the openapi documentation.
 
 use crate::order::OrderUid;
-use num_bigint::BigUint;
+use num::BigUint;
 use primitive_types::{H160, H256};
 use serde::{Deserialize, Serialize};
 

--- a/orderbook/Cargo.toml
+++ b/orderbook/Cargo.toml
@@ -29,7 +29,6 @@ hex-literal = "0.3"
 maplit = "1.0"
 model = { path = "../model" }
 num = "0.4"
-num-bigint = "0.3"
 primitive-types = { version = "0.10", features = ["fp-conversion"] }
 prometheus = "0.13"
 prometheus-metric-storage = "0.4"
@@ -44,7 +43,7 @@ thiserror = "1.0"
 tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "sync", "time", "signal"] }
 tracing = "0.1"
 url = "2.2"
-warp = "0.3"
+warp = { version = "0.3", default-features = false }
 web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev="a425fa747bca69c7aede4d2c2828f7267d79227e", default-features = false }
 
 [dev-dependencies]

--- a/orderbook/src/conversions.rs
+++ b/orderbook/src/conversions.rs
@@ -1,7 +1,8 @@
 use anyhow::{anyhow, Result};
-use bigdecimal::BigDecimal;
-use num_bigint::{BigInt, BigUint, Sign, ToBigInt};
+use bigdecimal::num_bigint::ToBigInt;
+use num::bigint::{BigInt, BigUint, Sign};
 use primitive_types::{H160, H256, U256};
+use sqlx::types::BigDecimal;
 use std::convert::TryInto;
 // TODO: It would be nice to avoid copying the underlying BigInt when converting BigDecimal to
 // anything else but the simple big_decimal.to_bigint makes a copy internally.
@@ -14,7 +15,7 @@ pub fn u256_to_big_uint(input: &U256) -> BigUint {
 
 pub fn u256_to_big_decimal(u256: &U256) -> BigDecimal {
     let big_uint = u256_to_big_uint(u256);
-    BigDecimal::from(BigInt::from(big_uint))
+    BigDecimal::from(bigint_04_to_03(BigInt::from(big_uint)))
 }
 
 pub fn bigint_to_u256(input: &BigInt) -> Option<U256> {
@@ -26,14 +27,14 @@ pub fn bigint_to_u256(input: &BigInt) -> Option<U256> {
 }
 
 pub fn big_decimal_to_big_uint(big_decimal: &BigDecimal) -> Option<BigUint> {
-    big_decimal.to_bigint()?.try_into().ok()
+    bigint_03_to_04(big_decimal.to_bigint()?).try_into().ok()
 }
 
 pub fn big_decimal_to_u256(big_decimal: &BigDecimal) -> Option<U256> {
     if !big_decimal.is_integer() {
         return None;
     }
-    let big_int = big_decimal.to_bigint()?;
+    let big_int = bigint_03_to_04(big_decimal.to_bigint()?);
     bigint_to_u256(&big_int)
 }
 
@@ -49,6 +50,30 @@ pub fn h256_from_vec(vec: Vec<u8>) -> Result<H256> {
         .try_into()
         .map_err(|_| anyhow!("h256 has wrong length"))?;
     Ok(H256::from(array))
+}
+
+fn bigint_03_to_04(input: bigdecimal::num_bigint::BigInt) -> BigInt {
+    let (sign, digits) = input.to_u32_digits();
+    BigInt::new(
+        match sign {
+            bigdecimal::num_bigint::Sign::Minus => Sign::Minus,
+            bigdecimal::num_bigint::Sign::NoSign => Sign::NoSign,
+            bigdecimal::num_bigint::Sign::Plus => Sign::Plus,
+        },
+        digits,
+    )
+}
+
+fn bigint_04_to_03(input: BigInt) -> bigdecimal::num_bigint::BigInt {
+    let (sign, digits) = input.to_u32_digits();
+    bigdecimal::num_bigint::BigInt::new(
+        match sign {
+            Sign::Minus => bigdecimal::num_bigint::Sign::Minus,
+            Sign::NoSign => bigdecimal::num_bigint::Sign::NoSign,
+            Sign::Plus => bigdecimal::num_bigint::Sign::Plus,
+        },
+        digits,
+    )
 }
 
 #[cfg(test)]

--- a/orderbook/src/database/orders.rs
+++ b/orderbook/src/database/orders.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::conversions::*;
 use anyhow::{anyhow, Context, Result};
-use bigdecimal::{BigDecimal, Zero};
 use chrono::{DateTime, Utc};
 use const_format::concatcp;
 use ethcontract::H256;
@@ -14,8 +13,9 @@ use model::{
     },
     signature::{Signature, SigningScheme},
 };
+use num::Zero;
 use primitive_types::H160;
-use sqlx::Connection;
+use sqlx::{types::BigDecimal, Connection};
 use std::{borrow::Cow, convert::TryInto};
 
 #[cfg_attr(test, mockall::automock)]
@@ -599,7 +599,7 @@ mod tests {
     use super::events::*;
     use super::*;
     use chrono::{Duration, NaiveDateTime};
-    use num_bigint::BigUint;
+    use num::BigUint;
     use primitive_types::U256;
     use shared::event_handling::EventIndex;
     use sqlx::Executor;

--- a/orderbook/src/database/trades.rs
+++ b/orderbook/src/database/trades.rs
@@ -1,11 +1,10 @@
 use crate::conversions::{big_decimal_to_big_uint, h160_from_vec, h256_from_vec};
 use crate::database::Postgres;
 use anyhow::{anyhow, Context, Result};
-use bigdecimal::BigDecimal;
 use ethcontract::H160;
 use futures::stream::TryStreamExt;
-use model::order::OrderUid;
-use model::trade::Trade;
+use model::{order::OrderUid, trade::Trade};
+use sqlx::types::BigDecimal;
 use std::convert::TryInto;
 
 #[async_trait::async_trait]

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -44,7 +44,7 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "time"] }
 url = "2.2"
-warp = "0.3"
+warp = { version = "0.3", default-features = false }
 web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev="a425fa747bca69c7aede4d2c2828f7267d79227e", default-features = false }
 
 [dev-dependencies]

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-bigdecimal = { version = "0.2", features = ["serde"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 contracts = { path = "../contracts" }
 derivative = "2.2"

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -14,14 +14,13 @@ use crate::{
     solver::{Auction, SettlementWithSolver, Solvers},
 };
 use anyhow::{anyhow, Context, Result};
-use bigdecimal::ToPrimitive;
 use contracts::GPv2Settlement;
 use ethcontract::errors::{ExecutionError, MethodError};
 use futures::future::join_all;
 use gas_estimation::{EstimatedGasPrice, GasPriceEstimating};
 use itertools::{Either, Itertools};
 use model::order::BUY_ETH_ADDRESS;
-use num::BigRational;
+use num::{BigRational, ToPrimitive};
 use primitive_types::{H160, U256};
 use rand::prelude::SliceRandom;
 use shared::{

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -11,12 +11,12 @@ use crate::{
 };
 use ::model::order::OrderKind;
 use anyhow::{anyhow, ensure, Context, Result};
-use bigdecimal::ToPrimitive;
 use buffers::{BufferRetrievalError, BufferRetrieving};
 use ethcontract::{Account, U256};
 use futures::{join, lock::Mutex};
 use lazy_static::lazy_static;
 use maplit::{btreemap, hashset};
+use num::ToPrimitive;
 use num::{BigInt, BigRational};
 use primitive_types::H160;
 use reqwest::{header::HeaderValue, Client, Url};


### PR DESCRIPTION
I looked through crates where we compile two versions and changed this:

- Remove BigDecimal where it isn't needed and import types through num
  instead when possible
- Remove default warp features (multipart and websocket)

The BigInteger conversion can go away once sqlx updates their BigDecmial dependency which I have made a PR for.

### Test Plan
CI
