### PR TITLE
Move pool fetching logic to their own submodules

### DIFF
--- a/crates/shared/src/price_estimation/priority.rs
+++ b/crates/shared/src/price_estimation/priority.rs
@@ -17,7 +17,7 @@ impl PriorityPriceEstimator {
 fn log_errors(results: &[Result<Estimate, PriceEstimationError>], estimator_index: usize) {
     for result in results {
         if let Err(err) = result {
-            tracing::warn!(%estimator_index, ?err,"priority price estimator failed");
+            tracing::warn!(%estimator_index, ?err, "priority price estimator failed");
         }
     }
 }

--- a/crates/shared/src/sources/balancer_v2.rs
+++ b/crates/shared/src/sources/balancer_v2.rs
@@ -38,5 +38,5 @@ pub mod pool_cache;
 pub mod pool_fetching;
 mod pool_init;
 mod pool_storage;
-mod pools;
+pub mod pools;
 pub mod swap;

--- a/crates/shared/src/sources/balancer_v2/pools.rs
+++ b/crates/shared/src/sources/balancer_v2/pools.rs
@@ -12,8 +12,32 @@ pub mod stable;
 pub mod weighted;
 pub mod weighted_2token;
 
-use super::graph_api::PoolData;
+use super::{graph_api::PoolData, swap::fixed_point::Bfp};
+use crate::Web3CallBatch;
 use anyhow::Result;
+use ethcontract::{BlockId, H256};
+use futures::future::BoxFuture;
+
+/// A Balancer pool.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Pool {
+    /// The ID of the pool.
+    pub id: H256,
+    /// The Balancer pool swap fees.
+    ///
+    /// Note that this is part of a Balancer `BasePool` and is shared across all
+    /// pool types.
+    pub swap_fee: Bfp,
+    /// The pool-specific kind and state.
+    pub kind: PoolKind,
+}
+
+/// Balancer pool state.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PoolKind {
+    Weighted(weighted::PoolState),
+    Stable(stable::PoolState),
+}
 
 /// A Balancer factory indexing implementation.
 #[mockall::automock(type PoolInfo = weighted::PoolInfo;)]
@@ -38,6 +62,23 @@ pub trait FactoryIndexing: Send + Sync + 'static {
     ///
     /// Returns an error if fetching the augmented pool data fails.
     async fn specialize_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo>;
+
+    /// Fetches specialized pool state for the specified pool specialized info
+    /// and common state.
+    ///
+    /// Additionally, a block spec and a batch call context is passed in to
+    /// specify exactly the block number the state should be read for, and allow
+    /// for more optimal performance when fetching a large number of pools.
+    fn fetch_pool_state(
+        &self,
+        pool_info: &Self::PoolInfo,
+        // This **needs** to be `'static` because of a `mockall` limitation
+        // where we can't use other lifetimes here.
+        // <https://github.com/asomers/mockall/issues/299>
+        common_pool_state: BoxFuture<'static, common::PoolState>,
+        batch: &mut Web3CallBatch,
+        block: BlockId,
+    ) -> BoxFuture<'static, Result<PoolKind>>;
 }
 
 /// Required information needed for indexing pools.

--- a/crates/shared/src/sources/balancer_v2/pools/common.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/common.rs
@@ -198,6 +198,16 @@ pub struct PoolState {
     pub tokens: BTreeMap<H160, TokenState>,
 }
 
+impl Default for PoolState {
+    fn default() -> Self {
+        Self {
+            paused: false,
+            swap_fee: 0.into(),
+            tokens: BTreeMap::new(),
+        }
+    }
+}
+
 /// Common pool token state information that is shared among all pool types.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TokenState {

--- a/crates/shared/src/sources/balancer_v2/pools/stable.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/stable.rs
@@ -1,9 +1,17 @@
 //! Module implementing stable pool specific indexing logic.
 
