### PR TITLE
Fixed issue where all Balancer pools were getting removed on startup

### DIFF
--- a/crates/shared/src/sources/balancer_v2/event_handler.rs
+++ b/crates/shared/src/sources/balancer_v2/event_handler.rs
@@ -268,6 +268,7 @@ impl Maintaining for BalancerPoolRegistry {
         futures::try_join!(
             self.two_token_pool_updater.run_maintenance(),
             self.weighted_pool_updater.run_maintenance(),
+            self.stable_pool_updater.run_maintenance(),
         )?;
         Ok(())
     }

--- a/crates/shared/src/sources/balancer_v2/pool_init.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_init.rs
@@ -89,7 +89,8 @@ impl PoolInitializing for DefaultPoolInitializer {
             DefaultPoolInitializer::Fetched(inner) => inner.initialize_pools().await,
         }?;
         tracing::debug!(
-            "initialized registered pools ({} Stable, {} Weighted & {} TwoTokenWeighted)",
+            "initialized registered pools (block {}: {} Stable, {} Weighted & {} TwoTokenWeighted)",
+            registered_pools.fetched_block_number,
             registered_pools.stable_pools.len(),
             registered_pools.weighted_pools.len(),
             registered_pools.weighted_2token_pools.len()


### PR DESCRIPTION
This PR addresses an issue where Balancer pools were getting removed on startup. This is because the Balancer pool store initializes with the Graph for some re-org safe block in the past pretending that all pools were added by events on that block. The event handler was replacing all events in that (this is needed because of subtle race conditions that can happen) with an empty list - causing all Balancer pools to be removed.

The fix is to track the block for which the initial pools were fetched on and just not delete events past that point. Since we use a re-org safe block to fetch these pools, there should not be any problems where a re-orgs causes these pools to no longer exist.

Additionally, this did not seem to affect Stable pools, which led me to find a separate issue where stable pools were being indexed after startup.

### Test Plan

CI still passes. Also, you can run the solver locally and see:
```
$ cargo run -p solver -- --baseline-sources BalancerV2
...
2021-11-23T12:57:30.426Z DEBUG shared::sources::balancer_v2::pool_init: initialized registered pools (block 13670942: 3 Stable, 73 Weighted & 72 TwoTokenWeighted)
...
2021-11-23T12:57:31.832Z DEBUG shared::sources::balancer_v2::pool_storage: replacing 0 events from block number 13670917
2021-11-23T12:57:31.832Z DEBUG shared::sources::balancer_v2::pool_storage: skipping deleting events from 13670917..=13670942
...
2021-11-23T12:57:32.303Z DEBUG solver::liquidity_collector: got 6 AMMs
...
```
