### PR TITLE
Differentiate between different settlement submission outcomes.

### DIFF
--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -40,11 +40,13 @@ pub enum SolverRunOutcome {
 pub enum SettlementSubmissionOutcome {
     /// A settlement transaction was mined and included on the blockchain.
     Success,
+    /// A transaction reverted.
+    Revert,
     /// Submission timed-out while waiting for the transaction to get mined.
     Timeout,
-    /// A transaction was either mined and reverted or, in the case of private
-    /// network submission, the blockchain state changed and the transaction is
-    /// no longer valid.
+    /// A transaction failed to be submitted or, in the case of private network
+    /// submission, the blockchain state changed and the transaction is no
+    /// longer valid.
     Failure,
 }
 
@@ -315,6 +317,7 @@ impl SolverMetrics for Metrics {
     fn settlement_submitted(&self, outcome: SettlementSubmissionOutcome, solver: &'static str) {
         let result = match outcome {
             SettlementSubmissionOutcome::Success => "success",
+            SettlementSubmissionOutcome::Revert => "revert",
             SettlementSubmissionOutcome::Timeout => "timeout",
             SettlementSubmissionOutcome::Failure => "failure",
         };

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -36,6 +36,18 @@ pub enum SolverRunOutcome {
     Failure,
 }
 
+/// The outcome of settlement submission.
+pub enum SettlementSubmissionOutcome {
+    /// A settlement transaction was mined and included on the blockchain.
+    Success,
+    /// Submission timed-out while waiting for the transaction to get mined.
+    Timeout,
+    /// A transaction was either mined and reverted or, in the case of private
+    /// network submission, the blockchain state changed and the transaction is
+    /// no longer valid.
+    Failure,
+}
+
 pub trait SolverMetrics: Send + Sync {
     fn orders_fetched(&self, orders: &[LimitOrder]);
     fn liquidity_fetched(&self, liquidity: &[Liquidity]);
@@ -47,7 +59,7 @@ pub trait SolverMetrics: Send + Sync {
     fn single_order_solver_succeeded(&self, solver: &'static str);
     fn single_order_solver_failed(&self, solver: &'static str);
     fn settlement_simulation_failed(&self, solver: &'static str);
-    fn settlement_submitted(&self, successful: bool, solver: &'static str);
+    fn settlement_submitted(&self, outcome: SettlementSubmissionOutcome, solver: &'static str);
     fn orders_matched_but_not_settled(&self, count: usize);
     fn report_order_surplus(&self, surplus_diff: f64);
     fn runloop_completed(&self);
@@ -300,8 +312,12 @@ impl SolverMetrics for Metrics {
             .inc()
     }
 
-    fn settlement_submitted(&self, successful: bool, solver: &'static str) {
-        let result = if successful { "success" } else { "failures" };
+    fn settlement_submitted(&self, outcome: SettlementSubmissionOutcome, solver: &'static str) {
+        let result = match outcome {
+            SettlementSubmissionOutcome::Success => "success",
+            SettlementSubmissionOutcome::Timeout => "timeout",
+            SettlementSubmissionOutcome::Failure => "failure",
+        };
         self.settlement_submissions
             .with_label_values(&[result, solver])
             .inc()
@@ -387,7 +403,7 @@ impl SolverMetrics for NoopMetrics {
     fn single_order_solver_succeeded(&self, _: &'static str) {}
     fn single_order_solver_failed(&self, _: &'static str) {}
     fn settlement_simulation_failed(&self, _: &'static str) {}
-    fn settlement_submitted(&self, _: bool, _: &'static str) {}
+    fn settlement_submitted(&self, _: SettlementSubmissionOutcome, _: &'static str) {}
     fn orders_matched_but_not_settled(&self, _: usize) {}
     fn report_order_surplus(&self, _: f64) {}
     fn runloop_completed(&self) {}
@@ -407,7 +423,7 @@ mod tests {
         metrics.order_settled(&Default::default(), "test");
         metrics.settlement_simulation_succeeded("test");
         metrics.settlement_simulation_failed("test");
-        metrics.settlement_submitted(true, "test");
+        metrics.settlement_submitted(SettlementSubmissionOutcome::Success, "test");
         metrics.orders_matched_but_not_settled(20);
     }
 }

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -7,11 +7,17 @@ mod gas_price_stream;
 pub mod retry;
 pub mod rpc;
 
-use crate::settlement::Settlement;
-use anyhow::{bail, Result};
+use self::{
+    archer_settlement::ArcherSolutionSubmitter, flashbots_settlement::FlashbotsSolutionSubmitter,
+};
+use crate::{metrics::SettlementSubmissionOutcome, settlement::Settlement};
+use anyhow::{anyhow, Result};
 use archer_api::ArcherApi;
 use contracts::GPv2Settlement;
-use ethcontract::Account;
+use ethcontract::{
+    errors::{ExecutionError, MethodError},
+    Account,
+};
 use flashbots_api::FlashbotsApi;
 use gas_estimation::GasPriceEstimating;
 use primitive_types::U256;
@@ -21,10 +27,6 @@ use std::{
     time::{Duration, SystemTime},
 };
 use web3::types::TransactionReceipt;
-
-use self::{
-    archer_settlement::ArcherSolutionSubmitter, flashbots_settlement::FlashbotsSolutionSubmitter,
-};
 
 const ESTIMATE_GAS_LIMIT_FACTOR: f64 = 1.2;
 const GAS_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
@@ -64,7 +66,7 @@ impl SolutionSubmitter {
         settlement: Settlement,
         gas_estimate: U256,
         account: Account,
-    ) -> Result<TransactionReceipt> {
+    ) -> Result<TransactionReceipt, SubmissionError> {
         match &self.transaction_strategy {
             TransactionStrategy::CustomNodes(nodes) => {
                 rpc::submit(
@@ -99,11 +101,7 @@ impl SolutionSubmitter {
                         gas_estimate,
                     )
                     .await;
-                match result {
-                    Ok(Some(hash)) => Ok(hash),
-                    Ok(None) => bail!("transaction did not get mined in time"),
-                    Err(err) => Err(err),
-                }
+                result?.ok_or(SubmissionError::Timeout)
             }
             TransactionStrategy::Flashbots {
                 flashbots_api,
@@ -127,15 +125,59 @@ impl SolutionSubmitter {
                         *flashbots_tip,
                     )
                     .await;
-                match result {
-                    Ok(Some(hash)) => Ok(hash),
-                    Ok(None) => bail!("transaction did not get mined in time"),
-                    Err(err) => Err(err),
-                }
+                result?.ok_or(SubmissionError::Timeout)
             }
             TransactionStrategy::DryRun => {
-                dry_run::log_settlement(account, &self.contract, settlement).await
+                Ok(dry_run::log_settlement(account, &self.contract, settlement).await?)
             }
+        }
+    }
+}
+
+/// An error during settlement submission.
+#[derive(Debug)]
+pub enum SubmissionError {
+    /// The settlement submission timed out.
+    Timeout,
+    /// An error occured.
+    Other(anyhow::Error),
+}
+
+impl SubmissionError {
+    /// Returns the outcome for use with metrics.
+    pub fn as_outcome(&self) -> SettlementSubmissionOutcome {
+        match self {
+            Self::Timeout => SettlementSubmissionOutcome::Timeout,
+            Self::Other(_) => SettlementSubmissionOutcome::Failure,
+        }
+    }
+
+    /// Convert this submission error into an `anyhow::Error`.
+    ///
+    /// This is implemented as a method instead of `From`/`Into` to avoid any
+    /// multiple trait implementation issues because of the `anyhow` blanket
+    /// `impl<T: Display> From<T> for anyhow::Error`.
+    pub fn into_anyhow(self) -> anyhow::Error {
+        match self {
+            SubmissionError::Timeout => anyhow!("transaction did not get mined in time"),
+            SubmissionError::Other(err) => err,
+        }
+    }
+}
+
+impl From<anyhow::Error> for SubmissionError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Other(err)
+    }
+}
+
+impl From<MethodError> for SubmissionError {
+    fn from(err: MethodError) -> Self {
+        match &err.inner {
+            ExecutionError::ConfirmTimeout(_) => SubmissionError::Timeout,
+            _ => SubmissionError::Other(
+                anyhow::Error::from(err).context("settlement transaction failed"),
+            ),
         }
     }
 }

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -116,7 +116,7 @@ impl SolutionSubmitter {
                     self.gas_price_estimator.as_ref(),
                     self.gas_price_cap,
                 )?;
-                let result = submitter
+                submitter
                     .submit(
                         self.target_confirm_time,
                         SystemTime::now() + *max_confirm_time,
@@ -124,8 +124,7 @@ impl SolutionSubmitter {
                         gas_estimate,
                         *flashbots_tip,
                     )
-                    .await;
-                result?.ok_or(SubmissionError::Timeout)
+                    .await
             }
             TransactionStrategy::DryRun => {
                 Ok(dry_run::log_settlement(account, &self.contract, settlement).await?)


### PR DESCRIPTION
This PR adds a new `SettlementSubmissionOutcome` enum and uses it for determining the `result` value for our `settlement_submission` metric. With this, the settlement submission metrics differentiates between different outcomes:
- success: transaction was mined
- timeout: transaction did not get mined in time
- revert: transaction was submitted and mined but reverted
- failure: transaction failed to submit - nothing was mined

Additionally, we no longer print `error!` logs for submission failures but instead can setup alerts for them instead.

### Test Plan

Added unit test for error conversion. Additionally we can check the metrics are working.

<details><summary>Apply the following patch</summary>

```diff
diff --git a/crates/solver/src/settlement_submission.rs b/crates/solver/src/settlement_submission.rs
index f70341b..4d90c59 100644
--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -31,6 +31,8 @@ use web3::types::TransactionReceipt;
 const ESTIMATE_GAS_LIMIT_FACTOR: f64 = 1.2;
 const GAS_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
 
+static COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
 pub struct SolutionSubmitter {
     pub web3: Web3,
     pub contract: GPv2Settlement,
@@ -128,7 +130,18 @@ impl SolutionSubmitter {
                 result?.ok_or(SubmissionError::Timeout)
             }
             TransactionStrategy::DryRun => {
-                Ok(dry_run::log_settlement(account, &self.contract, settlement).await?)
+                match COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed) % 4 {
+                    0 => Ok(TransactionReceipt {
+                        transaction_hash: Default::default(),
+                        block_hash: Some(Default::default()),
+                        block_number: Some(Default::default()),
+                        ..Default::default()
+                    }),
+                    1 => Err(SubmissionError::Revert(None)),
+                    2 => Err(SubmissionError::Timeout),
+                    _ => Err(SubmissionError::Other(anyhow::anyhow!("foo"))),
+                }
+                //Ok(dry_run::log_settlement(account, &self.contract, settlement).await?)
             }
         }
     }
```

</details>

Run the solver in `DryRun` mode for a new runs:
```
$ cargo run -p solver -- --solvers Baseline --transaction-strategy DryRun
...
```

And after a while check that the metrics counters are incrementing:
```
# TYPE gp_v2_solver_settlement_submissions counter
gp_v2_solver_settlement_submissions{result="failure",solver_type="BaselineSolver"} 2
gp_v2_solver_settlement_submissions{result="revert",solver_type="BaselineSolver"} 2
gp_v2_solver_settlement_submissions{result="success",solver_type="BaselineSolver"} 2
gp_v2_solver_settlement_submissions{result="timeout",solver_type="BaselineSolver"} 2
```
