### PR TITLE
Make HTTP solver API mockable

### DIFF
--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -19,7 +19,7 @@ use orderbook::{
     verify_deployed_contract_constants,
 };
 use primitive_types::H160;
-use shared::http_solver_api::{HttpSolverApi, SolverConfig};
+use shared::http_solver_api::{DefaultHttpSolverApi, SolverConfig};
 use shared::network::network_name;
 use shared::price_estimation::quasimodo::QuasimodoPriceEstimator;
 use shared::price_estimation::zeroex::ZeroExPriceEstimator;
@@ -430,7 +430,7 @@ async fn main() {
                     )),
                     PriceEstimatorType::Quasimodo => Box::new(InstrumentedPriceEstimator::new(
                         QuasimodoPriceEstimator {
-                            api: Arc::new(HttpSolverApi {
+                            api: Arc::new(DefaultHttpSolverApi {
                                 name: "quasimodo-price-estimator",
                                 network_name: network_name.to_string(),
                                 chain_id,

--- a/crates/shared/src/price_estimation/quasimodo.rs
+++ b/crates/shared/src/price_estimation/quasimodo.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 pub struct QuasimodoPriceEstimator {
-    pub api: Arc<HttpSolverApi>,
+    pub api: Arc<dyn HttpSolverApi>,
     pub pools: Arc<PoolCache>,
     pub bad_token_detector: Arc<dyn BadTokenDetecting>,
     pub token_info: Arc<dyn TokenInfoFetching>,
@@ -195,7 +195,7 @@ mod tests {
     use super::*;
     use crate::bad_token::list_based::ListBasedDetector;
     use crate::current_block::current_block_stream;
-    use crate::http_solver_api::SolverConfig;
+    use crate::http_solver_api::{DefaultHttpSolverApi, SolverConfig};
     use crate::price_estimation::Query;
     use crate::recent_block_cache::CacheConfig;
     use crate::sources::uniswap_v2;
@@ -275,7 +275,7 @@ mod tests {
         let gas_info = Arc::new(web3);
 
         let estimator = QuasimodoPriceEstimator {
-            api: Arc::new(HttpSolverApi {
+            api: Arc::new(DefaultHttpSolverApi {
                 name: "test",
                 network_name: "1".to_string(),
                 chain_id: 1,

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -13,7 +13,7 @@ use num::BigRational;
 use oneinch_solver::OneInchSolver;
 use paraswap_solver::ParaswapSolver;
 use reqwest::{Client, Url};
-use shared::http_solver_api::{HttpSolverApi, SolverConfig};
+use shared::http_solver_api::{DefaultHttpSolverApi, SolverConfig};
 use shared::zeroex_api::ZeroExApi;
 use shared::{
     baseline_solver::BaseTokens, conversions::U256Ext, token_info::TokenInfoFetching, Web3,
@@ -172,7 +172,7 @@ pub fn create(
     let create_http_solver =
         |account: Account, url: Url, name: &'static str, config: SolverConfig| -> HttpSolver {
             HttpSolver::new(
-                HttpSolverApi {
+                DefaultHttpSolverApi {
                     name,
                     network_name: network_id.clone(),
                     chain_id,

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -18,7 +18,7 @@ use num::ToPrimitive;
 use num::{BigInt, BigRational};
 use primitive_types::H160;
 use shared::http_solver_api::model::*;
-use shared::http_solver_api::HttpSolverApi;
+use shared::http_solver_api::{DefaultHttpSolverApi, HttpSolverApi};
 use shared::price_estimation::gas::{GAS_PER_BALANCER_SWAP, GAS_PER_ORDER, GAS_PER_UNISWAP};
 use shared::{
     measure_time,
@@ -46,7 +46,7 @@ pub struct InstanceData {
 pub type InstanceCache = Arc<Mutex<Option<InstanceData>>>;
 
 pub struct HttpSolver {
-    solver: HttpSolverApi,
+    solver: DefaultHttpSolverApi,
     account: Account,
     native_token: H160,
     token_info_fetcher: Arc<dyn TokenInfoFetching>,
@@ -57,7 +57,7 @@ pub struct HttpSolver {
 impl HttpSolver {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        solver: HttpSolverApi,
+        solver: DefaultHttpSolverApi,
         account: Account,
         native_token: H160,
         token_info_fetcher: Arc<dyn TokenInfoFetching>,
@@ -501,7 +501,7 @@ mod tests {
         let gas_price = 100.;
 
         let solver = HttpSolver::new(
-            HttpSolverApi {
+            DefaultHttpSolverApi {
                 name: "Test Solver",
                 network_name: "mock_network_id".to_string(),
                 chain_id: 0,


### PR DESCRIPTION
Preparation for #1410.

We're turning HTTP solver into a trait so that we can mock it.

### Test Plan
No logic changes were made, so existing tests should cover everything.
