### PR TITLE
Rename some balancer pool fields

### DIFF
--- a/crates/shared/src/sources/balancer_v2/graph_api.rs
+++ b/crates/shared/src/sources/balancer_v2/graph_api.rs
@@ -253,8 +253,8 @@ mod pools_query {
             self.tokens.iter().try_fold(
                 RegisteredWeightedPool {
                     common: CommonPoolData {
-                        pool_id: self.id,
-                        pool_address: self.address,
+                        id: self.id,
+                        address: self.address,
                         tokens: Vec::with_capacity(token_count),
                         scaling_exponents: Vec::with_capacity(token_count),
                         block_created: block_created_upper_bound,
@@ -285,8 +285,8 @@ mod pools_query {
             self.tokens.iter().try_fold(
                 RegisteredStablePool {
                     common: CommonPoolData {
-                        pool_id: self.id,
-                        pool_address: self.address,
+                        id: self.id,
+                        address: self.address,
                         tokens: Vec::with_capacity(token_count),
                         scaling_exponents: Vec::with_capacity(token_count),
                         block_created: block_created_upper_bound,
@@ -455,8 +455,8 @@ mod tests {
         // Note that this test also demonstrates unreachable code is indeed unreachable
         use pools_query::*;
         let common = CommonPoolData {
-            pool_id: H256([2; 32]),
-            pool_address: H160([1; 20]),
+            id: H256([2; 32]),
+            address: H160([1; 20]),
             tokens: vec![H160([2; 20]), H160([3; 20])],
             scaling_exponents: vec![17, 16],
             block_created: 42,

--- a/crates/shared/src/sources/balancer_v2/info_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/info_fetching.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct CommonPoolInfo {
-    pub pool_id: H256,
+    pub id: H256,
     pub tokens: Vec<H160>,
     pub scaling_exponents: Vec<u8>,
 }
@@ -77,7 +77,7 @@ impl PoolInfoFetching for PoolInfoFetcher {
         let scaling_exponents = self.get_scaling_exponents(&tokens).await?;
         Ok(WeightedPoolInfo {
             common: CommonPoolInfo {
-                pool_id,
+                id: pool_id,
                 tokens,
                 scaling_exponents,
             },
@@ -106,7 +106,7 @@ impl PoolInfoFetching for PoolInfoFetcher {
         let scaling_exponents = self.get_scaling_exponents(&tokens).await?;
         Ok(StablePoolInfo {
             common: CommonPoolInfo {
-                pool_id,
+                id: pool_id,
                 tokens,
                 scaling_exponents,
             },
@@ -280,7 +280,7 @@ mod tests {
             pool_info.common.tokens,
             vec![H160::from_low_u64_be(1), H160::from_low_u64_be(2)]
         );
-        assert_eq!(pool_info.common.pool_id, pool_id);
+        assert_eq!(pool_info.common.id, pool_id);
         assert_eq!(pool_info.common.scaling_exponents, vec![0u8, 1u8]);
         assert_eq!(pool_info.weights, vec![Bfp::from_wei(weight)]);
     }
@@ -334,7 +334,7 @@ mod tests {
             pool_info.common.tokens,
             vec![H160::from_low_u64_be(1), H160::from_low_u64_be(2)]
         );
-        assert_eq!(pool_info.common.pool_id, pool_id);
+        assert_eq!(pool_info.common.id, pool_id);
         assert_eq!(pool_info.common.scaling_exponents, vec![0u8, 1u8]);
     }
 }

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -40,7 +40,7 @@ pub struct TokenState {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WeightedTokenState {
-    pub token_state: TokenState,
+    pub common: TokenState,
     pub weight: Bfp,
 }
 
@@ -50,9 +50,9 @@ pub trait BalancerPoolEvaluating {
 
 #[derive(Clone, Debug)]
 pub struct CommonPoolState {
-    pub pool_id: H256,
-    pub pool_address: H160, // This one isn't actually used (yet)
-    pub swap_fee_percentage: Bfp,
+    pub id: H256,
+    pub address: H160,
+    pub swap_fee: Bfp,
     pub paused: bool,
 }
 
@@ -66,7 +66,7 @@ impl WeightedPool {
     pub fn new(
         pool_data: RegisteredWeightedPool,
         balances: Vec<U256>,
-        swap_fee_percentage: Bfp,
+        swap_fee: Bfp,
         paused: bool,
     ) -> Self {
         let mut reserves = HashMap::new();
@@ -82,7 +82,7 @@ impl WeightedPool {
             reserves.insert(
                 token,
                 WeightedTokenState {
-                    token_state: TokenState {
+                    common: TokenState {
                         balance,
                         scaling_exponent,
                     },
@@ -92,9 +92,9 @@ impl WeightedPool {
         }
         WeightedPool {
             common: CommonPoolState {
-                pool_id: pool_data.common.pool_id,
-                pool_address: pool_data.common.pool_address,
-                swap_fee_percentage,
+                id: pool_data.common.id,
+                address: pool_data.common.address,
+                swap_fee,
                 paused,
             },
             reserves,
@@ -146,7 +146,7 @@ impl StablePool {
     pub fn new(
         pool_data: RegisteredStablePool,
         balances: Vec<U256>,
-        swap_fee_percentage: Bfp,
+        swap_fee: Bfp,
         amplification_factor: U256,
         amplification_precision: U256,
         paused: bool,
@@ -172,9 +172,9 @@ impl StablePool {
             AmplificationParameter::new(amplification_factor, amplification_precision)?;
         Ok(StablePool {
             common: CommonPoolState {
-                pool_id: pool_data.common.pool_id,
-                pool_address: pool_data.common.pool_address,
-                swap_fee_percentage,
+                id: pool_data.common.id,
+                address: pool_data.common.address,
+                swap_fee,
                 paused,
             },
             reserves,
@@ -320,18 +320,18 @@ mod tests {
         let pools = vec![
             WeightedPool {
                 common: CommonPoolState {
-                    pool_id: H256::from_low_u64_be(0),
-                    pool_address: Default::default(),
-                    swap_fee_percentage: Bfp::zero(),
+                    id: H256::from_low_u64_be(0),
+                    address: Default::default(),
+                    swap_fee: Bfp::zero(),
                     paused: true,
                 },
                 reserves: Default::default(),
             },
             WeightedPool {
                 common: CommonPoolState {
-                    pool_id: H256::from_low_u64_be(1),
-                    pool_address: Default::default(),
-                    swap_fee_percentage: Bfp::zero(),
+                    id: H256::from_low_u64_be(1),
+                    address: Default::default(),
+                    swap_fee: Bfp::zero(),
                     paused: false,
                 },
                 reserves: Default::default(),
@@ -340,7 +340,7 @@ mod tests {
 
         let filtered_pools = filter_paused(pools.clone());
         assert_eq!(filtered_pools.len(), 1);
-        assert_eq!(filtered_pools[0].common.pool_id, pools[1].common.pool_id);
+        assert_eq!(filtered_pools[0].common.id, pools[1].common.id);
     }
 
     #[test]

--- a/crates/shared/src/sources/balancer_v2/pool_init.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_init.rs
@@ -282,7 +282,7 @@ where
             .then(|pool| {
                 let pool_info = self.pool_info.clone();
                 async move {
-                    RegisteredWeightedPool::new(block_number, pool.common.pool_address, &*pool_info)
+                    RegisteredWeightedPool::new(block_number, pool.common.address, &*pool_info)
                         .await
                 }
             })
@@ -299,8 +299,7 @@ where
             .then(|pool| {
                 let pool_info = self.pool_info.clone();
                 async move {
-                    RegisteredStablePool::new(block_number, pool.common.pool_address, &*pool_info)
-                        .await
+                    RegisteredStablePool::new(block_number, pool.common.address, &*pool_info).await
                 }
             })
             .try_collect()
@@ -542,8 +541,8 @@ mod tests {
                 weighted_pools_by_factory: hashmap! {
                     weighted_factory => vec![RegisteredWeightedPool {
                         common: CommonPoolData {
-                            pool_id: H256([1; 32]),
-                            pool_address: H160([1; 20]),
+                            id: H256([1; 32]),
+                            address: H160([1; 20]),
                             tokens: vec![],
                             scaling_exponents: vec![],
                             block_created: 42,
@@ -552,8 +551,8 @@ mod tests {
                     }],
                     weighted_2token_factory => vec![RegisteredWeightedPool {
                         common: CommonPoolData {
-                            pool_id: H256([2; 32]),
-                            pool_address: H160([2; 20]),
+                            id: H256([2; 32]),
+                            address: H160([2; 20]),
                             tokens: vec![],
                             scaling_exponents: vec![],
                             block_created: 42,
@@ -563,8 +562,8 @@ mod tests {
                     addr!("0102030405060708091011121314151617181920") => vec![
                         RegisteredWeightedPool {
                             common: CommonPoolData {
-                                pool_id: H256([4; 32]),
-                                pool_address: H160([4; 20]),
+                                id: H256([4; 32]),
+                                address: H160([4; 20]),
                                 tokens: vec![],
                                 scaling_exponents: vec![],
                                 block_created: 42,
@@ -576,8 +575,8 @@ mod tests {
                 stable_pools_by_factory: hashmap! {
                     stable_factory => vec![RegisteredStablePool {
                         common: CommonPoolData {
-                            pool_id: H256([3; 32]),
-                            pool_address: H160([3; 20]),
+                            id: H256([3; 32]),
+                            address: H160([3; 20]),
                             tokens: vec![],
                             scaling_exponents: vec![],
                             block_created: 42,
@@ -586,8 +585,8 @@ mod tests {
                     addr!("0102030405060708091011121314151617181920") => vec![
                         RegisteredStablePool {
                             common: CommonPoolData {
-                                pool_id: H256([5; 32]),
-                                pool_address: H160([5; 20]),
+                                id: H256([5; 32]),
+                                address: H160([5; 20]),
                                 tokens: vec![],
                                 scaling_exponents: vec![],
                                 block_created: 42,
@@ -609,7 +608,7 @@ mod tests {
             .returning(|_| {
                 Ok(WeightedPoolInfo {
                     common: CommonPoolInfo {
-                        pool_id: H256([1; 32]),
+                        id: H256([1; 32]),
                         tokens: vec![H160([0x11; 20]), H160([0x22; 20])],
                         scaling_exponents: vec![0, 0],
                     },
@@ -627,7 +626,7 @@ mod tests {
             .returning(|_| {
                 Ok(WeightedPoolInfo {
                     common: CommonPoolInfo {
-                        pool_id: H256([2; 32]),
+                        id: H256([2; 32]),
                         tokens: vec![H160([0x11; 20]), H160([0x33; 20]), H160([0x44; 20])],
                         scaling_exponents: vec![0, 0, 0],
                     },
@@ -646,7 +645,7 @@ mod tests {
             .returning(|_| {
                 Ok(StablePoolInfo {
                     common: CommonPoolInfo {
-                        pool_id: H256([3; 32]),
+                        id: H256([3; 32]),
                         tokens: vec![],
                         scaling_exponents: vec![],
                     },
@@ -664,8 +663,8 @@ mod tests {
             BalancerRegisteredPools {
                 weighted_pools: vec![RegisteredWeightedPool {
                     common: CommonPoolData {
-                        pool_id: H256([1; 32]),
-                        pool_address: H160([1; 20]),
+                        id: H256([1; 32]),
+                        address: H160([1; 20]),
                         tokens: vec![H160([0x11; 20]), H160([0x22; 20])],
                         scaling_exponents: vec![0, 0],
                         block_created: 42,
@@ -677,8 +676,8 @@ mod tests {
                 }],
                 weighted_2token_pools: vec![RegisteredWeightedPool {
                     common: CommonPoolData {
-                        pool_id: H256([2; 32]),
-                        pool_address: H160([2; 20]),
+                        id: H256([2; 32]),
+                        address: H160([2; 20]),
                         tokens: vec![H160([0x11; 20]), H160([0x33; 20]), H160([0x44; 20])],
                         scaling_exponents: vec![0, 0, 0],
                         block_created: 42,
@@ -691,8 +690,8 @@ mod tests {
                 }],
                 stable_pools: vec![RegisteredStablePool {
                     common: CommonPoolData {
-                        pool_id: H256([3; 32]),
-                        pool_address: H160([3; 20]),
+                        id: H256([3; 32]),
+                        address: H160([3; 20]),
                         tokens: vec![],
                         scaling_exponents: vec![],
                         block_created: 42,

--- a/crates/shared/src/sources/balancer_v2/pool_storage.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_storage.rs
@@ -44,8 +44,8 @@ pub trait PoolEvaluating {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct CommonPoolData {
-    pub pool_id: H256,
-    pub pool_address: H160,
+    pub id: H256,
+    pub address: H160,
     pub tokens: Vec<H160>,
     pub scaling_exponents: Vec<u8>,
     pub block_created: u64,
@@ -54,8 +54,8 @@ pub struct CommonPoolData {
 #[cfg(test)]
 pub fn common_pool(seed: u8) -> CommonPoolData {
     CommonPoolData {
-        pool_id: H256([seed; 32]),
-        pool_address: H160([seed; 20]),
+        id: H256([seed; 32]),
+        address: H160([seed; 20]),
         tokens: vec![H160([seed; 20]), H160([seed + 1; 20])],
         scaling_exponents: vec![0, 0],
         block_created: seed as _,
@@ -106,8 +106,8 @@ impl RegisteredWeightedPool {
         let pool_data = data_fetcher.get_weighted_pool_data(pool_address).await?;
         Ok(RegisteredWeightedPool {
             common: CommonPoolData {
-                pool_id: pool_data.common.pool_id,
-                pool_address,
+                id: pool_data.common.id,
+                address: pool_address,
                 tokens: pool_data.common.tokens,
                 scaling_exponents: pool_data.common.scaling_exponents,
                 block_created,
@@ -135,8 +135,8 @@ impl RegisteredStablePool {
         let pool_data = data_fetcher.get_stable_pool_data(pool_address).await?;
         Ok(RegisteredStablePool {
             common: CommonPoolData {
-                pool_id: pool_data.common.pool_id,
-                pool_address,
+                id: pool_data.common.id,
+                address: pool_address,
                 tokens: pool_data.common.tokens,
                 scaling_exponents: pool_data.common.scaling_exponents,
                 block_created,
@@ -261,7 +261,7 @@ impl PoolStorage {
                         &*self.data_fetcher,
                     )
                     .await?;
-                    let pool_id = pool.common.pool_id;
+                    let pool_id = pool.common.id;
                     self.stable_pools.insert(pool_id, pool.clone());
                     for token in pool.common.tokens {
                         self.pools_by_token
@@ -277,7 +277,7 @@ impl PoolStorage {
                         &*self.data_fetcher,
                     )
                     .await?;
-                    let pool_id = pool.common.pool_id;
+                    let pool_id = pool.common.id;
                     self.weighted_pools.insert(pool_id, pool.clone());
                     for token in pool.common.tokens {
                         self.pools_by_token
@@ -364,9 +364,9 @@ fn construct_pool_map<T: PoolEvaluating>(
                 pools_by_token
                     .entry(token)
                     .or_default()
-                    .insert(pool_data.pool_id);
+                    .insert(pool_data.id);
             }
-            (pool_data.pool_id, pool)
+            (pool_data.id, pool)
         })
         .collect()
 }
@@ -408,8 +408,8 @@ mod tests {
             vec![
                 RegisteredWeightedPool {
                     common: CommonPoolData {
-                        pool_id: H256([1; 32]),
-                        pool_address: H160([1; 20]),
+                        id: H256([1; 32]),
+                        address: H160([1; 20]),
                         tokens: vec![H160([0x11; 20]), H160([0x22; 20])],
                         scaling_exponents: vec![0, 0],
                         block_created: 0,
@@ -421,8 +421,8 @@ mod tests {
                 },
                 RegisteredWeightedPool {
                     common: CommonPoolData {
-                        pool_id: H256([2; 32]),
-                        pool_address: H160([2; 20]),
+                        id: H256([2; 32]),
+                        address: H160([2; 20]),
                         tokens: vec![H160([0x11; 20]), H160([0x33; 20]), H160([0x77; 20])],
                         scaling_exponents: vec![0, 0],
                         block_created: 0,
@@ -435,8 +435,8 @@ mod tests {
             ],
             vec![RegisteredStablePool {
                 common: CommonPoolData {
-                    pool_id: H256([3; 32]),
-                    pool_address: H160([3; 20]),
+                    id: H256([3; 32]),
+                    address: H160([3; 20]),
                     tokens: vec![H160([0x11; 20]), H160([0x77; 20])],
                     scaling_exponents: vec![0, 0],
                     block_created: 0,
@@ -472,7 +472,7 @@ mod tests {
         for i in 0..n {
             let expected_pool_data = WeightedPoolInfo {
                 common: CommonPoolInfo {
-                    pool_id: pool_ids[i],
+                    id: pool_ids[i],
                     tokens: vec![tokens[i], tokens[i + 1]],
                     scaling_exponents: vec![0, 0],
                 },
@@ -510,8 +510,8 @@ mod tests {
                 pool_store.weighted_pools.get(&pool_ids[i]).unwrap(),
                 &RegisteredWeightedPool {
                     common: CommonPoolData {
-                        pool_id: pool_ids[i],
-                        pool_address: pool_addresses[i],
+                        id: pool_ids[i],
+                        address: pool_addresses[i],
                         tokens: vec![tokens[i], tokens[i + 1]],
                         scaling_exponents: vec![0, 0],
                         block_created: i as u64 + 1,
@@ -538,7 +538,7 @@ mod tests {
         for i in 0..n {
             let expected_pool_data = StablePoolInfo {
                 common: CommonPoolInfo {
-                    pool_id: pool_ids[i],
+                    id: pool_ids[i],
                     tokens: vec![tokens[i], tokens[i + 1]],
                     scaling_exponents: vec![0, 0],
                 },
@@ -575,8 +575,8 @@ mod tests {
                 pool_store.stable_pools.get(&pool_ids[i]).unwrap(),
                 &RegisteredStablePool {
                     common: CommonPoolData {
-                        pool_id: pool_ids[i],
-                        pool_address: pool_addresses[i],
+                        id: pool_ids[i],
+                        address: pool_addresses[i],
                         tokens: vec![tokens[i], tokens[i + 1]],
                         scaling_exponents: vec![0, 0],
                         block_created: i as u64 + 1
@@ -602,7 +602,7 @@ mod tests {
         for i in start_block..end_block + 1 {
             let expected_pool_data = WeightedPoolInfo {
                 common: CommonPoolInfo {
-                    pool_id: pool_ids[i],
+                    id: pool_ids[i],
                     tokens: vec![tokens[i], tokens[i + 1]],
                     scaling_exponents: vec![0, 0],
                 },
@@ -630,7 +630,7 @@ mod tests {
             .returning(move |_| {
                 Ok(WeightedPoolInfo {
                     common: CommonPoolInfo {
-                        pool_id: new_pool_id,
+                        id: new_pool_id,
                         tokens: vec![new_token],
                         scaling_exponents: vec![0],
                     },
@@ -652,8 +652,8 @@ mod tests {
                 pool_store.weighted_pools.get(&pool_ids[i]).unwrap(),
                 &RegisteredWeightedPool {
                     common: CommonPoolData {
-                        pool_id: pool_ids[i],
-                        pool_address: pool_addresses[i],
+                        id: pool_ids[i],
+                        address: pool_addresses[i],
                         tokens: vec![tokens[i], tokens[i + 1]],
                         scaling_exponents: vec![0, 0],
                         block_created: i as u64,
@@ -694,8 +694,8 @@ mod tests {
             pool_store.weighted_pools.get(&new_pool_id).unwrap(),
             &RegisteredWeightedPool {
                 common: CommonPoolData {
-                    pool_id: new_pool_id,
-                    pool_address: new_pool_address,
+                    id: new_pool_id,
+                    address: new_pool_address,
                     tokens: vec![new_token],
                     scaling_exponents: vec![0],
                     block_created: new_event_block,
@@ -723,7 +723,7 @@ mod tests {
         for i in start_block..end_block + 1 {
             let expected_pool_data = StablePoolInfo {
                 common: CommonPoolInfo {
-                    pool_id: pool_ids[i],
+                    id: pool_ids[i],
                     tokens: vec![tokens[i], tokens[i + 1]],
                     scaling_exponents: vec![0, 0],
                 },
@@ -749,7 +749,7 @@ mod tests {
             .returning(move |_| {
                 Ok(StablePoolInfo {
                     common: CommonPoolInfo {
-                        pool_id: new_pool_id,
+                        id: new_pool_id,
                         tokens: vec![new_token],
                         scaling_exponents: vec![0],
                     },
@@ -770,8 +770,8 @@ mod tests {
                 pool_store.stable_pools.get(&pool_ids[i]).unwrap(),
                 &RegisteredStablePool {
                     common: CommonPoolData {
-                        pool_id: pool_ids[i],
-                        pool_address: pool_addresses[i],
+                        id: pool_ids[i],
+                        address: pool_addresses[i],
                         tokens: vec![tokens[i], tokens[i + 1]],
                         scaling_exponents: vec![0, 0],
                         block_created: i as u64
@@ -811,8 +811,8 @@ mod tests {
             pool_store.stable_pools.get(&new_pool_id).unwrap(),
             &RegisteredStablePool {
                 common: CommonPoolData {
-                    pool_id: new_pool_id,
-                    pool_address: new_pool_address,
+                    id: new_pool_id,
+                    address: new_pool_address,
                     tokens: vec![new_token],
                     scaling_exponents: vec![0],
                     block_created: new_event_block,
@@ -837,7 +837,7 @@ mod tests {
         for i in 0..n {
             let expected_pool_data = WeightedPoolInfo {
                 common: CommonPoolInfo {
-                    pool_id: pool_ids[i],
+                    id: pool_ids[i],
                     tokens: tokens[i..n].to_owned(),
                     scaling_exponents: vec![],
                 },
@@ -867,11 +867,11 @@ mod tests {
             // This is weighted_pools[i] has tokens [tokens[i], tokens[i+1], ... , tokens[n]]
             weighted_pools.push(RegisteredWeightedPool {
                 common: CommonPoolData {
-                    pool_id: pool_ids[i],
+                    id: pool_ids[i],
                     tokens: tokens[i..n].to_owned(),
                     scaling_exponents: vec![],
                     block_created: 0,
-                    pool_address: pool_addresses[i],
+                    address: pool_addresses[i],
                 },
                 normalized_weights: vec![],
             });

--- a/crates/solver/src/liquidity/balancer_v2.rs
+++ b/crates/solver/src/liquidity/balancer_v2.rs
@@ -86,9 +86,9 @@ impl BalancerV2Liquidity {
             .into_iter()
             .map(|pool| WeightedProductOrder {
                 reserves: pool.reserves,
-                fee: pool.common.swap_fee_percentage,
+                fee: pool.common.swap_fee,
                 settlement_handling: Arc::new(SettlementHandler {
-                    pool_id: pool.common.pool_id,
+                    pool_id: pool.common.id,
                     contracts: self.contracts.clone(),
                     allowances: allowances.clone(),
                 }),
@@ -99,10 +99,10 @@ impl BalancerV2Liquidity {
             .into_iter()
             .map(|pool| StablePoolOrder {
                 reserves: pool.reserves,
-                fee: pool.common.swap_fee_percentage.into(),
+                fee: pool.common.swap_fee.into(),
                 amplification_parameter: pool.amplification_parameter,
                 settlement_handling: Arc::new(SettlementHandler {
-                    pool_id: pool.common.pool_id,
+                    pool_id: pool.common.id,
                     contracts: self.contracts.clone(),
                     allowances: allowances.clone(),
                 }),
@@ -199,28 +199,28 @@ mod tests {
         let weighted_pools = vec![
             WeightedPool {
                 common: CommonPoolState {
-                    pool_id: H256([0x90; 32]),
-                    pool_address: H160([0x90; 20]),
-                    swap_fee_percentage: "0.002".parse().unwrap(),
+                    id: H256([0x90; 32]),
+                    address: H160([0x90; 20]),
+                    swap_fee: "0.002".parse().unwrap(),
                     paused: true,
                 },
                 reserves: hashmap! {
                     H160([0x70; 20]) => WeightedTokenState {
-                        token_state: TokenState {
+                        common: TokenState {
                             balance: 100.into(),
                             scaling_exponent: 16,
                         },
                         weight: "0.25".parse().unwrap(),
                     },
                     H160([0x71; 20]) => WeightedTokenState {
-                        token_state: TokenState {
+                        common: TokenState {
                             balance: 1_000_000.into(),
                             scaling_exponent: 12,
                         },
                         weight: "0.25".parse().unwrap(),
                     },
                     H160([0xb0; 20]) => WeightedTokenState {
-                        token_state: TokenState {
+                        common: TokenState {
                             balance: 1_000_000_000_000_000_000u128.into(),
                             scaling_exponent: 0,
                         },
@@ -230,21 +230,21 @@ mod tests {
             },
             WeightedPool {
                 common: CommonPoolState {
-                    pool_id: H256([0x91; 32]),
-                    pool_address: H160([0x91; 20]),
-                    swap_fee_percentage: "0.001".parse().unwrap(),
+                    id: H256([0x91; 32]),
+                    address: H160([0x91; 20]),
+                    swap_fee: "0.001".parse().unwrap(),
                     paused: true,
                 },
                 reserves: hashmap! {
                     H160([0x73; 20]) => WeightedTokenState {
-                        token_state: TokenState {
+                        common: TokenState {
                             balance: 1_000_000_000_000_000_000u128.into(),
                             scaling_exponent: 0,
                         },
                         weight: "0.5".parse().unwrap(),
                     },
                     H160([0xb0; 20]) => WeightedTokenState {
-                        token_state: TokenState {
+                        common: TokenState {
                             balance: 1_000_000_000_000_000_000u128.into(),
                             scaling_exponent: 0,
                         },
@@ -256,9 +256,9 @@ mod tests {
 
         let stable_pools = vec![StablePool {
             common: CommonPoolState {
-                pool_id: H256([0x92; 32]),
-                pool_address: H160([0x92; 20]),
-                swap_fee_percentage: "0.002".parse().unwrap(),
+                id: H256([0x92; 32]),
+                address: H160([0x92; 20]),
+                swap_fee: "0.002".parse().unwrap(),
                 paused: true,
             },
             amplification_parameter: AmplificationParameter::new(1.into(), 1.into()).unwrap(),

--- a/crates/solver/src/solver/baseline_solver.rs
+++ b/crates/solver/src/solver/baseline_solver.rs
@@ -286,7 +286,7 @@ fn amm_to_pool(amm: &ConstantProductOrder) -> Pool {
 fn amm_to_weighted_pool(amm: &WeightedProductOrder) -> WeightedPoolRef {
     WeightedPoolRef {
         reserves: &amm.reserves,
-        swap_fee_percentage: amm.fee,
+        swap_fee: amm.fee,
     }
 }
 
@@ -587,14 +587,14 @@ mod tests {
             Liquidity::BalancerWeighted(WeightedProductOrder {
                 reserves: hashmap! {
                     addr!("c778417e063141139fce010982780140aa0cd5ab") => WeightedTokenState {
-                        token_state: TokenState {
+                        common: TokenState {
                             balance: 799_086_982_149_629_058_u128.into(),
                             scaling_exponent: 0,
                         },
                         weight: "0.5".parse().unwrap(),
                     },
                     addr!("e4b9895e638f54c3bee2a3a78d6a297cc03e0353") => WeightedTokenState {
-                        token_state: TokenState {
+                        common: TokenState {
                             balance: 1_251_682_293_173_877_359_u128.into(),
                             scaling_exponent: 0,
                         },
@@ -640,7 +640,7 @@ mod tests {
                 (
                     tokens[0],
                     WeightedTokenState {
-                        token_state: TokenState {
+                        common: TokenState {
                             balance: 4294966784u64.into(),
                             scaling_exponent: 0,
                         },
@@ -650,7 +650,7 @@ mod tests {
                 (
                     tokens[1],
                     WeightedTokenState {
-                        token_state: TokenState {
+                        common: TokenState {
                             balance: 4278190173u64.into(),
                             scaling_exponent: 0,
                         },

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -293,7 +293,7 @@ fn amm_models(liquidity: &[Liquidity], gas_model: &GasModel) -> BTreeMap<usize, 
                                 (
                                     *token,
                                     WeightedPoolTokenData {
-                                        balance: state.token_state.balance,
+                                        balance: state.common.balance,
                                         weight: BigRational::from(state.weight),
                                     },
                                 )

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -265,14 +265,14 @@ mod tests {
             Liquidity::BalancerWeighted(WeightedProductOrder {
                 reserves: hashmap! {
                     t0 => WeightedTokenState {
-                        token_state: TokenState {
+                        common: TokenState {
                             balance: U256::from(200),
                             scaling_exponent: 4,
                         },
                         weight: Bfp::from(200_000_000_000_000_000),
                     },
                     t1 => WeightedTokenState {
-                        token_state: TokenState {
+                        common: TokenState {
                             balance: U256::from(800),
                             scaling_exponent: 6,
                         },
@@ -406,14 +406,14 @@ mod tests {
         let wpo = WeightedProductOrder {
             reserves: hashmap! {
                 token_c => WeightedTokenState {
-                    token_state: TokenState {
+                    common: TokenState {
                         balance: U256::from(1251682293173877359u128),
                         scaling_exponent: 0,
                     },
                     weight: Bfp::from(500_000_000_000_000_000),
                 },
                 token_b => WeightedTokenState {
-                    token_state: TokenState {
+                    common: TokenState {
                         balance: U256::from(799086982149629058u128),
                         scaling_exponent: 0,
                     },


### PR DESCRIPTION
Just a easy PR that renames a whole bunch of Balancer pool fields. Specifically:
- `pool_{id,address}` -> `{id,address}`: The reasoning here is that `pool.pool_id` is redundant.
- `swap_fee_percentage` -> `swap_fee`: This is just because the value wan't a percentage (i.e. `0.003` represented `0.3%` and not `0.003%`).

### Test Plan

CI - no logic changes.
