### PR TITLE
[easy] Adding cow-dex-ag solver

### DIFF
--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -60,6 +60,10 @@ struct Arguments {
     #[structopt(long, env, default_value = "http://localhost:8000")]
     quasimodo_solver_url: Url,
 
+    /// The API endpoint to call the cow-dex-ag-solver solver
+    #[structopt(long, env, default_value = "http://localhost:8000")]
+    cow_dex_ag_solver_url: Url,
+
     /// The account used by the driver to sign transactions. This can be either
     /// a 32-byte private key for offline signing, or a 20-byte Ethereum address
     /// for signing with a local node account.
@@ -496,6 +500,7 @@ async fn main() {
         base_tokens,
         native_token_contract.address(),
         args.mip_solver_url,
+        args.cow_dex_ag_solver_url,
         args.quasimodo_solver_url,
         &settlement_contract,
         token_info_fetcher,

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -127,6 +127,7 @@ arg_enum! {
         Naive,
         Baseline,
         Mip,
+        CowDexAg,
         OneInch,
         Paraswap,
         ZeroEx,
@@ -141,6 +142,7 @@ pub fn create(
     base_tokens: Arc<BaseTokens>,
     native_token: H160,
     mip_solver_url: Url,
+    cow_dex_ag_solver_url: Url,
     quasimodo_solver_url: Url,
     settlement_contract: &GPv2Settlement,
     token_info_fetcher: Arc<dyn TokenInfoFetching>,
@@ -198,6 +200,16 @@ pub fn create(
                     account,
                     mip_solver_url.clone(),
                     "Mip",
+                    SolverConfig {
+                        api_key: None,
+                        max_nr_exec_orders: 100,
+                        has_ucp_policy_parameter: false,
+                    },
+                )),
+                SolverType::CowDexAg => shared(create_http_solver(
+                    account,
+                    cow_dex_ag_solver_url.clone(),
+                    "CowDexAg",
                     SolverConfig {
                         api_key: None,
                         max_nr_exec_orders: 100,


### PR DESCRIPTION
Adding the cow dex ag solver

### Test Plan

run the c[ow-dex-ag solver](https://github.com/gnosis/cow-dex-solver) locally:
```
cargo run
```
and then run in the services:
```
cargo run -p solver --  --orderbook-url https://protocol-mainnet.gnosis.io \
  --node-url "https://mainnet.infura.io/v3/$INFURA_KEY" \
   --cow-dex-ag-solver-url "http://127.0.0.1:8000" \
  --solver-account 0xa6DDBD0dE6B310819b49f680F65871beE85f517e \
  --solvers CowDexAg \
  --transaction-strategy DryRun
``` 
Observe some tenderly tx go through.