### PR TITLE
[Trivial] Change dependabot to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
Because dependabot weekly is annoying and provides insignificant improvements on such a short time interval, here we propose to do it only monthly.
