### PR TITLE
[2/-] Split info fetching for each factory

### DIFF
--- a/crates/shared/src/sources/balancer_v2/event_handler.rs
+++ b/crates/shared/src/sources/balancer_v2/event_handler.rs
@@ -350,11 +350,14 @@ mod tests {
 
         let pool_init = EmptyPoolInitializer::for_chain(chain_id);
         let token_infos = TokenInfoFetcher { web3: web3.clone() };
-        let pool_info = PoolInfoFetcher {
-            web3: web3.clone(),
-            token_info_fetcher: Arc::new(token_infos),
-            vault: BalancerV2Vault::deployed(&web3).await.unwrap(),
-        };
+        let pool_info = PoolInfoFetcher::new(
+            BalancerV2Vault::deployed(&web3).await.unwrap(),
+            Arc::new(token_infos),
+            BalancerV2WeightedPoolFactory::deployed(&web3)
+                .await
+                .unwrap(),
+            BalancerV2StablePoolFactory::deployed(&web3).await.unwrap(),
+        );
         let registry = BalancerPoolRegistry::new(web3, pool_init, Arc::new(pool_info))
             .await
             .unwrap();

--- a/crates/shared/src/sources/balancer_v2/info_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/info_fetching.rs
@@ -8,9 +8,11 @@ use super::{
         FactoryIndexing as _,
     },
 };
+use crate::token_info::TokenInfoFetching;
 use anyhow::Result;
 use contracts::{BalancerV2StablePoolFactory, BalancerV2Vault, BalancerV2WeightedPoolFactory};
 use ethcontract::H160;
+use std::sync::Arc;
 
 /// Legacy pool info fetching implementation.
 ///