-use super::{common, FactoryIndexing, PoolIndexing};
-use crate::sources::balancer_v2::graph_api::{PoolData, PoolType};
-use anyhow::Result;
-use contracts::BalancerV2StablePoolFactory;
+use super::{common, FactoryIndexing, PoolIndexing, PoolKind};
+use crate::{
+    conversions::U256Ext as _,
+    sources::balancer_v2::graph_api::{PoolData, PoolType},
+    Web3CallBatch,
+};
+use anyhow::{ensure, Result};
+use contracts::{BalancerV2StablePool, BalancerV2StablePoolFactory};
+use ethcontract::{BlockId, H160, U256};
+use futures::{future::BoxFuture, FutureExt as _};
+use num::BigRational;
+use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct PoolInfo {
@@ -22,12 +30,75 @@ impl PoolIndexing for PoolInfo {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PoolState {
+    pub tokens: BTreeMap<H160, common::TokenState>,
+    pub amplification_parameter: AmplificationParameter,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AmplificationParameter {
+    factor: U256,
+    precision: U256,
+}
+
+impl AmplificationParameter {
+    pub fn new(factor: U256, precision: U256) -> Result<Self> {
+        ensure!(!precision.is_zero(), "Zero precision not allowed");
+        Ok(Self { factor, precision })
+    }
+
+    /// This is the format used to pass into smart contracts.
+    pub fn as_u256(&self) -> U256 {
+        self.factor * self.precision
+    }
+
+    /// This is the format used to pass along to HTTP solver.
+    pub fn as_big_rational(&self) -> BigRational {
+        // We can assert that the precision is non-zero as we check when constructing
+        // new `AmplificationParameter` instances that this invariant holds, and we don't
+        // allow modifications of `self.precision` such that it could become 0.
+        debug_assert!(!self.precision.is_zero());
+        BigRational::new(self.factor.to_big_int(), self.precision.to_big_int())
+    }
+}
+
 #[async_trait::async_trait]
 impl FactoryIndexing for BalancerV2StablePoolFactory {
     type PoolInfo = PoolInfo;
 
     async fn specialize_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
         Ok(PoolInfo { common: pool })
+    }
+
+    fn fetch_pool_state(
+        &self,
+        pool_info: &Self::PoolInfo,
+        common_pool_state: BoxFuture<'static, common::PoolState>,
+        batch: &mut Web3CallBatch,
+        block: BlockId,
+    ) -> BoxFuture<'static, Result<PoolKind>> {
+        let pool_contract =
+            BalancerV2StablePool::at(&self.raw_instance().web3(), pool_info.common.address);
+
+        let amplification_parameter = pool_contract
+            .get_amplification_parameter()
+            .block(block)
+            .batch_call(batch);
+
+        async move {
+            let tokens = common_pool_state.await.tokens;
+            let amplification_parameter = {
+                let (factor, _, precision) = amplification_parameter.await?;
+                AmplificationParameter::new(factor, precision)?
+            };
+
+            Ok(PoolKind::Stable(PoolState {
+                tokens,
+                amplification_parameter,
+            }))
+        }
+        .boxed()
     }
 }
 
@@ -36,6 +107,82 @@ mod tests {
     use super::*;
     use crate::sources::balancer_v2::graph_api::Token;
     use ethcontract::{H160, H256};
+    use ethcontract_mock::Mock;
+    use futures::future;
+    use maplit::btreemap;
+
+    #[tokio::test]
+    async fn fetch_pool_state() {
+        let tokens = btreemap! {
+            H160([1; 20]) => common::TokenState {
+                balance: bfp!("1000.0").as_uint256(),
+                scaling_exponent: 0,
+            },
+            H160([2; 20]) => common::TokenState {
+                balance: bfp!("10.0").as_uint256(),
+                scaling_exponent: 0,
+            },
+            H160([3; 20]) => common::TokenState {
+                balance: 15_000_000.into(),
+                scaling_exponent: 12,
+            },
+        };
+        let amplification_parameter =
+            AmplificationParameter::new(200.into(), 10000.into()).unwrap();
+
+        let mock = Mock::new(42);
+        let web3 = mock.web3();
+
+        let pool = mock.deploy(BalancerV2StablePool::raw_contract().abi.clone());
+        pool.expect_call(BalancerV2StablePool::signatures().get_amplification_parameter())
+            .returns((
+                amplification_parameter.factor,
+                false,
+                amplification_parameter.precision,
+            ));
+
+        let factory = dummy_contract!(BalancerV2StablePoolFactory, H160::default());
+        let pool_info = PoolInfo {
+            common: common::PoolInfo {
+                id: H256([0x90; 32]),
+                address: pool.address(),
+                tokens: tokens.keys().copied().collect(),
+                scaling_exponents: tokens
+                    .values()
+                    .map(|token| token.scaling_exponent)
+                    .collect(),
+                block_created: 1337,
+            },
+        };
+        let common_pool_state = common::PoolState {
+            paused: false,
+            swap_fee: bfp!("0.003"),
+            tokens,
+        };
+
+        let pool_state = {
+            let mut batch = Web3CallBatch::new(web3.transport().clone());
+            let block = web3.eth().block_number().await.unwrap();
+
+            let pool_state = factory.fetch_pool_state(
+                &pool_info,
+                future::ready(common_pool_state.clone()).boxed(),
+                &mut batch,
+                block.into(),
+            );
+
+            batch.execute_all(100).await;
+            pool_state.await.unwrap()
+        };
+
+        assert!(matches!(
+            pool_state,
+            PoolKind::Stable(pool) if pool == PoolState {
+                tokens: common_pool_state.tokens,
+                amplification_parameter,
+            }
+        ));
+    }
 
     #[test]
     fn errors_when_converting_wrong_pool_type() {
@@ -59,5 +206,28 @@ mod tests {
         };
 
         assert!(PoolInfo::from_graph_data(&pool, 42).is_err());
+    }
+
+    #[test]
+    fn amplification_parameter_conversions() {
+        assert_eq!(
+            AmplificationParameter::new(2.into(), 3.into())
+                .unwrap()
+                .as_u256(),
+            6.into()
+        );
+        assert_eq!(
+            AmplificationParameter::new(7.into(), 8.into())
+                .unwrap()
+                .as_big_rational(),
+            BigRational::new(7.into(), 8.into())
+        );
+
+        assert_eq!(
+            AmplificationParameter::new(1.into(), 0.into())
+                .unwrap_err()
+                .to_string(),
+            "Zero precision not allowed"
+        );
     }
 }

--- a/crates/shared/src/sources/balancer_v2/pools/weighted.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/weighted.rs
@@ -1,17 +1,34 @@
 //! Module implementing weighted pool specific indexing logic.
 
-use super::{common, FactoryIndexing, PoolIndexing};
-use crate::sources::balancer_v2::{
-    graph_api::{PoolData, PoolType},
-    swap::fixed_point::Bfp,
+use super::{common, FactoryIndexing, PoolIndexing, PoolKind};
+use crate::{
+    sources::balancer_v2::{
+        graph_api::{PoolData, PoolType},
+        swap::fixed_point::Bfp,
+    },
+    Web3CallBatch,
 };
 use anyhow::{anyhow, Result};
 use contracts::{BalancerV2WeightedPool, BalancerV2WeightedPoolFactory};
+use ethcontract::{BlockId, H160};
+use futures::{future::BoxFuture, FutureExt as _};
+use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct PoolInfo {
     pub common: common::PoolInfo,
     pub weights: Vec<Bfp>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PoolState {
+    pub tokens: BTreeMap<H160, TokenState>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TokenState {
+    pub common: common::TokenState,
+    pub weight: Bfp,
 }
 
 impl PoolIndexing for PoolInfo {
@@ -55,6 +72,28 @@ impl FactoryIndexing for BalancerV2WeightedPoolFactory {
             weights,
         })
     }
+
+    fn fetch_pool_state(
+        &self,
+        pool_info: &Self::PoolInfo,
+        common_pool_state: BoxFuture<'static, common::PoolState>,
+        _: &mut Web3CallBatch,
+        _: BlockId,
+    ) -> BoxFuture<'static, Result<PoolKind>> {
+        let pool_info = pool_info.clone();
+        async move {
+            let tokens = common_pool_state
+                .await
+                .tokens
+                .into_iter()
+                .zip(&pool_info.weights)
+                .map(|((address, common), &weight)| (address, TokenState { common, weight }))
+                .collect();
+
+            Ok(PoolKind::Weighted(PoolState { tokens }))
+        }
+        .boxed()
+    }
 }
 
 #[cfg(test)]
@@ -63,6 +102,8 @@ mod tests {
     use crate::sources::balancer_v2::graph_api::Token;
     use ethcontract::{H160, H256};
     use ethcontract_mock::Mock;
+    use futures::future;
+    use maplit::btreemap;
 
     #[test]
     fn convert_graph_pool_to_weighted_pool_info() {
@@ -151,5 +192,71 @@ mod tests {
             .unwrap();
 
         assert_eq!(pool.weights, weights);
+    }
+
+    #[tokio::test]
+    async fn fetch_pool_state() {
+        let tokens = btreemap! {
+            H160([1; 20]) => common::TokenState {
+                balance: bfp!("1000.0").as_uint256(),
+                scaling_exponent: 0,
+            },
+            H160([2; 20]) => common::TokenState {
+                balance: 10_000_000.into(),
+                scaling_exponent: 12,
+            },
+        };
+        let weights = [bfp!("0.8"), bfp!("0.2")];
+
+        let mock = Mock::new(42);
+        let web3 = mock.web3();
+
+        let factory = dummy_contract!(BalancerV2WeightedPoolFactory, H160::default());
+        let pool_info = PoolInfo {
+            common: common::PoolInfo {
+                id: H256([0x90; 32]),
+                address: H160([0x90; 20]),
+                tokens: tokens.keys().copied().collect(),
+                scaling_exponents: tokens
+                    .values()
+                    .map(|token| token.scaling_exponent)
+                    .collect(),
+                block_created: 1337,
+            },
+            weights: weights.to_vec(),
+        };
+        let common_pool_state = common::PoolState {
+            paused: false,
+            swap_fee: bfp!("0.003"),
+            tokens,
+        };
+
+        let pool_state = {
+            let mut batch = Web3CallBatch::new(web3.transport().clone());
+            let block = web3.eth().block_number().await.unwrap();
+
+            let pool_state = factory.fetch_pool_state(
+                &pool_info,
+                future::ready(common_pool_state.clone()).boxed(),
+                &mut batch,
+                block.into(),
+            );
+
+            batch.execute_all(100).await;
+            pool_state.await.unwrap()
+        };
+
+        let weighted_tokens = common_pool_state
+            .tokens
+            .into_iter()
+            .zip(weights)
+            .map(|((address, common), weight)| (address, TokenState { common, weight }))
+            .collect();
+        assert!(matches!(
+            pool_state,
+            PoolKind::Weighted(pool) if pool == PoolState {
+                tokens: weighted_tokens,
+            }
+        ));
     }
 }

--- a/crates/shared/src/sources/balancer_v2/pools/weighted_2token.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/weighted_2token.rs
@@ -1,7 +1,7 @@
 //! Module implementing two-token weighted pool specific indexing logic.
 
-pub use super::weighted::PoolInfo;
-use super::{common, FactoryIndexing, PoolKind};
+pub use super::weighted::{PoolInfo, PoolState};
+use super::{common, FactoryIndexing};
 use anyhow::Result;
 use contracts::{BalancerV2WeightedPool2TokensFactory, BalancerV2WeightedPoolFactory};
 use ethcontract::BlockId;
@@ -10,6 +10,7 @@ use futures::future::BoxFuture;
 #[async_trait::async_trait]
 impl FactoryIndexing for BalancerV2WeightedPool2TokensFactory {
     type PoolInfo = PoolInfo;
+    type PoolState = PoolState;
 
     async fn specialize_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
         as_weighted_factory(self).specialize_pool_info(pool).await
@@ -21,7 +22,7 @@ impl FactoryIndexing for BalancerV2WeightedPool2TokensFactory {
         common_pool_state: BoxFuture<'static, common::PoolState>,
         batch: &mut crate::Web3CallBatch,
         block: BlockId,
-    ) -> BoxFuture<'static, Result<PoolKind>> {
+    ) -> BoxFuture<'static, Result<Self::PoolState>> {
         as_weighted_factory(self).fetch_pool_state(pool_info, common_pool_state, batch, block)
     }
 }

