### PR TITLE
Fix timeout logic in HTTP solver client

### DIFF
--- a/crates/shared/src/http_solver_api.rs
+++ b/crates/shared/src/http_solver_api.rs
@@ -67,10 +67,10 @@ impl HttpSolverApi for DefaultHttpSolverApi {
         let timeout = deadline
             .checked_duration_since(Instant::now())
             .ok_or_else(|| anyhow!("no time left to send request"))?;
-        // The timeout we give to the solver is one second less than the deadline to make up for
-        // overhead from the network.
+        // The timeout we give to the solver is a few milliseconds less than
+        // the deadline to make up for overhead from the network.
         let solver_timeout = timeout
-            .checked_sub(Duration::from_secs(1))
+            .checked_sub(Duration::from_millis(250))
             .ok_or_else(|| anyhow!("no time left to send request"))?;
 
         let mut url = self.base.clone();
@@ -81,7 +81,7 @@ impl HttpSolverApi for DefaultHttpSolverApi {
 
         url.query_pairs_mut()
             .append_pair("instance_name", &instance_name)
-            .append_pair("time_limit", &solver_timeout.as_secs().to_string())
+            .append_pair("time_limit", &solver_timeout.as_secs_f64().to_string())
             .append_pair(
                 "max_nr_exec_orders",
                 self.config.max_nr_exec_orders.to_string().as_str(),

--- a/crates/shared/src/http_solver_api/model.rs
+++ b/crates/shared/src/http_solver_api/model.rs
@@ -151,6 +151,7 @@ pub struct SettledBatchAuctionModel {
     pub prices: HashMap<H160, U256>,
     #[serde(default)]
     pub interaction_data: Vec<InteractionData>,
+    pub metadata: Option<SettledBatchAuctionMetadataModel>,
 }
 
 impl SettledBatchAuctionModel {
@@ -167,6 +168,12 @@ impl SettledBatchAuctionModel {
 #[derive(Clone, Debug, Serialize)]
 pub struct MetadataModel {
     pub environment: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct SettledBatchAuctionMetadataModel {
+    pub has_solution: Option<bool>,
+    pub result: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -350,6 +350,7 @@ mod tests {
             ref_token: Some(t0),
             prices: hashmap! { t0 => 10.into(), t1 => 11.into() },
             interaction_data: Vec::new(),
+            metadata: None,
         };
 
         let prepared = SettlementContext { orders, liquidity };


### PR DESCRIPTION
This PR lowers allowed time to interact with network to 50ms, because one second is too much. Also it increases quasimodo price estimation timeout to 2s because quasimodo reserves at least one second for maintenante work.

### Test Plan
Manual testing: try estimating prices for different tokens using different timeouts.