### PR TITLE
Change gas limit for simulations

### DIFF
--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -95,9 +95,9 @@ pub async fn simulate_and_error_with_tenderly_link(
                 .block(BlockId::Number(block.into()))
                 // Since we now supply the gas price for the simulation, make sure to also
                 // set a gas limit so we don't get failed simulations because of insufficient
-                // solver balance for the default ~150M gas limit. Limit to around the
-                // block gas limit (since we can't fit more anyway).
-                .gas(30_000_000.into());
+                // solver balance for the default ~15M gas limit. Limit to around the
+                // block gas limit / 2 (since just filling the halve a block is unrealistic).
+                .gas(15_000_000.into());
             (view.batch_call(&mut batch), transaction_builder)
         })
         .collect::<Vec<_>>();

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -96,7 +96,7 @@ pub async fn simulate_and_error_with_tenderly_link(
                 // Since we now supply the gas price for the simulation, make sure to also
                 // set a gas limit so we don't get failed simulations because of insufficient
                 // solver balance for the default ~15M gas limit. Limit to around the
-                // block gas limit / 2 (since just filling the halve a block is unrealistic).
+                // block gas limit / 2 (as settling bigger tx is unrealistic anyways).
                 .gas(15_000_000.into());
             (view.batch_call(&mut batch), transaction_builder)
         })


### PR DESCRIPTION
Currently, we have a lot of failed simulations due to insufficient funds:
See for example [here](https://logs.gnosisdev.com/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2021-12-12T13:22:04.172Z',to:'2021-12-12T14:19:17.385Z'))&_a=(columns:!(log),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:de1f5360-a9ae-11ea-acbb-9d2e3cb124ca,key:kubernetes.pod_name,negate:!f,params:(query:dev-dfusion-v2-solver-mainnet),type:phrase),query:(match_phrase:(kubernetes.pod_name:dev-dfusion-v2-solver-mainnet))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:de1f5360-a9ae-11ea-acbb-9d2e3cb124ca,key:log,negate:!t,params:(query:DEBUG),type:phrase),query:(match_phrase:(log:DEBUG)))),index:de1f5360-a9ae-11ea-acbb-9d2e3cb124ca,interval:auto,query:(language:kuery,query:'log:%20%22insufficient%20funds%20for%20gas%20*%20price%20%2B%20value%22'),sort:!(!('@timestamp',desc))))

Hence, I am halving the gas limit for simulation. This will also halve the amount of funds needed to simulate a tx.

### Test Plan
non