### PR TITLE
Return 0 fee if buy equals sell token

### DIFF
--- a/crates/orderbook/src/fee.rs
+++ b/crates/orderbook/src/fee.rs
@@ -324,12 +324,16 @@ impl MinFeeCalculating for MinFeeCalculator {
         fee_data: FeeData,
         app_data: AppId,
     ) -> Result<Measurement, PriceEstimationError> {
-        ensure_token_supported(fee_data.sell_token, self.bad_token_detector.as_ref()).await?;
-        ensure_token_supported(fee_data.buy_token, self.bad_token_detector.as_ref()).await?;
-
         let now = (self.now)();
         let official_valid_until = now + Duration::seconds(STANDARD_VALIDITY_FOR_FEE_IN_SEC);
         let internal_valid_until = now + Duration::seconds(PERSISTED_VALIDITY_FOR_FEE_IN_SEC);
+
+        if fee_data.buy_token == fee_data.sell_token {
+            return Ok((U256::zero(), official_valid_until));
+        }
+
+        ensure_token_supported(fee_data.sell_token, self.bad_token_detector.as_ref()).await?;
+        ensure_token_supported(fee_data.buy_token, self.bad_token_detector.as_ref()).await?;
 
         tracing::debug!(?fee_data, ?app_data, "computing subsidized fee",);
 

--- a/crates/orderbook/src/fee.rs
+++ b/crates/orderbook/src/fee.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Duration, Utc, MAX_DATETIME};
 use gas_estimation::GasPriceEstimating;
 use model::{
     app_id::AppId,
@@ -324,16 +324,16 @@ impl MinFeeCalculating for MinFeeCalculator {
         fee_data: FeeData,
         app_data: AppId,
     ) -> Result<Measurement, PriceEstimationError> {
-        let now = (self.now)();
-        let official_valid_until = now + Duration::seconds(STANDARD_VALIDITY_FOR_FEE_IN_SEC);
-        let internal_valid_until = now + Duration::seconds(PERSISTED_VALIDITY_FOR_FEE_IN_SEC);
-
         if fee_data.buy_token == fee_data.sell_token {
-            return Ok((U256::zero(), official_valid_until));
+            return Ok((U256::zero(), MAX_DATETIME));
         }
 
         ensure_token_supported(fee_data.sell_token, self.bad_token_detector.as_ref()).await?;
         ensure_token_supported(fee_data.buy_token, self.bad_token_detector.as_ref()).await?;
+
+        let now = (self.now)();
+        let official_valid_until = now + Duration::seconds(STANDARD_VALIDITY_FOR_FEE_IN_SEC);
+        let internal_valid_until = now + Duration::seconds(PERSISTED_VALIDITY_FOR_FEE_IN_SEC);
 
         tracing::debug!(?fee_data, ?app_data, "computing subsidized fee",);
 


### PR DESCRIPTION
We have been seeing some logs of the form:

> WARN orderbook::fee: Computed negative fee after applying fee discount: -10000000000000000, capping at 0

which according to my analysis stem from the fact the frontend is sometimes querying us with sellToken == buyToken fee queries (cf. [slack message](https://gnosisinc.slack.com/archives/CSGLUC1BN/p1637761787180400)). In those case the gas cost is 0 so our fixed fee discount makes it negative.

This PR adds an early exit for this code path. Note, that as soon as the quote endpoint is used this type of query would return a BadRequest error.

### Test Plan
Unit tests still pass. Querying http://localhost:8080/api/v1/fee?sellToken=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&buyToken=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&amount=6837606881482500&kind=sell locally yields 0 fee estimate without a warning.
