### PR TITLE
New system for reporting API metrics

### DIFF
--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -10,6 +10,7 @@ mod get_solvable_orders;
 mod get_solvable_orders_v2;
 mod get_trades;
 mod get_user_orders;
+mod metrics;
 pub mod order_validation;
 pub mod post_quote;
 
@@ -18,7 +19,7 @@ use crate::{
 };
 use anyhow::{Error as anyhowError, Result};
 use serde::{de::DeserializeOwned, Serialize};
-use shared::{metrics::get_metric_storage_registry, price_estimation::PriceEstimationError};
+use shared::price_estimation::PriceEstimationError;
 use std::fmt::Debug;
 use std::{convert::Infallible, sync::Arc};
 use warp::{
@@ -32,48 +33,110 @@ pub fn handle_all_routes(
     orderbook: Arc<Orderbook>,
     quoter: Arc<OrderQuoter>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    let create_order = create_order::create_order(orderbook.clone()).boxed();
-    let get_orders = get_orders::get_orders(orderbook.clone()).boxed();
-    let fee_info = get_fee_info::get_fee_info(quoter.fee_calculator.clone()).boxed();
-    let get_order = get_order_by_uid::get_order_by_uid(orderbook.clone()).boxed();
-    let get_solvable_orders = get_solvable_orders::get_solvable_orders(orderbook.clone()).boxed();
-    let get_solvable_orders_v2 =
-        get_solvable_orders_v2::get_solvable_orders(orderbook.clone()).boxed();
-    let get_trades = get_trades::get_trades(database).boxed();
-    let cancel_order = cancel_order::cancel_order(orderbook.clone()).boxed();
-    let get_amount_estimate =
-        get_markets::get_amount_estimate(quoter.price_estimator.clone()).boxed();
-    let get_fee_and_quote_sell = get_fee_and_quote::get_fee_and_quote_sell(quoter.clone()).boxed();
-    let get_fee_and_quote_buy = get_fee_and_quote::get_fee_and_quote_buy(quoter.clone()).boxed();
-    let get_user_orders = get_user_orders::get_user_orders(orderbook.clone()).boxed();
-    let get_orders_by_tx = get_orders_by_tx::get_orders_by_tx(orderbook).boxed();
-    let post_quote = post_quote::post_quote(quoter).boxed();
+    // api/v1
+    let create_order = (
+        "/api/v1/orders",
+        create_order::create_order(orderbook.clone()),
+    );
+    let get_orders = ("/api/v1/orders", get_orders::get_orders(orderbook.clone()));
+    let get_fee_info = (
+        "/api/v1/fee",
+        get_fee_info::get_fee_info(quoter.fee_calculator.clone()),
+    );
+    let get_order_by_uid = (
+        "/api/v1/orders/*",
+        get_order_by_uid::get_order_by_uid(orderbook.clone()),
+    );
+    let get_solvable_orders = (
+        "/api/v1/solvable_orders",
+        get_solvable_orders::get_solvable_orders(orderbook.clone()),
+    );
+    let get_trades = ("/api/v1/trades", get_trades::get_trades(database));
+    let cancel_order = (
+        "/api/v1/orders/*",
+        cancel_order::cancel_order(orderbook.clone()),
+    );
+    let get_markets = (
+        "/api/v1/markets/*/*/*",
+        get_markets::get_amount_estimate(quoter.price_estimator.clone()),
+    );
+    let get_fee_and_quote_sell = (
+        "/api/v1/feeAndQuote/sell",
+        get_fee_and_quote::get_fee_and_quote_sell(quoter.clone()),
+    );
+    let get_fee_and_quote_buy = (
+        "/api/v1/feeAndQuote/buy",
+        get_fee_and_quote::get_fee_and_quote_buy(quoter.clone()),
+    );
+    let get_user_orders = (
+        "/api/v1/account/*/orders",
+        get_user_orders::get_user_orders(orderbook.clone()),
+    );
+    let get_orders_by_tx = (
+        "/api/v1/transactions/*/orders",
+        get_orders_by_tx::get_orders_by_tx(orderbook.clone()),
+    );
+    let post_quote = ("/api/v1/quote", post_quote::post_quote(quoter));
+
+    // api/v2
+    let get_solvable_orders_v2 = (
+        "/api/v2/solvable_orders",
+        get_solvable_orders_v2::get_solvable_orders(orderbook),
+    );
+
     let cors = warp::cors()
         .allow_any_origin()
         .allow_methods(vec!["GET", "POST", "DELETE", "OPTIONS", "PUT", "PATCH"])
         .allow_headers(vec!["Origin", "Content-Type", "X-Auth-Token", "X-AppId"]);
-    let routes_with_labels = (warp::path!("api" / "v1" / ..)
-        .and(create_order.with(handle_metrics("create_order"))))
-    .or(warp::path!("api" / "v1" / ..).and(get_orders.with(handle_metrics("get_orders"))))
-    .or(warp::path!("api" / "v1" / ..).and(fee_info.with(handle_metrics("fee_info"))))
-    .or(warp::path!("api" / "v1" / ..).and(get_order.with(handle_metrics("get_order"))))
-    .or(warp::path!("api" / "v1" / ..)
-        .and(get_solvable_orders.with(handle_metrics("get_solvable_orders"))))
-    .or(warp::path!("api" / "v2" / ..)
-        .and(get_solvable_orders_v2.with(handle_metrics("get_solvable_orders"))))
-    .or(warp::path!("api" / "v1" / ..).and(get_trades.with(handle_metrics("get_trades"))))
-    .or(warp::path!("api" / "v1" / ..).and(cancel_order.with(handle_metrics("cancel_order"))))
-    .or(warp::path!("api" / "v1" / ..)
-        .and(get_amount_estimate.with(handle_metrics("get_amount_estimate"))))
-    .or(warp::path!("api" / "v1" / ..)
-        .and(get_fee_and_quote_sell.with(handle_metrics("get_fee_and_quote_sell"))))
-    .or(warp::path!("api" / "v1" / ..)
-        .and(get_fee_and_quote_buy.with(handle_metrics("get_fee_and_quote_buy"))))
-    .or(warp::path!("api" / "v1" / ..).and(get_user_orders.with(handle_metrics("get_user_orders"))))
-    .or(warp::path!("api" / "v1" / ..).and(get_orders_by_tx.with(handle_metrics("get_user_by_tx"))))
-    .or(warp::path!("api" / "v1" / ..).and(post_quote.with(handle_metrics("post_quote"))));
 
-    routes_with_labels.recover(handle_rejection).with(cors)
+    let v1 = warp::path!("api" / "v1" / ..).and(
+        (create_order.1)
+            .or(get_orders.1)
+            .or(get_fee_info.1)
+            .or(get_order_by_uid.1)
+            .or(get_solvable_orders.1)
+            .or(get_trades.1)
+            .or(cancel_order.1)
+            .or(get_markets.1)
+            .or(get_fee_and_quote_sell.1)
+            .or(get_fee_and_quote_buy.1)
+            .or(get_user_orders.1)
+            .or(get_orders_by_tx.1)
+            .or(post_quote.1),
+    );
+
+    let v2 = warp::path!("api" / "v1" / ..).and(get_solvable_orders_v2.1);
+
+    let routes = v1.or(v2);
+
+    routes
+        .recover(handle_rejection)
+        .with(cors)
+        .with(metrics::handle_metrics([
+            create_order.0,
+            get_orders.0,
+            get_fee_info.0,
+            get_order_by_uid.0,
+            get_solvable_orders.0,
+            get_trades.0,
+            cancel_order.0,
+            get_markets.0,
+            get_fee_and_quote_sell.0,
+            get_fee_and_quote_buy.0,
+            get_user_orders.0,
+            get_orders_by_tx.0,
+            post_quote.0,
+            get_solvable_orders_v2.0,
+        ]))
+        .with(warp::log::custom(|info| {
+            tracing::info!(
+                "{} \"{}\" {} {:?}",
+                info.method(),
+                info.path(),
+                info.status().as_str(),
+                info.elapsed(),
+            );
+        }))
 }
 
 pub type ApiReply = warp::reply::WithStatus<warp::reply::Json>;
@@ -81,31 +144,6 @@ pub type ApiReply = warp::reply::WithStatus<warp::reply::Json>;
 // We turn Rejection into Reply to workaround warp not setting CORS headers on rejections.
 async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
     Ok(err.default_response())
-}
-
-fn handle_metrics(endpoint: impl Into<String>) -> warp::log::Log<impl Fn(warp::log::Info) + Clone> {
-    let metrics = ApiMetrics::instance(get_metric_storage_registry(), endpoint.into()).unwrap();
-
-    warp::log::custom(move |info: warp::log::Info| {
-        metrics
-            .requests_complete
-            .with_label_values(&[info.status().as_str()])
-            .inc();
-        metrics
-            .requests_duration_seconds
-            .observe(info.elapsed().as_secs_f64());
-    })
-}
-
-#[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
-#[metric(subsystem = "api", labels("endpoint"))]
-struct ApiMetrics {
-    /// Number of completed API requests.
-    #[metric(labels("status_code"))]
-    requests_complete: prometheus::CounterVec,
-
-    /// Execution time for each API request.
-    requests_duration_seconds: prometheus::Histogram,
 }
 
 #[derive(Serialize)]