--- a/crates/shared/src/sources/balancer_v2/pools/weighted_2token.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/weighted_2token.rs
@@ -1,9 +1,11 @@
 //! Module implementing two-token weighted pool specific indexing logic.
 
 pub use super::weighted::PoolInfo;
-use super::{common, FactoryIndexing};
+use super::{common, FactoryIndexing, PoolKind};
 use anyhow::Result;
 use contracts::{BalancerV2WeightedPool2TokensFactory, BalancerV2WeightedPoolFactory};
+use ethcontract::BlockId;
+use futures::future::BoxFuture;
 
 #[async_trait::async_trait]
 impl FactoryIndexing for BalancerV2WeightedPool2TokensFactory {
@@ -11,6 +13,16 @@ impl FactoryIndexing for BalancerV2WeightedPool2TokensFactory {
 
     async fn specialize_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
         as_weighted_factory(self).specialize_pool_info(pool).await
+    }
+
+    fn fetch_pool_state(
+        &self,
+        pool_info: &Self::PoolInfo,
+        common_pool_state: BoxFuture<'static, common::PoolState>,
+        batch: &mut crate::Web3CallBatch,
+        block: BlockId,
+    ) -> BoxFuture<'static, Result<PoolKind>> {
+        as_weighted_factory(self).fetch_pool_state(pool_info, common_pool_state, batch, block)
     }
 }
 


