### PR TITLE
Allow the http solver to pass on interaction data directly

### DIFF
--- a/crates/shared/src/http_solver_api/model.rs
+++ b/crates/shared/src/http_solver_api/model.rs
@@ -132,6 +132,14 @@ pub struct FeeModel {
     pub token: H160,
 }
 
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct InteractionData {
+    pub target: H160,
+    pub value: U256,
+    pub call_data: Vec<u8>,
+    pub exec_plan: Option<ExecutionPlanCoordinatesModel>,
+}
+
 #[serde_as]
 #[derive(Clone, Debug, Deserialize)]
 pub struct SettledBatchAuctionModel {
@@ -141,6 +149,8 @@ pub struct SettledBatchAuctionModel {
     pub ref_token: Option<H160>,
     #[serde_as(as = "HashMap<_, DecimalU256>")]
     pub prices: HashMap<H160, U256>,
+    #[serde(default)]
+    pub interaction_data: Vec<InteractionData>,
 }
 
 impl SettledBatchAuctionModel {


### PR DESCRIPTION
I know that there is actually quite some work left to define the api and a fair solver competition. But for now, we bypass all of this and just allow http_solvers to do pass custom interactions to their solutions.

Maybe this PR alleviates the pain, we can allow external solvers to participate on a trust basis, and we gain some time to define the future api and competition.

### Test Plan

clone repo:
https://github.com/gnosis/dex-cow-solver
in there run: `cargo run`

then start this repo with the current PR and run:
```
cargo run -p solver -- \
  --orderbook-url https://protocol-mainnet.gnosis.io \
  --node-url "https://mainnet.infura.io/v3/$INFURA_KEY" \
   --quasimodo-solver-url "http://127.0.0.1:8000" \
  --solver-account 0xa6DDBD0dE6B310819b49f680F65871beE85f517e \
  --solvers Quasimodo \
  --transaction-strategy DryRun
  ```
  (I am abusing quasimodo interface to talk to the new dex-cow solver)
  Observe beautiful solutions like:
  https://dashboard.tenderly.co/gp-v2/staging/simulator/d1039d01-4dbd-4ec2-9b5c-43d747a4ced9
  (quite often trivial solutions are returned, as the solver is still quite fragile)