### PR TITLE
Reject Partially Fillable Orders

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -753,6 +753,7 @@ components:
               ZeroAmount,
               UnsupportedBuyTokenDestination,
               UnsupportedSellTokenSource,
+              UnsupportedOrderType,
             ]
         description:
           type: string

--- a/crates/orderbook/src/api/order_validation.rs
+++ b/crates/orderbook/src/api/order_validation.rs
@@ -75,7 +75,10 @@ impl IntoWarpReply for PartialValidationError {
                 StatusCode::BAD_REQUEST,
             ),
             Self::UnsupportedOrderType => with_status(
-                super::error("UnsupportedOrderType", "This order type is currently not supported"),
+                super::error(
+                    "UnsupportedOrderType",
+                    "This order type is currently not supported",
+                ),
                 StatusCode::BAD_REQUEST,
             ),
             Self::Forbidden => with_status(
@@ -258,7 +261,7 @@ impl OrderValidator {
 #[async_trait::async_trait]
 impl OrderValidating for OrderValidator {
     async fn partial_validate(&self, order: PreOrderData) -> Result<(), PartialValidationError> {
-        if order. partially_fillable {
+        if order.partially_fillable {
             return Err(PartialValidationError::UnsupportedOrderType);
         }
         if self.banned_users.contains(&order.owner) {

--- a/crates/orderbook/src/api/order_validation.rs
+++ b/crates/orderbook/src/api/order_validation.rs
@@ -59,6 +59,7 @@ pub enum PartialValidationError {
     SameBuyAndSellToken,
     UnsupportedBuyTokenDestination(BuyTokenDestination),
     UnsupportedSellTokenSource(SellTokenSource),
+    UnsupportedOrderType,
     Other(anyhow::Error),
 }
 
@@ -71,6 +72,10 @@ impl IntoWarpReply for PartialValidationError {
             ),
             Self::UnsupportedSellTokenSource(src) => with_status(
                 super::error("UnsupportedSellTokenSource", format!("Type {:?}", src)),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::UnsupportedOrderType => with_status(
+                super::error("UnsupportedOrderType", "This order type is currently not supported"),
                 StatusCode::BAD_REQUEST,
             ),
             Self::Forbidden => with_status(
@@ -208,6 +213,7 @@ pub struct PreOrderData {
     pub buy_token: H160,
     pub receiver: H160,
     pub valid_to: u32,
+    pub partially_fillable: bool,
     pub buy_token_balance: BuyTokenDestination,
     pub sell_token_balance: SellTokenSource,
 }
@@ -220,6 +226,7 @@ impl From<Order> for PreOrderData {
             buy_token: order.order_creation.buy_token,
             receiver: order.actual_receiver(),
             valid_to: order.order_creation.valid_to,
+            partially_fillable: order.order_creation.partially_fillable,
             buy_token_balance: order.order_creation.buy_token_balance,
             sell_token_balance: order.order_creation.sell_token_balance,
         }
@@ -251,6 +258,9 @@ impl OrderValidator {
 #[async_trait::async_trait]
 impl OrderValidating for OrderValidator {
     async fn partial_validate(&self, order: PreOrderData) -> Result<(), PartialValidationError> {
+        if order. partially_fillable {
+            return Err(PartialValidationError::UnsupportedOrderType);
+        }
         if self.banned_users.contains(&order.owner) {
             return Err(PartialValidationError::Forbidden);
         }
@@ -508,6 +518,15 @@ mod tests {
             Arc::new(MockBadTokenDetecting::new()),
             Arc::new(MockBalanceFetching::new()),
         );
+        assert!(matches!(
+            validator
+                .partial_validate(PreOrderData {
+                    partially_fillable: true,
+                    ..Default::default()
+                })
+                .await,
+            Err(PartialValidationError::UnsupportedOrderType)
+        ));
         assert!(matches!(
             validator
                 .partial_validate(PreOrderData {

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -48,6 +48,7 @@ impl From<&OrderQuoteRequest> for PreOrderData {
             buy_token: quote_request.buy_token,
             receiver: quote_request.receiver.unwrap_or(owner),
             valid_to: quote_request.valid_to,
+            partially_fillable: quote_request.partially_fillable,
             buy_token_balance: quote_request.buy_token_balance,
             sell_token_balance: quote_request.sell_token_balance,
         }


### PR DESCRIPTION
Despite our expectation, partially fillable orders seem to be working and causing a good amount of economically unviable solutions (cf. https://etherscan.io/tokentxns?a=0x042b32ac6b453485e357938bdc38e0340d4b9276&p=3)

To be safe, we should prevent people from placing such orders via the API

### Test Plan
Added unit test, also checking that the place order script from the contracts repo yields the new error when placing a partially fillable order.