--- a/crates/orderbook/src/api/create_order.rs
+++ b/crates/orderbook/src/api/create_order.rs
@@ -5,6 +5,7 @@ use crate::{
 use anyhow::Result;
 use model::order::OrderCreationPayload;
 use std::{convert::Infallible, sync::Arc};
+use warp::filters::BoxedFilter;
 use warp::reply::with_status;
 use warp::{hyper::StatusCode, Filter, Rejection};
 
@@ -34,24 +35,24 @@ pub fn create_order_response(result: Result<AddOrderResult>) -> super::ApiReply 
     }
 }
 
-pub fn create_order(
-    orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    create_order_request().and_then(move |order_payload: OrderCreationPayload| {
-        let orderbook = orderbook.clone();
-        async move {
-            let order_payload_clone = order_payload.clone();
-            let result = orderbook.add_order(order_payload).await;
-            // TODO - This is one place where the error log is more rich than the
-            //  generic error inside internal_error (i.e. doesn't include order_payload).
-            //  Perhaps this should be a warning and the real alert comes from the internal error.
-            //  Otherwise we should just resort to using this error logging style everywhere.
-            if let Err(err) = &result {
-                tracing::error!(?err, ?order_payload_clone, "add_order error");
+pub fn create_order(orderbook: Arc<Orderbook>) -> BoxedFilter<(super::ApiReply,)> {
+    create_order_request()
+        .and_then(move |order_payload: OrderCreationPayload| {
+            let orderbook = orderbook.clone();
+            async move {
+                let order_payload_clone = order_payload.clone();
+                let result = orderbook.add_order(order_payload).await;
+                // TODO - This is one place where the error log is more rich than the
+                //  generic error inside internal_error (i.e. doesn't include order_payload).
+                //  Perhaps this should be a warning and the real alert comes from the internal error.
+                //  Otherwise we should just resort to using this error logging style everywhere.
+                if let Err(err) = &result {
+                    tracing::error!(?err, ?order_payload_clone, "add_order error");
+                }
+                Result::<_, Infallible>::Ok(create_order_response(result))
             }
-            Result::<_, Infallible>::Ok(create_order_response(result))
-        }
-    })
+        })
+        .boxed()
 }
 
 #[cfg(test)]

--- a/crates/orderbook/src/api/get_fee_and_quote.rs
+++ b/crates/orderbook/src/api/get_fee_and_quote.rs
@@ -8,6 +8,7 @@ use ethcontract::{H160, U256};
 use model::u256_decimal;
 use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, sync::Arc};
+use warp::filters::BoxedFilter;
 use warp::{Filter, Rejection};
 
 #[derive(Debug, Serialize)]
@@ -115,36 +116,36 @@ fn buy_request() -> impl Filter<Extract = (BuyQuery,), Error = Rejection> + Clon
         .and(warp::query::<BuyQuery>())
 }
 
