### PR TITLE
Log orders that have solutions but don't get settled

### DIFF
--- a/crates/solver/src/analytics.rs
+++ b/crates/solver/src/analytics.rs
@@ -1,13 +1,47 @@
-use crate::{metrics::SolverMetrics, settlement::Settlement};
+use crate::{
+    driver::solver_settlements::RatedSettlement, metrics::SolverMetrics, settlement::Settlement,
+    solver::Solver,
+};
 use ethcontract::H160;
 use model::order::OrderUid;
 use num::{BigRational, ToPrimitive, Zero};
 use shared::conversions::U256Ext;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt::{Display, Formatter},
     sync::Arc,
 };
+
+pub fn report_matched_but_not_settled(
+    metrics: &dyn SolverMetrics,
+    (_, winning_solution): &(Arc<dyn Solver>, RatedSettlement),
+    alternative_settlements: &[(Arc<dyn Solver>, RatedSettlement)],
+) {
+    let submitted_orders: HashSet<_> = winning_solution
+        .settlement
+        .trades()
+        .iter()
+        .map(|trade| trade.order.order_meta_data.uid)
+        .collect();
+    let other_matched_orders: HashSet<_> = alternative_settlements
+        .iter()
+        .flat_map(|(_, solution)| solution.settlement.trades().to_vec())
+        .map(|trade| trade.order.order_meta_data.uid)
+        .collect();
+    let matched_but_not_settled: HashSet<_> = other_matched_orders
+        .difference(&submitted_orders)
+        .copied()
+        .collect();
+
+    if !matched_but_not_settled.is_empty() {
+        tracing::debug!(
+            ?matched_but_not_settled,
+            "some orders were matched but not settled"
+        );
+    }
+
+    metrics.orders_matched_but_not_settled(matched_but_not_settled.len());
+}
 
 #[derive(Clone)]
 struct SurplusInfo {
@@ -43,13 +77,14 @@ fn get_prices(settlement: &Settlement) -> HashMap<H160, BigRational> {
 /// Record metric with surplus achieved in winning settlement
 /// vs that which was unrealized in other feasible solutions.
 pub fn report_alternative_settlement_surplus(
-    metrics: Arc<dyn SolverMetrics>,
-    winning_settlement: (&'static str, &Settlement),
-    alternative_settlements: Vec<(&'static str, &Settlement)>,
+    metrics: &dyn SolverMetrics,
+    winning_settlement: &(Arc<dyn Solver>, RatedSettlement),
+    alternative_settlements: &[(Arc<dyn Solver>, RatedSettlement)],
 ) {
     let (winning_solver, submitted) = winning_settlement;
-    let submitted_prices = get_prices(submitted);
+    let submitted_prices = get_prices(&submitted.settlement);
     let submitted_surplus: HashMap<_, _> = submitted
+        .settlement
         .trades()
         .iter()
         .map(|trade| {
@@ -58,7 +93,7 @@ pub fn report_alternative_settlement_surplus(
             (
                 trade.order.order_meta_data.uid,
                 SurplusInfo {
-                    solver_name: winning_solver,
+                    solver_name: winning_solver.name(),
                     ratio: trade
                         .surplus_ratio(sell_token_price, buy_token_price)
                         .unwrap_or_else(BigRational::zero),
@@ -67,7 +102,7 @@ pub fn report_alternative_settlement_surplus(
         })
         .collect();
 
-    let best_alternative = best_surplus_by_order(&alternative_settlements);
+    let best_alternative = best_surplus_by_order(alternative_settlements);
     for (order_id, submitted) in submitted_surplus.iter() {
         if let Some(alternative) = best_alternative.get(order_id) {
             metrics.report_order_surplus(
@@ -86,18 +121,18 @@ pub fn report_alternative_settlement_surplus(
 }
 
 fn best_surplus_by_order(
-    settlements: &[(&'static str, &Settlement)],
+    settlements: &[(Arc<dyn Solver>, RatedSettlement)],
 ) -> HashMap<OrderUid, SurplusInfo> {
     let mut best_surplus: HashMap<OrderUid, SurplusInfo> = HashMap::new();
-    for (solver, settlement) in settlements.iter() {
-        let trades = settlement.trades();
-        let clearing_prices = get_prices(settlement);
+    for (solver, solution) in settlements.iter() {
+        let trades = solution.settlement.trades();
+        let clearing_prices = get_prices(&solution.settlement);
         for trade in trades {
             let order_id = trade.order.order_meta_data.uid;
             let sell_token_price = &clearing_prices[&trade.order.order_creation.sell_token];
             let buy_token_price = &clearing_prices[&trade.order.order_creation.buy_token];
             let surplus = SurplusInfo {
-                solver_name: solver,
+                solver_name: solver.name(),
                 ratio: trade
                     .surplus_ratio(sell_token_price, buy_token_price)
                     .unwrap_or_else(BigRational::zero),

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -31,7 +31,7 @@ use shared::{
     Web3,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -283,33 +283,12 @@ impl Driver {
     ) {
         // Report surplus
         analytics::report_alternative_settlement_surplus(
-            self.metrics.clone(),
-            (submitted.0.name(), &submitted.1.settlement),
-            other_settlements
-                .iter()
-                .map(|(solver, rated_settlement)| (solver.name(), &rated_settlement.settlement))
-                .collect(),
+            &*self.metrics,
+            submitted,
+            &other_settlements,
         );
         // Report matched but not settled
-        // TODO - move all this data manipulation into analytics.rs
-        let submitted_orders: HashSet<_> = submitted
-            .1
-            .settlement
-            .trades()
-            .iter()
-            .map(|trade| trade.order.order_meta_data.uid)
-            .collect();
-        let other_matched_orders: HashSet<_> = other_settlements
-            .iter()
-            .flat_map(|(_, solution)| solution.settlement.trades().to_vec())
-            .map(|trade| trade.order.order_meta_data.uid)
-            .collect();
-        let matched_but_not_settled: HashSet<_> = other_matched_orders
-            .difference(&submitted_orders)
-            .copied()
-            .collect();
-        self.metrics
-            .orders_matched_but_not_settled(matched_but_not_settled.len());
+        analytics::report_matched_but_not_settled(&*self.metrics, submitted, &other_settlements);
     }
 
     // Rate settlements, ignoring those for which the rating procedure failed.


### PR DESCRIPTION
This PR adds an additional log message printing UIDs for orders that have settlements but don't end up getting settled on chain.

This is because we have an alert:
> Insufficient Settlement Throughput

On this metric, but it is hard to debug exactly what is going on since we can't actually easily read which orders are being "left behind" this way.

### Test Plan

Rust compiler (code moved to a separate module and we added a log statement, no new logic).
