### PR TITLE
[Easy] Simple Metric reporting refactor

### DIFF
--- a/crates/solver/src/analytics.rs
+++ b/crates/solver/src/analytics.rs
@@ -56,8 +56,8 @@ pub fn report_matched_but_unsettled_orders(
         .flat_map(|settlement| settlement.trades().to_vec())
         .map(|trade| trade.order.order_meta_data.uid)
         .collect();
-    // The recent refactoring and definition of other settlements deems this set difference invalid.
-    // However we still take the difference here since we don't enforce the sets to be disjoint.
+    // Recent refactoring and definition of `other_settlements` renders this difference unnecessary.
+    // However, we still take the difference here since we don't enforce the sets to be disjoint.
     let matched_but_not_settled: HashSet<_> = other_matched_orders
         .difference(&submitted_orders)
         .copied()

--- a/crates/solver/src/analytics.rs
+++ b/crates/solver/src/analytics.rs
@@ -41,6 +41,8 @@ fn get_prices(settlement: &Settlement) -> HashMap<H160, BigRational> {
         .collect::<HashMap<_, _>>()
 }
 
+/// Record Grafana metrics for the number of orders which were matched in a batch,
+/// but were not part of the winning settlement (i.e. matched by unsettled).
 pub fn report_matched_but_unsettled_orders(
     metrics: Arc<dyn SolverMetrics>,
     submitted: &Settlement,


### PR DESCRIPTION
Based on a TODO left in #1230 - we move the metric reporting logic of "matched but unsettled orders" to the recently introduced file `analytics.rs`. 

No logical changes made here, just moving data manipulation and computation outside of `driver.rs`. Looking for advices on iterating over the same list twice.
