### PR TITLE
Add metric to track the effective gas price used

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -526,7 +526,8 @@ impl Driver {
                     }
                 };
                 self.in_flight_orders.mark_settled_orders(block, orders);
-                self.metrics.transaction_gas_price(receipt.effective_gas_price);
+                self.metrics
+                    .transaction_gas_price(receipt.effective_gas_price);
             }
             self.metrics.transaction_submission(start.elapsed());
 

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -526,6 +526,7 @@ impl Driver {
                     }
                 };
                 self.in_flight_orders.mark_settled_orders(block, orders);
+                self.metrics.transaction_gas_price(receipt.effective_gas_price);
             }
             self.metrics.transaction_submission(start.elapsed());
 

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -1,8 +1,9 @@
 use crate::liquidity::{LimitOrder, Liquidity};
 use anyhow::Result;
+use ethcontract::U256;
 use model::order::Order;
 use prometheus::{
-    Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGaugeVec, Opts,
+    Gauge, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGaugeVec, Opts,
 };
 use shared::{
     metrics::get_metrics_registry,
@@ -40,6 +41,7 @@ pub trait SolverMetrics: Send + Sync {
     fn runloop_completed(&self);
     fn complete_runloop_until_transaction(&self, duration: Duration);
     fn transaction_submission(&self, duration: Duration);
+    fn transaction_gas_price(&self, gas_price: U256);
 }
 
 // TODO add labeled interaction counter once we support more than one interaction
@@ -60,6 +62,7 @@ pub struct Metrics {
     order_surplus_report: Histogram,
     complete_runloop_until_transaction: Histogram,
     transaction_submission: Histogram,
+    transaction_gas_price: Gauge,
 }
 
 impl Metrics {
@@ -174,6 +177,13 @@ impl Metrics {
         })?;
         registry.register(Box::new(transaction_submission.clone()))?;
 
+        let opts = Opts::new(
+            "transaction_gas_price",
+            "Actual gas price used by settlement transaction.",
+        );
+        let transaction_gas_price = Gauge::with_opts(opts).unwrap();
+        registry.register(Box::new(transaction_gas_price.clone()))?;
+
         Ok(Self {
             trade_counter,
             order_settlement_time,
@@ -191,6 +201,7 @@ impl Metrics {
             order_surplus_report,
             complete_runloop_until_transaction,
             transaction_submission,
+            transaction_gas_price,
         })
     }
 }
@@ -309,6 +320,11 @@ impl SolverMetrics for Metrics {
     fn transaction_submission(&self, duration: Duration) {
         self.transaction_submission.observe(duration.as_secs_f64());
     }
+
+    fn transaction_gas_price(&self, gas_price: U256) {
+        self.transaction_gas_price
+            .set(gas_price.to_f64_lossy() / 1e9)
+    }
 }
 
 impl TransportMetrics for Metrics {
@@ -368,6 +384,7 @@ impl SolverMetrics for NoopMetrics {
     fn runloop_completed(&self) {}
     fn complete_runloop_until_transaction(&self, _: Duration) {}
     fn transaction_submission(&self, _: Duration) {}
+    fn transaction_gas_price(&self, _: U256) {}
 }
 
 #[cfg(test)]

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -62,7 +62,7 @@ pub struct Metrics {
     order_surplus_report: Histogram,
     complete_runloop_until_transaction: Histogram,
     transaction_submission: Histogram,
-    transaction_gas_price: Gauge,
+    transaction_gas_price_gwei: Gauge,
 }
 
 impl Metrics {
@@ -178,11 +178,11 @@ impl Metrics {
         registry.register(Box::new(transaction_submission.clone()))?;
 
         let opts = Opts::new(
-            "transaction_gas_price",
+            "transaction_gas_price_gwei",
             "Actual gas price used by settlement transaction.",
         );
-        let transaction_gas_price = Gauge::with_opts(opts).unwrap();
-        registry.register(Box::new(transaction_gas_price.clone()))?;
+        let transaction_gas_price_gwei = Gauge::with_opts(opts).unwrap();
+        registry.register(Box::new(transaction_gas_price_gwei.clone()))?;
 
         Ok(Self {
             trade_counter,
@@ -201,7 +201,7 @@ impl Metrics {
             order_surplus_report,
             complete_runloop_until_transaction,
             transaction_submission,
-            transaction_gas_price,
+            transaction_gas_price_gwei,
         })
     }
 }
@@ -322,7 +322,7 @@ impl SolverMetrics for Metrics {
     }
 
     fn transaction_gas_price(&self, gas_price: U256) {
-        self.transaction_gas_price
+        self.transaction_gas_price_gwei
             .set(gas_price.to_f64_lossy() / 1e9)
     }
 }


### PR DESCRIPTION
This PR adds a new metric that plots the effective gas price of the transaction over time.

Note that this is not an ideal prometheus metric and relies on the fact that we don't settle transactions so often. In the future (especially if we start allowing solvers to mine transactions in parallel) we will likely have to change this.

For now, this will give us a nice plot of with two curves:
- gas estimates over time
- actual gas used over time

### Test Plan

Compiler.
