### PR TITLE
Add configuration for enabled Balancer factories

### DIFF
--- a/crates/shared/src/sources/balancer_v2.rs
+++ b/crates/shared/src/sources/balancer_v2.rs
@@ -37,3 +37,8 @@ pub mod pool_fetching;
 mod pool_init;
 pub mod pools;
 pub mod swap;
+
+pub use self::{
+    pool_fetching::{BalancerFactoryKind, BalancerPoolFetcher, BalancerPoolFetching},
+    pools::{Pool, PoolKind},
+};

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -152,7 +152,7 @@ impl BalancerFactoryKind {
     pub fn all() -> Vec<Self> {
         // take advantage of the auto-generated `::variants()` associated
         // function so we don't have to keep updating this method with new kinds
-        // as they get added. A little inneficient though.
+        // as they get added. Slightly inefficient.
         Self::variants()
             .iter()
             .map(|name| {

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -360,6 +360,11 @@ mod tests {
         );
     }
 
+    #[test]
+    fn enumerates_all_balancer_factory_kinds() {
+        assert!(!BalancerFactoryKind::all().is_empty());
+    }
+
     #[tokio::test]
     #[ignore]
     async fn balancer_fetched_pools_match_subgraph() {

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -278,8 +278,12 @@ async fn create_aggregate_pool_fetcher(
     // Just to catch cases where new Balancer factories get added for a pool
     // kind, but we don't index it, log a warning for unused pools.
     if !registered_pools_by_factory.is_empty() {
+        let total_count = registered_pools_by_factory
+            .values()
+            .map(|registered| registered.pools.len())
+            .sum::<usize>();
         tracing::warn!(
-            unused_pools = ?registered_pools_by_factory,
+            %total_count, unused_pools = ?registered_pools_by_factory,
             "found pools that don't correspond to any known Balancer pool factory",
         );
     }

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -12,7 +12,7 @@ use shared::{
     recent_block_cache::CacheConfig,
     sources::{
         self,
-        balancer_v2::pool_fetching::BalancerPoolFetcher,
+        balancer_v2::{BalancerFactoryKind, BalancerPoolFetcher},
         uniswap_v2::{
             pool_cache::PoolCache,
             pool_fetching::{PoolFetcher, PoolFetching},
@@ -257,6 +257,18 @@ struct Arguments {
     /// The maximum number of settlements the driver considers per solver.
     #[structopt(long, env, default_value = "20")]
     max_settlements_per_solver: usize,
+
+    /// The Balancer V2 factories to consider for indexing liquidity. Allows
+    /// specific pool kinds to be disabled via configuration. Will use all
+    /// supported Balancer V2 factory kinds if not specified.
+    #[structopt(
+        long,
+        env,
+        possible_values = &BalancerFactoryKind::variants(),
+        case_insensitive = true,
+        use_delimiter = true
+    )]
+    balancer_factories: Option<Vec<BalancerFactoryKind>>,
 }
 
 arg_enum! {
@@ -420,6 +432,8 @@ async fn main() {
                 chain_id,
                 web3.clone(),
                 token_info_fetcher.clone(),
+                args.balancer_factories
+                    .unwrap_or_else(BalancerFactoryKind::all),
                 cache_config,
                 current_block_stream.clone(),
                 metrics.clone(),


### PR DESCRIPTION
Fixes #1491. This PR is built on the refactor proposed in #1487.

This PR adds a new configuration option for selecting which Balancer V2 factories to use as baseline sources.

The motivation behind this change is that it would allow us to add new Balancer V2 factories kinds (like LBPs) with relatively low risk, since we can always disable them via configuration if we encounter an issue instead of requiring a code change + hotfix.

### Test Plan

Run with different configurations:
```
$ cargo run -p solver
...
2021-12-21T11:14:20.230Z DEBUG shared::sources::balancer_v2::pool_init: initialized registered pools block=13848181 pools=159
...
$ cargo run -p solver -- --balancer-factories Weighted
...
2021-12-21T11:20:49.509Z DEBUG shared::sources::balancer_v2::pool_init: initialized registered pools block=13848203 pools=159
2021-12-21T11:20:49.601Z  WARN shared::sources::balancer_v2::pool_fetching: found pools that don't correspond to any known Balancer pool factory total_count=75 unused_pools=...
...
$ cargo run -p solver -- --balancer-factories Weighed2Token
...
2021-12-21T11:24:17.287Z DEBUG shared::sources::balancer_v2::pool_init: initialized registered pools block=13848215 pools=159
2021-12-21T11:24:17.379Z  WARN shared::sources::balancer_v2::pool_fetching: found pools that don't correspond to any known Balancer pool factory total_count=87 unused_pools=...
...
$ cargo run -p solver -- --balancer-factories Stable
...
2021-12-21T11:22:39.179Z DEBUG shared::sources::balancer_v2::pool_init: initialized registered pools block=13848209 pools=159
2021-12-21T11:22:39.270Z  WARN shared::sources::balancer_v2::pool_fetching: found pools that don't correspond to any known Balancer pool factory total_count=156 unused_pools=...
...
```

Noticing that
- `Weighted`: `159 - 75 = 79`,
- `Weighted2Token`: `159 - 87 = 72`,
- `Stable`: `159 - 156 = 3`,
- Total: `79 + 72 + 3 = 159`