### PR TITLE
Turn submission timeouts into warnings and add metrics for those

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,6 +2658,7 @@ dependencies = [
  "num",
  "primitive-types",
  "prometheus",
+ "prometheus-metric-storage",
  "rand",
  "reqwest",
  "serde",

--- a/crates/solver/Cargo.toml
+++ b/crates/solver/Cargo.toml
@@ -35,6 +35,7 @@ model = { path = "../model" }
 num = "0.4"
 primitive-types = { version = "0.10", features = ["fp-conversion"] }
 prometheus = "0.13"
+prometheus-metric-storage = "0.4"
 rand = "0.8"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -1,6 +1,7 @@
 pub mod solver_settlements;
 
 use self::solver_settlements::RatedSettlement;
+use crate::settlement_submission::TransactionTimeoutError;
 use crate::{
     analytics, auction_preprocessing,
     in_flight_orders::InFlightOrders,
@@ -179,10 +180,11 @@ impl Driver {
                 // Since we simulate and only submit solutions when they used to pass before, there is no
                 // point in logging transaction failures in the form of race conditions as hard errors.
                 let name = solver.name();
-                if err
-                    .downcast_ref::<MethodError>()
-                    .map(|e| is_transaction_failure(&e.inner))
-                    .unwrap_or(false)
+                if err.is::<TransactionTimeoutError>()
+                    || err
+                        .downcast_ref::<MethodError>()
+                        .map(|e| is_transaction_failure(&e.inner))
+                        .unwrap_or(false)
                 {
                     tracing::warn!("Failed to submit {} settlement: {:?}", name, err)
                 } else {


### PR DESCRIPTION
Transaction timeout error is inactionable, so we turn it into a warning. We also add more metrics for the settlement submission subsystem.

### Test Plan
Manual testing
