### PR TITLE
Introduce `testlib` crate with things common for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,6 +1803,7 @@ dependencies = [
  "shared",
  "sqlx",
  "structopt",
+ "testlib",
  "thiserror",
  "tokio",
  "tracing",
@@ -2543,6 +2544,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "structopt",
+ "testlib",
  "thiserror",
  "time",
  "tokio",
@@ -2633,6 +2635,7 @@ dependencies = [
  "shared",
  "structopt",
  "strum",
+ "testlib",
  "thiserror",
  "tokio",
  "tracing",
@@ -2868,6 +2871,16 @@ name = "termtree"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
+
+[[package]]
+name = "testlib"
+version = "0.1.0"
+dependencies = [
+ "contracts",
+ "ethcontract",
+ "ethcontract-mock",
+ "hex-literal",
+]
 
 [[package]]
 name = "textwrap"

--- a/conf.toml
+++ b/conf.toml
@@ -1,0 +1,7 @@
+[[solvers]]
+type = "baseline"
+private_key = "0x00..."
+
+[[solvers]]
+type = "oneinch"
+private_key = "0x000..."

--- a/conf.toml
+++ b/conf.toml
@@ -1,7 +1,0 @@
-[[solvers]]
-type = "baseline"
-private_key = "0x00..."
-
-[[solvers]]
-type = "oneinch"
-private_key = "0x000..."

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -50,3 +50,4 @@ web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev="a425fa747bca69c
 [dev-dependencies]
 secp256k1 = "0.20"
 mockall = "0.10"
+testlib = { path = "../testlib" }

--- a/crates/orderbook/src/api/get_markets.rs
+++ b/crates/orderbook/src/api/get_markets.rs
@@ -100,7 +100,6 @@ pub fn get_amount_estimate(
 mod tests {
     use super::*;
     use crate::api::response_body;
-    use hex_literal::hex;
     use shared::price_estimation::PriceEstimationError;
     use warp::hyper::StatusCode;
     use warp::{test::request, Reply};

--- a/crates/orderbook/src/api/get_markets.rs
+++ b/crates/orderbook/src/api/get_markets.rs
@@ -120,8 +120,8 @@ mod tests {
             request,
             AmountEstimateQuery {
                 market: Market {
-                    base_token: H160(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")),
-                    quote_token: H160(hex!("6b175474e89094c44da98b954eedeac495271d0f")),
+                    base_token: testlib::tokens::WETH,
+                    quote_token: testlib::tokens::DAI,
                 },
                 kind: OrderKind::Sell,
                 amount: 100.into()

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -53,3 +53,4 @@ web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev="a425fa747bca69c
 
 [dev-dependencies]
 regex = "1.5.4"
+testlib = { path = "../testlib" }

--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -472,13 +472,13 @@ mod tests {
         let web3 = Web3::new(http);
 
         let base_tokens = &[
-            H160(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")), // weth
-            H160(hex!("6B175474E89094C44Da98b954EedeAC495271d0F")), // dai
-            H160(hex!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")), // usdc
-            H160(hex!("dAC17F958D2ee523a2206206994597C13D831ec7")), // usdt
-            H160(hex!("c00e94Cb662C3520282E6f5717214004A7f26888")), // comp
-            H160(hex!("9f8F72aA9304c8B593d555F12eF6589cC3A579A2")), // mkr
-            H160(hex!("2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599")), // wbtc
+            testlib::tokens::WETH,
+            testlib::tokens::DAI,
+            testlib::tokens::USDC,
+            testlib::tokens::USDT,
+            testlib::tokens::COMP,
+            testlib::tokens::MKR,
+            testlib::tokens::WBTC,
         ];
 
         // tokens from our deny list

--- a/crates/shared/src/paraswap_api.rs
+++ b/crates/shared/src/paraswap_api.rs
@@ -334,7 +334,7 @@ mod tests {
     #[ignore]
     async fn test_api_e2e_sell() {
         let src_token = crate::addr!("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
-        let dest_token = crate::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+        let dest_token = testlib::tokens::GNO;
         let price_query = PriceQuery {
             src_token,
             dest_token,
@@ -397,7 +397,7 @@ mod tests {
     #[ignore]
     async fn test_api_e2e_buy() {
         let src_token = crate::addr!("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
-        let dest_token = crate::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+        let dest_token = testlib::tokens::GNO;
         let price_query = PriceQuery {
             src_token,
             dest_token,
@@ -455,7 +455,7 @@ mod tests {
     fn test_price_query_serialization() {
         let query = PriceQuery {
             src_token: crate::addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-            dest_token: crate::addr!("6810e776880C02933D47DB1b9fc05908e5386b96"),
+            dest_token: testlib::tokens::GNO,
             src_decimals: 18,
             dest_decimals: 8,
             amount: 1_000_000_000_000_000_000u128.into(),
@@ -704,7 +704,7 @@ mod tests {
     #[ignore]
     async fn transaction_response_error() {
         let src_token = crate::addr!("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
-        let dest_token = crate::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+        let dest_token = testlib::tokens::GNO;
         let price_query = PriceQuery {
             src_token,
             dest_token,

--- a/crates/shared/src/price_estimation/paraswap.rs
+++ b/crates/shared/src/price_estimation/paraswap.rs
@@ -137,8 +137,8 @@ mod tests {
             disabled_paraswap_dexs: Vec::new(),
         };
 
-        let weth = addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
-        let gno = addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+        let weth = testlib::tokens::WETH;
+        let gno = testlib::tokens::GNO;
         let query = Query {
             sell_token: weth,
             buy_token: gno,

--- a/crates/shared/src/price_estimation/quasimodo.rs
+++ b/crates/shared/src/price_estimation/quasimodo.rs
@@ -263,16 +263,8 @@ mod tests {
         let infura_project_id =
             std::env::var("INFURA_PROJECT_ID").expect("env variable INFURA_PROJECT_ID is required");
 
-        let weth = addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
-
-        let _weth = ("weth", weth);
-        let _owl = ("owl", addr!("1A5F9352Af8aF974bFC03399e3767DF6370d82e4"));
-        let _bal = ("bal", addr!("ba100000625a3754423978a60c9317c58a424e3D"));
-        let _gno = ("gno", addr!("6810e776880c02933d47db1b9fc05908e5386b96"));
-        let _dai = ("dai", addr!("6B175474E89094C44Da98b954EedeAC495271d0F"));
-
-        let t1 = _weth;
-        let t2 = _gno;
+        let t1 = ("WETH", testlib::tokens::WETH);
+        let t2 = ("GNO", testlib::tokens::GNO);
         let amount: U256 = U256::from(1) * U256::exp10(18);
 
         let client = Client::new();
@@ -322,8 +314,11 @@ mod tests {
             bad_token_detector,
             token_info,
             gas_info,
-            native_token: weth,
-            base_tokens: Arc::new(BaseTokens::new(weth, &[weth, t1.1, t2.1])),
+            native_token: testlib::tokens::WETH,
+            base_tokens: Arc::new(BaseTokens::new(
+                testlib::tokens::WETH,
+                &[testlib::tokens::WETH, t1.1, t2.1],
+            )),
         };
 
         let result = estimator

--- a/crates/shared/src/price_estimation/zeroex.rs
+++ b/crates/shared/src/price_estimation/zeroex.rs
@@ -102,8 +102,8 @@ mod tests {
             })
         });
 
-        let weth = addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
-        let gno = addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+        let weth = testlib::tokens::WETH;
+        let gno = testlib::tokens::GNO;
 
         let estimator = ZeroExPriceEstimator {
             api: Arc::new(zeroex_api),
@@ -148,8 +148,8 @@ mod tests {
             })
         });
 
-        let weth = addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
-        let gno = addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+        let weth = testlib::tokens::WETH;
+        let gno = testlib::tokens::GNO;
 
         let estimator = ZeroExPriceEstimator {
             api: Arc::new(zeroex_api),
@@ -177,7 +177,7 @@ mod tests {
             bad_token_detector: Arc::new(ListBasedDetector::deny_list(Vec::new())),
         };
 
-        let weth = addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+        let weth = testlib::tokens::WETH;
 
         let est = estimator
             .estimate(&Query {
@@ -195,8 +195,8 @@ mod tests {
 
     #[tokio::test]
     async fn unsupported_token() {
-        let weth = addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
-        let gno = addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+        let weth = testlib::tokens::WETH;
+        let gno = testlib::tokens::GNO;
 
         let estimator = ZeroExPriceEstimator {
             api: Arc::new(MockZeroExApi::new()),
@@ -224,8 +224,8 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn real_estimate() {
-        let weth = addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
-        let gno = addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+        let weth = testlib::tokens::WETH;
+        let gno = testlib::tokens::GNO;
 
         let estimator = ZeroExPriceEstimator {
             api: Arc::new(DefaultZeroExApi::with_default_url(Client::new())),

--- a/crates/shared/src/sources/sushiswap.rs
+++ b/crates/shared/src/sources/sushiswap.rs
@@ -18,8 +18,8 @@ mod tests {
         // https://sushiswap.vision/pair/0x41328fdba556c8c969418ccccb077b7b8d932aa5
         let mainnet_pair_provider = get_pair_provider(&Mock::new(1).web3()).await.unwrap();
         let mainnet_pair = TokenPair::new(
-            addr!("6810e776880c02933d47db1b9fc05908e5386b96"),
-            addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+            testlib::tokens::GNO,
+            testlib::tokens::WETH,
         )
         .unwrap();
         assert_eq!(

--- a/crates/shared/src/sources/sushiswap.rs
+++ b/crates/shared/src/sources/sushiswap.rs
@@ -17,11 +17,7 @@ mod tests {
     async fn test_create2_sushiswap() {
         // https://sushiswap.vision/pair/0x41328fdba556c8c969418ccccb077b7b8d932aa5
         let mainnet_pair_provider = get_pair_provider(&Mock::new(1).web3()).await.unwrap();
-        let mainnet_pair = TokenPair::new(
-            testlib::tokens::GNO,
-            testlib::tokens::WETH,
-        )
-        .unwrap();
+        let mainnet_pair = TokenPair::new(testlib::tokens::GNO, testlib::tokens::WETH).unwrap();
         assert_eq!(
             mainnet_pair_provider.pair_address(&mainnet_pair),
             addr!("41328fdba556c8c969418ccccb077b7b8d932aa5")

--- a/crates/shared/src/sources/uniswap_v2.rs
+++ b/crates/shared/src/sources/uniswap_v2.rs
@@ -22,11 +22,7 @@ mod tests {
     async fn test_create2_mainnet() {
         // https://info.uniswap.org/pair/0x3e8468f66d30fc99f745481d4b383f89861702c6
         let mainnet_pair_provider = get_pair_provider(&Mock::new(1).web3()).await.unwrap();
-        let mainnet_pair = TokenPair::new(
-            testlib::tokens::GNO,
-            testlib::tokens::WETH,
-        )
-        .unwrap();
+        let mainnet_pair = TokenPair::new(testlib::tokens::GNO, testlib::tokens::WETH).unwrap();
         assert_eq!(
             mainnet_pair_provider.pair_address(&mainnet_pair),
             addr!("3e8468f66d30fc99f745481d4b383f89861702c6")

--- a/crates/shared/src/sources/uniswap_v2.rs
+++ b/crates/shared/src/sources/uniswap_v2.rs
@@ -23,8 +23,8 @@ mod tests {
         // https://info.uniswap.org/pair/0x3e8468f66d30fc99f745481d4b383f89861702c6
         let mainnet_pair_provider = get_pair_provider(&Mock::new(1).web3()).await.unwrap();
         let mainnet_pair = TokenPair::new(
-            addr!("6810e776880c02933d47db1b9fc05908e5386b96"),
-            addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+            testlib::tokens::GNO,
+            testlib::tokens::WETH,
         )
         .unwrap();
         assert_eq!(

--- a/crates/shared/src/sources/uniswap_v2/pair_provider.rs
+++ b/crates/shared/src/sources/uniswap_v2/pair_provider.rs
@@ -46,8 +46,8 @@ mod tests {
             ),
         };
         let pair = TokenPair::new(
-            addr!("6810e776880c02933d47db1b9fc05908e5386b96"),
-            addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+            testlib::tokens::GNO,
+            testlib::tokens::WETH,
         )
         .unwrap();
         assert_eq!(

--- a/crates/shared/src/sources/uniswap_v2/pair_provider.rs
+++ b/crates/shared/src/sources/uniswap_v2/pair_provider.rs
@@ -45,11 +45,7 @@ mod tests {
                 "96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"
             ),
         };
-        let pair = TokenPair::new(
-            testlib::tokens::GNO,
-            testlib::tokens::WETH,
-        )
-        .unwrap();
+        let pair = TokenPair::new(testlib::tokens::GNO, testlib::tokens::WETH).unwrap();
         assert_eq!(
             provider.pair_address(&pair),
             addr!("3e8468f66d30fc99f745481d4b383f89861702c6")

--- a/crates/shared/src/token_list.rs
+++ b/crates/shared/src/token_list.rs
@@ -153,9 +153,7 @@ pub mod tests {
     fn test_creation_with_chain_id() {
         let list = serde_json::from_str::<TokenListModel>(EXAMPLE_LIST).unwrap();
         let instance = TokenList::from_tokens(list.tokens, 1);
-        assert!(instance
-            .get(&testlib::tokens::USDC)
-            .is_some());
+        assert!(instance.get(&testlib::tokens::USDC).is_some());
         // Chain ID 4
         assert!(instance
             .get(&addr!("39AA39c021dfbaE8faC545936693aC917d5E7563"))

--- a/crates/shared/src/token_list.rs
+++ b/crates/shared/src/token_list.rs
@@ -129,7 +129,7 @@ pub mod tests {
                     TokenModel {
                         chain_id: 1,
                         token: Token {
-                            address: addr!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+                            address: testlib::tokens::USDC,
                             name: "USD Coin".into(),
                             symbol: "USDC".into(),
                             decimals: 6,
@@ -154,7 +154,7 @@ pub mod tests {
         let list = serde_json::from_str::<TokenListModel>(EXAMPLE_LIST).unwrap();
         let instance = TokenList::from_tokens(list.tokens, 1);
         assert!(instance
-            .get(&addr!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"))
+            .get(&testlib::tokens::USDC)
             .is_some());
         // Chain ID 4
         assert!(instance

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -232,8 +232,8 @@ mod tests {
     async fn test_api_e2e() {
         let zeroex_client = DefaultZeroExApi::default();
         let swap_query = SwapQuery {
-            sell_token: crate::addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
-            buy_token: crate::addr!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
+            sell_token: testlib::tokens::WETH,
+            buy_token: testlib::tokens::USDC,
             sell_amount: Some(U256::from_f64_lossy(1e18)),
             buy_amount: None,
             slippage_percentage: Slippage(0.1_f64),
@@ -251,8 +251,8 @@ mod tests {
         let api_key = std::env::var("ZEROEX_API_KEY").unwrap();
         let zeroex_client = DefaultZeroExApi::new(url, Some(api_key), Client::new()).unwrap();
         let swap_query = SwapQuery {
-            sell_token: crate::addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
-            buy_token: crate::addr!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
+            sell_token: testlib::tokens::WETH,
+            buy_token: testlib::tokens::USDC,
             sell_amount: Some(U256::from_f64_lossy(1e18)),
             buy_amount: None,
             slippage_percentage: Slippage(0.1_f64),

--- a/crates/solver/Cargo.toml
+++ b/crates/solver/Cargo.toml
@@ -52,3 +52,4 @@ web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev="a425fa747bca69c
 [dev-dependencies]
 tracing-subscriber = "0.3"
 mockall = "0.10"
+testlib = { path = "../testlib" }

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -455,7 +455,7 @@ mod tests {
         let settlement = GPv2Settlement::deployed(&web3).await.unwrap();
 
         let weth = WETH9::deployed(&web3).await.unwrap();
-        let gno = shared::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+        let gno = testlib::tokens::GNO;
 
         let solver = OneInchSolver::with_disabled_protocols(
             account(),

--- a/crates/solver/src/solver/oneinch_solver/api.rs
+++ b/crates/solver/src/solver/oneinch_solver/api.rs
@@ -442,7 +442,7 @@ mod tests {
                         from_token_address: shared::addr!(
                             "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
                         ),
-                        to_token_address: shared::addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+                        to_token_address: testlib::tokens::WETH,
                     }],
                     vec![Protocol {
                         name: "UNISWAP_V2".to_owned(),

--- a/crates/solver/src/solver/paraswap_solver.rs
+++ b/crates/solver/src/solver/paraswap_solver.rs
@@ -558,7 +558,7 @@ mod tests {
         let token_info_fetcher = Arc::new(TokenInfoFetcher { web3: web3.clone() });
 
         let weth = WETH9::deployed(&web3).await.unwrap();
-        let gno = shared::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+        let gno = testlib::tokens::GNO;
 
         let solver = ParaswapSolver::new(
             account(),

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -178,7 +178,7 @@ mod tests {
         let settlement = GPv2Settlement::deployed(&web3).await.unwrap();
 
         let weth = WETH9::deployed(&web3).await.unwrap();
-        let gno = shared::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+        let gno = testlib::tokens::GNO;
 
         let solver = ZeroExSolver::new(
             account(),
@@ -218,7 +218,7 @@ mod tests {
         let settlement = GPv2Settlement::deployed(&web3).await.unwrap();
 
         let weth = WETH9::deployed(&web3).await.unwrap();
-        let gno = shared::addr!("6810e776880c02933d47db1b9fc05908e5386b96");
+        let gno = testlib::tokens::GNO;
 
         let solver = ZeroExSolver::new(
             account(),

--- a/crates/testlib/Cargo.toml
+++ b/crates/testlib/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "testlib"
+version = "0.1.0"
+authors = ["Gnosis Developers <developers@gnosis.io>"]
+edition = "2018"
+license = "GPL-3.0-or-later"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+contracts = { path = "../contracts" }
+ethcontract = { git = "https://github.com/gnosis/ethcontract-rs.git", rev = "cafcac443f37cfe1e0e18b03a987a30b61b54695", default-features = false }
+ethcontract-mock = { git = "https://github.com/gnosis/ethcontract-rs.git", rev = "cafcac443f37cfe1e0e18b03a987a30b61b54695" }
+hex_literals = "0.1.6"

--- a/crates/testlib/Cargo.toml
+++ b/crates/testlib/Cargo.toml
@@ -11,4 +11,4 @@ license = "GPL-3.0-or-later"
 contracts = { path = "../contracts" }
 ethcontract = { git = "https://github.com/gnosis/ethcontract-rs.git", rev = "cafcac443f37cfe1e0e18b03a987a30b61b54695", default-features = false }
 ethcontract-mock = { git = "https://github.com/gnosis/ethcontract-rs.git", rev = "cafcac443f37cfe1e0e18b03a987a30b61b54695" }
-hex_literals = "0.1.6"
+hex-literal = "0.3"

--- a/crates/testlib/Cargo.toml
+++ b/crates/testlib/Cargo.toml
@@ -9,6 +9,6 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 contracts = { path = "../contracts" }
-ethcontract = { git = "https://github.com/gnosis/ethcontract-rs.git", rev = "cafcac443f37cfe1e0e18b03a987a30b61b54695", default-features = false }
-ethcontract-mock = { git = "https://github.com/gnosis/ethcontract-rs.git", rev = "cafcac443f37cfe1e0e18b03a987a30b61b54695" }
+ethcontract = { git = "https://github.com/gnosis/ethcontract-rs.git", branch = "eip1559", default-features = false }
+ethcontract-mock = { git = "https://github.com/gnosis/ethcontract-rs.git", branch = "eip1559" }
 hex-literal = "0.3"

--- a/crates/testlib/src/lib.rs
+++ b/crates/testlib/src/lib.rs
@@ -1,9 +1,5 @@
 //! Convenience utilities for unit-testing used across other crates.
 
-use contracts::GPv2Settlement;
-use ethcontract::{Account, Address};
-use ethcontract_mock::{Contract, Mock};
-
 pub use ethcontract_mock::utils::*;
 
 pub mod tokens;

--- a/crates/testlib/src/lib.rs
+++ b/crates/testlib/src/lib.rs
@@ -1,0 +1,9 @@
+//! Convenience utilities for unit-testing used across other crates.
+
+use contracts::GPv2Settlement;
+use ethcontract::{Account, Address};
+use ethcontract_mock::{Contract, Mock};
+
+pub use ethcontract_mock::utils::*;
+
+pub mod tokens;

--- a/crates/testlib/src/tokens.rs
+++ b/crates/testlib/src/tokens.rs
@@ -1,34 +1,33 @@
 //! Mainnet addresses of commonly used tokens.
 
 use ethcontract::H160;
-use hex_literals::hex;
 
 /// Address for the `WETH` token.
-pub const WETH: H160 = H160(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"));
+pub const WETH: H160 = H160(hex_literal::hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"));
 
 /// Address for the `GNO` token.
-pub const GNO: H160 = H160(hex!("6810e776880c02933d47db1b9fc05908e5386b96"));
+pub const GNO: H160 = H160(hex_literal::hex!("6810e776880c02933d47db1b9fc05908e5386b96"));
 
 /// Address for the `OWL` token.
-pub const OWL: H160 = H160(hex!("1A5F9352Af8aF974bFC03399e3767DF6370d82e4"));
+pub const OWL: H160 = H160(hex_literal::hex!("1A5F9352Af8aF974bFC03399e3767DF6370d82e4"));
 
 /// Address for the `BAL` token.
-pub const BAL: H160 = H160(hex!("ba100000625a3754423978a60c9317c58a424e3D"));
+pub const BAL: H160 = H160(hex_literal::hex!("ba100000625a3754423978a60c9317c58a424e3D"));
 
 /// Address for the `DAI` token.
-pub const DAI: H160 = H160(hex!("6B175474E89094C44Da98b954EedeAC495271d0F"));
+pub const DAI: H160 = H160(hex_literal::hex!("6B175474E89094C44Da98b954EedeAC495271d0F"));
 
 /// Address for the `USDC` token.
-pub const USDC: H160 = H160(hex!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"));
+pub const USDC: H160 = H160(hex_literal::hex!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"));
 
 /// Address for the `USDT` token.
-pub const USDT: H160 = H160(hex!("dAC17F958D2ee523a2206206994597C13D831ec7"));
+pub const USDT: H160 = H160(hex_literal::hex!("dAC17F958D2ee523a2206206994597C13D831ec7"));
 
 /// Address for the `COMP` token.
-pub const COMP: H160 = H160(hex!("c00e94Cb662C3520282E6f5717214004A7f26888"));
+pub const COMP: H160 = H160(hex_literal::hex!("c00e94Cb662C3520282E6f5717214004A7f26888"));
 
 /// Address for the `MKR` token.
-pub const MKR: H160 = H160(hex!("9f8F72aA9304c8B593d555F12eF6589cC3A579A2"));
+pub const MKR: H160 = H160(hex_literal::hex!("9f8F72aA9304c8B593d555F12eF6589cC3A579A2"));
 
 /// Address for the `WBTC` token.
-pub const WBTC: H160 = H160(hex!("2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"));
+pub const WBTC: H160 = H160(hex_literal::hex!("2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"));

--- a/crates/testlib/src/tokens.rs
+++ b/crates/testlib/src/tokens.rs
@@ -3,31 +3,51 @@
 use ethcontract::H160;
 
 /// Address for the `WETH` token.
-pub const WETH: H160 = H160(hex_literal::hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"));
+pub const WETH: H160 = H160(hex_literal::hex!(
+    "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+));
 
 /// Address for the `GNO` token.
-pub const GNO: H160 = H160(hex_literal::hex!("6810e776880c02933d47db1b9fc05908e5386b96"));
+pub const GNO: H160 = H160(hex_literal::hex!(
+    "6810e776880c02933d47db1b9fc05908e5386b96"
+));
 
 /// Address for the `OWL` token.
-pub const OWL: H160 = H160(hex_literal::hex!("1A5F9352Af8aF974bFC03399e3767DF6370d82e4"));
+pub const OWL: H160 = H160(hex_literal::hex!(
+    "1A5F9352Af8aF974bFC03399e3767DF6370d82e4"
+));
 
 /// Address for the `BAL` token.
-pub const BAL: H160 = H160(hex_literal::hex!("ba100000625a3754423978a60c9317c58a424e3D"));
+pub const BAL: H160 = H160(hex_literal::hex!(
+    "ba100000625a3754423978a60c9317c58a424e3D"
+));
 
 /// Address for the `DAI` token.
-pub const DAI: H160 = H160(hex_literal::hex!("6B175474E89094C44Da98b954EedeAC495271d0F"));
+pub const DAI: H160 = H160(hex_literal::hex!(
+    "6B175474E89094C44Da98b954EedeAC495271d0F"
+));
 
 /// Address for the `USDC` token.
-pub const USDC: H160 = H160(hex_literal::hex!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"));
+pub const USDC: H160 = H160(hex_literal::hex!(
+    "A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+));
 
 /// Address for the `USDT` token.
-pub const USDT: H160 = H160(hex_literal::hex!("dAC17F958D2ee523a2206206994597C13D831ec7"));
+pub const USDT: H160 = H160(hex_literal::hex!(
+    "dAC17F958D2ee523a2206206994597C13D831ec7"
+));
 
 /// Address for the `COMP` token.
-pub const COMP: H160 = H160(hex_literal::hex!("c00e94Cb662C3520282E6f5717214004A7f26888"));
+pub const COMP: H160 = H160(hex_literal::hex!(
+    "c00e94Cb662C3520282E6f5717214004A7f26888"
+));
 
 /// Address for the `MKR` token.
-pub const MKR: H160 = H160(hex_literal::hex!("9f8F72aA9304c8B593d555F12eF6589cC3A579A2"));
+pub const MKR: H160 = H160(hex_literal::hex!(
+    "9f8F72aA9304c8B593d555F12eF6589cC3A579A2"
+));
 
 /// Address for the `WBTC` token.
-pub const WBTC: H160 = H160(hex_literal::hex!("2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"));
+pub const WBTC: H160 = H160(hex_literal::hex!(
+    "2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+));

--- a/crates/testlib/src/tokens.rs
+++ b/crates/testlib/src/tokens.rs
@@ -1,0 +1,34 @@
+//! Mainnet addresses of commonly used tokens.
+
+use ethcontract::H160;
+use hex_literals::hex;
+
+/// Address for the `WETH` token.
+pub const WETH: H160 = H160(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"));
+
+/// Address for the `GNO` token.
+pub const GNO: H160 = H160(hex!("6810e776880c02933d47db1b9fc05908e5386b96"));
+
+/// Address for the `OWL` token.
+pub const OWL: H160 = H160(hex!("1A5F9352Af8aF974bFC03399e3767DF6370d82e4"));
+
+/// Address for the `BAL` token.
+pub const BAL: H160 = H160(hex!("ba100000625a3754423978a60c9317c58a424e3D"));
+
+/// Address for the `DAI` token.
+pub const DAI: H160 = H160(hex!("6B175474E89094C44Da98b954EedeAC495271d0F"));
+
+/// Address for the `USDC` token.
+pub const USDC: H160 = H160(hex!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"));
+
+/// Address for the `USDT` token.
+pub const USDT: H160 = H160(hex!("dAC17F958D2ee523a2206206994597C13D831ec7"));
+
+/// Address for the `COMP` token.
+pub const COMP: H160 = H160(hex!("c00e94Cb662C3520282E6f5717214004A7f26888"));
+
+/// Address for the `MKR` token.
+pub const MKR: H160 = H160(hex!("9f8F72aA9304c8B593d555F12eF6589cC3A579A2"));
+
+/// Address for the `WBTC` token.
+pub const WBTC: H160 = H160(hex!("2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"));


### PR DESCRIPTION
This PR introduces the `testlib` crate which will contain utility code used throughout unit tests. I plan to slowly move different stuff there. For now, it contains maiinet addresses of commonly used tokens.