### PR TITLE
Consider settlement with recent orders if they are part of "mature" settlements

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -444,13 +444,11 @@ impl Driver {
                 &mut settlements,
             );
 
-            solver_settlements::filter_settlements_without_old_orders(
-                self.min_order_age,
-                &mut settlements,
-            );
+            let mature_settlements =
+                solver_settlements::retain_mature_settlements(self.min_order_age, settlements);
 
-            solver_settlements.reserve(settlements.len());
-            for settlement in settlements {
+            solver_settlements.reserve(mature_settlements.len());
+            for settlement in mature_settlements {
                 solver_settlements.push((solver.clone(), settlement))
             }
         }


### PR DESCRIPTION
Fixes #1310 

See linked issue to read the motivation.  

Implementation:
We get a `Vec<Settlement>` and iterate over it. If a settlement includes a mature order (older than passed time) or a recent order which has been considered valid at one point, all orders within the current settlement (including recent orders) are considered valid and we look at the next settlement.
We keep looping over all settlements until we reach a point where no new orders have been added to the valid set. Now we know all of the valid orders.
Because this can get computationally expensive for many settlements with many orders, validated settlements get stored in a `HashSet` in order to quickly determine on each iteration whether we can skip looking at the current settlement.

### Test Plan
Added unit test for 3 scenarios:
1) No settlement includes any "mature" orders => No settlements should be considered
2) 2 disjoint settlements (one including mature order, one including no mature orders) => only the settlement with the mature order is considered
3) Multiple settlements (1 including mature order) arranged like a linked list => Because 1 settlement includes mature order the other settlements "linked" to it are also considered valid