### PR TITLE
Include e2e crate in workspace default members

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -38,16 +38,6 @@ jobs:
           path: flyway-${{ env.FLYWAY_VERSION }}
           key: ${{ runner.os }}-build-flyway-${{ env.FLYWAY_VERSION }}
       - run: "[[ -d flyway-${FLYWAY_VERSION} ]] || (curl -L https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz -o flyway-commandline-${FLYWAY_VERSION}.tar.gz && tar -xzf flyway-commandline-${FLYWAY_VERSION}.tar.gz && rm flyway-commandline-${FLYWAY_VERSION}.tar.gz)"
-      - run: cargo build --locked --all-features --tests
-      - run: cargo test --locked --all-features
-      - run: |
-          sudo systemctl start postgresql.service
-          sudo -u postgres createuser $USER
-          sudo -u postgres createdb $USER
-          psql -c "ALTER USER $USER PASSWORD '$FLYWAY_PASSWORD';"
-          flyway-${FLYWAY_VERSION}/flyway -url="jdbc:postgresql:///" -user=$USER -locations="filesystem:database/sql/" migrate
-        # Postgres tests should not run in parallel because they use the same database.
-      - run: cargo test --locked --all-features postgres -- --ignored --test-threads 1
       - run: |
           npm install hardhat
           cat > hardhat.config.js <<EOF
@@ -63,8 +53,22 @@ jobs:
           };
           EOF
           node_modules/.bin/hardhat node &
-      - run: cargo run --locked --all-features --bin deploy
-      - run: cargo test --locked --all-features --package e2e
+      - run: |
+          sudo systemctl start postgresql.service
+          sudo -u postgres createuser $USER
+          sudo -u postgres createdb $USER
+          psql -c "ALTER USER $USER PASSWORD '$FLYWAY_PASSWORD';"
+          flyway-${FLYWAY_VERSION}/flyway -url="jdbc:postgresql:///" -user=$USER -locations="filesystem:database/sql/" migrate
+      # Running deploy causes rebuild because contracts crate changes so we do it before building
+      # the rest.
+      - run: cargo build --features bin --bin deploy
+      - run: cargo run --features bin --bin deploy
+      - run: cargo test --no-run
+      - run: cargo test
+      # tests requiring a Postgres instance.
+      - run: cargo test postgres -- --ignored --test-threads 1
+      # tests requiring a local ethereum node
+      - run: cargo test local_node -- --ignored --test-threads 1
   openapi:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,6 @@ members = [
     "solver",
 ]
 
-default-members = [
-    "alerter",
-    "contracts",
-    "model",
-    "orderbook",
-    "shared",
-    "solver",
-]
-
 [patch.crates-io]
 # Warp fork with an extra commit to allow turning rejections into responses.
 warp = { git = 'https://github.com/vkgnosis/warp.git', rev = "87a91e24311b0ca6ed67408d2d302c569331dfec" }

--- a/e2e/tests/e2e/eth_integration.rs
+++ b/e2e/tests/e2e/eth_integration.rs
@@ -32,8 +32,9 @@ const ORDER_PLACEMENT_ENDPOINT: &str = "/api/v1/orders/";
 const FEE_ENDPOINT: &str = "/api/v1/fee/";
 
 #[tokio::test]
-async fn ganache_eth_integration() {
-    crate::ganache::test(eth_integration).await;
+#[ignore]
+async fn local_node_eth_integration() {
+    crate::local_node::test(eth_integration).await;
 }
 
 async fn eth_integration(web3: Web3) {

--- a/e2e/tests/e2e/main.rs
+++ b/e2e/tests/e2e/main.rs
@@ -3,7 +3,7 @@
 // here and in this test we include all the tests we want to run.
 
 mod eth_integration;
-mod ganache;
+mod local_node;
 mod onchain_settlement;
 #[macro_use]
 mod services;

--- a/e2e/tests/e2e/onchain_settlement.rs
+++ b/e2e/tests/e2e/onchain_settlement.rs
@@ -34,8 +34,9 @@ const TRADER_B_PK: [u8; 32] =
 const ORDER_PLACEMENT_ENDPOINT: &str = "/api/v1/orders/";
 
 #[tokio::test]
-async fn ganache_onchain_settlement() {
-    crate::ganache::test(onchain_settlement).await;
+#[ignore]
+async fn local_node_onchain_settlement() {
+    crate::local_node::test(onchain_settlement).await;
 }
 
 async fn onchain_settlement(web3: Web3) {

--- a/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -30,8 +30,9 @@ const TRADER_A_PK: [u8; 32] =
 const ORDER_PLACEMENT_ENDPOINT: &str = "/api/v1/orders/";
 
 #[tokio::test]
-async fn ganache_onchain_settlement_without_liquidity() {
-    crate::ganache::test(onchain_settlement_without_liquidity).await;
+#[ignore]
+async fn local_node_onchain_settlement_without_liquidity() {
+    crate::local_node::test(onchain_settlement_without_liquidity).await;
 }
 
 async fn onchain_settlement_without_liquidity(web3: Web3) {

--- a/e2e/tests/e2e/smart_contract_orders.rs
+++ b/e2e/tests/e2e/smart_contract_orders.rs
@@ -21,8 +21,9 @@ const TRADER: [u8; 32] = [1; 32];
 const ORDER_PLACEMENT_ENDPOINT: &str = "/api/v1/orders/";
 
 #[tokio::test]
-async fn ganache_smart_contract_orders() {
-    crate::ganache::test(smart_contract_orders).await;
+#[ignore]
+async fn local_node_smart_contract_orders() {
+    crate::local_node::test(smart_contract_orders).await;
 }
 
 async fn smart_contract_orders(web3: Web3) {

--- a/e2e/tests/e2e/vault_balances.rs
+++ b/e2e/tests/e2e/vault_balances.rs
@@ -26,8 +26,9 @@ const TRADER: [u8; 32] = [1; 32];
 const ORDER_PLACEMENT_ENDPOINT: &str = "/api/v1/orders/";
 
 #[tokio::test]
-async fn ganache_vault_balances() {
-    crate::ganache::test(vault_balances).await;
+#[ignore]
+async fn local_node_vault_balances() {
+    crate::local_node::test(vault_balances).await;
 }
 
 async fn vault_balances(web3: Web3) {


### PR DESCRIPTION
Draft while testing.

Advantages:
- No rebuilding needed when running e2e tests (good for CI).
- `cargo check` now includes the e2e crate so it now catches
  compilation errors where before you needed to run with --workspace

Disadvantages:
- Slightly higher compilation time by default because e2e crate is
  included. When I tested this was minor: always < 0.5 seconds after
  `touch shared/src/lib.rs` and rebuilding.

### Test Plan
CI
