### PR TITLE
Add a competition based price estimator

### DIFF
--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -1,4 +1,5 @@
 pub mod baseline;
+pub mod competition;
 pub mod gas;
 pub mod instrumented;
 pub mod paraswap;
@@ -19,6 +20,13 @@ arg_enum! {
         Baseline,
         Paraswap,
         ZeroEx,
+    }
+}
+
+impl PriceEstimatorType {
+    /// Returns the name of this price estimator type.
+    pub fn name(&self) -> String {
+        format!("{:?}", self)
     }
 }
 
@@ -57,7 +65,7 @@ pub struct Query {
     pub kind: OrderKind,
 }
 
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct Estimate {
     pub out_amount: U256,
     /// full gas cost when settling this order alone on gp

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -1,6 +1,8 @@
 use super::{Estimate, PriceEstimating, PriceEstimationError, Query};
 use anyhow::{anyhow, Result};
 use futures::future;
+use num::BigRational;
+use std::cmp;
 
 /// Price estimator that pulls estimates from various sources
 /// and competes on the best price.
@@ -30,41 +32,87 @@ impl PriceEstimating for CompetitionPriceEstimator {
             .map(|(i, query)| {
                 all_estimates
                     .iter()
-                    .filter_map(|(name, estimates)| match &estimates[i] {
-                        Ok(estimate) => Some((name, estimate)),
-                        Err(err) => {
-                            tracing::warn!(
-                                estimator_name = %name, ?query, ?err,
-                                "price estimation error",
-                            );
-                            None
-                        }
-                    })
-                    .filter_map(|(name, estimate)| {
-                        match estimate.price_in_sell_token_rational(query) {
-                            Some(price) => Some((name, estimate, price)),
-                            None => {
-                                tracing::warn!(
-                                    estimator_name = %name, ?query, ?estimate,
-                                    "price estimate with zero amounts",
-                                );
-                                None
-                            }
-                        }
-                    })
-                    .max_by_key(|(_, _, price)| price.clone())
-                    .ok_or_else(|| {
-                        PriceEstimationError::Other(anyhow!("no successful price estimates"))
-                    })
-                    .map(|(name, estimate, _)| {
-                        tracing::debug!(
-                            winning_estimator = %name, ?query, ?estimate,
-                            "winning price estimate",
-                        );
-                        *estimate
+                    .fold(
+                        Err(PriceEstimationError::Other(anyhow!(
+                            "no successful price estimates"
+                        ))),
+                        |previous_result, (name, estimates)| {
+                            fold_price_estimation_result(
+                                query,
+                                name,
+                                previous_result,
+                                estimates[i].clone(),
+                            )
+                        },
+                    )
+                    .map(|winning_estimate| {
+                        tracing::debug!(?query, ?winning_estimate, "winning price estimate",);
+                        winning_estimate.estimate
                     })
             })
             .collect()
+    }
+}
+
+#[derive(Debug)]
+struct EstimateData<'a> {
+    estimator_name: &'a str,
+    estimate: Estimate,
+    price: BigRational,
+}
+
+fn fold_price_estimation_result<'a>(
+    query: &'a Query,
+    estimator_name: &'a str,
+    previous_result: Result<EstimateData<'a>, PriceEstimationError>,
+    estimate: Result<Estimate, PriceEstimationError>,
+) -> Result<EstimateData<'a>, PriceEstimationError> {
+    match &estimate {
+        Ok(estimate) => tracing::debug!(
+            %estimator_name, ?query, ?estimate,
+            "received price estimate",
+        ),
+        Err(err) => tracing::warn!(
+            %estimator_name, ?query, ?err,
+            "price estimation error",
+        ),
+    }
+
+    let estimate_with_price = estimate.and_then(|estimate| {
+        let price = estimate
+            .price_in_sell_token_rational(query)
+            .ok_or(PriceEstimationError::ZeroAmount)?;
+        Ok(EstimateData {
+            estimator_name,
+            estimate,
+            price,
+        })
+    });
+
+    match (previous_result, estimate_with_price) {
+        (Ok(previous), Ok(estimate)) => Ok(cmp::max_by_key(previous, estimate, |data| {
+            data.price.clone()
+        })),
+        (Ok(estimate), Err(_)) | (Err(_), Ok(estimate)) => Ok(estimate),
+        (Err(previous_err), Err(err)) => Err(join_error(previous_err, err)),
+    }
+}
+
+fn join_error(a: PriceEstimationError, b: PriceEstimationError) -> PriceEstimationError {
+    // NOTE(nlordell): How errors are joined is kind of arbitrary. I decided to
+    // just order them in the following priority:
+    // - ZeroAmount
+    // - UnsupportedToken
+    // - NoLiquidity
+    // - Other
+    match (a, b) {
+        (err @ PriceEstimationError::ZeroAmount, _)
+        | (_, err @ PriceEstimationError::ZeroAmount) => err,
+        (err @ PriceEstimationError::UnsupportedToken(_), _)
+        | (_, err @ PriceEstimationError::UnsupportedToken(_)) => err,
+        (err @ PriceEstimationError::NoLiquidity, _)
+        | (_, err @ PriceEstimationError::NoLiquidity) => err,
+        (err @ PriceEstimationError::Other(_), _) => err,
     }
 }
 
