### PR TITLE
Adjust slippage for zeroEx Solver

### DIFF
--- a/crates/shared/src/solver_utils.rs
+++ b/crates/shared/src/solver_utils.rs
@@ -30,7 +30,7 @@ impl Slippage {
     }
 
     /// Creates a slippage amount from the specified basis points as number.
-    pub fn number_from_basis_points(basis_points: u16) -> Result<Self> {
+    pub fn number_from_basis_points(basis_points: u32) -> Result<Self> {
         let number_representation = (basis_points as f64) / 10000.;
         Ok(Slippage(number_representation))
     }

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -176,6 +176,10 @@ struct Arguments {
     #[structopt(long, env, default_value = "10")]
     paraswap_slippage_bps: u32,
 
+    /// The slippage tolerance we apply to the price quoted by Paraswap
+    #[structopt(long, env, default_value = "10")]
+    zeroex_slippage_bps: u16,
+
     /// The authorization for the archer api.
     #[structopt(long, env)]
     archer_authorization: Option<String>,
@@ -473,6 +477,7 @@ async fn main() {
         native_token_price_estimation_amount,
         metrics.clone(),
         zeroex_api,
+        args.zeroex_slippage_bps,
     )
     .expect("failure creating solvers");
     let liquidity_collector = LiquidityCollector {

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -176,9 +176,9 @@ struct Arguments {
     #[structopt(long, env, default_value = "10")]
     paraswap_slippage_bps: u32,
 
-    /// The slippage tolerance we apply to the price quoted by Paraswap
+    /// The slippage tolerance we apply to the price quoted by zeroEx
     #[structopt(long, env, default_value = "10")]
-    zeroex_slippage_bps: u16,
+    zeroex_slippage_bps: u32,
 
     /// The authorization for the archer api.
     #[structopt(long, env)]

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -157,7 +157,7 @@ pub fn create(
     native_token_amount_to_estimate_prices_with: U256,
     solver_metrics: Arc<dyn SolverMetrics>,
     zeroex_api: Arc<dyn ZeroExApi>,
-    zeroex_slippage_bps: u16,
+    zeroex_slippage_bps: u32,
 ) -> Result<Solvers> {
     // Tiny helper function to help out with type inference. Otherwise, all
     // `Box::new(...)` expressions would have to be cast `as Box<dyn Solver>`.

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -157,6 +157,7 @@ pub fn create(
     native_token_amount_to_estimate_prices_with: U256,
     solver_metrics: Arc<dyn SolverMetrics>,
     zeroex_api: Arc<dyn ZeroExApi>,
+    zeroex_slippage_bps: u16,
 ) -> Result<Solvers> {
     // Tiny helper function to help out with type inference. Otherwise, all
     // `Box::new(...)` expressions would have to be cast `as Box<dyn Solver>`.
@@ -243,6 +244,7 @@ pub fn create(
                         settlement_contract.clone(),
                         chain_id,
                         zeroex_api.clone(),
+                        zeroex_slippage_bps,
                     )
                     .unwrap();
                     shared(SingleOrderSolver::new(

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -44,7 +44,7 @@ pub struct ZeroExSolver {
     account: Account,
     api: Arc<dyn ZeroExApi>,
     allowance_fetcher: Box<dyn AllowanceManaging>,
-    zeroex_slippage_bps: u16,
+    zeroex_slippage_bps: u32,
 }
 
 /// Chain ID for Mainnet.
@@ -57,7 +57,7 @@ impl ZeroExSolver {
         settlement_contract: GPv2Settlement,
         chain_id: u64,
         api: Arc<dyn ZeroExApi>,
-        zeroex_slippage_bps: u16,
+        zeroex_slippage_bps: u32,
     ) -> Result<Self> {
         ensure!(
             chain_id == MAINNET_CHAIN_ID,

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -39,14 +39,12 @@ use std::{
     sync::Arc,
 };
 
-/// Constant maximum slippage of 5 BPS (0.05%) to use for on-chain liquidity.
-pub const STANDARD_ZEROEX_SLIPPAGE_BPS: u16 = 5;
-
 /// A GPv2 solver that matches GP orders to direct 0x swaps.
 pub struct ZeroExSolver {
     account: Account,
     api: Arc<dyn ZeroExApi>,
     allowance_fetcher: Box<dyn AllowanceManaging>,
+    zeroex_slippage_bps: u16,
 }
 
 /// Chain ID for Mainnet.
@@ -59,6 +57,7 @@ impl ZeroExSolver {
         settlement_contract: GPv2Settlement,
         chain_id: u64,
         api: Arc<dyn ZeroExApi>,
+        zeroex_slippage_bps: u16,
     ) -> Result<Self> {
         ensure!(
             chain_id == MAINNET_CHAIN_ID,
@@ -69,6 +68,7 @@ impl ZeroExSolver {
             account,
             allowance_fetcher: Box::new(allowance_fetcher),
             api,
+            zeroex_slippage_bps,
         })
     }
 }
@@ -88,7 +88,7 @@ impl SingleOrderSolving for ZeroExSolver {
             buy_token: order.buy_token,
             sell_amount,
             buy_amount,
-            slippage_percentage: Slippage::number_from_basis_points(STANDARD_ZEROEX_SLIPPAGE_BPS)
+            slippage_percentage: Slippage::number_from_basis_points(self.zeroex_slippage_bps)
                 .unwrap(),
         };
 

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -186,6 +186,7 @@ mod tests {
             settlement,
             chain_id,
             Arc::new(DefaultZeroExApi::default()),
+            10u32,
         )
         .unwrap();
         let settlement = solver
@@ -225,6 +226,7 @@ mod tests {
             settlement,
             chain_id,
             Arc::new(DefaultZeroExApi::default()),
+            10u32,
         )
         .unwrap();
         let settlement = solver
@@ -287,6 +289,7 @@ mod tests {
             account: account(),
             api: Arc::new(client),
             allowance_fetcher,
+            zeroex_slippage_bps: 10u32,
         };
 
         let buy_order_passing_limit = LimitOrder {
@@ -375,7 +378,8 @@ mod tests {
             web3,
             settlement,
             chain_id,
-            Arc::new(DefaultZeroExApi::default())
+            Arc::new(DefaultZeroExApi::default()),
+            10u32
         )
         .is_err())
     }
@@ -427,6 +431,7 @@ mod tests {
             account: account(),
             api: Arc::new(client),
             allowance_fetcher,
+            zeroex_slippage_bps: 10u32,
         };
 
         let order = LimitOrder {
@@ -480,6 +485,7 @@ mod tests {
             account: account(),
             api: Arc::new(client),
             allowance_fetcher,
+            zeroex_slippage_bps: 10u32,
         };
 
         let order = LimitOrder {


### PR DESCRIPTION
ZeroEx slippage is quite tight right now with 0.05% 
I think this tightness contributes to the huge costs of failed tx. Hence, I want it to be adaptable.

### Test Plan
*<Explain how you and a reviewer have/intend to test this change>*
