### PR TITLE
Treat Flashbots simulation error like method errors

### DIFF
--- a/crates/solver/src/settlement_submission/flashbots_settlement.rs
+++ b/crates/solver/src/settlement_submission/flashbots_settlement.rs
@@ -15,7 +15,7 @@
 
 use super::{flashbots_api::FlashbotsApi, ESTIMATE_GAS_LIMIT_FACTOR};
 use crate::settlement::Settlement;
-use anyhow::{anyhow, ensure, Error, Context, Result};
+use anyhow::{anyhow, ensure, Context, Error, Result};
 use contracts::GPv2Settlement;
 use ethcontract::{transaction::Transaction, Account};
 use futures::FutureExt;

--- a/crates/solver/src/settlement_submission/flashbots_settlement.rs
+++ b/crates/solver/src/settlement_submission/flashbots_settlement.rs
@@ -15,7 +15,7 @@
 
 use super::{flashbots_api::FlashbotsApi, ESTIMATE_GAS_LIMIT_FACTOR};
 use crate::settlement::Settlement;
-use anyhow::{anyhow, ensure, Context, Result};
+use anyhow::{anyhow, ensure, Error, Context, Result};
 use contracts::GPv2Settlement;
 use ethcontract::{transaction::Transaction, Account};
 use futures::FutureExt;
@@ -267,7 +267,7 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
                         tracing::warn!("flashbots cancellation request not sent: {:?}", err);
                     }
                 }
-                return anyhow::Error::new(err).context("flashbots failed simulation");
+                return Error::from(err).context("flashbots failed simulation");
             }
 
             // If gas price has increased cancel old and submit new transaction.

--- a/crates/solver/src/settlement_submission/flashbots_settlement.rs
+++ b/crates/solver/src/settlement_submission/flashbots_settlement.rs
@@ -97,10 +97,19 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
                 .unwrap_or_else(|_| Duration::from_secs(0)),
         );
 
-        futures::select! {
-            method_error = submit_future.fuse() => tracing::info!("stopping submission because simulation failed: {:?}", method_error),
-            new_nonce = nonce_future.fuse() => tracing::info!("stopping submission because account nonce changed to {}", new_nonce),
-            _ = deadline_future.fuse() => tracing::info!("stopping submission because deadline has been reached"),
+        let fallback_result = tokio::select! {
+            method_error = submit_future.fuse() => {
+                tracing::info!("stopping submission because simulation failed: {:?}", method_error);
+                Err(method_error)
+            },
+            new_nonce = nonce_future.fuse() => {
+                tracing::info!("stopping submission because account nonce changed to {}", new_nonce);
+                Ok(None)
+            },
+            _ = deadline_future.fuse() => {
+                tracing::info!("stopping submission because deadline has been reached");
+                Ok(None)
+            },
         };
 
         // After stopping submission of new transactions we wait for some time to give a potentially
@@ -137,7 +146,7 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
         }
 
         tracing::info!("did not find any mined transaction");
-        Ok(None)
+        fallback_result
     }
 
     async fn nonce(&self) -> Result<U256> {
@@ -258,7 +267,7 @@ impl<'a> FlashbotsSolutionSubmitter<'a> {
                         tracing::warn!("flashbots cancellation request not sent: {:?}", err);
                     }
                 }
-                return anyhow!("flashbots failed simulation: {}", err);
+                return anyhow::Error::new(err).context("flashbots failed simulation");
             }
 
             // If gas price has increased cancel old and submit new transaction.


### PR DESCRIPTION
Fixes noisy alerts whenever we cancel a flashbots tx due to it no longer succeeding to simulate

### Test Plan

Before the PR

> 2021-11-11T15:13:05.284Z ERROR solver::driver: Failed to submit 0x settlement: transaction did not get mined in time

Running this PR with against mainnet (with the adjustment of overriding miner tip with 0 to ensure we never actually get mined):

> 2021-11-11T15:51:54.062Z  WARN solver::driver: Failed to submit 0x settlement: flashbots failed simulation
Caused by:
    0: method 'settle(address[],uint256[],(uint256,uint256,address,uint256,uint256,uint32,bytes32,uint256,uint256,uint256,bytes)[],(address,uint256,bytes)[][3])' failure: contract call reverted with message: Some("GPv2: order filled")
    1: contract call reverted with message: Some("GPv2: order filled")
