### PR TITLE
Add Balancer `BasePool` ABI

### DIFF
--- a/crates/contracts/artifacts/BalancerV2BasePool.json
+++ b/crates/contracts/artifacts/BalancerV2BasePool.json
@@ -1,0 +1,53 @@
+{
+  "abi": [
+    {
+      "inputs": [],
+      "name": "getPausedState",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "paused",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint256",
+          "name": "pauseWindowEndTime",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "bufferPeriodEndTime",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getPoolId",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getSwapFeePercentage",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -21,6 +21,9 @@ fn main() {
     generate_contract_with_config("BalancerV2Authorizer", |builder| {
         builder.contract_mod_override("balancer_v2_authorizer")
     });
+    generate_contract_with_config("BalancerV2BasePool", |builder| {
+        builder.contract_mod_override("balancer_v2_base_pool")
+    });
     generate_contract_with_config("BalancerV2BasePoolFactory", |builder| {
         builder.contract_mod_override("balancer_v2_base_pool_factory")
     });

--- a/crates/contracts/src/bin/vendor.rs
+++ b/crates/contracts/src/bin/vendor.rs
@@ -105,6 +105,10 @@ fn run() -> Result<()> {
             "@uniswap/v2-periphery@1.1.0-beta.0/build/IUniswapV2Router02.json",
         )?
         .manual(
+            "BalancerV2BasePool",
+            "Balancer does not publish ABIs for base contracts",
+        )
+        .manual(
             "BalancerV2BasePoolFactory",
             "Balancer does not publish ABIs for base contracts",
         );

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -3,6 +3,8 @@ pub mod paths;
 pub mod vault;
 
 include!(concat!(env!("OUT_DIR"), "/BalancerV2Authorizer.rs"));
+include!(concat!(env!("OUT_DIR"), "/BalancerV2BasePool.rs"));
+include!(concat!(env!("OUT_DIR"), "/BalancerV2BasePoolFactory.rs"));
 include!(concat!(env!("OUT_DIR"), "/BalancerV2StablePool.rs"));
 include!(concat!(env!("OUT_DIR"), "/BalancerV2StablePoolFactory.rs"));
 include!(concat!(env!("OUT_DIR"), "/BalancerV2Vault.rs"));


### PR DESCRIPTION
This PR adds the Balancer `BasePool` ABI to our project which we will use later (in #1449). Specifically, it will be used for fetching common pool data that is the same for all Balancer pools (for example, all Balancer pools implement the `getPoolId` function for querying the ID of the pool at a given address).

It allows us use every indexed pool by address (regardless if its a `Weighted(2Token)Pool`, `StablePool` or some fictional `FooBarPool`) as `BalancerV2BasePool::at(&web3, pool_address)` in order to access the common view functions.

I just split this into a separate PR because the aforementioned #1449 was a little too big to review.

### Test Plan

Compiler :guitar:.
