### PR TITLE
Fix Tenderly simulation block

### DIFF
--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -139,9 +139,15 @@ pub fn tenderly_link(
     network_id: &str,
     tx: TransactionBuilder<DynTransport>,
 ) -> String {
+    // Tenderly simulates transactions for block N at transaction index 0, while
+    // `eth_call` simulates transactions "on top" of the block (i.e. after the
+    // last transaction index). Therefore, in order for the Tenderly simulation
+    // to be the same as the `eth_call`, we want to create it on the next block
+    // (since `block_N{tx_last} == block_(N+1){tx_0}`).
+    let next_block = current_block + 1;
     format!(
         "https://dashboard.tenderly.co/gp-v2/staging/simulator/new?block={}&blockIndex=0&from={:#x}&gas=8000000&gasPrice=0&value=0&contractAddress={:#x}&network={}&rawFunctionInput=0x{}",
-        current_block,
+        next_block,
         tx.from.unwrap().address(),
         tx.to.unwrap(),
         network_id,

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -142,8 +142,8 @@ pub fn tenderly_link(
     // Tenderly simulates transactions for block N at transaction index 0, while
     // `eth_call` simulates transactions "on top" of the block (i.e. after the
     // last transaction index). Therefore, in order for the Tenderly simulation
-    // to be the same as the `eth_call`, we want to create it on the next block
-    // (since `block_N{tx_last} == block_(N+1){tx_0}`).
+    // to be as close as possible to the `eth_call`, we want to create it on the
+    // next block (since `block_N{tx_last} ~= block_(N+1){tx_0}`).
     let next_block = current_block + 1;
     format!(
         "https://dashboard.tenderly.co/gp-v2/staging/simulator/new?block={}&blockIndex=0&from={:#x}&gas=8000000&gasPrice=0&value=0&contractAddress={:#x}&network={}&rawFunctionInput=0x{}",


### PR DESCRIPTION
This PR fixes the block we specify for Tenderly simulations to match the settlement simulatation we do with `eth_call`.

The reason this is needed is that our Tenderly simulation is created with a transaction index 0 (i.e. the first transaction on the block) while `eth_call` simulates a transaction "on top" of the block, i.e. after all other transactions in the block.

As far as we can tell, there is no way to specify when generating a Tenderly simulation link to use the "maximum block index" (something like `blockIndex=-1`), so we do the next best thing and simulate at index 0 on the next block.

Note that this may cause slightly different results for simulations that are sensitive to the block number (a SC that has logicon the current block number - for a contrived example, a token that is paused up to a certain block number). However, I assume this is less likely than results being different because of state changes (like changes in pool reserves) from simulating before all other transactions on the block.

### Test Plan

Trivial change, so Rust compiler and CI.
