### PR TITLE
Make pool info fetching component generic on its factory

### DIFF
--- a/crates/shared/src/sources/balancer_v2/pool_cache.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_cache.rs
@@ -94,14 +94,13 @@ impl CacheFetching<H256, WeightedPool> for PoolReserveFetcher<BalancerV2Weighted
 
                 async move {
                     let pool_status = pool_status.await?;
-                    let weighted_pool = match pool_status.active() {
+                    match pool_status.active() {
                         Some(Pool {
                             kind: PoolKind::Weighted(state),
                             ..
-                        }) => WeightedPool::new_unpaused(registered_pool, state),
-                        _ => return Ok(None),
-                    };
-                    Ok(Some(weighted_pool))
+                        }) => Ok(Some(WeightedPool::new_unpaused(registered_pool, state))),
+                        _ => Ok(None),
+                    }
                 }
             })
             .collect::<Vec<_>>();
@@ -133,14 +132,13 @@ impl CacheFetching<H256, StablePool> for PoolReserveFetcher<BalancerV2StablePool
 
                 async move {
                     let pool_status = pool_status.await?;
-                    let stable_pool = match pool_status.active() {
+                    match pool_status.active() {
                         Some(Pool {
                             kind: PoolKind::Stable(state),
                             ..
-                        }) => StablePool::new_unpaused(registered_pool, state),
-                        _ => return Ok(None),
-                    };
-                    Ok(Some(stable_pool))
+                        }) => Ok(Some(StablePool::new_unpaused(registered_pool, state))),
+                        _ => Ok(None),
+                    }
                 }
             })
             .collect::<Vec<_>>();

