### PR TITLE
Validate Price Estimation Queries Early and at a Single Point

### DIFF
--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -401,7 +401,6 @@ async fn main() {
                             pool_fetcher.clone(),
                             gas_price_estimator.clone(),
                             base_tokens.clone(),
-                            bad_token_detector.clone(),
                             native_token.address(),
                             native_token_price_estimation_amount,
                         ),
@@ -415,7 +414,6 @@ async fn main() {
                                 partner: args.shared.paraswap_partner.clone().unwrap_or_default(),
                             }),
                             token_info: token_info_fetcher.clone(),
-                            bad_token_detector: bad_token_detector.clone(),
                             disabled_paraswap_dexs: args.shared.disabled_paraswap_dexs.clone(),
                         },
                         estimator.name(),
@@ -424,7 +422,6 @@ async fn main() {
                     PriceEstimatorType::ZeroEx => Box::new(InstrumentedPriceEstimator::new(
                         ZeroExPriceEstimator {
                             api: zeroex_api.clone(),
-                            bad_token_detector: bad_token_detector.clone(),
                         },
                         estimator.name(),
                         metrics.clone(),
@@ -448,7 +445,6 @@ async fn main() {
                                 },
                             }),
                             pools: pool_fetcher.clone(),
-                            bad_token_detector: bad_token_detector.clone(),
                             token_info: token_info_fetcher.clone(),
                             gas_info: gas_price_estimator.clone(),
                             native_token: native_token.address(),

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -22,6 +22,7 @@ use primitive_types::H160;
 use shared::http_solver_api::{DefaultHttpSolverApi, SolverConfig};
 use shared::network::network_name;
 use shared::price_estimation::quasimodo::QuasimodoPriceEstimator;
+use shared::price_estimation::sanitized::SanitizedPriceEstimator;
 use shared::price_estimation::zeroex::ZeroExPriceEstimator;
 use shared::zeroex_api::DefaultZeroExApi;
 use shared::{
@@ -460,7 +461,11 @@ async fn main() {
             )
         })
         .collect::<Vec<_>>();
