### PR TITLE
Move HTTP solver API to common crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,6 +2560,7 @@ dependencies = [
  "assert_approx_eq",
  "async-trait",
  "atty",
+ "chrono",
  "contracts",
  "derivative",
  "ethcontract",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0"
 assert_approx_eq = "1.1"
 async-trait = "0.1"
 atty = "0.2"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 contracts = { path = "../contracts" }
 derivative = "2.2"
 ethcontract = { git = "https://github.com/gnosis/ethcontract-rs.git", rev = "cafcac443f37cfe1e0e18b03a987a30b61b54695", default-features = false }

--- a/shared/src/http_solver_api.rs
+++ b/shared/src/http_solver_api.rs
@@ -74,7 +74,8 @@ impl HttpSolverApi {
                 self.config.max_nr_exec_orders.to_string().as_str(),
             );
         if self.config.has_ucp_policy_parameter {
-            url.query_pairs_mut().append_pair("ucp_policy", "EnforceForOrders");
+            url.query_pairs_mut()
+                .append_pair("ucp_policy", "EnforceForOrders");
         }
 
         let query = url.query().map(ToString::to_string).unwrap_or_default();

--- a/shared/src/http_solver_api.rs
+++ b/shared/src/http_solver_api.rs
@@ -1,0 +1,129 @@
+use anyhow::{anyhow, ensure, Context, Result};
+use reqwest::header::HeaderValue;
+use reqwest::{Client, Url};
+use std::time::{Duration, Instant};
+
+pub mod model;
+
+/// Configuration for solver requests.
+#[derive(Debug, Default)]
+pub struct SolverConfig {
+    /// Optional value for the `X-API-KEY` header.
+    pub api_key: Option<String>,
+
+    /// Controls value of the `max_nr_exec_orders` parameter.
+    pub max_nr_exec_orders: u32,
+
+    /// Controls if we should fill the `ucp_policy` parameter.
+    pub has_ucp_policy_parameter: bool,
+}
+
+pub struct HttpSolverApi {
+    /// Name of this solver.
+    ///
+    /// Used for logging and metrics reporting purposes.
+    pub name: &'static str,
+
+    /// Network ID or name.
+    ///
+    /// Used for logging and metrics reporting purposes.
+    pub network_name: String,
+
+    /// Chain ID.
+    ///
+    /// Used for logging and metrics reporting purposes.
+    pub chain_id: u64,
+
+    /// Base solver url.
+    pub base: Url,
+
+    /// An async HTTP client instance that will be used to interact with the solver.
+    pub client: Client,
+
+    /// Other solver parameters.
+    pub config: SolverConfig,
+}
+
+impl HttpSolverApi {
+    /// Submit a batch auction to the solver and wait for a solution.
+    pub async fn solve(
+        &self,
+        model: &model::BatchAuctionModel,
+        deadline: Instant,
+    ) -> Result<model::SettledBatchAuctionModel> {
+        let timeout = deadline
+            .checked_duration_since(Instant::now())
+            .ok_or_else(|| anyhow!("no time left to send request"))?;
+        // The timeout we give to the solver is one second less than the deadline to make up for
+        // overhead from the network.
+        let solver_timeout = timeout
+            .checked_sub(Duration::from_secs(1))
+            .ok_or_else(|| anyhow!("no time left to send request"))?;
+
+        let mut url = self.base.clone();
+        url.set_path("/solve");
+
+        let instance_name = self.generate_instance_name();
+        tracing::debug!("http solver instance name is {}", instance_name);
+
+        url.query_pairs_mut()
+            .append_pair("instance_name", &instance_name)
+            .append_pair("time_limit", &solver_timeout.as_secs().to_string())
+            .append_pair(
+                "max_nr_exec_orders",
+                self.config.max_nr_exec_orders.to_string().as_str(),
+            );
+        if self.config.has_ucp_policy_parameter {
+            url.query_pairs_mut().append_pair("ucp_policy", "EnforceForOrders");
+        }
+
+        let query = url.query().map(ToString::to_string).unwrap_or_default();
+        let mut request = self.client.post(url).timeout(timeout);
+        if let Some(api_key) = &self.config.api_key {
+            let mut header = HeaderValue::from_str(api_key.as_str()).unwrap();
+            header.set_sensitive(true);
+            request = request.header("X-API-KEY", header);
+        }
+        let body = serde_json::to_string(&model).context("failed to encode body")?;
+        tracing::trace!("request {}", body);
+        let request = request.body(body.clone());
+        let response = request.send().await.context("failed to send request")?;
+        let status = response.status();
+        let text = response
+            .text()
+            .await
+            .context("failed to decode response body")?;
+        tracing::trace!("response {}", text);
+        let context = || {
+            format!(
+                "request query {}, request body {}, response body {}",
+                query, body, text
+            )
+        };
+        ensure!(
+            status.is_success(),
+            "solver response is not success: status {}, {}",
+            status,
+            context()
+        );
+        serde_json::from_str(text.as_str())
+            .with_context(|| format!("failed to decode response json, {}", context()))
+    }
+
+    fn generate_instance_name(&self) -> String {
+        let now = chrono::Utc::now();
+        format!(
+            "{}_{}_{}",
+            now.to_string(),
+            self.network_name,
+            self.chain_id
+        )
+        .chars()
+        .map(|x| match x {
+            ' ' => '_',
+            '/' => '_',
+            _ => x,
+        })
+        .collect()
+    }
+}

--- a/shared/src/http_solver_api/model.rs
+++ b/shared/src/http_solver_api/model.rs
@@ -232,7 +232,7 @@ mod tests {
                 trivial_execution_without_plan
             ],
         }
