### PR TITLE
Re-introduce driver wait time.

### DIFF
--- a/e2e/tests/e2e/eth_integration.rs
+++ b/e2e/tests/e2e/eth_integration.rs
@@ -214,6 +214,7 @@ async fn eth_integration(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
+        Duration::from_secs(30),
         weth.address(),
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),

--- a/e2e/tests/e2e/onchain_settlement.rs
+++ b/e2e/tests/e2e/onchain_settlement.rs
@@ -223,6 +223,7 @@ async fn onchain_settlement(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
+        Duration::from_secs(30),
         gpv2.native_token.address(),
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),

--- a/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -206,6 +206,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
+        Duration::from_secs(30),
         gpv2.native_token.address(),
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),

--- a/e2e/tests/e2e/smart_contract_orders.rs
+++ b/e2e/tests/e2e/smart_contract_orders.rs
@@ -181,6 +181,7 @@ async fn smart_contract_orders(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
+        Duration::from_secs(30),
         gpv2.native_token.address(),
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),

--- a/e2e/tests/e2e/vault_balances.rs
+++ b/e2e/tests/e2e/vault_balances.rs
@@ -159,6 +159,7 @@ async fn vault_balances(web3: Web3) {
         price_estimator,
         vec![solver],
         Arc::new(web3.clone()),
+        Duration::from_secs(30),
         gpv2.native_token.address(),
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),

--- a/solver/src/driver.rs
+++ b/solver/src/driver.rs
@@ -44,6 +44,7 @@ pub struct Driver {
     price_estimator: Arc<dyn PriceEstimating>,
     solvers: Solvers,
     gas_price_estimator: Arc<dyn GasPriceEstimating>,
+    settle_interval: Duration,
     native_token: H160,
     min_order_age: Duration,
     metrics: Arc<dyn SolverMetrics>,
@@ -69,6 +70,7 @@ impl Driver {
         price_estimator: Arc<dyn PriceEstimating>,
         solvers: Solvers,
         gas_price_estimator: Arc<dyn GasPriceEstimating>,
+        settle_interval: Duration,
         native_token: H160,
         min_order_age: Duration,
         metrics: Arc<dyn SolverMetrics>,
@@ -90,6 +92,7 @@ impl Driver {
             price_estimator,
             solvers,
             gas_price_estimator,
+            settle_interval,
             native_token,
             min_order_age,
             metrics,
@@ -116,7 +119,7 @@ impl Driver {
                 Err(err) => tracing::error!("single run errored: {:?}", err),
             }
             self.metrics.runloop_completed();
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            tokio::time::sleep(self.settle_interval).await;
         }
     }
 

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -74,6 +74,20 @@ struct Arguments {
     )]
     target_confirm_time: Duration,
 
+    /// Specify the interval in seconds between consecutive driver run loops.
+    ///
+    /// This is typically a low value to prevent busy looping in case of some
+    /// internal driver error, but can be set to a larger value for running
+    /// drivers in dry-run mode to prevent repeatedly settling the same
+    /// orders.
+    #[structopt(
+        long,
+        env,
+        default_value = "1",
+        parse(try_from_str = shared::arguments::duration_from_seconds),
+    )]
+    settle_interval: Duration,
+
     /// Which type of solver to use
     #[structopt(
         long,
@@ -533,6 +547,7 @@ async fn main() {
         price_estimator,
         solver,
         gas_price_estimator,
+        args.settle_interval,
         native_token_contract.address(),
         args.min_order_age,
         metrics.clone(),


### PR DESCRIPTION
This PR re-introduces the driver settle interval command line argument. Previously, it was removed because it is not usually needed, however, it is still useful for the shadow solver instance we run to prevent it running way to often and overloading our optimization solvers.

The default value has been updated.

### Test Plan

Run the solver in dry-run mode with a large interval and see that it waits:
```
$ cargo run -p solver -- \
  --orderbook-url https://protocol-mainnet.gnosis.io \
  --node-url "https://mainnet.infura.io/v3/$INFURA_PROJECT_ID" \
  --settle-interval 30 \
  --solver-account 0xa6DDBD0dE6B310819b49f680F65871beE85f517e \
  --transaction-strategy DryRun
...
2021-11-09T07:38:58.505Z DEBUG solver::driver: single run finished ok
# waits for 30 seconds before continuing...
```
