### PR TITLE
Add Balancer event indexing manual test

### DIFF
--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -80,8 +80,7 @@ fn main() {
                 Network {
                     address: addr("0xa5bf2ddf098bb0ef6d120c98217dd6b141c74ee0"),
                     // <https://rinkeby.etherscan.io/tx/0xbe28062b575c2743b3b4525c3a175b9acad36695c15dba1c69af5f3fc3ceca37>
-                    //deployment_information: Some(DeploymentInformation::BlockNumber(8510540)),
-                    deployment_information: Some(DeploymentInformation::BlockNumber(8723587)),
+                    deployment_information: Some(DeploymentInformation::BlockNumber(8510540)),
                 },
             )
     });

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -31,9 +31,8 @@ fn main() {
                 "1",
                 Network {
                     address: addr("0xBA12222222228d8Ba445958a75a0704d566BF2C8"),
-                    deployment_information: Some(tx(
-                        "0x28c44bb10d469cbd42accf97bd00b73eabbace138e9d44593e851231fbed1cb7",
-                    )),
+                    // <https://etherscan.io/tx/0x28c44bb10d469cbd42accf97bd00b73eabbace138e9d44593e851231fbed1cb7>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(12272146)),
                 },
             )
             .add_network(
@@ -52,18 +51,16 @@ fn main() {
                 "1",
                 Network {
                     address: addr("0x8E9aa87E45e92bad84D5F8DD1bff34Fb92637dE9"),
-                    deployment_information: Some(tx(
-                        "0x0f9bb3624c185b4e107eaf9176170d2dc9cb1c48d0f070ed18416864b3202792",
-                    )),
+                    // <https://etherscan.io/tx/0x0f9bb3624c185b4e107eaf9176170d2dc9cb1c48d0f070ed18416864b3202792>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(12272147)),
                 },
             )
             .add_network(
                 "4",
                 Network {
                     address: addr("0x8E9aa87E45e92bad84D5F8DD1bff34Fb92637dE9"),
-                    deployment_information: Some(tx(
-                        "0xae8c45c1d40756d0eb312723a2993341e379ea6d8bef4adfae2709345939f8eb",
-                    )),
+                    // <https://rinkeby.etherscan.io/tx/0xae8c45c1d40756d0eb312723a2993341e379ea6d8bef4adfae2709345939f8eb>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(8441703)),
                 },
             )
     });
@@ -74,18 +71,17 @@ fn main() {
                 "1",
                 Network {
                     address: addr("0xa5bf2ddf098bb0ef6d120c98217dd6b141c74ee0"),
-                    deployment_information: Some(tx(
-                        "0xf40c05058422d730b7035c254f8b765722935a5d3003ac37b13a61860adbaf08",
-                    )),
+                    // <https://etherscan.io/tx/0xf40c05058422d730b7035c254f8b765722935a5d3003ac37b13a61860adbaf08>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(12349891)),
                 },
             )
             .add_network(
                 "4",
                 Network {
                     address: addr("0xa5bf2ddf098bb0ef6d120c98217dd6b141c74ee0"),
-                    deployment_information: Some(tx(
-                        "be28062b575c2743b3b4525c3a175b9acad36695c15dba1c69af5f3fc3ceca37",
-                    )),
+                    // <https://rinkeby.etherscan.io/tx/0xbe28062b575c2743b3b4525c3a175b9acad36695c15dba1c69af5f3fc3ceca37>
+                    //deployment_information: Some(DeploymentInformation::BlockNumber(8510540)),
+                    deployment_information: Some(DeploymentInformation::BlockNumber(8723587)),
                 },
             )
     });
@@ -96,18 +92,16 @@ fn main() {
                 "1",
                 Network {
                     address: addr("0xc66ba2b6595d3613ccab350c886ace23866ede24"),
-                    deployment_information: Some(tx(
-                        "0xfd417511f3902a304cca51023e8e771de22ffa7f30b9c8650ec5757328ab89a6",
-                    )),
+                    // <https://etherscan.io/tx/0xfd417511f3902a304cca51023e8e771de22ffa7f30b9c8650ec5757328ab89a6>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(12703127)),
                 },
             )
             .add_network(
                 "4",
                 Network {
                     address: addr("0xc66ba2b6595d3613ccab350c886ace23866ede24"),
-                    deployment_information: Some(tx(
-                        "26ccac4bd7af78607107489fa05868a68291b5e6f217f6829fc3767d8926264a",
-                    )),
+                    // <https://rinkeby.etherscan.io/tx/0x26ccac4bd7af78607107489fa05868a68291b5e6f217f6829fc3767d8926264a>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(8822477)),
                 },
             )
     });
