### PR TITLE
Flashbots gas price implemented

### DIFF
--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -183,7 +183,7 @@ struct Arguments {
     /// network before going to back to solving.
     #[structopt(
         long,
-        default_value = "90",
+        default_value = "120",
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
     max_flashbots_submission_seconds: Duration,

--- a/solver/src/settlement_submission/flashbots_settlement.rs
+++ b/solver/src/settlement_submission/flashbots_settlement.rs
@@ -186,6 +186,7 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
     ) -> anyhow::Error {
         const UPDATE_INTERVAL: Duration = Duration::from_secs(5);
         const CANCEL_PROPAGATION_TIME: Duration = Duration::from_secs(2);
+        const MINIMAL_MAX_PRIORITY_FEE: f64 = 10_000_000_000.0;
 
         // The amount of extra gas it costs to include the payment to block.coinbase interaction in
         // an existing settlement.
@@ -209,8 +210,9 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
                     match self.gas_price(gas_limit, time_limit).await {
                         Ok(mut gas_price) => {
                             if let Some(ref mut eip1559) = gas_price.eip1559 {
-                                if eip1559.max_priority_fee_per_gas < 10_000_000_000.0 {
-                                    eip1559.max_priority_fee_per_gas = 10_000_000_000.0;
+                                if eip1559.max_priority_fee_per_gas < MINIMAL_MAX_PRIORITY_FEE {
+                                    tracing::debug!("max_priority_fee_per_gas old value {} replaced with minimal value {}", eip1559.max_priority_fee_per_gas, MINIMAL_MAX_PRIORITY_FEE);
+                                    eip1559.max_priority_fee_per_gas = MINIMAL_MAX_PRIORITY_FEE;
                                 }
                             }
                             gas_price

--- a/solver/src/settlement_submission/flashbots_settlement.rs
+++ b/solver/src/settlement_submission/flashbots_settlement.rs
@@ -185,6 +185,7 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
         transactions: &mut Vec<H256>,
     ) -> anyhow::Error {
         const UPDATE_INTERVAL: Duration = Duration::from_secs(5);
+        const CANCEL_PROPAGATION_TIME: Duration = Duration::from_secs(2);
 
         // The amount of extra gas it costs to include the payment to block.coinbase interaction in
         // an existing settlement.
@@ -199,17 +200,27 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
             // Account for some buffer in the gas limit in case racing state changes result in slightly more heavy computation at execution time.
             let gas_limit = gas_estimate.to_f64_lossy() * ESTIMATE_GAS_LIMIT_FACTOR;
             let time_limit = target_confirm_time.saturating_duration_since(Instant::now());
-            let gas_price = match self.gas_price(gas_limit, time_limit).await {
-                Ok(mut gas_price) => {
-                    if let Some(ref mut eip1559) = gas_price.eip1559 {
-                        eip1559.max_priority_fee_per_gas = 10_000_000_000.0;
-                    }
-                    gas_price
-                }
+            let gas_price = match self.flashbots_api.gas_price().await {
+                Ok(gas_price) => gas_price,
                 Err(err) => {
-                    tracing::error!("gas estimation failed: {:?}", err);
-                    tokio::time::sleep(UPDATE_INTERVAL).await;
-                    continue;
+                    tracing::warn!("flashbots gas price estimator failed: {:?}", err);
+
+                    // fallback to standard gas price estimators, with hardcoded max_priority_fee if less than 10gwei
+                    match self.gas_price(gas_limit, time_limit).await {
+                        Ok(mut gas_price) => {
+                            if let Some(ref mut eip1559) = gas_price.eip1559 {
+                                if eip1559.max_priority_fee_per_gas < 10_000_000_000.0 {
+                                    eip1559.max_priority_fee_per_gas = 10_000_000_000.0;
+                                }
+                            }
+                            gas_price
+                        }
+                        Err(err) => {
+                            tracing::error!("gas estimation failed: {:?}", err);
+                            tokio::time::sleep(UPDATE_INTERVAL).await;
+                            continue;
+                        }
+                    }
                 }
             };
 
@@ -236,7 +247,7 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
             if let Err(err) = method.clone().view().call().await {
                 if let Some((_, previous_tx)) = previous_tx.as_ref() {
                     if let Err(err) = self.flashbots_api.cancel(previous_tx).await {
-                        tracing::error!("flashbots cancellation failed: {:?}", err);
+                        tracing::error!("flashbots cancellation request not sent: {:?}", err);
                     }
                 }
                 return anyhow!("flashbots failed simulation: {}", err);
@@ -248,14 +259,14 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
                 let previous_gas_price = previous_gas_price.bump(1.125);
                 if gas_price.cap() > previous_gas_price.cap() {
                     if let Err(err) = self.flashbots_api.cancel(previous_tx).await {
-                        tracing::error!(
-                            "flashbots cancellation failed, probably already completed: {:?}",
-                            err
-                        );
+                        tracing::error!("flashbots cancellation request not sent: {:?}", err);
 
-                        // if cancellation fails, return from function since we can't send any more txs from the same sender
+                        // if cancellation request was not sent, return from function since we can't send any more txs from the same sender
                         return anyhow!("flashbots failed to cancel: {}", err);
                     }
+
+                    // wait for a sec to give flashbots api time to update the cancel status before sending a new tx
+                    tokio::time::sleep(CANCEL_PROPAGATION_TIME).await;
                 } else {
                     tokio::time::sleep(UPDATE_INTERVAL).await;
                     continue;


### PR DESCRIPTION
Several improvements:

1. Increased deadline for flashbots transaction submitting from 90s to 120s (with flashbots occasional slow API this should reduce number of deadline expires)
2. Implemented eth_gasFees - get gas price estimation directly from flashbots API - in case of failure, fallback to standard gas price estimator. (this should make inclusion faster)
3. Added 2s cancellation period - increase our chances of successful submit of next transaction.

Test plan
- [x] Manual tx to pass on local