### PR TITLE
Default baseline sources per chain

### DIFF
--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -290,10 +290,9 @@ async fn main() {
         metrics.clone(),
     ));
 
-    let baseline_sources = args
-        .shared
-        .baseline_sources
-        .unwrap_or_else(|| sources::defaults_for_chain(chain_id));
+    let baseline_sources = args.shared.baseline_sources.unwrap_or_else(|| {
+        sources::defaults_for_chain(chain_id).expect("failed to get default baseline sources")
+    });
     tracing::info!(?baseline_sources, "using baseline sources");
     let pair_providers = sources::pair_providers(&web3, &baseline_sources)
         .await

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -290,7 +290,12 @@ async fn main() {
         metrics.clone(),
     ));
 
-    let pair_providers = sources::pair_providers(&web3, &args.shared.baseline_sources)
+    let baseline_sources = args
+        .shared
+        .baseline_sources
+        .unwrap_or_else(|| sources::defaults_for_chain(chain_id));
+    tracing::info!(?baseline_sources, "using baseline sources");
+    let pair_providers = sources::pair_providers(&web3, &baseline_sources)
         .await
         .expect("failed to load baseline source pair providers")
         .values()

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -66,12 +66,11 @@ pub struct Arguments {
     #[structopt(
         long,
         env,
-        default_value = "Uniswap,Sushiswap",
         possible_values = &BaselineSource::variants(),
         case_insensitive = true,
         use_delimiter = true
     )]
-    pub baseline_sources: Vec<BaselineSource>,
+    pub baseline_sources: Option<Vec<BaselineSource>>,
 
     /// The number of blocks kept in the pool cache.
     #[structopt(long, env, default_value = "10")]

--- a/crates/shared/src/sources.rs
+++ b/crates/shared/src/sources.rs
@@ -30,6 +30,18 @@ arg_enum! {
     }
 }
 
+pub fn defaults_for_chain(chain_id: u64) -> Vec<BaselineSource> {
+    match chain_id {
+        1 | 4 => vec![
+            BaselineSource::UniswapV2,
+            BaselineSource::SushiSwap,
+            BaselineSource::BalancerV2,
+        ],
+        100 => vec![BaselineSource::Honeyswap, BaselineSource::SushiSwap],
+        _ => panic!("unsupported chain {:#x}", chain_id),
+    }
+}
+
 /// Returns a mapping of baseline sources to their respective pair providers.
 pub async fn pair_providers(
     web3: &Web3,

--- a/crates/shared/src/sources.rs
+++ b/crates/shared/src/sources.rs
@@ -37,7 +37,11 @@ pub fn defaults_for_chain(chain_id: u64) -> Result<Vec<BaselineSource>> {
             BaselineSource::SushiSwap,
             BaselineSource::BalancerV2,
         ],
-        100 => vec![BaselineSource::Honeyswap, BaselineSource::SushiSwap],
+        100 => vec![
+            BaselineSource::Honeyswap,
+            BaselineSource::SushiSwap,
+            BaselineSource::Baoswap,
+        ],
         _ => bail!("unsupported chain {:#x}", chain_id),
     })
 }

--- a/crates/shared/src/sources.rs
+++ b/crates/shared/src/sources.rs
@@ -11,7 +11,7 @@ use self::uniswap_v2::{
     pool_fetching::{Pool, PoolFetching},
 };
 use crate::{recent_block_cache::Block, Web3};
-use anyhow::Result;
+use anyhow::{bail, Result};
 use model::TokenPair;
 use std::{
     collections::{HashMap, HashSet},
@@ -30,16 +30,16 @@ arg_enum! {
     }
 }
 
-pub fn defaults_for_chain(chain_id: u64) -> Vec<BaselineSource> {
-    match chain_id {
+pub fn defaults_for_chain(chain_id: u64) -> Result<Vec<BaselineSource>> {
+    Ok(match chain_id {
         1 | 4 => vec![
             BaselineSource::UniswapV2,
             BaselineSource::SushiSwap,
             BaselineSource::BalancerV2,
         ],
         100 => vec![BaselineSource::Honeyswap, BaselineSource::SushiSwap],
-        _ => panic!("unsupported chain {:#x}", chain_id),
-    }
+        _ => bail!("unsupported chain {:#x}", chain_id),
+    })
 }
 
 /// Returns a mapping of baseline sources to their respective pair providers.

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -356,10 +356,9 @@ async fn main() {
         max_retries: args.shared.pool_cache_maximum_retries,
         delay_between_retries: args.shared.pool_cache_delay_between_retries_seconds,
     };
-    let baseline_sources = args
-        .shared
-        .baseline_sources
-        .unwrap_or_else(|| sources::defaults_for_chain(chain_id));
+    let baseline_sources = args.shared.baseline_sources.unwrap_or_else(|| {
+        sources::defaults_for_chain(chain_id).expect("failed to get default baseline sources")
+    });
     tracing::info!(?baseline_sources, "using baseline sources");
     let pool_caches: HashMap<BaselineSource, Arc<PoolCache>> =
         sources::pair_providers(&web3, &baseline_sources)

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -356,8 +356,13 @@ async fn main() {
         max_retries: args.shared.pool_cache_maximum_retries,
         delay_between_retries: args.shared.pool_cache_delay_between_retries_seconds,
     };
+    let baseline_sources = args
+        .shared
+        .baseline_sources
+        .unwrap_or_else(|| sources::defaults_for_chain(chain_id));
+    tracing::info!(?baseline_sources, "using baseline sources");
     let pool_caches: HashMap<BaselineSource, Arc<PoolCache>> =
-        sources::pair_providers(&web3, &args.shared.baseline_sources)
+        sources::pair_providers(&web3, &baseline_sources)
             .await
             .expect("failed to load baseline source pair providers")
             .into_iter()
@@ -384,9 +389,7 @@ async fn main() {
             .collect(),
     });
 
-    let (balancer_pool_maintainer, balancer_v2_liquidity) = if args
-        .shared
-        .baseline_sources
+    let (balancer_pool_maintainer, balancer_v2_liquidity) = if baseline_sources
         .contains(&BaselineSource::BalancerV2)
     {
         let balancer_pool_fetcher = Arc::new(


### PR DESCRIPTION
This PR adds default baseline sources per chain, using all supported sources.

### Test Plan

Try out some commands:
```
$ cargo run -p solver -- --node-url https://mainnet.infura.io/v3/$INFURA_PROJECT_ID
...
2021-11-18T09:44:03.730Z  INFO solver: using baseline sources baseline_sources=[UniswapV2, SushiSwap, BalancerV2]
...
$ cargo run -p solver -- --node-url https://rpc.xdaichain.com
...
2021-11-18T09:44:35.165Z  INFO solver: using baseline sources baseline_sources=[Honeyswap, SushiSwap]
...
$ cargo run -p solver -- --node-url https://mainnet.infura.io/v3/$INFURA_PROJECT_ID --baseline-sources SushiSwap
...
2021-11-18T09:45:09.981Z  INFO solver: using baseline sources baseline_sources=[SushiSwap]
...
```
