### PR TITLE
[1/-] Introduce factory indexing module

### DIFF
--- a/crates/shared/src/sources/balancer_v2.rs
+++ b/crates/shared/src/sources/balancer_v2.rs
@@ -39,4 +39,5 @@ pub mod pool_cache;
 pub mod pool_fetching;
 mod pool_init;
 mod pool_storage;
+mod pools;
 pub mod swap;

--- a/crates/shared/src/sources/balancer_v2/pool_cache.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_cache.rs
@@ -4,7 +4,7 @@ use crate::{
         balancer_v2::{
             event_handler::BalancerPoolRegistry,
             pool_fetching::{BalancerPoolEvaluating, StablePool, WeightedPool},
-            pool_storage::{PoolEvaluating, RegisteredStablePool, RegisteredWeightedPool},
+            pool_storage::{RegisteredStablePool, RegisteredWeightedPool},
             swap::fixed_point::Bfp,
         },
         uniswap_v2::pool_fetching::handle_contract_error,
@@ -135,14 +135,14 @@ impl CacheFetching<H256, StablePool> for PoolReserveFetcher {
             .into_iter()
             .map(|registered_pool| {
                 let pool_contract =
-                    BalancerV2StablePool::at(&self.web3, registered_pool.properties().address);
+                    BalancerV2StablePool::at(&self.web3, registered_pool.common.address);
                 let swap_fee = pool_contract
                     .get_swap_fee_percentage()
                     .block(block)
                     .batch_call(&mut batch);
                 let reserves = self
                     .vault
-                    .get_pool_tokens(Bytes(registered_pool.properties().id.0))
+                    .get_pool_tokens(Bytes(registered_pool.common.id.0))
                     .block(block)
                     .batch_call(&mut batch);
                 let paused_state = pool_contract

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -77,7 +77,7 @@ impl WeightedPool {
             &pool_data.common.tokens,
             balances,
             &pool_data.common.scaling_exponents,
-            &pool_data.normalized_weights
+            &pool_data.weights
         ) {
             reserves.insert(
                 token,

--- a/crates/shared/src/sources/balancer_v2/pool_init.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_init.rs
@@ -6,6 +6,7 @@
 use super::{
     graph_api::{BalancerSubgraphClient, PoolType, RegisteredPools},
     pool_storage::{RegisteredStablePool, RegisteredWeightedPool},
+    pools::PoolIndexing,
 };
 use anyhow::{anyhow, bail, Result};
 use contracts::{
@@ -109,17 +110,26 @@ impl BalancerRegisteredPools {
                 PoolType::Weighted if pool.factory == deployment.weighted_factory => {
                     result
                         .weighted_pools
-                        .push(pool.as_weighted(fetched_block_number)?);
+                        .push(RegisteredWeightedPool::from_graph_data(
+                            &pool,
+                            fetched_block_number,
+                        )?);
                 }
                 PoolType::Weighted if pool.factory == deployment.weighted_2token_factory => {
                     result
                         .weighted_2token_pools
-                        .push(pool.as_weighted(fetched_block_number)?);
+                        .push(RegisteredWeightedPool::from_graph_data(
+                            &pool,
+                            fetched_block_number,
+                        )?);
                 }
                 PoolType::Stable if pool.factory == deployment.stable_factory => {
                     result
                         .stable_pools
-                        .push(pool.as_stable(fetched_block_number)?);
+                        .push(RegisteredStablePool::from_graph_data(
+                            &pool,
+                            fetched_block_number,
+                        )?);
                 }
                 _ => {
                     // Log an error in order to trigger an alert. This will
@@ -268,7 +278,7 @@ mod tests {
                 block_created: fetched_block_number,
                 ..common_pool(seed)
             },
-            normalized_weights: vec![
+            weights: vec![
                 Bfp::from_wei(500_000_000_000_000_000u128.into()),
                 Bfp::from_wei(500_000_000_000_000_000u128.into()),
             ],

--- a/crates/shared/src/sources/balancer_v2/pools.rs
+++ b/crates/shared/src/sources/balancer_v2/pools.rs
@@ -1,0 +1,38 @@
+//! Abstraction around a Balancer pool factory.
+//!
+//! These factories are used for indexing pool events, fetching "permanent" pool
+//! information (such as token addresses for pools) as well as pool "state"
+//! (such as current reserve balances, and current swap fee).
+//!
+//! This abstraction is provided in a way to simplify adding new Balancer pool
+//! types by just implementing the required `BalancerFactory` trait.
+
+pub mod common;
+pub mod stable;
+pub mod weighted;
+pub mod weighted_2token;
+
+use super::graph_api::PoolData;
+use anyhow::Result;
+
+/// A Balancer factory indexing implementation.
+#[async_trait::async_trait]
+pub trait FactoryIndexing {
+    /// The permanent pool info for this.
+    ///
+    /// This contains all pool information that never changes and only needs to
+    /// be retrieved once. This data will be passed in when fetching the current
+    /// pool state via `fetch_pool`.
+    type PoolInfo: PoolIndexing;
+}
+
+/// Required information needed for indexing pools.
+pub trait PoolIndexing {
+    /// Creates a new instance from a pool
+    fn from_graph_data(pool: &PoolData, block_created: u64) -> Result<Self>
+    where
+        Self: Sized;
+
+    /// Gets the common pool data.
+    fn common(&self) -> &common::PoolInfo;
+}

--- a/crates/shared/src/sources/balancer_v2/pools/common.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/common.rs
@@ -1,7 +1,6 @@
 //! Module with data types and logic common to multiple Balancer pool types
 
-use super::PoolIndexing;
-use crate::sources::balancer_v2::graph_api::PoolData;
+use crate::sources::balancer_v2::graph_api::{PoolData, PoolType};
 use anyhow::{anyhow, ensure, Result};
 use ethcontract::{H160, H256};
 
@@ -15,8 +14,9 @@ pub struct PoolInfo {
     pub block_created: u64,
 }
 
-impl PoolIndexing for PoolInfo {
-    fn from_graph_data(pool: &PoolData, block_created: u64) -> Result<Self> {
+impl PoolInfo {
+    /// Loads a pool info from Graph pool data.
+    pub fn from_graph_data(pool: &PoolData, block_created: u64) -> Result<Self> {
         ensure!(pool.tokens.len() > 1, "insufficient tokens in pool");
 
         Ok(PoolInfo {
@@ -32,8 +32,16 @@ impl PoolIndexing for PoolInfo {
         })
     }
 
-    fn common(&self) -> &PoolInfo {
-        self
+    /// Loads a common pool info from Graph pool data, requiring the pool type
+    /// to be the specified value.
+    pub fn for_type(pool_type: PoolType, pool: &PoolData, block_created: u64) -> Result<Self> {
+        ensure!(
+            pool.pool_type == pool_type,
+            "cannot convert {:?} pool to {:?} pool",
+            pool.pool_type,
+            pool_type,
+        );
+        Self::from_graph_data(pool, block_created)
     }
 }
 

--- a/crates/shared/src/sources/balancer_v2/pools/common.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/common.rs
@@ -1,0 +1,135 @@
+//! Module with data types and logic common to multiple Balancer pool types
+
+use super::PoolIndexing;
+use crate::sources::balancer_v2::graph_api::PoolData;
+use anyhow::{anyhow, ensure, Result};
+use ethcontract::{H160, H256};
+
+/// Common pool data shared across all Balancer pools.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PoolInfo {
+    pub id: H256,
+    pub address: H160,
+    pub tokens: Vec<H160>,
+    pub scaling_exponents: Vec<u8>,
+    pub block_created: u64,
+}
+
+impl PoolIndexing for PoolInfo {
+    fn from_graph_data(pool: &PoolData, block_created: u64) -> Result<Self> {
+        ensure!(pool.tokens.len() > 1, "insufficient tokens in pool");
+
+        Ok(PoolInfo {
+            id: pool.id,
+            address: pool.address,
+            tokens: pool.tokens.iter().map(|token| token.address).collect(),
+            scaling_exponents: pool
+                .tokens
+                .iter()
+                .map(|token| scaling_exponent_from_decimals(token.decimals))
+                .collect::<Result<_>>()?,
+            block_created,
+        })
+    }
+
+    fn common(&self) -> &PoolInfo {
+        self
+    }
+}
+
+fn scaling_exponent_from_decimals(decimals: u8) -> Result<u8> {
+    // Technically this should never fail for Balancer Pools since tokens
+    // with more than 18 decimals (not supported by balancer contracts)
+    // https://github.com/balancer-labs/balancer-v2-monorepo/blob/deployments-latest/pkg/pool-utils/contracts/BasePool.sol#L476-L487
+    18u8.checked_sub(decimals)
+        .ok_or_else(|| anyhow!("unsupported token with more than 18 decimals"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sources::balancer_v2::graph_api::{PoolType, Token};
+
+    #[test]
+    fn convert_graph_pool_to_common_pool_info() {
+        let pool = PoolData {
+            pool_type: PoolType::Stable,
+            id: H256([4; 32]),
+            address: H160([3; 20]),
+            factory: H160([0xfb; 20]),
+            tokens: vec![
+                Token {
+                    address: H160([0x33; 20]),
+                    decimals: 3,
+                    weight: None,
+                },
+                Token {
+                    address: H160([0x44; 20]),
+                    decimals: 18,
+                    weight: None,
+                },
+            ],
+        };
+
+        assert_eq!(
+            PoolInfo::from_graph_data(&pool, 42).unwrap(),
+            PoolInfo {
+                id: H256([4; 32]),
+                address: H160([3; 20]),
+                tokens: vec![H160([0x33; 20]), H160([0x44; 20])],
+                scaling_exponents: vec![15, 0],
+                block_created: 42,
+            }
+        );
+    }
+
+    #[test]
+    fn pool_conversion_insufficient_tokens() {
+        let pool = PoolData {
+            pool_type: PoolType::Weighted,
+            id: H256([2; 32]),
+            address: H160([1; 20]),
+            factory: H160([0; 20]),
+            tokens: vec![Token {
+                address: H160([2; 20]),
+                decimals: 18,
+                weight: Some("1.337".parse().unwrap()),
+            }],
+        };
+        assert!(PoolInfo::from_graph_data(&pool, 42).is_err());
+    }
+
+    #[test]
+    fn pool_conversion_invalid_decimals() {
+        let pool = PoolData {
+            pool_type: PoolType::Weighted,
+            id: H256([2; 32]),
+            address: H160([1; 20]),
+            factory: H160([0; 20]),
+            tokens: vec![
+                Token {
+                    address: H160([2; 20]),
+                    decimals: 19,
+                    weight: Some("1.337".parse().unwrap()),
+                },
+                Token {
+                    address: H160([3; 20]),
+                    decimals: 18,
+                    weight: Some("1.337".parse().unwrap()),
+                },
+            ],
+        };
+        assert!(PoolInfo::from_graph_data(&pool, 42).is_err());
+    }
+
+    #[test]
+    fn scaling_exponent_from_decimals_ok_and_err() {
+        for i in 0..=18 {
+            assert_eq!(scaling_exponent_from_decimals(i).unwrap(), 18u8 - i);
+        }
+        assert_eq!(
+            scaling_exponent_from_decimals(19).unwrap_err().to_string(),
+            "unsupported token with more than 18 decimals"
+        )
+    }
+}

--- a/crates/shared/src/sources/balancer_v2/pools/stable.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/stable.rs
@@ -1,0 +1,65 @@
+//! Module implementing stable pool specific indexing logic.
+
+use super::{common, FactoryIndexing, PoolIndexing};
+use crate::sources::balancer_v2::graph_api::{PoolData, PoolType};
+use anyhow::{ensure, Result};
+use contracts::BalancerV2StablePoolFactory;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PoolInfo {
+    pub common: common::PoolInfo,
+}
+
+impl PoolIndexing for PoolInfo {
+    fn from_graph_data(pool: &PoolData, block_created: u64) -> Result<Self> {
+        ensure!(
+            pool.pool_type == PoolType::Stable,
+            "cannot convert {:?} pool to stable pool",
+            pool.pool_type,
+        );
+
+        Ok(PoolInfo {
+            common: common::PoolInfo::from_graph_data(pool, block_created)?,
+        })
+    }
+
+    fn common(&self) -> &common::PoolInfo {
+        &self.common
+    }
+}
+
+#[async_trait::async_trait]
+impl FactoryIndexing for BalancerV2StablePoolFactory {
+    type PoolInfo = PoolInfo;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sources::balancer_v2::graph_api::Token;
+    use ethcontract::{H160, H256};
+
+    #[test]
+    fn errors_when_converting_wrong_pool_type() {
+        let pool = PoolData {
+            pool_type: PoolType::Weighted,
+            id: H256([2; 32]),
+            address: H160([1; 20]),
+            factory: H160([0xfa; 20]),
+            tokens: vec![
+                Token {
+                    address: H160([0x11; 20]),
+                    decimals: 1,
+                    weight: None,
+                },
+                Token {
+                    address: H160([0x22; 20]),
+                    decimals: 2,
+                    weight: None,
+                },
+            ],
+        };
+
+        assert!(PoolInfo::from_graph_data(&pool, 42).is_err());
+    }
+}

--- a/crates/shared/src/sources/balancer_v2/pools/stable.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/stable.rs
@@ -2,7 +2,7 @@
 
 use super::{common, FactoryIndexing, PoolIndexing};
 use crate::sources::balancer_v2::graph_api::{PoolData, PoolType};
-use anyhow::{ensure, Result};
+use anyhow::Result;
 use contracts::BalancerV2StablePoolFactory;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -12,14 +12,8 @@ pub struct PoolInfo {
 
 impl PoolIndexing for PoolInfo {
     fn from_graph_data(pool: &PoolData, block_created: u64) -> Result<Self> {
-        ensure!(
-            pool.pool_type == PoolType::Stable,
-            "cannot convert {:?} pool to stable pool",
-            pool.pool_type,
-        );
-
         Ok(PoolInfo {
-            common: common::PoolInfo::from_graph_data(pool, block_created)?,
+            common: common::PoolInfo::for_type(PoolType::Stable, pool, block_created)?,
         })
     }
 

--- a/crates/shared/src/sources/balancer_v2/pools/weighted.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/weighted.rs
@@ -1,0 +1,117 @@
+//! Module implementing weighted pool specific indexing logic.
+
+use super::{common, FactoryIndexing, PoolIndexing};
+use crate::sources::balancer_v2::{
+    graph_api::{PoolData, PoolType},
+    swap::fixed_point::Bfp,
+};
+use anyhow::{anyhow, ensure, Result};
+use contracts::BalancerV2WeightedPoolFactory;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PoolInfo {
+    pub common: common::PoolInfo,
+    pub weights: Vec<Bfp>,
+}
+
+impl PoolIndexing for PoolInfo {
+    fn from_graph_data(pool: &PoolData, block_created: u64) -> Result<Self> {
+        ensure!(
+            pool.pool_type == PoolType::Weighted,
+            "cannot convert {:?} pool to weighted pool",
+            pool.pool_type,
+        );
+
+        Ok(PoolInfo {
+            common: common::PoolInfo::from_graph_data(pool, block_created)?,
+            weights: pool
+                .tokens
+                .iter()
+                .map(|token| {
+                    token
+                        .weight
+                        .ok_or_else(|| anyhow!("missing weights for pool {:?}", pool.id))
+                })
+                .collect::<Result<_>>()?,
+        })
+    }
+
+    fn common(&self) -> &common::PoolInfo {
+        &self.common
+    }
+}
+
+#[async_trait::async_trait]
+impl FactoryIndexing for BalancerV2WeightedPoolFactory {
+    type PoolInfo = PoolInfo;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sources::balancer_v2::graph_api::Token;
+    use ethcontract::{H160, H256};
+
+    #[test]
+    fn convert_graph_pool_to_weighted_pool_info() {
+        let pool = PoolData {
+            pool_type: PoolType::Weighted,
+            id: H256([2; 32]),
+            address: H160([1; 20]),
+            factory: H160([0xfa; 20]),
+            tokens: vec![
+                Token {
+                    address: H160([0x11; 20]),
+                    decimals: 1,
+                    weight: Some("1.337".parse().unwrap()),
+                },
+                Token {
+                    address: H160([0x22; 20]),
+                    decimals: 2,
+                    weight: Some("4.2".parse().unwrap()),
+                },
+            ],
+        };
+
+        assert_eq!(
+            PoolInfo::from_graph_data(&pool, 42).unwrap(),
+            PoolInfo {
+                common: common::PoolInfo {
+                    id: H256([2; 32]),
+                    address: H160([1; 20]),
+                    tokens: vec![H160([0x11; 20]), H160([0x22; 20])],
+                    scaling_exponents: vec![17, 16],
+                    block_created: 42,
+                },
+                weights: vec![
+                    Bfp::from_wei(1_337_000_000_000_000_000u128.into()),
+                    Bfp::from_wei(4_200_000_000_000_000_000u128.into()),
+                ],
+            },
+        );
+    }
+
+    #[test]
+    fn errors_when_converting_wrong_pool_type() {
+        let pool = PoolData {
+            pool_type: PoolType::Stable,
+            id: H256([2; 32]),
+            address: H160([1; 20]),
+            factory: H160([0xfa; 20]),
+            tokens: vec![
+                Token {
+                    address: H160([0x11; 20]),
+                    decimals: 1,
+                    weight: Some("1.337".parse().unwrap()),
+                },
+                Token {
+                    address: H160([0x22; 20]),
+                    decimals: 2,
+                    weight: Some("4.2".parse().unwrap()),
+                },
+            ],
+        };
+
+        assert!(PoolInfo::from_graph_data(&pool, 42).is_err());
+    }
+}

--- a/crates/shared/src/sources/balancer_v2/pools/weighted.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/weighted.rs
@@ -5,7 +5,7 @@ use crate::sources::balancer_v2::{
     graph_api::{PoolData, PoolType},
     swap::fixed_point::Bfp,
 };
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{anyhow, Result};
 use contracts::BalancerV2WeightedPoolFactory;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -16,14 +16,8 @@ pub struct PoolInfo {
 
 impl PoolIndexing for PoolInfo {
     fn from_graph_data(pool: &PoolData, block_created: u64) -> Result<Self> {
-        ensure!(
-            pool.pool_type == PoolType::Weighted,
-            "cannot convert {:?} pool to weighted pool",
-            pool.pool_type,
-        );
-
         Ok(PoolInfo {
-            common: common::PoolInfo::from_graph_data(pool, block_created)?,
+            common: common::PoolInfo::for_type(PoolType::Weighted, pool, block_created)?,
             weights: pool
                 .tokens
                 .iter()

--- a/crates/shared/src/sources/balancer_v2/pools/weighted_2token.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/weighted_2token.rs
@@ -1,0 +1,10 @@
+//! Module implementing two-token weighted pool specific indexing logic.
+
+pub use super::weighted::PoolInfo;
+use super::FactoryIndexing;
+use contracts::BalancerV2WeightedPool2TokensFactory;
+
+#[async_trait::async_trait]
+impl FactoryIndexing for BalancerV2WeightedPool2TokensFactory {
+    type PoolInfo = PoolInfo;
+}


### PR DESCRIPTION
This PR introduces a new `pools` module that will ultimately contain all the Balancer pool specific logic. Ultimately, the goal is to be able to add new Balancer pools by:
- Extending the `graph_api::PoolData` to include required fields
- Add a new `pools::$POOL_TYPE` module for the new factory/pool
- Implement the `FactoryIndexing` and `PoolIndexing` traits.

The `FactoryIndexing` trait was defined (although, it is still missing a lot of things that will be introduced later, such as fetching permanent pool info and fetching current pool state). Mostly this PR moves the `PoolData` -> `Registered*Pool` conversion logic to the new module.

### Test Plan

Logic moved around. There is a could extra error cases that were checked with new unit tests.