@@ -134,27 +128,24 @@ fn main() {
                 "1",
                 Network {
                     address: addr("0x9008D19f58AAbD9eD0D60971565AA8510560ab41"),
-                    deployment_information: Some(tx(
-                        "f49f90aa5a268c40001d1227b76bb4dd8247f18361fcad9fffd4a7a44f1320d3",
-                    )),
+                    // <https://etherscan.io/tx/0xf49f90aa5a268c40001d1227b76bb4dd8247f18361fcad9fffd4a7a44f1320d3>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(12593265)),
                 },
             )
             .add_network(
                 "4",
                 Network {
                     address: addr("0x9008D19f58AAbD9eD0D60971565AA8510560ab41"),
-                    deployment_information: Some(tx(
-                        "609fa2e8f32c73c1f5dc21ff60a26238dacb50d4674d336c90d6950bdda17a21",
-                    )),
+                    // <https://rinkeby.etherscan.io/tx/0x609fa2e8f32c73c1f5dc21ff60a26238dacb50d4674d336c90d6950bdda17a21>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(8727415)),
                 },
             )
             .add_network(
                 "100",
                 Network {
                     address: addr("0x9008D19f58AAbD9eD0D60971565AA8510560ab41"),
-                    deployment_information: Some(tx(
-                        "9ddc538f89cd8433f4a19bc4de0de27e7c68a1d04a14b327185e4bba9af87133",
-                    )),
+                    // <https://blockscout.com/xdai/mainnet/tx/0x9ddc538f89cd8433f4a19bc4de0de27e7c68a1d04a14b327185e4bba9af87133>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(16465100)),
                 },
             )
     });
