### PR TITLE
implements timeout for price estimators 

### DIFF
--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -4,7 +4,6 @@ use futures::future;
 use num::BigRational;
 use std::cmp;
 use std::time::Duration;
-use tokio::time::error::Elapsed;
 use tokio::time::timeout;
 /// Price estimator that pulls estimates from various sources
 /// and competes on the best price.
@@ -41,12 +40,11 @@ impl PriceEstimating for CompetitionPriceEstimator {
                         Err(PriceEstimationError::Other(anyhow!(
                             "no successful price estimates"
                         ))),
-                        |previous_result, (name, estimates): &(&String, Result<Vec<Result<Estimate, PriceEstimationError>>, Elapsed>)| {
+                        |previous_result, (name, estimates)| {
                             match estimates {
                                 Ok(estimates) => fold_price_estimation_result(
                                     query,
                                     name,
-
                                     previous_result,
                                     estimates.clone()[i].clone(),
                                 ),


### PR DESCRIPTION
implements timeout for price estimators to quicker send results back to front-end

Currently, we have a lot of warnings that some price estimations take a long time on post quote. My suspicion is that the price estimator takes quite long for these instances. Hence, we eliminate all price estimations that take longer than 3 secs in order to provide a good result after 3 seconds from other estimators. Always waiting for the slowest makes no sense to me.

I am very unsure whether this is the right approach. Maybe just measuring the time for price-estimator and then working on the price estimators itself makes more sense. That is why this PR is in draft.
### Test Plan
Non