### PR TITLE
Use integer seconds for HTTP solver timelimit.

### DIFF
--- a/crates/shared/src/http_solver_api.rs
+++ b/crates/shared/src/http_solver_api.rs
@@ -81,7 +81,10 @@ impl HttpSolverApi for DefaultHttpSolverApi {
 
         url.query_pairs_mut()
             .append_pair("instance_name", &instance_name)
-            .append_pair("time_limit", &solver_timeout.as_secs_f64().to_string())
+            // Use integer remaining seconds for the time limit as the MIP solver
+            // does not support fractional values here. Note that this means that
+            // we don't have much granularity with the time limit.
+            .append_pair("time_limit", &solver_timeout.as_secs().to_string())
             .append_pair(
                 "max_nr_exec_orders",
                 self.config.max_nr_exec_orders.to_string().as_str(),


### PR DESCRIPTION
This PR fixes the HTTP solver time limit query parameter to use integer seconds.

I noticed this from the logs:
```
2021-12-05T06:32:32.595Z  WARN solver::driver: solver Mip error: ... {"detail":[{"loc":["query","time_limit"],"msg":"value is not a valid integer","type":"type_error.integer"}]})
```

### Test Plan

Check that both solvers can produce valid solutions:
```
$ cargo run -p solver -- \
  --orderbook-url https://protocol-mainnet.gnosis.io \
  --node-url "https://mainnet.infura.io/v3/$INFURA_PROJECT_ID" \
  --mip-solver-url "$MIP_SOLVER_URL" \
  --quasimodo-solver-url "$QUASIMODO_SOLVER_URL" \
  --settle-interval 30 \
  --solver-account 0xa6DDBD0dE6B310819b49f680F65871beE85f517e \
  --solvers Mip,Quasimodo \
  --transaction-strategy DryRun
...
2021-12-05T06:45:57.753Z DEBUG solver::driver: solver Mip found solution: ...
2021-12-05T06:45:57.754Z DEBUG solver::driver: solver Quasimodo found solution: ...
...
```
