### PR TITLE
Work around potential rounding issue with fee validation

### DIFF
--- a/crates/orderbook/src/fee.rs
+++ b/crates/orderbook/src/fee.rs
@@ -366,6 +366,9 @@ impl MinFeeCalculating for MinFeeCalculator {
         app_data: AppId,
         subsidized_fee: f64,
     ) -> Result<FeeParameters, ()> {
+        // As a temporary workaround to make sure rounding issues from the U256 f64 conversion
+        // don't cause fees to be rejected we increase the fee slightly.
+        let subsidized_fee = subsidized_fee * 1.01;
         // When validating we allow fees taken for larger amounts because as the amount increases
         // the fee increases too because it is worth to trade off more gas use for a slightly better
         // price. Thus it is acceptable if the new order has an amount <= an existing fee
@@ -789,7 +792,7 @@ mod tests {
             .get_unsubsidized_min_fee(fee_data, Default::default(), fee)
             .await
             .is_err());
-        let lower_fee = fee - 1.;
+        let lower_fee = fee * 0.9;
         assert!(fee_estimator
             .get_unsubsidized_min_fee(fee_data, app_data, lower_fee)
             .await


### PR DESCRIPTION
We recently started seeing issues where fees would not validate https://github.com/gnosis/cowswap/issues/1868 . The timing makes https://github.com/gnosis/gp-v2-services/pull/1387 the likely culprit.
I am not sure yet but a potential side effect of that PR is that it changes where the U256 f64 conversion happens. Since this is lossy it is possible that it could cause the fee verification to fail. As a quick fix this PR increases the perceived fee by 1% to make up for rounding errors.
We want to fix this quickly so that frontend related testing for the Friday Kaffeekranz becomes unblocked. I will continue to investigate the issue further and see if there is a more proper fix afterwards.

### Test Plan
CI
