### PR TITLE
Pass in conctracts instead of calling deployed locally

### DIFF
--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -6,8 +6,7 @@ use crate::{
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use contracts::ERC20;
 use ethcontract::{
-    batch::CallBatch, dyns::DynTransport, errors::DeployError, transaction::TransactionBuilder,
-    PrivateKey,
+    batch::CallBatch, dyns::DynTransport, transaction::TransactionBuilder, PrivateKey,
 };
 use model::TokenPair;
 use primitive_types::{H160, U256};
@@ -43,28 +42,12 @@ impl TokenOwnerFinding for UniswapLikePairProviderFinder {
 }
 
 /// The balancer vault contract contains all the balances of all pools.
-pub struct BalancerVaultFinder {
-    address: H160,
-}
-
-impl BalancerVaultFinder {
-    /// Ok(None) if the vault isn't deployed on this network.
-    /// Err if communication with the node failed.
-    pub async fn new(web3: &Web3) -> Result<Option<Self>> {
-        match contracts::BalancerV2Vault::deployed(web3).await {
-            Ok(contract) => Ok(Some(Self {
-                address: contract.address(),
-            })),
-            Err(DeployError::NotFound(_)) => Ok(None),
-            Err(err) => Err(err.into()),
-        }
-    }
-}
+pub struct BalancerVaultFinder(pub contracts::BalancerV2Vault);
 
 #[async_trait::async_trait]
 impl TokenOwnerFinding for BalancerVaultFinder {
     async fn find_candidate_owners(&self, _: H160) -> Result<Vec<H160>> {
-        Ok(vec![self.address])
+        Ok(vec![self.0.address()])
     }
 }
 

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -424,35 +424,37 @@ async fn main() {
             .collect(),
     });
 
-    let (balancer_pool_maintainer, balancer_v2_liquidity) = if baseline_sources
-        .contains(&BaselineSource::BalancerV2)
-    {
-        let balancer_pool_fetcher = Arc::new(
-            BalancerPoolFetcher::new(
-                chain_id,
-                web3.clone(),
-                token_info_fetcher.clone(),
-                args.balancer_factories
-                    .unwrap_or_else(BalancerFactoryKind::all),
-                cache_config,
-                current_block_stream.clone(),
-                metrics.clone(),
-                client.clone(),
+    let (balancer_pool_maintainer, balancer_v2_liquidity) =
+        if baseline_sources.contains(&BaselineSource::BalancerV2) {
+            let vault = contracts::BalancerV2Vault::deployed(&web3).await.unwrap();
+            let balancer_pool_fetcher = Arc::new(
+                BalancerPoolFetcher::new(
+                    chain_id,
+                    web3.clone(),
+                    token_info_fetcher.clone(),
+                    args.balancer_factories
+                        .unwrap_or_else(BalancerFactoryKind::all),
+                    cache_config,
+                    current_block_stream.clone(),
+                    metrics.clone(),
+                    client.clone(),
+                )
+                .await
+                .expect("failed to create Balancer pool fetcher"),
+            );
+            (
+                Some(balancer_pool_fetcher.clone() as Arc<dyn Maintaining>),
+                Some(BalancerV2Liquidity::new(
+                    web3.clone(),
+                    balancer_pool_fetcher,
+                    base_tokens.clone(),
+                    settlement_contract.clone(),
+                    vault,
+                )),
             )
-            .await
-            .expect("failed to create Balancer pool fetcher"),
-        );
-        (
-            Some(balancer_pool_fetcher.clone() as Arc<dyn Maintaining>),
-            Some(
-                BalancerV2Liquidity::new(web3.clone(), balancer_pool_fetcher, base_tokens.clone())
-                    .await
-                    .expect("failed to create Balancer V2 liquidity"),
-            ),
-        )
-    } else {
-        (None, None)
-    };
+        } else {
+            (None, None)
+        };
 
     let price_estimator = Arc::new(BaselinePriceEstimator::new(
         pool_aggregator,


### PR DESCRIPTION
Fixes https://github.com/gnosis/gp-v2-services/issues/1379

I decided to go with this simple solution of passing all required contracts in and querying them from the node in main. We can  still decide on a different refactoring in the future but this already makes the code more pure and future work easier.

### Test Plan
CI, run locally
