### PR TITLE
Speed up hardhat installation on CI

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -26,20 +26,47 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
       FLYWAY_VERSION: 7.3.1
+      FLYWAY_PATH: /home/runner/flyway
       # Flyway is connecting via TCP/IP (authentication via password), whereas psql connects via Unix-domain sockets (authentication via username)
       # We set the db password of $USER to this value which is also used by the flyway command
       FLYWAY_PASSWORD: password
+      # Extra underscore because conflicts with hardhat internally used variables.
+      HARDHAT_VERSION_: 2.6.8
+      HARDHAT_PATH_: /home/runner/hardhat
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
       - name: Cache flyway
+        id: cache-flyway
         uses: actions/cache@v2
         with:
-          path: flyway-${{ env.FLYWAY_VERSION }}
-          key: ${{ runner.os }}-build-flyway-${{ env.FLYWAY_VERSION }}
-      - run: "[[ -d flyway-${FLYWAY_VERSION} ]] || (curl -L https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz -o flyway-commandline-${FLYWAY_VERSION}.tar.gz && tar -xzf flyway-commandline-${FLYWAY_VERSION}.tar.gz && rm flyway-commandline-${FLYWAY_VERSION}.tar.gz)"
-      - run: |
-          npm install hardhat
+          path: ${{ env.FLYWAY_PATH }}
+          key: ${{ runner.os }}-flyway-${{ env.FLYWAY_VERSION }}
+      - name: Install Flyway
+        if: steps.cache-flyway.outputs.cache-hit != 'true'
+        run: |
+          mkdir --parents ${{ env.FLYWAY_PATH }}
+          cd ${{ env.FLYWAY_PATH }}
+          curl -L https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz -o out.tar.gz
+          tar --strip-components=1 -xzf out.tar.gz
+          rm out.tar.gz
+          ls -al
+      - name: Cache Hardhat
+        id: cache-hardhat
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.HARDHAT_PATH_ }}/node_modules
+          key: ${{ runner.os }}-hardhat-${{ env.HARDHAT_VERSION_ }}
+      - name: Install Hardhat
+        if: steps.cache-hardhat.outputs.cache-hit != 'true'
+        run: |
+          mkdir --parents ${{ env.HARDHAT_PATH_ }}
+          cd ${{ env.HARDHAT_PATH_ }}
+          npm install hardhat@${{ env.HARDHAT_VERSION_ }}
+          ls -al
+      - name: Setup Hardhat
+        working-directory: ${{ env.HARDHAT_PATH_ }}
+        run: |
           cat > hardhat.config.js <<EOF
           module.exports = {
             networks: {
@@ -53,12 +80,13 @@ jobs:
           };
           EOF
           node_modules/.bin/hardhat node &
-      - run: |
+      - name: Setup Database
+        run: |
           sudo systemctl start postgresql.service
           sudo -u postgres createuser $USER
           sudo -u postgres createdb $USER
           psql -c "ALTER USER $USER PASSWORD '$FLYWAY_PASSWORD';"
-          flyway-${FLYWAY_VERSION}/flyway -url="jdbc:postgresql:///" -user=$USER -locations="filesystem:database/sql/" migrate
+          ${{ env.FLYWAY_PATH }}/flyway -url="jdbc:postgresql:///" -user=$USER -locations="filesystem:database/sql/" migrate
       - run: cargo test --no-run
       - run: cargo test
       # tests requiring a Postgres instance.


### PR DESCRIPTION
Installing hardhat from scratch takes ~30 seconds. With this PR we cache it instead. The cache is small so this is much faster (1s).
Also changed how flyway is cached to make it nicer (put files into separate directory, don't run install if cache action ran).

### Test Plan
CI still works