-pub fn get_fee_and_quote_sell(
-    quoter: Arc<OrderQuoter>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    sell_request().and_then(move |query: SellQuery| {
-        let quoter = quoter.clone();
-        async move {
-            Result::<_, Infallible>::Ok(convert_json_response(
-                quoter
-                    .calculate_quote(&query.into())
-                    .await
-                    .map(SellResponse::from),
-            ))
-        }
-    })
+pub fn get_fee_and_quote_sell(quoter: Arc<OrderQuoter>) -> BoxedFilter<(super::ApiReply,)> {
+    sell_request()
+        .and_then(move |query: SellQuery| {
+            let quoter = quoter.clone();
+            async move {
+                Result::<_, Infallible>::Ok(convert_json_response(
+                    quoter
+                        .calculate_quote(&query.into())
+                        .await
+                        .map(SellResponse::from),
+                ))
+            }
+        })
+        .boxed()
 }
 
-pub fn get_fee_and_quote_buy(
-    quoter: Arc<OrderQuoter>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    buy_request().and_then(move |query: BuyQuery| {
-        let quoter = quoter.clone();
-        async move {
-            Result::<_, Infallible>::Ok(convert_json_response(
-                quoter
-                    .calculate_quote(&query.into())
-                    .await
-                    .map(BuyResponse::from),
-            ))
-        }
-    })
+pub fn get_fee_and_quote_buy(quoter: Arc<OrderQuoter>) -> BoxedFilter<(super::ApiReply,)> {
+    buy_request()
+        .and_then(move |query: BuyQuery| {
+            let quoter = quoter.clone();
+            async move {
+                Result::<_, Infallible>::Ok(convert_json_response(
+                    quoter
+                        .calculate_quote(&query.into())
+                        .await
+                        .map(BuyResponse::from),
+                ))
+            }
+        })
+        .boxed()
 }
 
 #[cfg(test)]

--- a/crates/orderbook/src/api/get_orders_by_tx.rs
+++ b/crates/orderbook/src/api/get_orders_by_tx.rs
@@ -2,22 +2,23 @@ use crate::{api::convert_json_response, orderbook::Orderbook};
 use anyhow::Result;
 use ethcontract::H256;
 use std::{convert::Infallible, sync::Arc};
+use warp::filters::BoxedFilter;
 use warp::{Filter, Rejection};
 
 pub fn get_orders_by_tx_request() -> impl Filter<Extract = (H256,), Error = Rejection> + Clone {
     warp::path!("transactions" / H256 / "orders").and(warp::get())
 }
 
-pub fn get_orders_by_tx(
-    orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    get_orders_by_tx_request().and_then(move |hash: H256| {
-        let orderbook = orderbook.clone();
-        async move {
-            let result = orderbook.get_orders_for_tx(&hash).await;
-            Result::<_, Infallible>::Ok(convert_json_response(result))
-        }
-    })
+pub fn get_orders_by_tx(orderbook: Arc<Orderbook>) -> BoxedFilter<(super::ApiReply,)> {
+    get_orders_by_tx_request()
+        .and_then(move |hash: H256| {
+            let orderbook = orderbook.clone();
+            async move {
+                let result = orderbook.get_orders_for_tx(&hash).await;
+                Result::<_, Infallible>::Ok(convert_json_response(result))
+            }
+        })
+        .boxed()
 }
 
 #[cfg(test)]

--- a/crates/orderbook/src/api/get_solvable_orders.rs
+++ b/crates/orderbook/src/api/get_solvable_orders.rs
@@ -1,22 +1,23 @@
 use crate::{api::convert_json_response, orderbook::Orderbook};
 use anyhow::Result;
 use std::{convert::Infallible, sync::Arc};
+use warp::filters::BoxedFilter;
 use warp::{Filter, Rejection};
 
 fn get_solvable_orders_request() -> impl Filter<Extract = (), Error = Rejection> + Clone {
     warp::path!("solvable_orders").and(warp::get())
 }
 
-pub fn get_solvable_orders(
-    orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    get_solvable_orders_request().and_then(move || {
-        let orderbook = orderbook.clone();
-        async move {
-            let result = orderbook.get_solvable_orders().await;
-            Result::<_, Infallible>::Ok(convert_json_response(
-                result.map(|solvable_orders| solvable_orders.orders),
-            ))
-        }
-    })
+pub fn get_solvable_orders(orderbook: Arc<Orderbook>) -> BoxedFilter<(super::ApiReply,)> {
+    get_solvable_orders_request()
+        .and_then(move || {
+            let orderbook = orderbook.clone();
+            async move {
+                let result = orderbook.get_solvable_orders().await;
+                Result::<_, Infallible>::Ok(convert_json_response(
+                    result.map(|solvable_orders| solvable_orders.orders),
+                ))
+            }
+        })
+        .boxed()
 }

--- a/crates/orderbook/src/api/metrics.rs
+++ b/crates/orderbook/src/api/metrics.rs
@@ -1,0 +1,172 @@
+//! Code for reporting per-url metrics.
+//!
+//! The only correct way to report a request is by wrapping the top-level
+//! warp filter into a `warp::log::custom`. Other ways (logging with `map`
+//! or wrapping API filters separately) have some pitfalls. Specifically,
+//! they don't report requests that didn't match any filter, they also
+//! may report a request multiple times.
+//!
+//! When using `warp::log::custom`, we get a full request path for reporting.
+//! The issue is that we can't create a separate metric for each requested
+//! path. This is because our paths contain variable parameters. For example,
+//! consider two requests, `/api/v1/orders/id1` and `/api/v1/orders/id2`.
+//! If we were to use a request path as a metric label, we'd get two metrics,
+//! one for `id1` and another one for `id2`.
+//!
+//! Therefore, we need to sanitize the path and replace all variable parameters
+//! with asterisks, so our metric label looks like `/api/v1/orders/*`.
+//! We also need to strip any unexpected parts of the url, in case someone
+//! sends a request to a path that doesn't exist. So `/api/v1/some-junk`
+//! should become `/api/v1/..`.
+//!
+//! We do this by taking a list of allowed path patterns, and comparing
+//! all requested paths to them.
+//!
+//! Patterns are just regular paths with asterisks in places
+//! of variable parameters. For the example above, the pattern
+//! would be `/api/v1/orders/*`.
+
+use shared::metrics::get_metric_storage_registry;
+use std::collections::HashMap;
+
+/// Creates a wrapper for warp filters that reports per-request metrics.
+///
+/// See the module documentation for more info.
+pub fn handle_metrics<Paths, Path>(paths: Paths) -> warp::log::Log<impl Fn(warp::log::Info) + Clone>
+where
+    Paths: IntoIterator<Item = Path>,
+    Path: AsRef<str>,
+{
+    handle_metrics_impl(PathSegmentTree::from_paths(paths))
+}
+
+fn handle_metrics_impl(tree: PathSegmentTree) -> warp::log::Log<impl Fn(warp::log::Info) + Clone> {
+    let metrics = ApiMetrics::instance(get_metric_storage_registry()).unwrap();
+
+    warp::log::custom(move |info: warp::log::Info| {
+        let path = tree.sanitize(info.path());
+        metrics
+            .requests_complete
+            .with_label_values(&[&path, info.method().as_str(), info.status().as_str()])
+            .inc();
+        metrics
+            .requests_duration_seconds
+            .with_label_values(&[&path, info.method().as_str()])
+            .observe(info.elapsed().as_secs_f64());
+    })
+}
+
+#[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
+#[metric(subsystem = "api")]
+struct ApiMetrics {
+    /// Number of completed API requests.
+    #[metric(labels("url", "method", "status_code"))]
+    requests_complete: prometheus::CounterVec,
+
+    /// Execution time for each API request.
+    #[metric(labels("url", "method"))]
+    requests_duration_seconds: prometheus::HistogramVec,
+}
+
+#[derive(Default, Debug, Clone)]
+struct PathSegmentTree {
+    root: PathSegmentTreeNode,
+}
+
+#[derive(Default, Debug, Clone)]
+struct PathSegmentTreeNode {
+    leaves: HashMap<String, PathSegmentTreeNode>,
+}
+
+impl PathSegmentTree {
+    fn from_paths<Paths, Path>(paths: Paths) -> Self
+    where
+        Paths: IntoIterator<Item = Path>,
+        Path: AsRef<str>,
+    {
+        let mut tree = PathSegmentTree::default();
+        for path in paths {
+            tree.add_path(path.as_ref());
+        }
+        tree
+    }
+
+    fn add_path(&mut self, mut path: &str) {
+        let mut segments = &mut self.root;
+
+        // Path always starts with a slash, so we ignore it.
+        path = path.strip_prefix('/').unwrap_or(path);
+
+        while !path.is_empty() {
+            let (head, tail) = path.split_once('/').unwrap_or((path, ""));
+            segments = segments
+                .leaves
+                .entry(head.into())
+                .or_insert_with(Default::default);
+            path = tail;
+        }
+    }
+
+    fn sanitize(&self, mut path: &str) -> String {
+        let mut segments = &self.root;
+
+        // Path always starts with a slash, so we ignore it.
+        path = path.strip_prefix('/').unwrap_or(path);
+
+        if path.is_empty() {
+            return "/".into();
+        }
+
+        let mut sanitized = String::with_capacity(128);
+
+        while !path.is_empty() {
+            let (head, tail) = path.split_once('/').unwrap_or((path, ""));
+            if let Some(subsegments) = segments.leaves.get(head) {
+                sanitized.push('/');
+                sanitized.push_str(head);
+                segments = subsegments;
+            } else if let Some(subsegments) = segments.leaves.get("*") {
+                sanitized.push_str("/*");
+                segments = subsegments;
+            } else {
+                sanitized.push_str("/..");
+                break;
+            }
+            path = tail;
+        }
+
+        sanitized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize() {
+        let segments =
+            PathSegmentTree::from_paths(["/orders", "/orders/*", "/orders/*/status", "/fee"]);
+
+        assert_eq!(segments.sanitize("/"), "/");
+        assert_eq!(segments.sanitize("/orders"), "/orders");
+        assert_eq!(segments.sanitize("/orders/1"), "/orders/*");
+        assert_eq!(segments.sanitize("/orders/1/status"), "/orders/*/status");
+        assert_eq!(
+            segments.sanitize("/orders/1/status/whatever"),
+            "/orders/*/status/.."
+        );
+        assert_eq!(
+            segments.sanitize("/orders/1/status/x/y/z"),
+            "/orders/*/status/.."
+        );
+        assert_eq!(segments.sanitize("/orders/1/x/y/z"), "/orders/*/..");
+        assert_eq!(segments.sanitize("/fee"), "/fee");
+        assert_eq!(segments.sanitize("/fee/x"), "/fee/..");
+        assert_eq!(segments.sanitize("/other/url"), "/..");
+
+        assert_eq!(segments.sanitize("/fee"), "/fee");
+        assert_eq!(segments.sanitize("/fee/"), "/fee");
+        assert_eq!(segments.sanitize("/fee//"), "/fee/..");
+    }
+}


### PR DESCRIPTION
Fixes over-reporting of API metrics for non-200 requests.

So far, we've tried two ways of reporting warp metrics. Both had issues.

The first version used the `map` filter. It didn't report requests that didn't end with an `Ok`. This is because `map` don't handle errors, and `map_err` is not available in the public warp interface. It also didn't report requests for URLs that don't match any endpoints.

The second version used one `warp::log::custom` for each endpoint. It ended up over-reporting 404s. This is becuase of how warp filters work. Consider the following setup:

```rust
    path!("endpoint_1").with(handle_metrics_for_endpoint_1)
.or(path!("endpoint_2").with(handle_metrics_for_endpoint_2))
.or(path!("endpoint_3").with(handle_metrics_for_endpoint_3))
```

In this case we have the following class structure:

```

or ---- handle_metrics_for_endpoint_1 ---- path!("endpoint_1")
|
or ---- handle_metrics_for_endpoint_2 ---- path!("endpoint_2")
|
+------ handle_metrics_for_endpoint_3 ---- path!("endpoint_3")

```

If we request `endpoint_3`, warp will run all filters top-to-bottom. It will first descend into `path!("endpoint_1")`. Then `path!("endpoint_1")` will reject url `endpoint_3` and bail an error into `handle_metrics_for_endpoint_1`. The `handle_metrics_for_endpoint_1` will report a 404 for endpoint 1 and bail an error into the first `or`. The first `or` will then call its right branch, eventually descending into `path!("endpoint_2")`... By the time we reach `path!("endpoint_3")`, a whole bunch of 404s would've been already reported.

So, the only correct way to report a request is by wrapping the top-level filter into a `warp::log::custom`.

For this to work correctly, we'll need to sanitize paths by removing variable parameters from them (i.e. replace `/api/v1/orders/<order_id>` with `/api/v1/orders/*`). I've tried my best to come up with a solution that don't require explicitly listing all allowed URLs, but failed. Unfortunately, we can't inspect warp filters and extract all endpoints and their parameters. Therefore, we have to create an explicit list of all valid URLs, and pass it to the sanitizer. I don't like it, but I don't know how to improve it.

### Test Plan
New and existing unit tests.
Manual testing:
- check that 200s are reported correctly for multiple API endpoints,
- check that 400s and 404s are reported correctly for multiple API endpoints,
- check that requests that don't match any endpoint are reported correctly.