-    let price_estimator = Arc::new(CompetitionPriceEstimator::new(price_estimators));
+    let price_estimator = Arc::new(SanitizedPriceEstimator::new(
+        CompetitionPriceEstimator::new(price_estimators),
+        native_token.address(),
+        bad_token_detector.clone(),
+    ));
     let fee_calculator = Arc::new(EthAwareMinFeeCalculator::new(
         price_estimator.clone(),
         gas_price_estimator,

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -5,6 +5,7 @@ pub mod instrumented;
 pub mod paraswap;
 pub mod priority;
 pub mod quasimodo;
+pub mod sanitized;
 pub mod zeroex;
 
 use crate::{bad_token::BadTokenDetecting, conversions::U256Ext};

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -20,6 +20,12 @@ impl CompetitionPriceEstimator {
 #[async_trait::async_trait]
 impl PriceEstimating for CompetitionPriceEstimator {
     async fn estimates(&self, queries: &[Query]) -> Vec<Result<Estimate, PriceEstimationError>> {
+        debug_assert!(queries.iter().all(|query| {
+            query.buy_token != model::order::BUY_ETH_ADDRESS
+                && query.sell_token != model::order::BUY_ETH_ADDRESS
+                && query.sell_token != query.buy_token
+        }));
+
         let all_estimates =
             future::join_all(self.inner.iter().map(|(name, estimator)| async move {
                 (name, estimator.estimates(queries).await)

--- a/crates/shared/src/price_estimation/gas.rs
+++ b/crates/shared/src/price_estimation/gas.rs
@@ -51,3 +51,5 @@ pub static GAS_PER_UNISWAP: u64 = 94_696;
 /// https://etherscan.io/tx/0x72d234d35fd169ef497ba0a1dc23258c96f278fb688d375d135eb012e5311009
 /// https://etherscan.io/tx/0x1c345a6da1edb2bba953685a4cf85f6a0d967ac751f8c5b518578c5fd20a7c96
 pub static GAS_PER_BALANCER_SWAP: u64 = 120_000;
+
+pub static GAS_PER_WETH_UNWRAP: u64 = 14_192;

--- a/crates/shared/src/price_estimation/priority.rs
+++ b/crates/shared/src/price_estimation/priority.rs
@@ -25,6 +25,12 @@ fn log_errors(results: &[Result<Estimate, PriceEstimationError>], estimator_inde
 #[async_trait::async_trait]
 impl PriceEstimating for PriorityPriceEstimator {
     async fn estimates(&self, queries: &[Query]) -> Vec<Result<Estimate, PriceEstimationError>> {
+        debug_assert!(queries.iter().all(|query| {
+            query.buy_token != model::order::BUY_ETH_ADDRESS
+                && query.sell_token != model::order::BUY_ETH_ADDRESS
+                && query.sell_token != query.buy_token
+        }));
+
         let mut results = self.inner[0].estimates(queries).await;
         log_errors(&results, 0);
         for (i, inner) in (&self.inner[1..]).iter().enumerate() {

--- a/crates/shared/src/price_estimation/sanitized.rs
+++ b/crates/shared/src/price_estimation/sanitized.rs
@@ -1,0 +1,245 @@
+use super::{ensure_token_supported, Estimate, PriceEstimating, PriceEstimationError, Query};
+use crate::bad_token::BadTokenDetecting;
+use crate::price_estimation::gas::GAS_PER_WETH_UNWRAP;
+use anyhow::Result;
+use futures::future;
+use model::order::BUY_ETH_ADDRESS;
+use primitive_types::H160;
+use std::sync::Arc;
+
+/// Verifies that buy and sell tokens are supported and handles
+/// ETH as buy token appropriately.
+pub struct SanitizedPriceEstimator<T: PriceEstimating> {
+    inner: T,
+    bad_token_detector: Arc<dyn BadTokenDetecting>,
+    native_token: H160,
+}
+
+impl<T: PriceEstimating> SanitizedPriceEstimator<T> {
+    pub fn new(
+        inner: T,
+        native_token: H160,
+        bad_token_detector: Arc<dyn BadTokenDetecting>,
+    ) -> Self {
+        Self {
+            inner,
+            native_token,
+            bad_token_detector,
+        }
+    }
+    async fn estimate_sanitized_query(
+        &self,
+        query: &Query,
+    ) -> Result<Estimate, PriceEstimationError> {
+        if query.buy_token == query.sell_token {
+            return Ok(Estimate {
+                out_amount: query.in_amount,
+                gas: 0.into(),
+            });
+        }
+
+        ensure_token_supported(query.buy_token, self.bad_token_detector.as_ref()).await?;
+        ensure_token_supported(query.sell_token, self.bad_token_detector.as_ref()).await?;
+
+        let buy_eth = query.buy_token == BUY_ETH_ADDRESS;
+        let sanitized_query = if buy_eth {
+            Query {
+                buy_token: self.native_token,
+                ..*query
+            }
+        } else {
+            *query
+        };
+
+        let mut estimated_price = self.inner.estimate(&sanitized_query).await?;
+
+        if buy_eth {
+            estimated_price.gas = estimated_price
+                .gas
+                .checked_add(GAS_PER_WETH_UNWRAP.into())
+                .ok_or(anyhow::anyhow!(
+                    "cost of unwrapping ETH would overflow gas price"
+                ))?;
+        }
+
+        Ok(estimated_price)
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: PriceEstimating> PriceEstimating for SanitizedPriceEstimator<T> {
+    async fn estimates(&self, queries: &[Query]) -> Vec<Result<Estimate, PriceEstimationError>> {
+        future::join_all(
+            queries
+                .iter()
+                .map(|query| self.estimate_sanitized_query(query)),
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bad_token::{MockBadTokenDetecting, TokenQuality};
+    use crate::price_estimation::MockPriceEstimating;
+    use mockall::predicate::eq;
+    use model::order::OrderKind;
+    use primitive_types::{H160, U256};
+
+    const BAD_TOKEN: H160 = H160([0x12; 20]);
+
+    #[tokio::test]
+    async fn works() {
+        let mut bad_token_detector = MockBadTokenDetecting::new();
+        bad_token_detector.expect_detect().returning(|token| {
+            if token == BAD_TOKEN {
+                Ok(TokenQuality::Bad {
+                    reason: "Token not supported".into(),
+                })
+            } else {
+                Ok(TokenQuality::Good)
+            }
+        });
+
+        let native_token = H160::from_low_u64_le(1);
+
+        let queries = [
+            // This is the common case (Tokens are supported, distinct and not ETH).
+            // Will be estimated by the wrapped_estimator.
+            Query {
+                sell_token: H160::from_low_u64_le(1),
+                buy_token: H160::from_low_u64_le(2),
+                in_amount: 1.into(),
+                kind: OrderKind::Buy,
+            },
+            // `sanitized_estimator` will replace `buy_token` with `native_token` before querying
+            // `wrapped_estimator`.
+            // `sanitized_estimator` will add cost of unwrapping ETH to Estimate.
+            Query {
+                sell_token: H160::from_low_u64_le(1),
+                buy_token: BUY_ETH_ADDRESS,
+                in_amount: 1.into(),
+                kind: OrderKind::Buy,
+            },
+            // Will cause buffer overflow of gas price in `sanitized_estimator`.
+            Query {
+                sell_token: H160::from_low_u64_le(1),
+                buy_token: BUY_ETH_ADDRESS,
+                in_amount: U256::MAX,
+                kind: OrderKind::Buy,
+            },
+            // Can be estimated by `sanitized_estimator` because `buy_token` and `sell_token` are identical.
+            Query {
+                sell_token: H160::from_low_u64_le(1),
+                buy_token: H160::from_low_u64_le(1),
+                in_amount: 1.into(),
+                kind: OrderKind::Sell,
+            },
+            // Will throw `UnsupportedToken` error in `sanitized_estimator`.
+            Query {
+                sell_token: BAD_TOKEN,
+                buy_token: H160::from_low_u64_le(1),
+                in_amount: 1.into(),
+                kind: OrderKind::Buy,
+            },
+            // Will throw `UnsupportedToken` error in `sanitized_estimator`.
+            Query {
+                sell_token: H160::from_low_u64_le(1),
+                buy_token: BAD_TOKEN,
+                in_amount: 1.into(),
+                kind: OrderKind::Buy,
+            },
+        ];
+
+        let mut wrapped_estimator = MockPriceEstimating::new();
+        // Tests for estimates[0]
+        wrapped_estimator
+            .expect_estimate()
+            .times(1)
+            .with(eq(queries[0]))
+            .returning(|_| {
+                Ok(Estimate {
+                    out_amount: 1.into(),
+                    gas: 100.into(),
+                })
+            });
+        // Tests for estimates[1]
+        wrapped_estimator
+            .expect_estimate()
+            .times(1)
+            .with(eq(Query {
+                // SanitizedPriceEstimator replaces ETH buy token with native token
+                buy_token: native_token,
+                ..queries[1]
+            }))
+            .returning(|_| {
+                Ok(Estimate {
+                    out_amount: 1.into(),
+                    gas: 100.into(),
+                })
+            });
+        // Tests for estimates[2]
+        wrapped_estimator
+            .expect_estimate()
+            .times(1)
+            .with(eq(Query {
+                // SanitizedPriceEstimator replaces ETH buy token with native token
+                buy_token: native_token,
+                ..queries[2]
+            }))
+            .returning(|_| {
+                Ok(Estimate {
+                    out_amount: 1.into(),
+                    gas: U256::MAX,
+                })
+            });
+
+        let sanitized_estimator = SanitizedPriceEstimator {
+            inner: wrapped_estimator,
+            bad_token_detector: Arc::new(bad_token_detector),
+            native_token,
+        };
+
+        let result = sanitized_estimator.estimates(&queries).await;
+        assert_eq!(result.len(), 6);
+        assert_eq!(
+            result[0].as_ref().unwrap(),
+            &Estimate {
+                out_amount: 1.into(),
+                gas: 100.into()
+            }
+        );
+        assert_eq!(
+            result[1].as_ref().unwrap(),
+            &Estimate {
+                out_amount: 1.into(),
+                //sanitized_estimator will add ETH_UNWRAP_COST to the gas of any
+                //Query with ETH as the buy_token.
+                gas: U256::from(GAS_PER_WETH_UNWRAP)
+                    .checked_add(100.into())
+                    .unwrap()
+            }
+        );
+        assert!(matches!(
+            result[2].as_ref().unwrap_err(),
+            PriceEstimationError::Other(err)
+                if err.to_string() == "cost of unwrapping ETH would overflow gas price",
+        ));
+        assert_eq!(
+            result[3].as_ref().unwrap(),
+            &Estimate {
+                out_amount: 1.into(),
+                gas: 0.into()
+            }
+        );
+        assert!(matches!(
+            result[4].as_ref().unwrap_err(),
+            PriceEstimationError::UnsupportedToken(_)
+        ));
+        assert!(matches!(
+            result[5].as_ref().unwrap_err(),
+            PriceEstimationError::UnsupportedToken(_)
+        ));
+    }
+}

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -3,7 +3,6 @@ use contracts::{BalancerV2Vault, IUniswapLikeRouter, WETH9};
 use ethcontract::{Account, PrivateKey, H160, U256};
 use reqwest::Url;
 use shared::{
-    bad_token::list_based::ListBasedDetector,
     baseline_solver::BaseTokens,
     current_block::current_block_stream,
     maintenance::{Maintaining, ServiceMaintenance},
@@ -451,8 +450,6 @@ async fn main() {
         pool_aggregator,
         gas_price_estimator.clone(),
         base_tokens.clone(),
-        // Order book already filters bad tokens
-        Arc::new(ListBasedDetector::deny_list(Vec::new())),
         native_token_contract.address(),
         native_token_price_estimation_amount,
     ));


### PR DESCRIPTION
Fixes #1495

Some price estimators had problems estimating prices for ETH buy orders.
Because the price estimators don't really deal with ETH but with WETH we now detect ETH buy orders and pretend they are WETH buy orders.
To not have to implement that behavior for every price estimator a new type `SanitizedPriceEstimator` was added which is a wrapper for types implementing the `PriceEstimating` trait. I wrapped the `CompetitionPriceEstimator` which bundles all our estimators in a `SanitizedPriceEstimator` which means all price price estimator can assume that they will only ever get valid price estimation queries.
This lead to some duplicated code and tests being removed as well as the `bad_token_detector` being dropped from the individual estimators. The estimators only needed that member to find unsupported tokens which they no longer have to worry about.

Having this single point where all price estimations go through also enables us to easily implement a nice optimization Ben had in mind. If the buy_token was ETH we did not include the cost of unwrapping WETH->ETH in the price estimation. This is something the `SanitizedPriceEstimator` does as well.

### Test Plan
Unit tests for `SanitizedPriceEstimator`
1) normal order
2) unsupported buy_token
3) unsupported sell_token
4) ETH as buy_token where adding gas cost for unwrapping ETH would NOT overflow U256 for gas price
5) ETH as buy_token where adding gas cost for unwrapping ETH would overflow U256 for gas price
6) buy_token and sell_token are identical

Did manual integration tests:
1) Buying ETH
2) Buying WETH
3) Buying and selling same token
<details>
<summary>logs of orderbook</summary>
<pre>
2021-12-23T11:13:40.510Z DEBUG orderbook::api::post_quote: Received quote request OrderQuoteRequest { from: 0x1a015ad600829d8b288bf3c50b9f557a2c12e9ca, sell_token: 0x6b175474e89094c44da98b954eedeac495271d0f, buy_token: 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, receiver: Some(0x0000000000000000000000000000000000000000), side: Buy { buy_amount_after_fee: 1000000000000000000 }, valid_to: 2147483648, app_data: 0x0000000000000000000000000000000000000000000000000000000000000000, partially_fillable: false, sell_token_balance: Erc20, buy_token_balance: Erc20 }
2021-12-23T11:13:40.630Z DEBUG orderbook::fee: computing subsidized fee fee_data=FeeData { sell_token: 0x6b175474e89094c44da98b954eedeac495271d0f, buy_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, amount: 1000000000000000000, kind: Buy } app_data=0x0000000000000000000000000000000000000000000000000000000000000000<br/>
<b>2021-12-23T11:13:40.631Z DEBUG shared::price_estimation::sanitized: estimate price for native token instead of ETH query=Query { sell_token: 0x6b175474e89094c44da98b954eedeac495271d0f, buy_token: 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, in_amount: 1000000000000000000, kind: Buy } sanitized_query=Query { sell_token: 0x6b175474e89094c44da98b954eedeac495271d0f, buy_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, in_amount: 1000000000000000000, kind: Buy }</b>
<br/>2021-12-23T11:13:40.649Z DEBUG orderbook::fee: using existing fee measurement FeeParameters { gas_amount: 255402.0, gas_price: 56185118873.0, sell_token_price: 3947.210642883208 }
2021-12-23T11:13:40.650Z DEBUG orderbook::fee: computed subsidized fee of (56641650641400004608, 0x6b175474e89094c44da98b954eedeac495271d0f)
2021-12-23T11:13:40.752Z DEBUG shared::http_solver_api: http solver instance name is 2021-12-23_11:13:40.751862_UTC_Ethereum___Mainnet_1
2021-12-23T11:13:40.809Z DEBUG shared::price_estimation::competition: received price estimate estimator_name=Quasimodo query=Query { sell_token: 0x6b175474e89094c44da98b954eedeac495271d0f, buy_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, in_amount: 1000000000000000000, kind: Buy } estimate=Estimate { out_amount: 3947210642883208051882, gas: 255402 }
2021-12-23T11:13:40.810Z DEBUG shared::price_estimation::competition: winning price estimate query=Query { sell_token: 0x6b175474e89094c44da98b954eedeac495271d0f, buy_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, in_amount: 1000000000000000000, kind: Buy } winning_estimate=EstimateData { estimator_name: "Quasimodo", estimate: Estimate { out_amount: 3947210642883208051882, gas: 255402 }, sell_over_buy: Ratio { numer: 1973605321441604025941, denom: 500000000000000000 } }
<br/><b>2021-12-23T11:13:40.811Z DEBUG shared::price_estimation::sanitized: added cost of unwrapping WETH to price estimation query=Query { sell_token: 0x6b175474e89094c44da98b954eedeac495271d0f, buy_token: 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, in_amount: 1000000000000000000, kind: Buy } final_estimation=Estimate { out_amount: 3947210642883208051882, gas: 269594 }</b><br/>
2021-12-23T11:13:40.859Z DEBUG orderbook::api::post_quote: Received quote request OrderQuoteRequest { from: 0x1a015ad600829d8b288bf3c50b9f557a2c12e9ca, sell_token: 0x6b175474e89094c44da98b954eedeac495271d0f, buy_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, receiver: Some(0x0000000000000000000000000000000000000000), side: Buy { buy_amount_after_fee: 1000000000000000000 }, valid_to: 2147483648, app_data: 0x0000000000000000000000000000000000000000000000000000000000000000, partially_fillable: false, sell_token_balance: Erc20, buy_token_balance: Erc20 }
2021-12-23T11:13:40.859Z DEBUG orderbook::fee: computing subsidized fee fee_data=FeeData { sell_token: 0x6b175474e89094c44da98b954eedeac495271d0f, buy_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, amount: 1000000000000000000, kind: Buy } app_data=0x0000000000000000000000000000000000000000000000000000000000000000
2021-12-23T11:13:40.867Z DEBUG orderbook::fee: using existing fee measurement FeeParameters { gas_amount: 255402.0, gas_price: 56185118873.0, sell_token_price: 3947.210642883208 }
2021-12-23T11:13:40.867Z DEBUG orderbook::fee: computed subsidized fee of (56641650641400004608, 0x6b175474e89094c44da98b954eedeac495271d0f)
2021-12-23T11:13:40.978Z DEBUG shared::http_solver_api: http solver instance name is 2021-12-23_11:13:40.978531_UTC_Ethereum___Mainnet_1
2021-12-23T11:13:41.032Z DEBUG shared::price_estimation::competition: received price estimate estimator_name=Quasimodo query=Query { sell_token: 0x6b175474e89094c44da98b954eedeac495271d0f, buy_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, in_amount: 1000000000000000000, kind: Buy } estimate=Estimate { out_amount: 3947210642883208051882, gas: 255402 }
2021-12-23T11:13:41.033Z DEBUG shared::price_estimation::competition: winning price estimate query=Query { sell_token: 0x6b175474e89094c44da98b954eedeac495271d0f, buy_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, in_amount: 1000000000000000000, kind: Buy } winning_estimate=EstimateData { estimator_name: "Quasimodo", estimate: Estimate { out_amount: 3947210642883208051882, gas: 255402 }, sell_over_buy: Ratio { numer: 1973605321441604025941, denom: 500000000000000000 } }
2021-12-23T11:13:41.081Z DEBUG orderbook::api::post_quote: Received quote request OrderQuoteRequest { from: 0x1a015ad600829d8b288bf3c50b9f557a2c12e9ca, sell_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, buy_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, receiver: Some(0x0000000000000000000000000000000000000000), side: Buy { buy_amount_after_fee: 1000000000000000000 }, valid_to: 2147483648, app_data: 0x0000000000000000000000000000000000000000000000000000000000000000, partially_fillable: false, sell_token_balance: Erc20, buy_token_balance: Erc20 }
2021-12-23T11:13:41.082Z  WARN orderbook::api::post_quote: post_quote error err=Order(Partial(SameBuyAndSellToken)) request=OrderQuoteRequest { from: 0x1a015ad600829d8b288bf3c50b9f557a2c12e9ca, sell_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, buy_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, receiver: Some(0x0000000000000000000000000000000000000000), side: Buy { buy_amount_after_fee: 1000000000000000000 }, valid_to: 2147483648, app_data: 0x0000000000000000000000000000000000000000000000000000000000000000, partially_fillable: false, sell_token_balance: Erc20, buy_token_balance: Erc20 }
</pre>