-        .is_non_trivial());
+            .is_non_trivial());
 
         let execution_with_sell = ExecutedAmmModel {
             exec_sell_amount: U256::one(),
@@ -247,18 +247,18 @@ mod tests {
         assert!(UpdatedAmmModel {
             execution: vec![execution_with_buy.clone()]
         }
-        .is_non_trivial());
+            .is_non_trivial());
 
         assert!(UpdatedAmmModel {
             execution: vec![execution_with_sell]
         }
-        .is_non_trivial());
+            .is_non_trivial());
 
         assert!(UpdatedAmmModel {
             // One trivial and one non-trivial -> non-trivial
             execution: vec![execution_with_buy, trivial_execution_with_plan]
         }
-        .is_non_trivial());
+            .is_non_trivial());
     }
 
     #[test]

--- a/shared/src/http_solver_api/model.rs
+++ b/shared/src/http_solver_api/model.rs
@@ -232,7 +232,7 @@ mod tests {
                 trivial_execution_without_plan
             ],
         }
-            .is_non_trivial());
+        .is_non_trivial());
 
         let execution_with_sell = ExecutedAmmModel {
             exec_sell_amount: U256::one(),
@@ -247,18 +247,18 @@ mod tests {
         assert!(UpdatedAmmModel {
             execution: vec![execution_with_buy.clone()]
         }
-            .is_non_trivial());
+        .is_non_trivial());
 
         assert!(UpdatedAmmModel {
             execution: vec![execution_with_sell]
         }
-            .is_non_trivial());
+        .is_non_trivial());
 
         assert!(UpdatedAmmModel {
             // One trivial and one non-trivial -> non-trivial
             execution: vec![execution_with_buy, trivial_execution_with_plan]
         }
-            .is_non_trivial());
+        .is_non_trivial());
     }
 
     #[test]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -9,6 +9,7 @@ pub mod current_block;
 pub mod ethcontract_error;
 pub mod event_handling;
 pub mod gas_price_estimation;
+pub mod http_solver_api;
 pub mod maintenance;
 pub mod metrics;
 pub mod network;

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use baseline_solver::BaselineSolver;
 use contracts::GPv2Settlement;
 use ethcontract::{Account, H160, U256};
-use http_solver::{buffers::BufferRetriever, HttpSolver, SolverConfig};
+use http_solver::{buffers::BufferRetriever, HttpSolver};
 use naive_solver::NaiveSolver;
 use num::BigRational;
 use oneinch_solver::OneInchSolver;
@@ -25,6 +25,7 @@ use std::{
     time::{Duration, Instant},
 };
 use structopt::clap::arg_enum;
+use shared::http_solver_api::{HttpSolverApi, SolverConfig};
 use zeroex_solver::ZeroExSolver;
 
 mod baseline_solver;