### PR DESCRIPTION
Follow up from #1465 

This PR moves pool fetching logic into their own submodules.

This PR has a few "oddities" that should be clarified:

#### Duplicate Pool State Types

One oddity is that we now have `common::PoolState`/`CommonPoolState`, `weighted::PoolState`/`WeightedPool` and `stable::PoolState`/`StablePool` types. Eventually the `CommonPoolState` and `{Weighted,Stable}Pool` types will go away in favour of the new ones, I just couldn't fit it into this PR. It will be done in a _follow-up PR_ coming soon to a Github near you!

#### Additional Complexity in `pool_cache` Module

The code in `pool_cache` module got a bit more complicated 😢. This is a "necessary evil" in order to make everything generic (note that we now can queue necessary `eth_call`s into a batch for fetching specialized pool information unique to stable and weighted pools, and that the `fetch_values` implementations for weighted and stable pools are almost identical with the exception of `s/weighted/stable/g`). Actually making this type generic will be the _next PR_.

#### `swap_fee` Duplicated For All `PoolState`s

`swap_fee` is common to both weighted and stable pools. It was duplicated to each `PoolState` so that we can implement `BaselineSolvable` for each individual `PoolState` without requiring any additional auxiliary data. This way, the `balancer_v2::pools::Pool` type can just contain common data that is important for interaction encoding, while each `*::PoolState` can have all the data required for computing input and output amounts.

#### Shared `common::PoolState` Future.

One final technical note of importance - `PoolInfoFetching::fetch_common_pool_state` returns a future that resolves to a `Result<common::PoolState>`, but we pass in a future that resolves to a `common::PoolState` (not a result) to the `FactoryIndexing::fetch_pool_state` method! The reason for this choice was that handling errors in fetching the common pool state should be handled by the caller and not by the `FactoryIndexing` implementation. In order to make this happen, we needed a `share_common_pool_state` method that would take a `Future<Output = Result<common::PoolState>` and produce a tuple of futures `(Future<Output = Result<common::PoolState>>, Future<Output = common::PoolState>)` where `poll`-ing the latter future would panic if the first future doesn't resolve to a success value. This means that using `share_common_pool_state` comes with some assumptions that if not upheld can cause panics. Since this is private and only used in the `pool_cache` module and these assumptions don't leak at all, I thought it was OK (especially since it allows for a cleaner `FactoryIndexing` interface which is arguably more important since future pool types will implement this and not require touching code in `pool_cache`). 

### Test Plan

Added a new tests for the specialized pool fetching logic that didn't exist before as well as new tests for the slightly "weird" `share_common_pool_state`
