### PR TITLE
Update Balancer cache

### DIFF
--- a/crates/shared/src/sources/balancer_v2/pool_fetching/cache.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching/cache.rs
@@ -75,7 +75,8 @@ where
     Inner: InternalPoolFetching,
 {
     async fn run_maintenance(&self) -> Result<()> {
-        self.inner.run_maintenance().await
+        futures::try_join!(self.inner.run_maintenance(), self.cache.update_cache())?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This PR changes the `Cached` pool fetcher to actually update its cache!

This is important for a couple of reasons:
- eagerly fetch Balancer pools on new blocks to speed up solving.
- clean up old pool data so the cache doesn't grow indefinitely.

We noticed this because we found a what looked like a memory leak in our solver pod. It turns out that this is because the cache is on `(BlockNumber, PoolId)` keys. So every time we fetched Balancer pools for new blocks, we would add the pool data to the cache. However, cache clean-up (i.e. removing old `(BlockNumber, PoolId)`) only happens on `update_cache`! This meant that our cache was growing indefinitely and never cleaning up older Balancer pools.

### Test Plan

Trivial change. No new tests.

We can run the solver locally to see it actually cleaning up pools now:
```
$ cargo run -p solver
...
2021-12-21T09:35:33.983Z DEBUG shared::recent_block_cache: dropping blocks older than 13847749 from cache
2021-12-21T09:35:33.983Z DEBUG shared::recent_block_cache: the cache now contains entries for 12 block-key combinations
...
```

Additionally, once this change merges, we should look at memory consumption in Grafana to make sure it isn't increasing non-stop.