@@ -230,8 +221,4 @@ fn generate_contract_with_config(
 
 fn addr(s: &str) -> Address {
     s.parse().unwrap()
-}
-
-fn tx(s: &str) -> DeploymentInformation {
-    DeploymentInformation::TransactionHash(s.parse().unwrap())
 }

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -37,6 +37,7 @@ include!(concat!(env!("OUT_DIR"), "/WETH9.rs"));
 mod tests {
     use super::*;
     use ethcontract::{
+        common::DeploymentInformation,
         futures::future::{self, FutureExt as _, Ready},
         json::json,
         jsonrpc::{Call, Id, MethodCall, Params, Value},
@@ -119,7 +120,10 @@ mod tests {
             ($contract:ident for $network:expr) => {{
                 let web3 = Web3::new(ChainIdTransport($network));
                 let instance = $contract::deployed(&web3).now_or_never().unwrap().unwrap();
-                assert!(instance.deployment_information().is_some());
+                assert!(matches!(
+                    instance.deployment_information(),
+                    Some(DeploymentInformation::BlockNumber(_)),
+                ));
             }};
         }
 

--- a/crates/shared/src/sources/balancer_v2/event_handler.rs
+++ b/crates/shared/src/sources/balancer_v2/event_handler.rs
@@ -340,7 +340,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn balancer_index_pool_events() {
+    async fn balancer_indexed_pool_events_match_subgraph() {
         let transport = transport::create_env_test_transport();
         let web3 = Web3::new(transport);
         let chain_id = web3.eth().chain_id().await.unwrap().as_u64();

--- a/crates/shared/src/sources/balancer_v2/event_handler.rs
+++ b/crates/shared/src/sources/balancer_v2/event_handler.rs
@@ -322,3 +322,90 @@ fn convert_stable_pool_created(
         },
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        sources::balancer_v2::{
+            info_fetching::PoolInfoFetcher,
+            pool_init::{EmptyPoolInitializer, SubgraphPoolInitializer},
+        },
+        token_info::TokenInfoFetcher,
+        transport,
+    };
+    use contracts::BalancerV2Vault;
+    use maplit::hashset;
+    use reqwest::Client;
+
+    #[tokio::test]
+    #[ignore]
+    async fn balancer_index_pool_events() {
+        let transport = transport::create_env_test_transport();
+        let web3 = Web3::new(transport);
+        let chain_id = web3.eth().chain_id().await.unwrap().as_u64();
+
+        println!("Indexing events for chain {}", chain_id);
+        crate::tracing::initialize_for_tests("warn,shared=debug");
+
+        let pool_init = EmptyPoolInitializer::for_chain(chain_id);
+        let token_infos = TokenInfoFetcher { web3: web3.clone() };
+        let pool_info = PoolInfoFetcher {
+            web3: web3.clone(),
+            token_info_fetcher: Arc::new(token_infos),
+            vault: BalancerV2Vault::deployed(&web3).await.unwrap(),
+        };
+        let registry = BalancerPoolRegistry::new(web3, pool_init, Arc::new(pool_info))
+            .await
+            .unwrap();
+
+        // index all the pools.
+        registry.run_maintenance().await.unwrap();
+
+        // compare to what the subgraph says.
+        let client = SubgraphPoolInitializer::new(chain_id, Client::new()).unwrap();
+        let subgraph_pools = client.initialize_pools().await.unwrap();
+
+        for mut subgraph_pool in subgraph_pools.weighted_pools {
+            let indexed_pool = registry
+                .weighted_pool_updater
+                .lock()
+                .await
+                .store
+                .weighted_pools_for(&hashset!(subgraph_pool.common.id));
+
+            subgraph_pool.common.block_created = indexed_pool[0].common.block_created;
+            assert_eq!(indexed_pool, [subgraph_pool]);
+
+            tracing::info!(weighted_pool = ?indexed_pool[0]);
+        }
+
+        for mut subgraph_pool in subgraph_pools.weighted_2token_pools {
+            let indexed_pool = registry
+                .two_token_pool_updater
+                .lock()
+                .await
+                .store
+                .weighted_pools_for(&hashset!(subgraph_pool.common.id));
+
+            subgraph_pool.common.block_created = indexed_pool[0].common.block_created;
+            assert_eq!(indexed_pool, [subgraph_pool]);
+
+            tracing::info!(weighted_2token_pool = ?indexed_pool[0]);
+        }
+
+        for mut subgraph_pool in subgraph_pools.stable_pools {
+            let indexed_pool = registry
+                .stable_pool_updater
+                .lock()
+                .await
+                .store
+                .stable_pools_for(&hashset!(subgraph_pool.common.id));
+
+            subgraph_pool.common.block_created = indexed_pool[0].common.block_created;
+            assert_eq!(indexed_pool, [subgraph_pool]);
+
+            tracing::info!(stable_pool = ?indexed_pool[0]);
+        }
+    }
+}

--- a/crates/shared/src/sources/balancer_v2/pool_init.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_init.rs
@@ -37,6 +37,14 @@ pub trait PoolInitializing: Send + Sync {
 /// Balancer subgraph for example.
 pub struct EmptyPoolInitializer(u64);
 
+impl EmptyPoolInitializer {
+    /// Creates a new empty pool initializer for the specified chain ID.
+    #[cfg(test)]
+    pub fn for_chain(chain_id: u64) -> Self {
+        Self(chain_id)
+    }
+}
+
 #[async_trait::async_trait]
 impl PoolInitializing for EmptyPoolInitializer {
     async fn initialize_pools(&self) -> Result<BalancerRegisteredPools> {


### PR DESCRIPTION
This PR just adds a manual test for verifying complete Balancer pool indexing via events (we don't exercise this path usually because we typically initialize by reading the Subgraph, but its useful for refactoring event indexing code to make sure everything is working).

Additionally, I noticed that the test was failing because the deployment information included the transaction hash and not the block number which we use to know which block to start indexing events on. I changed all `DeploymentInformation`s to use block numbers instead of transaction hashes.

### Test Plan

This is the test!
```
$ export NODE_URL=...
$ cargo test -p shared -- balancer_index_pool_events --nocapture --ignored
...
test sources::balancer_v2::event_handler::tests::balancer_index_pool_events ... ok
```