--- a/crates/shared/src/sources/balancer_v2/pool_cache.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_cache.rs
@@ -1,7 +1,7 @@
 use super::{
     event_handler::BalancerPoolRegistry,
     pool_fetching::{BalancerPoolEvaluating, StablePool, WeightedPool},
-    pools::{common, FactoryIndexing},
+    pools::{common, Pool, PoolKind},
 };
 use crate::{
     ethcontract_error::EthcontractErrorType,
@@ -12,15 +12,12 @@ use crate::{
 use anyhow::Result;
 use contracts::{BalancerV2StablePoolFactory, BalancerV2WeightedPoolFactory};
 use ethcontract::{batch::CallBatch, errors::MethodError, BlockId, H256};
-use futures::{future, FutureExt as _};
-use std::{collections::HashSet, future::Future, sync::Arc};
-use tokio::sync::oneshot;
+use futures::future;
+use std::{collections::HashSet, sync::Arc};
 
-pub struct PoolReserveFetcher {
+pub struct PoolReserveFetcher<Factory> {
     pool_registry: Arc<BalancerPoolRegistry>,
-    common_pool_fetcher: Arc<dyn common::PoolInfoFetching>,
-    weighted_pool_factory: BalancerV2WeightedPoolFactory,
-    stable_pool_factory: BalancerV2StablePoolFactory,
+    pool_fetcher: Arc<dyn common::PoolInfoFetching<Factory>>,
     web3: Web3,
 }
 
@@ -28,30 +25,33 @@ pub trait BalancerPoolCacheMetrics: Send + Sync {
     fn pools_fetched(&self, cache_hits: usize, cache_misses: usize);
 }
 
-impl PoolReserveFetcher {
-    pub async fn new(
+impl<Factory> PoolReserveFetcher<Factory> {
+    pub fn new(
         pool_registry: Arc<BalancerPoolRegistry>,
-        common_pool_fetcher: Arc<dyn common::PoolInfoFetching>,
+        pool_fetcher: Arc<dyn common::PoolInfoFetching<Factory>>,
         web3: Web3,
     ) -> Result<Self> {
-        let weighted_pool_factory = BalancerV2WeightedPoolFactory::deployed(&web3).await?;
-        let stable_pool_factory = BalancerV2StablePoolFactory::deployed(&web3).await?;
-
         Ok(Self {
             pool_registry,
-            common_pool_fetcher,
-            weighted_pool_factory,
-            stable_pool_factory,
+            pool_fetcher,
             web3,
         })
     }
 }
 
-pub type WeightedPoolReserveCache =
-    RecentBlockCache<H256, WeightedPool, PoolReserveFetcher, Arc<dyn BalancerPoolCacheMetrics>>;
+pub type WeightedPoolReserveCache = RecentBlockCache<
+    H256,
+    WeightedPool,
+    PoolReserveFetcher<BalancerV2WeightedPoolFactory>,
+    Arc<dyn BalancerPoolCacheMetrics>,
+>;
 
-pub type StablePoolReserveCache =
-    RecentBlockCache<H256, StablePool, PoolReserveFetcher, Arc<dyn BalancerPoolCacheMetrics>>;
+pub type StablePoolReserveCache = RecentBlockCache<
+    H256,
+    StablePool,
+    PoolReserveFetcher<BalancerV2StablePoolFactory>,
+    Arc<dyn BalancerPoolCacheMetrics>,
+>;
 
 impl CacheKey<StablePool> for H256 {
     fn first_ord() -> Self {
@@ -74,7 +74,7 @@ impl CacheKey<WeightedPool> for H256 {
 }
 
 #[async_trait::async_trait]
-impl CacheFetching<H256, WeightedPool> for PoolReserveFetcher {
+impl CacheFetching<H256, WeightedPool> for PoolReserveFetcher<BalancerV2WeightedPoolFactory> {
     async fn fetch_values(
         &self,
         pool_ids: HashSet<H256>,
@@ -88,27 +88,20 @@ impl CacheFetching<H256, WeightedPool> for PoolReserveFetcher {
             .await
             .into_iter()
             .map(|registered_pool| {
-                let (common_pool_state, common_pool_state_ok) =
-                    share_common_pool_state(self.common_pool_fetcher.fetch_common_pool_state(
-                        &registered_pool.common,
-                        &mut batch,
-                        block,
-                    ));
-                let weighted_pool_state = self.weighted_pool_factory.fetch_pool_state(
-                    &registered_pool,
-                    common_pool_state_ok.boxed(),
-                    &mut batch,
-                    block,
-                );
+                let pool_status = self
+                    .pool_fetcher
+                    .fetch_pool(&registered_pool, &mut batch, block);
 
                 async move {
-                    let common_pool_state = common_pool_state.await?;
-                    let weighted_pool_state = weighted_pool_state.await?;
-                    Ok(WeightedPool::new(
-                        registered_pool,
-                        common_pool_state,
-                        weighted_pool_state,
-                    ))
+                    let pool_status = pool_status.await?;
+                    let weighted_pool = match pool_status.active() {
+                        Some(Pool {
+                            kind: PoolKind::Weighted(state),
+                            ..
+                        }) => WeightedPool::new_unpaused(registered_pool, state),
+                        _ => return Ok(None),
+                    };
+                    Ok(Some(weighted_pool))
                 }
             })
             .collect::<Vec<_>>();
@@ -120,7 +113,7 @@ impl CacheFetching<H256, WeightedPool> for PoolReserveFetcher {
 }
 
 #[async_trait::async_trait]
-impl CacheFetching<H256, StablePool> for PoolReserveFetcher {
+impl CacheFetching<H256, StablePool> for PoolReserveFetcher<BalancerV2StablePoolFactory> {
     async fn fetch_values(
         &self,
         pool_ids: HashSet<H256>,
@@ -134,28 +127,20 @@ impl CacheFetching<H256, StablePool> for PoolReserveFetcher {
             .await
             .into_iter()
             .map(|registered_pool| {
-                let (common_pool_state, common_pool_state_ok) =
-                    share_common_pool_state(self.common_pool_fetcher.fetch_common_pool_state(
-                        &registered_pool.common,
-                        &mut batch,
-                        block,
-                    ));
-                let stable_pool_state = self.stable_pool_factory.fetch_pool_state(
-                    &registered_pool,
-                    common_pool_state_ok.boxed(),
-                    &mut batch,
-                    block,
-                );
+                let pool_status = self
+                    .pool_fetcher
+                    .fetch_pool(&registered_pool, &mut batch, block);
 
                 async move {
-                    let common_pool_state = common_pool_state.await?;
-                    let stable_pool_state = stable_pool_state.await?;
-
-                    Ok(StablePool::new(
-                        registered_pool,
-                        common_pool_state,
-                        stable_pool_state,
-                    ))
+                    let pool_status = pool_status.await?;
+                    let stable_pool = match pool_status.active() {
+                        Some(Pool {
+                            kind: PoolKind::Stable(state),
+                            ..
+                        }) => StablePool::new_unpaused(registered_pool, state),
+                        _ => return Ok(None),
+                    };
+                    Ok(Some(stable_pool))
                 }
             })
             .collect::<Vec<_>>();
@@ -172,10 +157,10 @@ impl CacheMetrics for Arc<dyn BalancerPoolCacheMetrics> {
     }
 }
 
-fn accumulate_handled_results<T>(results: Vec<Result<T>>) -> Result<Vec<T>> {
+fn accumulate_handled_results<T>(results: Vec<Result<Option<T>>>) -> Result<Vec<T>> {
     results
         .into_iter()
-        .filter_map(|result| match result {
+        .filter_map(|result| match result.transpose()? {
             Ok(value) => Some(Ok(value)),
             Err(err) if is_contract_error(&err) => None,
             Err(err) => Some(Err(err)),
@@ -191,101 +176,31 @@ fn is_contract_error(err: &anyhow::Error) -> bool {
     )
 }
 
-/// An internal utility method for sharing the success value for an
-/// `anyhow::Result`.
-///
-/// Typically, this is pretty trivial using `FutureExt::shared`. However, since
-/// `anyhow::Error: !Clone` we need to use a different approach.
-///
-/// # Panics
-///
-/// Polling the future with the shared success value will panic if the result
-/// future has not already resolved to a `Ok` value. This method is only ever
-/// meant to be used internally, so we don't have to worry that these
-/// assumptions leak out of this module.
-fn share_common_pool_state(
-    fut: impl Future<Output = Result<common::PoolState>>,
-) -> (
-    impl Future<Output = Result<common::PoolState>>,
-    impl Future<Output = common::PoolState>,
-) {
-    let (pool_sender, pool_receiver) = oneshot::channel();
-
-    let result = fut.inspect(|pool_result| {
-        // We can't clone `anyhow::Error` so just clone the pool data and use
-        // an empty `()` error.
-        let pool_result = pool_result.as_ref().map(Clone::clone).map_err(|_| ());
-        // Ignore error if the shared future was dropped.
-        let _ = pool_sender.send(pool_result);
-    });
-    let shared = async move {
-        pool_receiver
-            .now_or_never()
-            .expect("result future is still pending")
-            .expect("result future was dropped")
-            .expect("result future resolved to an error")
-    };
-
-    (result, shared)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::ethcontract_error;
-    use anyhow::bail;
 
     #[test]
     fn pool_fetcher_forwards_node_error() {
         assert!(accumulate_handled_results(vec![
-            Ok(()),
+            Ok(Some(())),
             Err(ethcontract_error::testing_node_error().into()),
         ])
         .is_err())
     }
 
     #[test]
-    fn pool_fetcher_skips_contract_error() {
+    fn pool_fetcher_skips_contract_errors_and_nones() {
         assert_eq!(
             accumulate_handled_results(vec![
-                Ok(()),
+                Ok(Some(())),
+                Ok(None),
                 Err(ethcontract_error::testing_contract_error().into()),
             ])
             .unwrap()
             .len(),
             1
         )
-    }
-
-    #[tokio::test]
-    async fn share_pool_state_future() {
-        let (pool_state, pool_state_ok) = share_common_pool_state(async { Ok(Default::default()) });
-        assert_eq!({ pool_state.await.unwrap() }, pool_state_ok.await);
-    }
-
-    #[tokio::test]
-    #[should_panic]
-    async fn shared_pool_state_future_panics_if_pending() {
-        let (_pool_state, pool_state_ok) = share_common_pool_state(async {
-            futures::pending!();
-            Ok(Default::default())
-        });
-        pool_state_ok.await;
-    }
-
-    #[tokio::test]
-    #[should_panic]
-    async fn share_pool_state_future_if_dropped() {
-        let (pool_state, pool_state_ok) = share_common_pool_state(async { Ok(Default::default()) });
-        drop(pool_state);
-        pool_state_ok.await;
-    }
-
-    #[tokio::test]
-    #[should_panic]
-    async fn share_pool_state_future_if_errored() {
-        let (pool_state, pool_state_ok) = share_common_pool_state(async { bail!("error") });
-        let _ = pool_state.await;
-        pool_state_ok.await;
     }
 }

--- a/crates/shared/src/sources/balancer_v2/pool_storage.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_storage.rs
@@ -59,10 +59,8 @@ pub struct PoolStorage<Factory>
 where
     Factory: FactoryIndexing,
 {
-    factory: Factory,
-
-    /// Component used to fetch common pool information.
-    common_pool_fetcher: Arc<dyn common::PoolInfoFetching>,
+    /// Component used to fetch pool information.
+    pool_info_fetcher: Arc<dyn common::PoolInfoFetching<Factory>>,
     /// Used for O(1) access to all pool_ids for a given token
     pools_by_token: HashMap<H160, HashSet<H256>>,
     /// All indexed pool infos by ID.
@@ -77,14 +75,12 @@ where
     Factory: FactoryIndexing,
 {
     pub fn new(
-        factory: Factory,
         initial_pools: Vec<Factory::PoolInfo>,
-        common_pool_fetcher: Arc<dyn common::PoolInfoFetching>,
+        pool_info_fetcher: Arc<dyn common::PoolInfoFetching<Factory>>,
     ) -> Self {
         initial_pools.into_iter().fold(
             Self {
-                factory,
-                common_pool_fetcher,
+                pool_info_fetcher,
                 pools_by_token: Default::default(),
                 pools: Default::default(),
                 initial_fetched_block: 0,
@@ -152,12 +148,10 @@ where
         pool_creation: PoolCreated,
         block_created: u64,
     ) -> Result<()> {
-        let common_pool_info = self
-            .common_pool_fetcher
-            .fetch_common_pool_info(pool_creation.pool, block_created)
+        let pool = self
+            .pool_info_fetcher
+            .fetch_pool_info(pool_creation.pool, block_created)
             .await?;
-        let pool = self.factory.specialize_pool_info(common_pool_info).await?;
-
         self.insert_pool(pool);
 
         Ok(())
@@ -247,9 +241,7 @@ mod tests {
 
     #[test]
     fn initialize_storage() {
-        let factory = MockFactoryIndexing::new();
         let storage = PoolStorage::new(
-            factory,
             vec![
                 RegisteredWeightedPool {
                     common: CommonPoolData {
@@ -292,7 +284,7 @@ mod tests {
                     ],
                 },
             ],
-            Arc::new(MockPoolInfoFetching::new()),
+            Arc::new(MockPoolInfoFetching::<MockFactoryIndexing>::new()),
         );
 
         assert_eq!(
@@ -311,8 +303,7 @@ mod tests {
         let n = 3usize;
         let (pool_ids, pool_addresses, tokens, weights, creation_events) = pool_init_data(0, n);
 
-        let mut mock_factory = MockFactoryIndexing::new();
-        let mut mock_pool_fetcher = MockPoolInfoFetching::new();
+        let mut mock_pool_fetcher = MockPoolInfoFetching::<MockFactoryIndexing>::new();
         for i in 0..n {
             let expected_pool_data = RegisteredWeightedPool {
                 common: CommonPoolData {
@@ -325,24 +316,16 @@ mod tests {
                 weights: vec![weights[i], weights[i + 1]],
             };
 
-            mock_factory
-                .expect_specialize_pool_info()
-                .with(eq(expected_pool_data.common.clone()))
+            mock_pool_fetcher
+                .expect_fetch_pool_info()
+                .with(eq(pool_addresses[i]), eq(creation_events[i].1))
                 .returning({
                     let expected_pool_data = expected_pool_data.clone();
-                    move |_| Ok(expected_pool_data.clone())
+                    move |_, _| Ok(expected_pool_data.clone())
                 });
-            mock_pool_fetcher
-                .expect_fetch_common_pool_info()
-                .with(eq(pool_addresses[i]), eq(creation_events[i].1))
-                .returning(move |_, _| Ok(expected_pool_data.common.clone()));
         }
 
-        let mut pool_store = PoolStorage::new(
-            mock_factory,
-            Default::default(),
-            Arc::new(mock_pool_fetcher),
-        );
+        let mut pool_store = PoolStorage::new(Default::default(), Arc::new(mock_pool_fetcher));
         for (pool_created, block_created) in creation_events.into_iter().take(n) {
             pool_store
                 .index_pool_creation(pool_created, block_created)
@@ -395,8 +378,7 @@ mod tests {
             pool_init_data(start_block, end_block);
         // Setup all the variables to initialize Balancer Pool State
 
-        let mut mock_factory = MockFactoryIndexing::new();
-        let mut mock_pool_fetcher = MockPoolInfoFetching::new();
+        let mut mock_pool_fetcher = MockPoolInfoFetching::<MockFactoryIndexing>::new();
         for i in start_block..=end_block {
             let expected_pool_data = RegisteredWeightedPool {
                 common: CommonPoolData {
@@ -409,17 +391,13 @@ mod tests {
                 weights: vec![weights[i], weights[i + 1]],
             };
 
-            mock_factory
-                .expect_specialize_pool_info()
-                .with(eq(expected_pool_data.common.clone()))
+            mock_pool_fetcher
+                .expect_fetch_pool_info()
+                .with(eq(pool_addresses[i]), eq(creation_events[i].1))
                 .returning({
                     let expected_pool_data = expected_pool_data.clone();
-                    move |_| Ok(expected_pool_data.clone())
+                    move |_, _| Ok(expected_pool_data.clone())
                 });
-            mock_pool_fetcher
-                .expect_fetch_common_pool_info()
-                .with(eq(pool_addresses[i]), eq(creation_events[i].1))
-                .returning(move |_, _| Ok(expected_pool_data.common.clone()));
         }
 
         let new_pool = RegisteredWeightedPool {
@@ -436,30 +414,19 @@ mod tests {
             pool: new_pool.common.address,
         };
 
-        mock_factory
-            .expect_specialize_pool_info()
-            .with(eq(new_pool.common.clone()))
-            .returning({
-                let new_pool = new_pool.clone();
-                move |_| Ok(new_pool.clone())
-            });
         mock_pool_fetcher
-            .expect_fetch_common_pool_info()
+            .expect_fetch_pool_info()
             .with(
                 eq(new_pool.common.address),
                 eq(new_pool.common.block_created),
             )
             .returning({
                 let new_pool = new_pool.clone();
-                move |_, _| Ok(new_pool.common.clone())
+                move |_, _| Ok(new_pool.clone())
             });
 
         // Let the tests begin!
-        let mut pool_store = PoolStorage::new(
-            mock_factory,
-            Default::default(),
-            Arc::new(mock_pool_fetcher),
-        );
+        let mut pool_store = PoolStorage::new(Default::default(), Arc::new(mock_pool_fetcher));
         for (pool_creation, block_created) in creation_events {
             pool_store
                 .index_pool_creation(pool_creation, block_created)
@@ -539,9 +506,8 @@ mod tests {
             .collect();
 
         let mut registry = PoolStorage::new(
-            MockFactoryIndexing::new(),
             Default::default(),
-            Arc::new(MockPoolInfoFetching::new()),
+            Arc::new(MockPoolInfoFetching::<MockFactoryIndexing>::new()),
         );
         // Test the empty registry.
         for token_pair in &token_pairs {


### PR DESCRIPTION
Follow up to #1466 and #1465 

The `common::PoolInfoFetcher` is now generic on a factory type. This means that external consumers of this API can `fetch_pool_info` and `fetch_pool` directly instead of having to first `fetch_common_{pool_info, pool_state}` and then `fetch_specialized_{pool_info, pool_state}`.

This also has the advantage that setting up mocks for components like the `PoolStorage` are easier now, since we only need to setup mock for a `MockPoolInfoFetching` instead of setting up mocks for both a `MockPoolInfoFetcher` (for fetching common pool info) and `MockFactoryIndexing` (for specializing the pool info).

This also allowed us to make `PoolReserveFetcher` generic on a `Factory` type 🎉. Note that we still provide specialized implementations for `CacheFetching<H256, WeightedPool>` and `CacheFetching<H256, StablePool>`, but this will change once we start using the common `balancer_v2::pools::Pool` type - which is also coming in a follow up.

### Test Plan

Mostly just refactoring making things generic. Added some new unit tests to test fetching specialized state also when fetching paused pools (which behaves slightly differently now).

