### PR TITLE
Disable doctests

### DIFF
--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Gnosis Developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[lib]
+doctest = false
+
 [[bin]]
 name = "deploy"
 required-features = ["bin"]

--- a/crates/model/Cargo.toml
+++ b/crates/model/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Gnosis Developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[lib]
+doctest = false
+
 [dependencies]
 anyhow = "1"
 bigdecimal = "0.3"

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-or-later"
 [lib]
 name = "orderbook"
 path = "src/lib.rs"
+doctest = false
 
 [[bin]]
 name = "orderbook"

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Gnosis Developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[lib]
+doctest = false
+
 [dependencies]
 anyhow = "1.0"
 assert_approx_eq = "1.1"

--- a/crates/solver/Cargo.toml
+++ b/crates/solver/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-or-later"
 [lib]
 name = "solver"
 path = "src/lib.rs"
+doctest = false
 
 [[bin]]
 name = "solver"


### PR DESCRIPTION
They are slow to compile because each is its own binary. See https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html .

We only have [one](https://github.com/gnosis/gp-v2-services/blob/32408a704e644f26aab856257a3178ccd57ae25a/model/src/u256_decimal.rs#L68) doctest at the moment so this isn't a problem now but I like the change anyway to remind us to not rely on them in the future. We can still write them as a form of *documentation* but we shouldn't write them as *unit tests*.

### Test Plan
CI