### PR TITLE
Surplus Reporting: fix bucket definition

### DIFF
--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -132,7 +132,8 @@ impl Metrics {
                 "Surplus ratio differences between winning and best settlement per order",
             )
             .buckets(vec![
-                -f64::INFINITY,
+                -2.0,  // Difference of percentages can not exceed +/- 2
+                -1.0,
                 -0.1,
                 -0.01,
                 -0.005,
@@ -140,7 +141,8 @@ impl Metrics {
                 0.005,
                 0.01,
                 0.1,
-                f64::INFINITY,
+                1.0,
+                2.0,
             ]),
         )?;
         registry.register(Box::new(order_surplus_report.clone()))?;

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -132,17 +132,8 @@ impl Metrics {
                 "Surplus ratio differences between winning and best settlement per order",
             )
             .buckets(vec![
-                -2.0,  // Difference of percentages can not exceed +/- 2
-                -1.0,
-                -0.1,
-                -0.01,
-                -0.005,
-                0.,
-                0.005,
-                0.01,
-                0.1,
-                1.0,
-                2.0,
+                -2.0, // Difference of percentages can not exceed +/- 2
+                -1.0, -0.1, -0.01, -0.005, 0., 0.005, 0.01, 0.1, 1.0, 2.0,
             ]),
         )?;
         registry.register(Box::new(order_surplus_report.clone()))?;


### PR DESCRIPTION
While attempting to understand the heat map generated from the best alternative surplus reporting, @vkgnosis and I concluded that the buckets weren't defined correctly. This PR changes the bucket definitions to the true upper and lower bounds of the calculation excluding infinities because grafana would include them anyway if necessary.

Note the additional comment that +/- 2 is indeed the max upper and lower bound of the calculation performed when taking the difference of two percentages.

Furthermore, we noticed that the reason the y-axis did not make any sense here (i.e. did not appear to correspond to the bucket definitions themselves)
<img width="1104" alt="Screenshot 2021-11-22 at 11 59 59 AM" src="https://user-images.githubusercontent.com/11778116/142850213-70389a99-971e-4a71-8b63-9ced5be37223.png">

If because we need to select time series buckets in the visualization:

<img width="294" alt="Screenshot 2021-11-22 at 12 00 09 PM" src="https://user-images.githubusercontent.com/11778116/142850269-b2d629ab-e8de-42bf-bc01-642ff7a58fd8.png">

