### PR TITLE
Round up in fee estimation

### DIFF
--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -64,7 +64,7 @@ impl Order {
         order_creation: OrderCreation,
         domain: &DomainSeparator,
         settlement_contract: H160,
-        full_fee_amount: f64,
+        full_fee_amount: U256,
     ) -> Option<Self> {
         let owner = order_creation
             .signature
@@ -75,7 +75,7 @@ impl Order {
                 owner,
                 uid: order_creation.uid(domain, &owner),
                 settlement_contract,
-                full_fee_amount: U256::from_f64_lossy(full_fee_amount),
+                full_fee_amount,
                 ..Default::default()
             },
             order_creation,

--- a/crates/orderbook/src/api/get_fee_info.rs
+++ b/crates/orderbook/src/api/get_fee_info.rs
@@ -53,7 +53,7 @@ pub fn get_fee_info(
             Result::<_, Infallible>::Ok(convert_json_response(result.map(
                 |(amount, expiration_date)| FeeInfo {
                     expiration_date,
-                    amount: U256::from_f64_lossy(amount),
+                    amount,
                 },
             )))
         }

--- a/crates/orderbook/src/api/order_validation.rs
+++ b/crates/orderbook/src/api/order_validation.rs
@@ -283,7 +283,7 @@ impl OrderValidating for OrderValidator {
                     kind: order_creation.kind,
                 },
                 order_creation.app_data,
-                order_creation.fee_amount.to_f64_lossy(),
+                order_creation.fee_amount,
             )
             .await
             .map_err(|()| ValidationError::InsufficientFee)?;

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -244,7 +244,6 @@ impl OrderQuoter {
                     )
                     .await
                     .map_err(FeeError::PriceEstimate)?;
-                let fee = U256::from_f64_lossy(fee);
                 let sell_amount_after_fee = sell_amount_before_fee
                     .checked_sub(fee)
                     .ok_or(FeeError::SellAmountDoesNotCoverFee)?
@@ -309,7 +308,7 @@ impl OrderQuoter {
                 FeeParameters {
                     buy_amount: buy_amount_after_fee,
                     sell_amount: sell_amount_after_fee,
-                    fee_amount: U256::from_f64_lossy(fee),
+                    fee_amount: fee,
                     expiration,
                     kind: OrderKind::Buy,
                 }
@@ -540,7 +539,7 @@ mod tests {
         let expiration = Utc::now();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(move |_, _| Ok((3., expiration)));
+            .returning(move |_, _| Ok((3.into(), expiration)));
 
         let fee_calculator = Arc::new(fee_calculator);
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
@@ -582,7 +581,7 @@ mod tests {
         let mut fee_calculator = MockMinFeeCalculating::new();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(|_, _| Ok((3., Utc::now())));
+            .returning(|_, _| Ok((3.into(), Utc::now())));
 
         let fee_calculator = Arc::new(fee_calculator);
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
@@ -619,7 +618,7 @@ mod tests {
         let expiration = Utc::now();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(move |_, _| Ok((3., expiration)));
+            .returning(move |_, _| Ok((3.into(), expiration)));
 
         let fee_calculator = Arc::new(fee_calculator);
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
@@ -679,7 +678,7 @@ mod tests {
         let mut fee_calculator = MockMinFeeCalculating::new();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(move |_, _| Ok((3., Utc::now())));
+            .returning(move |_, _| Ok((3.into(), Utc::now())));
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
             out_amount: 14.into(),
             gas: 1000.into(),


### PR DESCRIPTION
And add some fee estimation debug traces.

I decided to go back to U256 instead of f64 in some interfaces so that the rounding is an implementation detail that api users do not have to think about.

### Test Plan
new unit test that highlights the issue