@@ -173,18 +174,19 @@ pub fn create(
     let create_http_solver =
         |account: Account, url: Url, name: &'static str, config: SolverConfig| -> HttpSolver {
             HttpSolver::new(
-                name,
+                HttpSolverApi {
+                    name,
+                    network_name: network_id.clone(),
+                    chain_id,
+                    base: url,
+                    client: client.clone(),
+                    config,
+                },
                 account,
-                url,
-                None,
-                config,
                 native_token,
                 token_info_fetcher.clone(),
                 price_estimator.clone(),
                 buffer_retriever.clone(),
-                network_id.clone(),
-                chain_id,
-                client.clone(),
                 http_solver_cache.clone(),
                 native_token_amount_to_estimate_prices_with,
             )
@@ -201,6 +203,7 @@ pub fn create(
                     mip_solver_url.clone(),
                     "Mip",
                     SolverConfig {
+                        api_key: None,
                         max_nr_exec_orders: 100,
                         has_ucp_policy_parameter: false,
                     },
@@ -210,6 +213,7 @@ pub fn create(
                     quasimodo_solver_url.clone(),
                     "Quasimodo",
                     SolverConfig {
+                        api_key: None,
                         max_nr_exec_orders: 100,
                         has_ucp_policy_parameter: true,
                     },

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -13,6 +13,7 @@ use num::BigRational;
 use oneinch_solver::OneInchSolver;
 use paraswap_solver::ParaswapSolver;
 use reqwest::{Client, Url};
+use shared::http_solver_api::{HttpSolverApi, SolverConfig};
 use shared::zeroex_api::ZeroExApi;
 use shared::{
     baseline_solver::BaseTokens, conversions::U256Ext, price_estimation::PriceEstimating,
@@ -25,7 +26,6 @@ use std::{
     time::{Duration, Instant},
 };
 use structopt::clap::arg_enum;
-use shared::http_solver_api::{HttpSolverApi, SolverConfig};
 use zeroex_solver::ZeroExSolver;
 
 mod baseline_solver;

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -9,7 +9,6 @@ use crate::{
     solver::{Auction, Solver},
 };
 use anyhow::{anyhow, Context, Result};
-use bigdecimal::ToPrimitive;
 use buffers::{BufferRetrievalError, BufferRetrieving};
 use ethcontract::{Account, U256};
 use futures::{join, lock::Mutex};

--- a/solver/src/solver/http_solver.rs
+++ b/solver/src/solver/http_solver.rs
@@ -1,25 +1,26 @@
 pub mod buffers;
-pub mod model;
 mod settlement;
 
-use self::{model::*, settlement::SettlementContext};
+use self::settlement::SettlementContext;
 use crate::{
     liquidity::{LimitOrder, Liquidity},
     settlement::Settlement,
     settlement_submission::retry::is_transaction_failure,
     solver::{Auction, Solver},
 };
-use ::model::order::OrderKind;
-use anyhow::{anyhow, ensure, Context, Result};
+use anyhow::{anyhow, Context, Result};
+use bigdecimal::ToPrimitive;
 use buffers::{BufferRetrievalError, BufferRetrieving};
 use ethcontract::{Account, U256};
 use futures::{join, lock::Mutex};
 use lazy_static::lazy_static;
 use maplit::{btreemap, hashset};
+use model::order::OrderKind;
 use num::ToPrimitive;
 use num::{BigInt, BigRational};
 use primitive_types::H160;
-use reqwest::{header::HeaderValue, Client, Url};
+use shared::http_solver_api::model::*;
+use shared::http_solver_api::HttpSolverApi;
 use shared::{
     measure_time,
     price_estimation::{self, PriceEstimating},
@@ -29,7 +30,6 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     iter::FromIterator as _,
     sync::Arc,
-    time::{Duration, Instant},
 };
 
 lazy_static! {
@@ -48,25 +48,6 @@ lazy_static! {
 // TODO: set settlement.fee_factor
 // TODO: special rounding for the prices we get from the solver?
 
-/// The configuration passed as url parameters to the solver.
-#[derive(Debug, Default)]
-pub struct SolverConfig {
-    pub max_nr_exec_orders: u32,
-    pub has_ucp_policy_parameter: bool,
-}
-
-impl SolverConfig {
-    fn add_to_query(&self, url: &mut Url, ucp_policy: &str) {
-        url.query_pairs_mut().append_pair(
-            "max_nr_exec_orders",
-            self.max_nr_exec_orders.to_string().as_str(),
-        );
-        if self.has_ucp_policy_parameter {
-            url.query_pairs_mut().append_pair("ucp_policy", ucp_policy);
-        }
-    }
-}
-
 /// Data shared between multiple instances of the http solver for the same solve id.
 pub struct InstanceData {
     solve_id: u64,
@@ -79,18 +60,12 @@ pub struct InstanceData {
 pub type InstanceCache = Arc<Mutex<Option<InstanceData>>>;
 
 pub struct HttpSolver {
-    name: &'static str,
+    solver: HttpSolverApi,
     account: Account,
-    base: Url,
-    client: Client,
-    api_key: Option<String>,
-    config: SolverConfig,
     native_token: H160,
     token_info_fetcher: Arc<dyn TokenInfoFetching>,
     price_estimator: Arc<dyn PriceEstimating>,
     buffer_retriever: Arc<dyn BufferRetrieving>,
-    network_name: String,
-    chain_id: u64,
     instance_cache: InstanceCache,
     native_token_amount_to_estimate_prices_with: U256,
 }
@@ -98,34 +73,22 @@ pub struct HttpSolver {
 impl HttpSolver {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        name: &'static str,
+        solver: HttpSolverApi,
         account: Account,
-        base: Url,
-        api_key: Option<String>,
-        config: SolverConfig,
         native_token: H160,
         token_info_fetcher: Arc<dyn TokenInfoFetching>,
         price_estimator: Arc<dyn PriceEstimating>,
         buffer_retriever: Arc<dyn BufferRetrieving>,
-        network_name: String,
-        chain_id: u64,
-        client: Client,
         instance_cache: InstanceCache,
         native_token_amount_to_estimate_prices_with: U256,
     ) -> Self {
         Self {
-            name,
+            solver,
             account,
-            base,
-            client,
-            api_key,
-            config,
             native_token,
             token_info_fetcher,
             price_estimator,
             buffer_retriever,
-            network_name,
-            chain_id,
             instance_cache,
             native_token_amount_to_estimate_prices_with,
         }
@@ -219,86 +182,10 @@ impl HttpSolver {
             orders: order_models,
             amms: amm_models,
             metadata: Some(MetadataModel {
-                environment: Some(self.network_name.clone()),
+                environment: Some(self.solver.network_name.clone()),
             }),
         };
         Ok((model, SettlementContext { orders, liquidity }))
-    }
-
-    async fn send(
-        &self,
-        model: &BatchAuctionModel,
-        deadline: Instant,
-    ) -> Result<SettledBatchAuctionModel> {
-        // The timeout we give to the solver is one second less than the deadline to make up for
-        // overhead from the network.
-        let timeout_buffer = Duration::from_secs(1);
-        let timeout = deadline
-            .checked_duration_since(Instant::now() + timeout_buffer)
-            .ok_or_else(|| anyhow!("no time left to send request"))?;
-
-        let mut url = self.base.clone();
-        url.set_path("/solve");
-
-        let instance_name = self.generate_instance_name();
-        tracing::debug!("http solver instance name is {}", instance_name);
-        url.query_pairs_mut()
-            .append_pair("instance_name", &instance_name)
-            .append_pair("time_limit", &timeout.as_secs().to_string());
-
-        self.config.add_to_query(&mut url, "EnforceForOrders");
-
-        let query = url.query().map(ToString::to_string).unwrap_or_default();
-        // The default Client created in main has a short http request timeout which we might
-        // exceed. We remove it here because the solver already internally enforces the timeout and
-        // the driver code that calls us also enforces the timeout.
-        let mut request = self.client.post(url).timeout(Duration::from_secs(u64::MAX));
-        if let Some(api_key) = &self.api_key {
-            let mut header = HeaderValue::from_str(api_key.as_str()).unwrap();
-            header.set_sensitive(true);
-            request = request.header("X-API-KEY", header);
-        }
-        let body = serde_json::to_string(&model).context("failed to encode body")?;
-        tracing::trace!("request {}", body);
-        let request = request.body(body.clone());
-        let response = request.send().await.context("failed to send request")?;
-        let status = response.status();
-        let text = response
-            .text()
-            .await
-            .context("failed to decode response body")?;
-        tracing::trace!("response {}", text);
-        let context = || {
-            format!(
-                "request query {}, request body {}, response body {}",
-                query, body, text
-            )
-        };
-        ensure!(
-            status.is_success(),
-            "solver response is not success: status {}, {}",
-            status,
-            context()
-        );
-        serde_json::from_str(text.as_str())
-            .with_context(|| format!("failed to decode response json, {}", context()))
-    }
-
-    pub fn generate_instance_name(&self) -> String {
-        let now = chrono::Utc::now();
-        format!(
-            "{}_{}_{}",
-            now.to_string(),
-            self.network_name,
-            self.chain_id
-        )
-        .chars()
-        .map(|x| match x {
-            ' ' => '_',
-            '/' => '_',
-            _ => x,
-        })
-        .collect()
     }
 }
 
@@ -582,7 +469,7 @@ impl Solver for HttpSolver {
                 }
             }
         };
-        let settled = self.send(&model, deadline).await?;
+        let settled = self.solver.solve(&model, deadline).await?;
         tracing::trace!(?settled);
         if !settled.has_execution_plan() {
             return Ok(Vec::new());
@@ -595,7 +482,7 @@ impl Solver for HttpSolver {
     }
 
     fn name(&self) -> &'static str {
-        self.name
+        self.solver.name
     }
 }
 
@@ -608,10 +495,13 @@ mod tests {
     use ethcontract::Address;
     use maplit::hashmap;
     use num::rational::Ratio;
+    use reqwest::Client;
+    use shared::http_solver_api::SolverConfig;
     use shared::price_estimation::mocks::FakePriceEstimator;
     use shared::token_info::MockTokenInfoFetching;
     use shared::token_info::TokenInfo;
     use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     // cargo test real_solver -- --ignored --nocapture
     // set the env variable GP_V2_OPTIMIZER_URL to use a non localhost optimizer
@@ -658,21 +548,23 @@ mod tests {
         let gas_price = 100.;
 
         let solver = HttpSolver::new(
-            "Test Solver",
-            Account::Local(Address::default(), None),
-            url.parse().unwrap(),
-            None,
-            SolverConfig {
-                max_nr_exec_orders: 100,
-                has_ucp_policy_parameter: false,
+            HttpSolverApi {
+                name: "Test Solver",
+                network_name: "mock_network_id".to_string(),
+                chain_id: 0,
+                base: url.parse().unwrap(),
+                client: Client::new(),
+                config: SolverConfig {
+                    api_key: None,
+                    max_nr_exec_orders: 0,
+                    has_ucp_policy_parameter: false,
+                },
             },
+            Account::Local(Address::default(), None),
             H160::zero(),
             mock_token_info_fetcher,
             mock_price_estimation,
             mock_buffer_retriever,
-            "mock_network_id".to_string(),
-            0,
-            Client::new(),
             Default::default(),
             1.into(),
         );
@@ -700,7 +592,8 @@ mod tests {
             .await
             .unwrap();
         let settled = solver
-            .send(&model, Instant::now() + Duration::from_secs(1000))
+            .solver
+            .solve(&model, Instant::now() + Duration::from_secs(1000))
             .await
             .unwrap();
         dbg!(&settled);

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -1,4 +1,3 @@
-use shared::http_solver_api::model::*;
 use crate::{
     liquidity::{AmmOrderExecution, LimitOrder, Liquidity},
     settlement::Settlement,
@@ -7,6 +6,7 @@ use anyhow::{anyhow, Result};
 use itertools::Itertools;
 use model::order::OrderKind;
 use primitive_types::{H160, U256};
+use shared::http_solver_api::model::*;
 use std::collections::{hash_map::Entry, HashMap};
 
 // To send an instance to the solver we need to identify tokens and orders through strings. This

--- a/solver/src/solver/http_solver/settlement.rs
+++ b/solver/src/solver/http_solver/settlement.rs
@@ -1,4 +1,4 @@
-use super::model::*;
+use shared::http_solver_api::model::*;
 use crate::{
     liquidity::{AmmOrderExecution, LimitOrder, Liquidity},
     settlement::Settlement,


### PR DESCRIPTION
In preparation of using Quasimodo for price estimation, we're moving the HTTP solver API code to the common crate. We will then reuse it in orderbook.

### Test Plan
CI