@@ -26,11 +28,12 @@ pub struct PoolInfoFetcher {
 impl PoolInfoFetcher {
     pub fn new(
         vault: BalancerV2Vault,
+        token_infos: Arc<dyn TokenInfoFetching>,
         weighted_factory: BalancerV2WeightedPoolFactory,
         stable_factory: BalancerV2StablePoolFactory,
     ) -> Self {
         Self {
-            inner: common::PoolInfoFetcher::new(vault),
+            inner: common::PoolInfoFetcher::new(vault, token_infos),
             weighted_factory,
             stable_factory,
         }

--- a/crates/shared/src/sources/balancer_v2/info_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/info_fetching.rs
@@ -1,340 +1,75 @@
-//! Responsible for conversion of a `pool_address` into `WeightedPoolInfo` which is used by the
-//! event handler to construct a `RegisteredWeightedPool`.
-use crate::{
-    sources::balancer_v2::swap::fixed_point::Bfp, token_info::TokenInfoFetching,
-    transport::MAX_BATCH_SIZE, Web3,
+//! Responsible for conversion of a `pool_address` into `*::PoolInfo` which is
+//! stored by the event handler
+
+use super::{
+    pool_storage::{RegisteredStablePool, RegisteredWeightedPool},
+    pools::{
+        common::{self, PoolInfoFetching as _},
+        FactoryIndexing as _,
+    },
 };
-use anyhow::{anyhow, Result};
-use contracts::{BalancerV2StablePool, BalancerV2Vault, BalancerV2WeightedPool};
-use ethcontract::{batch::CallBatch, Bytes, H160, H256};
-use mockall::*;
-use std::sync::Arc;
+use anyhow::Result;
+use contracts::{BalancerV2StablePoolFactory, BalancerV2Vault, BalancerV2WeightedPoolFactory};
+use ethcontract::H160;
 
-#[derive(Clone, Debug)]
-pub struct CommonPoolInfo {
-    pub id: H256,
-    pub tokens: Vec<H160>,
-    pub scaling_exponents: Vec<u8>,
-}
-
-#[derive(Clone, Debug)]
-pub struct WeightedPoolInfo {
-    pub common: CommonPoolInfo,
-    pub weights: Vec<Bfp>,
-}
-
-#[derive(Clone, Debug)]
-pub struct StablePoolInfo {
-    pub common: CommonPoolInfo,
-}
-
-/// Via `PoolInfoFetcher` (leverages a combination of `Web3` and `TokenInfoFetching`)
-/// to recover `WeightedPoolInfo` from a `pool_address` in steps as follows:
-/// 1. The `pool_id` is recovered first from the deployed `BalancerV2Vault` contract.
-/// 2. With `pool_id` we can BatchCall for `tokens` (just the addresses) and `normalized_weights`
-///     Technically, `normalized_weights` could be queried along with `pool_id` in step 1,
-///     but batching here or there doesn't make a difference.
-/// 3. Finally, the `scaling_exponents` are derived as 18 - decimals (for each the token in the pool)
-///     `TokenInfoFetching` is used here since it is optimized for recovering ERC20 info internally.
+/// Legacy pool info fetching implementation.
 ///
-/// Note that all token decimals are required to be returned from `TokenInfoFetching` in order
-/// to accurately construct `WeightedPoolInfo`.
+/// This is used as an interim adapter between the new "split" token fetching
+/// where each pool kind gets its dedicated module and the "legacy" way where
+/// each pool gets its own method.
 pub struct PoolInfoFetcher {
-    pub web3: Web3,
-    pub token_info_fetcher: Arc<dyn TokenInfoFetching>,
-    pub vault: BalancerV2Vault,
+    inner: common::PoolInfoFetcher,
+    weighted_factory: BalancerV2WeightedPoolFactory,
+    stable_factory: BalancerV2StablePoolFactory,
 }
 
-#[automock]
+impl PoolInfoFetcher {
+    pub fn new(
+        vault: BalancerV2Vault,
+        weighted_factory: BalancerV2WeightedPoolFactory,
+        stable_factory: BalancerV2StablePoolFactory,
+    ) -> Self {
+        Self {
+            inner: common::PoolInfoFetcher::new(vault),
+            weighted_factory,
+            stable_factory,
+        }
+    }
+}
+
+#[mockall::automock]
 #[async_trait::async_trait]
 pub trait PoolInfoFetching: Send + Sync {
-    async fn get_weighted_pool_data(&self, pool_address: H160) -> Result<WeightedPoolInfo>;
-    async fn get_stable_pool_data(&self, pool_address: H160) -> Result<StablePoolInfo>;
-    async fn get_scaling_exponents(&self, tokens: &[H160]) -> Result<Vec<u8>>;
+    async fn get_weighted_pool_data(
+        &self,
+        pool_address: H160,
+        block_created: u64,
+    ) -> Result<RegisteredWeightedPool>;
+    async fn get_stable_pool_data(
+        &self,
+        pool_address: H160,
+        block_created: u64,
+    ) -> Result<RegisteredStablePool>;
 }
 
 #[async_trait::async_trait]
 impl PoolInfoFetching for PoolInfoFetcher {
     /// Could result in ethcontract::{NodeError, MethodError or ContractError}
-    async fn get_weighted_pool_data(&self, pool_address: H160) -> Result<WeightedPoolInfo> {
-        let mut batch = CallBatch::new(self.web3.transport());
-        let pool_contract = BalancerV2WeightedPool::at(&self.web3, pool_address);
-        let pool_id = H256::from(pool_contract.methods().get_pool_id().call().await?.0);
-
-        // token_data and weight calls can be batched
-        let token_data = self
-            .vault
-            .methods()
-            .get_pool_tokens(Bytes(pool_id.0))
-            .batch_call(&mut batch);
-        let raw_normalized_weights = pool_contract
-            .methods()
-            .get_normalized_weights()
-            .batch_call(&mut batch);
-        batch.execute_all(MAX_BATCH_SIZE).await;
-
-        let tokens = token_data.await?.0;
-        let scaling_exponents = self.get_scaling_exponents(&tokens).await?;
-        Ok(WeightedPoolInfo {
-            common: CommonPoolInfo {
-                id: pool_id,
-                tokens,
-                scaling_exponents,
-            },
-            weights: raw_normalized_weights
-                .await?
-                .into_iter()
-                .map(Bfp::from_wei)
-                .collect(),
-        })
+    async fn get_weighted_pool_data(
+        &self,
+        pool_address: H160,
+        block_created: u64,
+    ) -> Result<RegisteredWeightedPool> {
+        let common_info = self.inner.pool_info(pool_address, block_created).await?;
+        self.weighted_factory.pool_info(common_info).await
     }
 
-    async fn get_stable_pool_data(&self, pool_address: H160) -> Result<StablePoolInfo> {
-        let mut batch = CallBatch::new(self.web3.transport());
-        let pool_contract = BalancerV2StablePool::at(&self.web3, pool_address);
-        let pool_id = H256::from(pool_contract.methods().get_pool_id().call().await?.0);
-
-        // token_data and weight calls can be batched
-        let token_data = self
-            .vault
-            .methods()
-            .get_pool_tokens(Bytes(pool_id.0))
-            .batch_call(&mut batch);
-        batch.execute_all(MAX_BATCH_SIZE).await;
-
-        let tokens = token_data.await?.0;
-        let scaling_exponents = self.get_scaling_exponents(&tokens).await?;
-        Ok(StablePoolInfo {
-            common: CommonPoolInfo {
-                id: pool_id,
-                tokens,
-                scaling_exponents,
-            },
-        })
-    }
-
-    async fn get_scaling_exponents(&self, tokens: &[H160]) -> Result<Vec<u8>> {
-        let token_decimals = self.token_info_fetcher.get_token_infos(tokens).await;
-        let ordered_decimals = tokens
-            .iter()
-            .map(|token| token_decimals.get(token).and_then(|t| t.decimals))
-            .collect::<Option<Vec<_>>>()
-            .ok_or_else(|| anyhow!("all token decimals required to build scaling factors"))?;
-        // Note that balancer does not support tokens with more than 18 decimals
-        // https://github.com/balancer-labs/balancer-v2-monorepo/blob/ce70f7663e0ac94b25ed60cb86faaa8199fd9e13/pkg/pool-utils/contracts/BasePool.sol#L497-L508
-        ordered_decimals
-            .iter()
-            .map(|decimals| 18u8.checked_sub(*decimals))
-            .collect::<Option<Vec<_>>>()
-            .ok_or_else(|| anyhow!("token with more than 18 decimals"))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::token_info::{MockTokenInfoFetching, TokenInfo};
-    use ethcontract::U256;
-    use ethcontract_mock::Mock;
-    use maplit::hashmap;
-
-    #[tokio::test]
-    async fn get_scaling_exponents_ok() {
-        let tokens = [
-            H160::from_low_u64_be(1),
-            H160::from_low_u64_be(2),
-            H160::from_low_u64_be(3),
-        ];
-
-        let mock = Mock::new(49);
-        let web3 = mock.web3();
-        let vault_contract = mock.deploy(BalancerV2Vault::raw_contract().abi.clone());
-        let vault = BalancerV2Vault::at(&web3.clone(), vault_contract.address());
-
-        let mut mock_token_info_fetcher = MockTokenInfoFetching::new();
-        mock_token_info_fetcher
-            .expect_get_token_infos()
-            .return_once(move |_| {
-                hashmap! {
-                    tokens[0] => TokenInfo { decimals: Some(0), symbol: Some("CAT".to_string()) },
-                    tokens[1] => TokenInfo { decimals: Some(9), symbol: Some("DOG".to_string()) },
-                    tokens[2] => TokenInfo { decimals: Some(18), symbol: Some("FOX".to_string()) },
-                }
-            });
-
-        let pool_info_fetcher = PoolInfoFetcher {
-            web3,
-            token_info_fetcher: Arc::new(mock_token_info_fetcher),
-            vault,
-        };
-
-        let scaling_exponents = pool_info_fetcher
-            .get_scaling_exponents(&tokens)
-            .await
-            .unwrap();
-        assert_eq!(scaling_exponents, vec![18, 9, 0]);
-    }
-
-    #[tokio::test]
-    async fn get_scaling_exponents_err() {
-        let token = H160::from_low_u64_be(1);
-
-        let mock = Mock::new(49);
-        let web3 = mock.web3();
-        let vault_contract = mock.deploy(BalancerV2Vault::raw_contract().abi.clone());
-        let vault = BalancerV2Vault::at(&web3.clone(), vault_contract.address());
-
-        let mut seq = Sequence::new();
-        let mut mock_token_info_fetcher = MockTokenInfoFetching::new();
-        mock_token_info_fetcher
-            .expect_get_token_infos()
-            .times(1)
-            .in_sequence(&mut seq)
-            .return_once(move |_| {
-                hashmap! {
-                    token => TokenInfo { decimals: None, symbol: Some("GNO".to_string()) },
-                    H160::zero() => TokenInfo { decimals: Some(1), symbol: Some("WETH".to_string()) }
-                }
-            });
-        mock_token_info_fetcher
-            .expect_get_token_infos()
-            .times(1)
-            .in_sequence(&mut seq)
-            .return_once(move |_| {
-                hashmap! {
-                    token => TokenInfo { decimals: Some(19), symbol: Some("BAD".to_string()) },
-                }
-            });
-
-        let pool_info_fetcher = PoolInfoFetcher {
-            web3,
-            token_info_fetcher: Arc::new(mock_token_info_fetcher),
-            vault,
-        };
-
-        assert_eq!(
-            pool_info_fetcher
-                .get_scaling_exponents(&[token])
-                .await
-                .unwrap_err()
-                .to_string(),
-            "all token decimals required to build scaling factors"
-        );
-
-        assert_eq!(
-            pool_info_fetcher
-                .get_scaling_exponents(&[token])
-                .await
-                .unwrap_err()
-                .to_string(),
-            "token with more than 18 decimals"
-        );
-    }
-
-    #[tokio::test]
-    async fn get_weighted_pool_data_ok() {
-        let mock = Mock::new(49);
-        let web3 = mock.web3();
-
-        let vault_contract = mock.deploy(BalancerV2Vault::raw_contract().abi.clone());
-        let vault = BalancerV2Vault::at(&web3.clone(), vault_contract.address());
-        let weighted_pool_contract =
-            mock.deploy(BalancerV2WeightedPool::raw_contract().abi.clone());
-        let weight = U256::from(1);
-
-        let pool_id = H256::from_low_u64_be(1);
-        let tokens = vec![H160::from_low_u64_be(1), H160::from_low_u64_be(2)];
-        weighted_pool_contract
-            .expect_call(BalancerV2WeightedPool::signatures().get_pool_id())
-            .returns(Bytes(pool_id.0));
-        vault_contract
-            .expect_call(BalancerV2Vault::signatures().get_pool_tokens())
-            .predicate((predicate::eq(Bytes(pool_id.0)),))
-            .returns((vec![tokens[0], tokens[1]], vec![], U256::zero()));
-        weighted_pool_contract
-            .expect_call(BalancerV2WeightedPool::signatures().get_normalized_weights())
-            .returns(vec![weight]);
-
-        let mut token_info_fetcher = MockTokenInfoFetching::new();
-        token_info_fetcher
-            .expect_get_token_infos()
-            .return_once(move |_| {
-                hashmap! {
-                    tokens[0] => TokenInfo { decimals: Some(18), symbol: Some("DAI".to_string()) },
-                    tokens[1] => TokenInfo { decimals: Some(17), symbol: Some("TOK".to_string()) },
-                }
-            });
-
-        let pool_info_fetcher = PoolInfoFetcher {
-            web3,
-            token_info_fetcher: Arc::new(token_info_fetcher),
-            vault,
-        };
-
-        let pool_info = pool_info_fetcher
-            .get_weighted_pool_data(weighted_pool_contract.address())
-            .await
-            .unwrap();
-
-        assert_eq!(
-            pool_info.common.tokens,
-            vec![H160::from_low_u64_be(1), H160::from_low_u64_be(2)]
-        );
-        assert_eq!(pool_info.common.id, pool_id);
-        assert_eq!(pool_info.common.scaling_exponents, vec![0u8, 1u8]);
-        assert_eq!(pool_info.weights, vec![Bfp::from_wei(weight)]);
-    }
-
-    #[tokio::test]
-    async fn get_stable_pool_data_ok() {
-        let mock = Mock::new(49);
-        let web3 = mock.web3();
-
-        let vault_contract = mock.deploy(BalancerV2Vault::raw_contract().abi.clone());
-        let vault = BalancerV2Vault::at(&web3.clone(), vault_contract.address());
-        let stable_pool = mock.deploy(BalancerV2StablePool::raw_contract().abi.clone());
-
-        let pool_id = H256::from_low_u64_be(1);
-        let tokens = vec![H160::from_low_u64_be(1), H160::from_low_u64_be(2)];
-
-        stable_pool
-            .expect_call(BalancerV2StablePool::signatures().get_pool_id())
-            .returns(Bytes(pool_id.0));
-        vault_contract
-            .expect_call(BalancerV2Vault::signatures().get_pool_tokens())
-            .predicate((predicate::eq(Bytes(pool_id.0)),))
-            .returns((tokens.clone(), vec![], U256::zero()));
-        stable_pool
-            .expect_call(BalancerV2StablePool::signatures().get_amplification_parameter())
-            .returns((U256::one(), false, U256::from(1000)));
-
-        let mut token_info_fetcher = MockTokenInfoFetching::new();
-        token_info_fetcher
-            .expect_get_token_infos()
-            .return_once(move |_| {
-                hashmap! {
-                    tokens[0] => TokenInfo { decimals: Some(18), symbol: Some("CAT".to_string()) },
-                    tokens[1] => TokenInfo { decimals: Some(17), symbol: Some("CAT".to_string()) },
-                }
-            });
-
-        let pool_info_fetcher = PoolInfoFetcher {
-            web3,
-            token_info_fetcher: Arc::new(token_info_fetcher),
-            vault,
-        };
-
-        let pool_info_result = pool_info_fetcher
-            .get_stable_pool_data(stable_pool.address())
-            .await;
-        assert!(pool_info_result.is_ok());
-
-        let pool_info = pool_info_result.unwrap();
-        assert_eq!(
-            pool_info.common.tokens,
-            vec![H160::from_low_u64_be(1), H160::from_low_u64_be(2)]
-        );
-        assert_eq!(pool_info.common.id, pool_id);
-        assert_eq!(pool_info.common.scaling_exponents, vec![0u8, 1u8]);
+    async fn get_stable_pool_data(
+        &self,
+        pool_address: H160,
+        block_created: u64,
+    ) -> Result<RegisteredStablePool> {
+        let common_info = self.inner.pool_info(pool_address, block_created).await?;
+        self.stable_factory.pool_info(common_info).await
     }
 }

--- a/crates/shared/src/sources/balancer_v2/info_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/info_fetching.rs
@@ -63,8 +63,11 @@ impl PoolInfoFetching for PoolInfoFetcher {
         pool_address: H160,
         block_created: u64,
     ) -> Result<RegisteredWeightedPool> {
-        let common_info = self.inner.pool_info(pool_address, block_created).await?;
-        self.weighted_factory.pool_info(common_info).await
+        let common_info = self
+            .inner
+            .fetch_common_pool_info(pool_address, block_created)
+            .await?;
+        self.weighted_factory.augment_pool_info(common_info).await
     }
 
     async fn get_stable_pool_data(
@@ -72,7 +75,10 @@ impl PoolInfoFetching for PoolInfoFetcher {
         pool_address: H160,
         block_created: u64,
     ) -> Result<RegisteredStablePool> {
-        let common_info = self.inner.pool_info(pool_address, block_created).await?;
-        self.stable_factory.pool_info(common_info).await
+        let common_info = self
+            .inner
+            .fetch_common_pool_info(pool_address, block_created)
+            .await?;
+        self.stable_factory.augment_pool_info(common_info).await
     }
 }

--- a/crates/shared/src/sources/balancer_v2/info_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/info_fetching.rs
@@ -67,7 +67,7 @@ impl PoolInfoFetching for PoolInfoFetcher {
             .inner
             .fetch_common_pool_info(pool_address, block_created)
             .await?;
-        self.weighted_factory.augment_pool_info(common_info).await
+        self.weighted_factory.specialize_pool_info(common_info).await
     }
 
     async fn get_stable_pool_data(
@@ -79,6 +79,6 @@ impl PoolInfoFetching for PoolInfoFetcher {
             .inner
             .fetch_common_pool_info(pool_address, block_created)
             .await?;
-        self.stable_factory.augment_pool_info(common_info).await
+        self.stable_factory.specialize_pool_info(common_info).await
     }
 }

--- a/crates/shared/src/sources/balancer_v2/info_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/info_fetching.rs
@@ -67,7 +67,9 @@ impl PoolInfoFetching for PoolInfoFetcher {
             .inner
             .fetch_common_pool_info(pool_address, block_created)
             .await?;
-        self.weighted_factory.specialize_pool_info(common_info).await
+        self.weighted_factory
+            .specialize_pool_info(common_info)
+            .await
     }
 
     async fn get_stable_pool_data(

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -18,6 +18,7 @@ use crate::{
         pool_storage::{RegisteredStablePool, RegisteredWeightedPool},
         swap::fixed_point::Bfp,
     },
+    token_info::TokenInfoFetching,
     Web3,
 };
 use anyhow::{ensure, Result};
@@ -230,6 +231,7 @@ impl BalancerPoolFetcher {
     pub async fn new(
         chain_id: u64,
         web3: Web3,
+        token_info_fetcher: Arc<dyn TokenInfoFetching>,
         config: CacheConfig,
         block_stream: CurrentBlockStream,
         metrics: Arc<dyn BalancerPoolCacheMetrics>,
@@ -237,6 +239,7 @@ impl BalancerPoolFetcher {
     ) -> Result<Self> {
         let pool_info = Arc::new(PoolInfoFetcher::new(
             BalancerV2Vault::deployed(&web3).await?,
+            token_info_fetcher,
             BalancerV2WeightedPoolFactory::deployed(&web3).await?,
             BalancerV2StablePoolFactory::deployed(&web3).await?,
         ));

--- a/crates/shared/src/sources/balancer_v2/pools.rs
+++ b/crates/shared/src/sources/balancer_v2/pools.rs
@@ -24,6 +24,9 @@ pub trait FactoryIndexing {
     /// be retrieved once. This data will be passed in when fetching the current
     /// pool state via `fetch_pool`.
     type PoolInfo: PoolIndexing;
+
+    /// Retrive the permanent pool info for the specified common pool info.
+    async fn pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo>;
 }
 
 /// Required information needed for indexing pools.

--- a/crates/shared/src/sources/balancer_v2/pools.rs
+++ b/crates/shared/src/sources/balancer_v2/pools.rs
@@ -25,8 +25,15 @@ pub trait FactoryIndexing {
     /// pool state via `fetch_pool`.
     type PoolInfo: PoolIndexing;
 
-    /// Retrive the permanent pool info for the specified common pool info.
-    async fn pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo>;
+    /// Augments the specified common pool info for this factory.
+    ///
+    /// This allows pool factories like the `WeightedPoolFactory` to add
+    /// `weights` to the common pool info, since these are declared as
+    /// `immuatble` in the smart contract and thus can never change and don't
+    /// need to be re-fetched.
+    ///
+    /// Returns an error if fetching the augmented pool data fails.
+    async fn augment_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo>;
 }
 
 /// Required information needed for indexing pools.

--- a/crates/shared/src/sources/balancer_v2/pools.rs
+++ b/crates/shared/src/sources/balancer_v2/pools.rs
@@ -32,8 +32,11 @@ pub trait FactoryIndexing {
     /// `immuatble` in the smart contract and thus can never change and don't
     /// need to be re-fetched.
     ///
+    /// The implementation is not expected to verify on-chain that the type of
+    /// pool matches what it is expecting.
+    ///
     /// Returns an error if fetching the augmented pool data fails.
-    async fn augment_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo>;
+    async fn specialize_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo>;
 }
 
 /// Required information needed for indexing pools.

--- a/crates/shared/src/sources/balancer_v2/pools/common.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/common.rs
@@ -2,7 +2,62 @@
 
 use crate::sources::balancer_v2::graph_api::{PoolData, PoolType};
 use anyhow::{anyhow, ensure, Result};
-use ethcontract::{H160, H256};
+use contracts::{BalancerV2BasePool, BalancerV2Vault};
+use ethcontract::{batch::CallBatch, Bytes, H160, H256, U256};
+
+/// Trait for fetching common pool data by address.
+#[mockall::automock]
+#[async_trait::async_trait]
+pub trait PoolInfoFetching: Send + Sync {
+    async fn pool_info(&self, pool_address: H160, block_created: u64) -> Result<PoolInfo>;
+}
+
+/// Via `PoolInfoFetcher` leverages a combination of `Web3` and `TokenInfoFetching`
+/// to recover common `PoolInfo` from an address.
+pub struct PoolInfoFetcher {
+    vault: BalancerV2Vault,
+}
+
+impl PoolInfoFetcher {
+    pub fn new(vault: BalancerV2Vault) -> Self {
+        Self { vault }
+    }
+}
+
+#[async_trait::async_trait]
+impl PoolInfoFetching for PoolInfoFetcher {
+    /// Could result in ethcontract::{NodeError, MethodError or ContractError}
+    async fn pool_info(&self, pool_address: H160, block_created: u64) -> Result<PoolInfo> {
+        let web3 = self.vault.raw_instance().web3();
+        let pool = BalancerV2BasePool::at(&web3, pool_address);
+
+        // Fetch the pool ID and scaling factors in a single call.
+        let (pool_id, scaling_factors) = {
+            let mut batch = CallBatch::new(web3.transport());
+            let pool_id = pool.methods().get_pool_id().batch_call(&mut batch);
+            let scaling_factors = pool.methods().get_scaling_factors().batch_call(&mut batch);
+            batch.execute_all(2).await;
+
+            (H256(pool_id.await?.0), scaling_factors.await?)
+        };
+
+        let (tokens, _, _) = self
+            .vault
+            .methods()
+            .get_pool_tokens(Bytes(pool_id.0))
+            .call()
+            .await?;
+        let scaling_exponents = scaling_exponents_from_factors(&scaling_factors)?;
+
+        Ok(PoolInfo {
+            id: pool_id,
+            address: pool_address,
+            tokens,
+            scaling_exponents,
+            block_created,
+        })
+    }
+}
 
 /// Common pool data shared across all Balancer pools.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -45,6 +100,30 @@ impl PoolInfo {
     }
 }
 
+/// Converts a slice of scaling factors to their corresponding exponents.
+fn scaling_exponents_from_factors(factors: &[U256]) -> Result<Vec<u8>> {
+    // Technically this should never fail for Balancer Pools since tokens
+    // with more than 18 decimals (not supported by balancer contracts).
+
+    let ten = U256::from(10);
+    factors
+        .iter()
+        .copied()
+        .map(|mut factor| {
+            let mut exponent = 0u8;
+            while factor > U256::one() {
+                ensure!(exponent < 18, "scaling factor overflow");
+                ensure!((factor % ten).is_zero(), "scaling factor not a power of 10");
+                exponent += 1;
+                factor /= ten;
+            }
+
+            Ok(exponent)
+        })
+        .collect()
+}
+
+/// Converts a token decimal count to its corresponding scaling exponent.
 fn scaling_exponent_from_decimals(decimals: u8) -> Result<u8> {
     // Technically this should never fail for Balancer Pools since tokens
     // with more than 18 decimals (not supported by balancer contracts)
@@ -57,6 +136,49 @@ fn scaling_exponent_from_decimals(decimals: u8) -> Result<u8> {
 mod tests {
     use super::*;
     use crate::sources::balancer_v2::graph_api::{PoolType, Token};
+    use ethcontract_mock::Mock;
+    use mockall::predicate;
+
+    #[tokio::test]
+    async fn fetch_pool_info() {
+        let pool_id = H256([0x90; 32]);
+        let tokens = [H160([1; 20]), H160([2; 20]), H160([3; 20])];
+        let scaling_factors = [U256::one(), U256::from(1), U256::from(1_000_000_000)];
+
+        let mock = Mock::new(42);
+        let web3 = mock.web3();
+
+        let pool = mock.deploy(BalancerV2BasePool::raw_contract().abi.clone());
+        pool.expect_call(BalancerV2BasePool::signatures().get_pool_id())
+            .returns(Bytes(pool_id.0));
+        pool.expect_call(BalancerV2BasePool::signatures().get_scaling_factors())
+            .returns(scaling_factors.to_vec());
+
+        let vault = mock.deploy(BalancerV2Vault::raw_contract().abi.clone());
+        vault
+            .expect_call(BalancerV2Vault::signatures().get_pool_tokens())
+            .predicate((predicate::eq(Bytes(pool_id.0)),))
+            .returns((tokens.to_vec(), vec![], U256::zero()));
+
+        let pool_info_fetcher = PoolInfoFetcher {
+            vault: BalancerV2Vault::at(&web3, vault.address()),
+        };
+        let pool_info = pool_info_fetcher
+            .pool_info(pool.address(), 1337)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            pool_info,
+            PoolInfo {
+                id: pool_id,
+                address: pool.address(),
+                tokens: tokens.to_vec(),
+                scaling_exponents: vec![0, 0, 9],
+                block_created: 1337,
+            }
+        )
+    }
 
     #[test]
     fn convert_graph_pool_to_common_pool_info() {
@@ -128,6 +250,19 @@ mod tests {
             ],
         };
         assert!(PoolInfo::from_graph_data(&pool, 42).is_err());
+    }
+
+    #[test]
+    fn scaling_exponents_from_factors_ok_and_err() {
+        let scaling_exponents = scaling_exponents_from_factors(
+            &(0..=18)
+                .map(|i| U256::from(10_u128.pow(i)))
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+        assert_eq!(scaling_exponents, (0..=18).collect::<Vec<_>>());
+
+        assert!(scaling_exponents_from_factors(&[19.into()]).is_err());
     }
 
     #[test]

--- a/crates/shared/src/sources/balancer_v2/pools/common.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/common.rs
@@ -13,7 +13,11 @@ use std::sync::Arc;
 #[mockall::automock]
 #[async_trait::async_trait]
 pub trait PoolInfoFetching: Send + Sync {
-    async fn pool_info(&self, pool_address: H160, block_created: u64) -> Result<PoolInfo>;
+    async fn fetch_common_pool_info(
+        &self,
+        pool_address: H160,
+        block_created: u64,
+    ) -> Result<PoolInfo>;
 }
 
 /// Via `PoolInfoFetcher` leverages a combination of `Web3` and `TokenInfoFetching`
@@ -48,7 +52,11 @@ impl PoolInfoFetcher {
 #[async_trait::async_trait]
 impl PoolInfoFetching for PoolInfoFetcher {
     /// Could result in ethcontract::{NodeError, MethodError or ContractError}
-    async fn pool_info(&self, pool_address: H160, block_created: u64) -> Result<PoolInfo> {
+    async fn fetch_common_pool_info(
+        &self,
+        pool_address: H160,
+        block_created: u64,
+    ) -> Result<PoolInfo> {
         let web3 = self.vault.raw_instance().web3();
         let pool = BalancerV2BasePool::at(&web3, pool_address);
 
@@ -168,7 +176,7 @@ mod tests {
             token_infos: Arc::new(token_infos),
         };
         let pool_info = pool_info_fetcher
-            .pool_info(pool.address(), 1337)
+            .fetch_common_pool_info(pool.address(), 1337)
             .await
             .unwrap();
 

--- a/crates/shared/src/sources/balancer_v2/pools/stable.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/stable.rs
@@ -25,6 +25,10 @@ impl PoolIndexing for PoolInfo {
 #[async_trait::async_trait]
 impl FactoryIndexing for BalancerV2StablePoolFactory {
     type PoolInfo = PoolInfo;
+
+    async fn pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
+        Ok(PoolInfo { common: pool })
+    }
 }
 
 #[cfg(test)]

--- a/crates/shared/src/sources/balancer_v2/pools/stable.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/stable.rs
@@ -26,7 +26,7 @@ impl PoolIndexing for PoolInfo {
 impl FactoryIndexing for BalancerV2StablePoolFactory {
     type PoolInfo = PoolInfo;
 
-    async fn pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
+    async fn augment_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
         Ok(PoolInfo { common: pool })
     }
 }

--- a/crates/shared/src/sources/balancer_v2/pools/stable.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/stable.rs
@@ -26,7 +26,7 @@ impl PoolIndexing for PoolInfo {
 impl FactoryIndexing for BalancerV2StablePoolFactory {
     type PoolInfo = PoolInfo;
 
-    async fn augment_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
+    async fn specialize_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
         Ok(PoolInfo { common: pool })
     }
 }

--- a/crates/shared/src/sources/balancer_v2/pools/weighted.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/weighted.rs
@@ -39,7 +39,7 @@ impl PoolIndexing for PoolInfo {
 impl FactoryIndexing for BalancerV2WeightedPoolFactory {
     type PoolInfo = PoolInfo;
 
-    async fn pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
+    async fn augment_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
         let pool_contract = BalancerV2WeightedPool::at(&self.raw_instance().web3(), pool.address);
         let weights = pool_contract
             .methods()
@@ -144,7 +144,7 @@ mod tests {
 
         let factory = BalancerV2WeightedPoolFactory::at(&web3, H160([0xfa; 20]));
         let pool = factory
-            .pool_info(common::PoolInfo {
+            .augment_pool_info(common::PoolInfo {
                 id: H256([0x90; 32]),
                 tokens: vec![H160([1; 20]), H160([2; 20]), H160([3; 20])],
                 address: pool.address(),

--- a/crates/shared/src/sources/balancer_v2/pools/weighted.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/weighted.rs
@@ -39,7 +39,7 @@ impl PoolIndexing for PoolInfo {
 impl FactoryIndexing for BalancerV2WeightedPoolFactory {
     type PoolInfo = PoolInfo;
 
-    async fn augment_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
+    async fn specialize_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
         let pool_contract = BalancerV2WeightedPool::at(&self.raw_instance().web3(), pool.address);
         let weights = pool_contract
             .methods()
@@ -144,7 +144,7 @@ mod tests {
 
         let factory = BalancerV2WeightedPoolFactory::at(&web3, H160([0xfa; 20]));
         let pool = factory
-            .augment_pool_info(common::PoolInfo {
+            .specialize_pool_info(common::PoolInfo {
                 id: H256([0x90; 32]),
                 tokens: vec![H160([1; 20]), H160([2; 20]), H160([3; 20])],
                 address: pool.address(),

--- a/crates/shared/src/sources/balancer_v2/pools/weighted_2token.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/weighted_2token.rs
@@ -9,8 +9,8 @@ use contracts::{BalancerV2WeightedPool2TokensFactory, BalancerV2WeightedPoolFact
 impl FactoryIndexing for BalancerV2WeightedPool2TokensFactory {
     type PoolInfo = PoolInfo;
 
-    async fn pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
-        as_weighted_factory(self).pool_info(pool).await
+    async fn augment_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
+        as_weighted_factory(self).augment_pool_info(pool).await
     }
 }
 

--- a/crates/shared/src/sources/balancer_v2/pools/weighted_2token.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/weighted_2token.rs
@@ -1,10 +1,21 @@
 //! Module implementing two-token weighted pool specific indexing logic.
 
 pub use super::weighted::PoolInfo;
-use super::FactoryIndexing;
-use contracts::BalancerV2WeightedPool2TokensFactory;
+use super::{common, FactoryIndexing};
+use anyhow::Result;
+use contracts::{BalancerV2WeightedPool2TokensFactory, BalancerV2WeightedPoolFactory};
 
 #[async_trait::async_trait]
 impl FactoryIndexing for BalancerV2WeightedPool2TokensFactory {
     type PoolInfo = PoolInfo;
+
+    async fn pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
+        as_weighted_factory(self).pool_info(pool).await
+    }
+}
+
+fn as_weighted_factory(
+    factory: &BalancerV2WeightedPool2TokensFactory,
+) -> BalancerV2WeightedPoolFactory {
+    BalancerV2WeightedPoolFactory::at(&factory.raw_instance().web3(), factory.address())
 }

--- a/crates/shared/src/sources/balancer_v2/pools/weighted_2token.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/weighted_2token.rs
@@ -9,8 +9,8 @@ use contracts::{BalancerV2WeightedPool2TokensFactory, BalancerV2WeightedPoolFact
 impl FactoryIndexing for BalancerV2WeightedPool2TokensFactory {
     type PoolInfo = PoolInfo;
 
-    async fn augment_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
-        as_weighted_factory(self).augment_pool_info(pool).await
+    async fn specialize_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
+        as_weighted_factory(self).specialize_pool_info(pool).await
     }
 }
 

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -395,6 +395,7 @@ async fn main() {
             BalancerPoolFetcher::new(
                 chain_id,
                 web3.clone(),
+                token_info_fetcher.clone(),
                 cache_config,
                 current_block_stream.clone(),
                 metrics.clone(),

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -395,7 +395,6 @@ async fn main() {
             BalancerPoolFetcher::new(
                 chain_id,
                 web3.clone(),
-                token_info_fetcher.clone(),
                 cache_config,
                 current_block_stream.clone(),
                 metrics.clone(),


### PR DESCRIPTION
This PR splits each `PoolInfo` fetching into each individual pool's `FactoryIndexing` implementation.

Currently we make use of a legacy `PoolInfoFetcher` adapter to avoid changing too much in this PR.

In the future, we will be able to create a generic `PoolFetcher<FactoryIndexing>` instance that will will for every pool:
1. Fetch `common::PoolInfo` which all pools have (this is using the `common::PoolInfoFetching` interface).
2. Pass the fetched `common::PoolInfo` into the `FactoryIndexing` implementation in order to augment it into a `{weighted,stable}::PoolInfo`
3. Index the `{weighted,stable}::PoolInfo` and create lookups by token address (as we do now).

### Test Plan

Added new tests with mock contract calls.

Use manual test to index all past events:
```
$ export NODE_URL=...
$ cargo test -p shared -- balancer_indexed_pool_events_match_subgraph --nocapture --ignored
...
test sources::balancer_v2::event_handler::tests::balancer_index_pool_events ... ok
```