@@ -97,6 +145,12 @@ mod tests {
                 in_amount: 1.into(),
                 kind: OrderKind::Buy,
             },
+            Query {
+                sell_token: H160::from_low_u64_le(5),
+                buy_token: H160::from_low_u64_le(6),
+                in_amount: 1.into(),
+                kind: OrderKind::Buy,
+            },
         ];
         let estimates = [
             Estimate {
@@ -111,11 +165,12 @@ mod tests {
 
         let mut first = MockPriceEstimating::new();
         first.expect_estimates().times(1).returning(move |queries| {
-            assert_eq!(queries.len(), 3);
+            assert_eq!(queries.len(), 4);
             vec![
                 Ok(estimates[0]),
                 Ok(estimates[0]),
                 Err(PriceEstimationError::Other(anyhow!(""))),
+                Err(PriceEstimationError::NoLiquidity),
             ]
         });
         let mut second = MockPriceEstimating::new();
@@ -123,11 +178,12 @@ mod tests {
             .expect_estimates()
             .times(1)
             .returning(move |queries| {
-                assert_eq!(queries.len(), 3);
+                assert_eq!(queries.len(), 4);
                 vec![
                     Err(PriceEstimationError::Other(anyhow!(""))),
                     Ok(estimates[1]),
                     Err(PriceEstimationError::Other(anyhow!(""))),
+                    Err(PriceEstimationError::UnsupportedToken(H160([0; 20]))),
                 ]
             });
 
@@ -137,12 +193,17 @@ mod tests {
         ]);
 
         let result = priority.estimates(&queries).await;
-        assert_eq!(result.len(), 3);
+        assert_eq!(result.len(), 4);
         assert_eq!(result[0].as_ref().unwrap(), &estimates[0]);
         assert_eq!(result[1].as_ref().unwrap(), &estimates[1]);
         assert!(matches!(
             result[2].as_ref().unwrap_err(),
-            PriceEstimationError::Other(_),
+            PriceEstimationError::Other(err)
+                if err.to_string() == "no successful price estimates",
+        ));
+        assert!(matches!(
+            result[3].as_ref().unwrap_err(),
+            PriceEstimationError::UnsupportedToken(_),
         ));
     }
 }

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -1,0 +1,148 @@
+use super::{Estimate, PriceEstimating, PriceEstimationError, Query};
+use anyhow::{anyhow, Result};
+use futures::future;
+
+/// Price estimator that pulls estimates from various sources
+/// and competes on the best price.
+pub struct CompetitionPriceEstimator {
+    inner: Vec<(String, Box<dyn PriceEstimating>)>,
+}
+
+impl CompetitionPriceEstimator {
+    pub fn new(inner: Vec<(String, Box<dyn PriceEstimating>)>) -> Self {
+        assert!(!inner.is_empty());
+        Self { inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl PriceEstimating for CompetitionPriceEstimator {
+    async fn estimates(&self, queries: &[Query]) -> Vec<Result<Estimate, PriceEstimationError>> {
+        let all_estimates =
+            future::join_all(self.inner.iter().map(|(name, estimator)| async move {
+                (name, estimator.estimates(queries).await)
+            }))
+            .await;
+
+        queries
+            .iter()
+            .enumerate()
+            .map(|(i, query)| {
+                all_estimates
+                    .iter()
+                    .filter_map(|(name, estimates)| match &estimates[i] {
+                        Ok(estimate) => Some((name, estimate)),
+                        Err(err) => {
+                            tracing::warn!(
+                                estimator_name = %name, ?query, ?err,
+                                "price estimation error",
+                            );
+                            None
+                        }
+                    })
+                    .filter_map(|(name, estimate)| {
+                        match estimate.price_in_sell_token_rational(query) {
+                            Some(price) => Some((name, estimate, price)),
+                            None => {
+                                tracing::warn!(
+                                    estimator_name = %name, ?query, ?estimate,
+                                    "price estimate with zero amounts",
+                                );
+                                None
+                            }
+                        }
+                    })
+                    .max_by_key(|(_, _, price)| price.clone())
+                    .ok_or_else(|| {
+                        PriceEstimationError::Other(anyhow!("no successful price estimates"))
+                    })
+                    .map(|(name, estimate, _)| {
+                        tracing::debug!(
+                            winning_estimator = %name, ?query, ?estimate,
+                            "winning price estimate",
+                        );
+                        *estimate
+                    })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::price_estimation::MockPriceEstimating;
+    use anyhow::anyhow;
+    use model::order::OrderKind;
+    use primitive_types::H160;
+
+    #[tokio::test]
+    async fn works() {
+        let queries = [
+            Query {
+                sell_token: H160::from_low_u64_le(0),
+                buy_token: H160::from_low_u64_le(1),
+                in_amount: 1.into(),
+                kind: OrderKind::Buy,
+            },
+            Query {
+                sell_token: H160::from_low_u64_le(2),
+                buy_token: H160::from_low_u64_le(3),
+                in_amount: 1.into(),
+                kind: OrderKind::Buy,
+            },
+            Query {
+                sell_token: H160::from_low_u64_le(3),
+                buy_token: H160::from_low_u64_le(4),
+                in_amount: 1.into(),
+                kind: OrderKind::Buy,
+            },
+        ];
+        let estimates = [
+            Estimate {
+                out_amount: 1.into(),
+                ..Default::default()
+            },
+            Estimate {
+                out_amount: 2.into(),
+                ..Default::default()
+            },
+        ];
+
+        let mut first = MockPriceEstimating::new();
+        first.expect_estimates().times(1).returning(move |queries| {
+            assert_eq!(queries.len(), 3);
+            vec![
+                Ok(estimates[0]),
+                Ok(estimates[0]),
+                Err(PriceEstimationError::Other(anyhow!(""))),
+            ]
+        });
+        let mut second = MockPriceEstimating::new();
+        second
+            .expect_estimates()
+            .times(1)
+            .returning(move |queries| {
+                assert_eq!(queries.len(), 3);
+                vec![
+                    Err(PriceEstimationError::Other(anyhow!(""))),
+                    Ok(estimates[1]),
+                    Err(PriceEstimationError::Other(anyhow!(""))),
+                ]
+            });
+
+        let priority = CompetitionPriceEstimator::new(vec![
+            ("first".to_owned(), Box::new(first)),
+            ("second".to_owned(), Box::new(second)),
+        ]);
+
+        let result = priority.estimates(&queries).await;
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].as_ref().unwrap(), &estimates[0]);
+        assert_eq!(result[1].as_ref().unwrap(), &estimates[1]);
+        assert!(matches!(
+            result[2].as_ref().unwrap_err(),
+            PriceEstimationError::Other(_),
+        ));
+    }
+}


### PR DESCRIPTION
This PR adds a new price estimator that computes price estimates using all configured estimators and chooses the one with the best price.

We define "best" price by the highest sell token price. This means that given a sell amount of `S` and buy amount of `B` we want maximize `S/B` - i.e. which estimator offers the best price to the user.

Additionally, we try to merge errors on a "best-effort" basis. This is done by considering them in a certain priority:
- `ZeroAmount`: The rational here being that this should only happen when estimating 0 amounts, so all estimators should, in theory, return this error for those queries. In practice, I don't think this path will be hit because the API filters out queries with 0 amounts anyway.
- `UnsupportedToken`: This means that one of the price estimators determined the token was unsupported. Again, in theory this should be returned by all price estimators. The reason I ranked this slightly higher than `NoLiquidity` error is that, in theory a token may be unsupported but by an external price estimator (0x for example) be reported as "no liquidity" because they don't consider any AMMs with this token because it isn't tradable.
- `NoLiquidity`: The last typed error.
- `Other`: Fallback error type. Note that we start "folding" the estimate results with an error of `Other("no successful price estimates")` so in the case all our estimators fail for some "internal" error, we will also get a generic message.

### Test Plan

Added a unit test.

Run manually and see price competition happening:
```
2021-11-16T11:29:13.141Z DEBUG shared::price_estimation::competition: received price estimate estimator_name=Baseline query=Query { sell_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, buy_token: 0xba100000625a3754423978a60c9317c58a424e3d, in_amount: 1000000000000000000, kind: Sell } estimate=Estimate { out_amount: 197195284678621485677, gas: 220417 }
2021-11-16T11:29:13.141Z DEBUG shared::price_estimation::competition: received price estimate estimator_name=ZeroEx query=Query { sell_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, buy_token: 0xba100000625a3754423978a60c9317c58a424e3d, in_amount: 1000000000000000000, kind: Sell } estimate=Estimate { out_amount: 197195284678621485677, gas: 217391 }
2021-11-16T11:29:13.141Z DEBUG shared::price_estimation::competition: winning price estimate query=Query { sell_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, buy_token: 0xba100000625a3754423978a60c9317c58a424e3d, in_amount: 1000000000000000000, kind: Sell } winning_estimate=EstimateData { estimator_name: "ZeroEx", estimate: Estimate { out_amount: 197195284678621485677, gas: 217391 }, price: Ratio { numer: 1000000000000000000, denom: 197195284678621485677 } }
```