### PR TITLE
Move common pool state fetching logic

### DIFF
--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -29,7 +29,10 @@ pub mod transport;
 pub mod web3_traits;
 pub mod zeroex_api;
 
-use ethcontract::dyns::{DynTransport, DynWeb3};
+use ethcontract::{
+    batch::CallBatch,
+    dyns::{DynTransport, DynWeb3},
+};
 use std::{
     future::Future,
     time::{Duration, Instant},
@@ -38,6 +41,7 @@ use web3::types::Bytes;
 
 pub type Web3Transport = DynTransport;
 pub type Web3 = DynWeb3;
+pub type Web3CallBatch = CallBatch<Web3Transport>;
 
 /// The standard http client we use in the api and driver.
 pub fn http_client(timeout: Duration) -> reqwest::Client {

--- a/crates/shared/src/macros.rs
+++ b/crates/shared/src/macros.rs
@@ -6,6 +6,15 @@ macro_rules! addr {
 }
 
 #[macro_export]
+macro_rules! bfp {
+    ($val:literal) => {
+        ($val)
+            .parse::<$crate::sources::balancer_v2::swap::fixed_point::Bfp>()
+            .unwrap()
+    };
+}
+
+#[macro_export]
 macro_rules! json_map {
     ($($key:expr => $value:expr),* $(,)?) => {{
         #[allow(unused_mut)]

--- a/crates/shared/src/sources/balancer_v2/pool_cache.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_cache.rs
@@ -156,8 +156,9 @@ fn accumulate_handled_results<T>(results: Vec<Result<T>>) -> Result<Vec<T>> {
     results
         .into_iter()
         .filter_map(|result| match result {
+            Ok(value) => Some(Ok(value)),
             Err(err) if is_contract_error(&err) => None,
-            _ => Some(result.map(Into::into)),
+            Err(err) => Some(Err(err)),
         })
         .collect()
 }

--- a/crates/shared/src/sources/balancer_v2/pool_cache.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_cache.rs
@@ -1,25 +1,23 @@
+use super::{
+    event_handler::BalancerPoolRegistry,
+    pool_fetching::{AmplificationParameter, BalancerPoolEvaluating, StablePool, WeightedPool},
+    pools::common,
+};
 use crate::{
+    ethcontract_error::EthcontractErrorType,
     recent_block_cache::{Block, CacheFetching, CacheKey, CacheMetrics, RecentBlockCache},
-    sources::{
-        balancer_v2::{
-            event_handler::BalancerPoolRegistry,
-            pool_fetching::{BalancerPoolEvaluating, StablePool, WeightedPool},
-            pool_storage::{RegisteredStablePool, RegisteredWeightedPool},
-            swap::fixed_point::Bfp,
-        },
-        uniswap_v2::pool_fetching::handle_contract_error,
-    },
     transport::MAX_BATCH_SIZE,
     Web3,
 };
 use anyhow::Result;
-use contracts::{BalancerV2StablePool, BalancerV2Vault, BalancerV2WeightedPool};
-use ethcontract::{batch::CallBatch, errors::MethodError, BlockId, Bytes, H160, H256, U256};
+use contracts::BalancerV2StablePool;
+use ethcontract::{batch::CallBatch, errors::MethodError, BlockId, H256};
+use futures::future;
 use std::{collections::HashSet, sync::Arc};
 
 pub struct PoolReserveFetcher {
     pool_registry: Arc<BalancerPoolRegistry>,
-    vault: BalancerV2Vault,
+    common_pool_fetcher: Arc<dyn common::PoolInfoFetching>,
     web3: Web3,
 }
 
@@ -28,11 +26,14 @@ pub trait BalancerPoolCacheMetrics: Send + Sync {
 }
 
 impl PoolReserveFetcher {
-    pub async fn new(pool_registry: Arc<BalancerPoolRegistry>, web3: Web3) -> Result<Self> {
-        let vault = BalancerV2Vault::deployed(&web3).await?;
+    pub async fn new(
+        pool_registry: Arc<BalancerPoolRegistry>,
+        common_pool_fetcher: Arc<dyn common::PoolInfoFetching>,
+        web3: Web3,
+    ) -> Result<Self> {
         Ok(Self {
             pool_registry,
-            vault,
+            common_pool_fetcher,
             web3,
         })
     }
@@ -71,7 +72,7 @@ impl CacheFetching<H256, WeightedPool> for PoolReserveFetcher {
         pool_ids: HashSet<H256>,
         at_block: Block,
     ) -> Result<Vec<WeightedPool>> {
-        let mut batch = CallBatch::new(self.web3.transport());
+        let mut batch = CallBatch::new(self.web3.transport().clone());
         let block = BlockId::Number(at_block.into());
         let weighted_pool_futures = self
             .pool_registry
@@ -79,42 +80,18 @@ impl CacheFetching<H256, WeightedPool> for PoolReserveFetcher {
             .await
             .into_iter()
             .map(|registered_pool| {
-                let pool_contract =
-                    BalancerV2WeightedPool::at(&self.web3, registered_pool.common.address);
-                let swap_fee = pool_contract
-                    .get_swap_fee_percentage()
-                    .block(block)
-                    .batch_call(&mut batch);
-                let reserves = self
-                    .vault
-                    .get_pool_tokens(Bytes(registered_pool.common.id.0))
-                    .block(block)
-                    .batch_call(&mut batch);
-                let paused_state = pool_contract
-                    .get_paused_state()
-                    .block(block)
-                    .batch_call(&mut batch);
-                async move {
-                    #[allow(clippy::eval_order_dependence)]
-                    FetchedWeightedPool {
-                        registered_pool,
-                        common: FetchedCommonPool {
-                            swap_fee: swap_fee.await,
-                            reserves: reserves.await,
-                            paused_state: paused_state.await,
-                        },
-                    }
-                }
+                let common_pool_state = self.common_pool_fetcher.fetch_common_pool_state(
+                    &registered_pool.common,
+                    &mut batch,
+                    block,
+                );
+
+                async move { Ok(WeightedPool::new(registered_pool, common_pool_state.await?)) }
             })
             .collect::<Vec<_>>();
         batch.execute_all(MAX_BATCH_SIZE).await;
 
-        let mut results: Vec<FetchedWeightedPool> = Vec::new();
-        for future in weighted_pool_futures {
-            // Batch has already been executed, so these awaits resolve immediately.
-            results.push(future.await);
-        }
-
+        let results = future::join_all(weighted_pool_futures).await;
         accumulate_handled_results(results)
     }
 }
@@ -126,7 +103,7 @@ impl CacheFetching<H256, StablePool> for PoolReserveFetcher {
         pool_ids: HashSet<H256>,
         at_block: Block,
     ) -> Result<Vec<StablePool>> {
-        let mut batch = CallBatch::new(self.web3.transport());
+        let mut batch = CallBatch::new(self.web3.transport().clone());
         let block = BlockId::Number(at_block.into());
         let futures = self
             .pool_registry
@@ -134,48 +111,37 @@ impl CacheFetching<H256, StablePool> for PoolReserveFetcher {
             .await
             .into_iter()
             .map(|registered_pool| {
+                let common_pool_state = self.common_pool_fetcher.fetch_common_pool_state(
+                    &registered_pool.common,
+                    &mut batch,
+                    block,
+                );
+
                 let pool_contract =
                     BalancerV2StablePool::at(&self.web3, registered_pool.common.address);
-                let swap_fee = pool_contract
-                    .get_swap_fee_percentage()
-                    .block(block)
-                    .batch_call(&mut batch);
-                let reserves = self
-                    .vault
-                    .get_pool_tokens(Bytes(registered_pool.common.id.0))
-                    .block(block)
-                    .batch_call(&mut batch);
-                let paused_state = pool_contract
-                    .get_paused_state()
-                    .block(block)
-                    .batch_call(&mut batch);
                 let amplification_parameter = pool_contract
                     .get_amplification_parameter()
                     .block(block)
                     .batch_call(&mut batch);
+
                 async move {
-                    #[allow(clippy::eval_order_dependence)]
-                    FetchedStablePool {
+                    let common = common_pool_state.await?;
+                    let amplification_parameter = {
+                        let (factor, _, precision) = amplification_parameter.await?;
+                        AmplificationParameter::new(factor, precision)?
+                    };
+
+                    Ok(StablePool::new(
                         registered_pool,
-                        common: FetchedCommonPool {
-                            swap_fee: swap_fee.await,
-                            reserves: reserves.await,
-                            paused_state: paused_state.await,
-                        },
-                        amplification_parameter: amplification_parameter.await,
-                    }
+                        common,
+                        amplification_parameter,
+                    ))
                 }
             })
             .collect::<Vec<_>>();
         batch.execute_all(MAX_BATCH_SIZE).await;
 
-        let mut results: Vec<FetchedStablePool> = Vec::new();
-
-        for future in futures {
-            // Batch has already been executed, so these awaits resolve immediately.
-            results.push(future.await);
-        }
-
+        let results = future::join_all(futures).await;
         accumulate_handled_results(results)
     }
 }
@@ -186,163 +152,48 @@ impl CacheMetrics for Arc<dyn BalancerPoolCacheMetrics> {
     }
 }
 
-struct FetchedCommonPool {
-    swap_fee: Result<U256, MethodError>,
-    /// getPoolTokens returns (Tokens, Balances, LastBlockUpdated)
-    reserves: Result<(Vec<H160>, Vec<U256>, U256), MethodError>,
-    /// getPausedState returns (paused, pauseWindowEndTime, bufferPeriodEndTime)
-    paused_state: Result<(bool, U256, U256), MethodError>,
-}
-
-/// An internal temporary struct used during pool fetching to handle errors.
-struct FetchedWeightedPool {
-    registered_pool: RegisteredWeightedPool,
-    common: FetchedCommonPool,
-}
-
-struct FetchedStablePool {
-    registered_pool: RegisteredStablePool,
-    common: FetchedCommonPool,
-    /// getAmplificationParameter returns (value, isUpdating, precision)
-    amplification_parameter: Result<(U256, bool, U256), MethodError>,
-}
-
-pub trait FetchedBalancerPoolConverting<T> {
-    fn handle_results(self) -> Result<Option<T>>;
-}
-
-fn accumulate_handled_results<T>(
-    results: Vec<impl FetchedBalancerPoolConverting<T>>,
-) -> Result<Vec<T>> {
+fn accumulate_handled_results<T>(results: Vec<Result<T>>) -> Result<Vec<T>> {
     results
         .into_iter()
-        .try_fold(Vec::new(), |mut acc, fetched_pool| {
-            match fetched_pool.handle_results()? {
-                None => return Ok(acc),
-                Some(pool) => acc.push(pool),
-            }
-            Ok(acc)
+        .filter_map(|result| match result {
+            Err(err) if is_contract_error(&err) => None,
+            _ => Some(result.map(Into::into)),
         })
+        .collect()
 }
 
-impl FetchedBalancerPoolConverting<CommonFetchedPoolInfo> for FetchedCommonPool {
-    fn handle_results(self) -> Result<Option<CommonFetchedPoolInfo>> {
-        let balances = match handle_contract_error(self.reserves)? {
-            // We only keep the balances entry of reserves query.
-            Some(reserves) => reserves.1,
-            None => return Ok(None),
-        };
-        let swap_fee_percentage = match handle_contract_error(self.swap_fee)? {
-            Some(swap_fee) => swap_fee,
-            None => return Ok(None),
-        };
-        let paused = match handle_contract_error(self.paused_state)? {
-            // We only keep the boolean value regarding whether the pool is paused or not
-            Some(state) => state.0,
-            None => return Ok(None),
-        };
-
-        Ok(Some((balances, swap_fee_percentage, paused)))
-    }
-}
-
-type CommonFetchedPoolInfo = (Vec<U256>, U256, bool);
-
-impl FetchedBalancerPoolConverting<StablePool> for FetchedStablePool {
-    fn handle_results(self) -> Result<Option<StablePool>> {
-        let (balances, swap_fee_percentage, paused) = match self.common.handle_results()? {
-            Some(results) => results,
-            None => return Ok(None),
-        };
-
-        let (amplification_factor, amplification_precision) =
-            match handle_contract_error(self.amplification_parameter)? {
-                Some((factor, _, precision)) => (factor, precision),
-                None => return Ok(None),
-            };
-        let result = StablePool::new(
-            self.registered_pool,
-            balances,
-            Bfp::from_wei(swap_fee_percentage),
-            amplification_factor,
-            amplification_precision,
-            paused,
-        )?;
-        Ok(Some(result))
-    }
-}
-
-impl FetchedBalancerPoolConverting<WeightedPool> for FetchedWeightedPool {
-    fn handle_results(self) -> Result<Option<WeightedPool>> {
-        let (balances, swap_fee_percentage, paused) = match self.common.handle_results()? {
-            Some(results) => results,
-            None => return Ok(None),
-        };
-
-        Ok(Some(WeightedPool::new(
-            self.registered_pool,
-            balances,
-            Bfp::from_wei(swap_fee_percentage),
-            paused,
-        )))
-    }
+fn is_contract_error(err: &anyhow::Error) -> bool {
+    matches!(
+        err.downcast_ref::<MethodError>()
+            .map(EthcontractErrorType::classify),
+        Some(EthcontractErrorType::Contract),
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ethcontract_error, sources::balancer_v2::pool_storage::RegisteredWeightedPool};
+    use crate::ethcontract_error;
 
     #[test]
     fn pool_fetcher_forwards_node_error() {
-        let fetched_weighted_pool = FetchedWeightedPool {
-            registered_pool: RegisteredWeightedPool::default(),
-            common: FetchedCommonPool {
-                swap_fee: Ok(U256::zero()),
-                reserves: Err(ethcontract_error::testing_node_error()),
-                paused_state: Ok((true, U256::zero(), U256::zero())),
-            },
-        };
-        assert!(fetched_weighted_pool.handle_results().is_err());
-        let fetched_weighted_pool = FetchedWeightedPool {
-            registered_pool: RegisteredWeightedPool::default(),
-            common: FetchedCommonPool {
-                swap_fee: Err(ethcontract_error::testing_node_error()),
-                reserves: Ok((vec![], vec![], U256::zero())),
-                paused_state: Ok((true, U256::zero(), U256::zero())),
-            },
-        };
-        assert!(fetched_weighted_pool.handle_results().is_err());
+        assert!(accumulate_handled_results(vec![
+            Ok(()),
+            Err(ethcontract_error::testing_node_error().into()),
+        ])
+        .is_err())
     }
 
     #[test]
     fn pool_fetcher_skips_contract_error() {
-        let results = vec![
-            FetchedWeightedPool {
-                registered_pool: RegisteredWeightedPool::default(),
-                common: FetchedCommonPool {
-                    swap_fee: Ok(U256::zero()),
-                    reserves: Err(ethcontract_error::testing_contract_error()),
-                    paused_state: Ok((true, U256::zero(), U256::zero())),
-                },
-            },
-            FetchedWeightedPool {
-                registered_pool: RegisteredWeightedPool::default(),
-                common: FetchedCommonPool {
-                    swap_fee: Err(ethcontract_error::testing_contract_error()),
-                    reserves: Ok((vec![], vec![], U256::zero())),
-                    paused_state: Ok((true, U256::zero(), U256::zero())),
-                },
-            },
-            FetchedWeightedPool {
-                registered_pool: RegisteredWeightedPool::default(),
-                common: FetchedCommonPool {
-                    swap_fee: Ok(U256::zero()),
-                    reserves: Ok((vec![], vec![], U256::zero())),
-                    paused_state: Ok((true, U256::zero(), U256::zero())),
-                },
-            },
-        ];
-        assert_eq!(accumulate_handled_results(results).unwrap().len(), 1);
+        assert_eq!(
+            accumulate_handled_results(vec![
+                Ok(()),
+                Err(ethcontract_error::testing_contract_error().into()),
+            ])
+            .unwrap()
+            .len(),
+            1
+        )
     }
 }

--- a/crates/shared/src/sources/balancer_v2/pools/weighted.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/weighted.rs
@@ -64,10 +64,6 @@ mod tests {
     use ethcontract::{H160, H256};
     use ethcontract_mock::Mock;
 
-    fn bfp(amount: &str) -> Bfp {
-        amount.parse().unwrap()
-    }
-
     #[test]
     fn convert_graph_pool_to_weighted_pool_info() {
         let pool = PoolData {
@@ -79,12 +75,12 @@ mod tests {
                 Token {
                     address: H160([0x11; 20]),
                     decimals: 1,
-                    weight: Some(bfp("1.337")),
+                    weight: Some(bfp!("1.337")),
                 },
                 Token {
                     address: H160([0x22; 20]),
                     decimals: 2,
-                    weight: Some(bfp("4.2")),
+                    weight: Some(bfp!("4.2")),
                 },
             ],
         };
@@ -118,12 +114,12 @@ mod tests {
                 Token {
                     address: H160([0x11; 20]),
                     decimals: 1,
-                    weight: Some(bfp("1.337")),
+                    weight: Some(bfp!("1.337")),
                 },
                 Token {
                     address: H160([0x22; 20]),
                     decimals: 2,
-                    weight: Some(bfp("4.2")),
+                    weight: Some(bfp!("4.2")),
                 },
             ],
         };
@@ -133,7 +129,7 @@ mod tests {
 
     #[tokio::test]
     async fn fetch_weighted_pool() {
-        let weights = [bfp("0.5"), bfp("0.25"), bfp("0.25")];
+        let weights = [bfp!("0.5"), bfp!("0.25"), bfp!("0.25")];
 
         let mock = Mock::new(42);
         let web3 = mock.web3();


### PR DESCRIPTION
This PR moves the fetching logic for all common pool data (the swap fee, whether or not its paused and current reserves) into the `pools::common` module. Additionally, I simplified some of the pool fetching code to try and get rid of some of the code duplication.

Currently, stable and weighted pool fetching logic are still in the `pool_cache` module where they were before. They will be moved to their respective `pools::*` modules as a follow up, it was just too many changes for a single PR.

As a separate note, we now, unfortunately, have `pools::common::PoolState` and `pool_fetching::CommonPoolState` types for representing common pool state information. The plan is to eventually phase out `pool_fetching::CommonPoolState` in favour of the former in a follow up. Again, this is because otherwise, it would have touched a much larger portion of the project and made the PR too big to review. 

### Test Plan

New unit tests were added for the fetching of the common pool data that was moved from the `pool_cache` module.

<details><summary>Also you can check that pool fetching still works</summary>

Apply patch for some extra logging:
```diff
diff --git a/crates/shared/src/sources/balancer_v2/pool_fetching.rs b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
index 37399ba..e1b72b7 100644
--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -240,6 +240,11 @@ impl BalancerPoolFetching for BalancerPoolFetcher {
             .weighted_pool_reserve_cache
             .fetch(pool_ids, at_block)
             .await?;
+        tracing::info!(
+            weighted = %fetched_weighted_pools.len(),
+            stable = %fetched_stable_pools.len(),
+            "FETCHED_POOLS",
+        );
         // Return only those pools which are not paused.
         Ok(FetchedBalancerPools {
             stable_pools: filter_paused(fetched_stable_pools),
```

And run the solver:
```
$ cargo run -p solver -- --baseline-sources BalancerV2 --orderbook-url https://protocol-mainnet.gnosis.io/ --solver-account 0xa6DDBD0dE6B310819b49f680F65871beE85f517e
...
2021-12-07T21:23:18.043Z  INFO shared::sources::balancer_v2::pool_fetching: FETCHED_POOLS weighted=12 stable=1
```

</details>
