### PR TITLE
Add support for "No Protocol Fee" Liquidity Bootstrapping Pools

### DIFF
--- a/crates/contracts/artifacts/BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory.json
+++ b/crates/contracts/artifacts/BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory.json
@@ -1,0 +1,1 @@
+BalancerV2LiquidityBootstrappingPoolFactory.json

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -142,6 +142,14 @@ fn main() {
                         deployment_information: Some(DeploymentInformation::BlockNumber(13730248)),
                     },
                 )
+                .add_network(
+                    "4",
+                    Network {
+                        address: addr("0x41B953164995c11C81DA73D212ED8Af25741b7Ac"),
+                        // <https://rinkeby.etherscan.io/tx/0x69211f2b510d5d18b49e226822f4b920979b75ba87f5041034dc53d38a79a7c3>
+                        deployment_information: Some(DeploymentInformation::BlockNumber(13730248)),
+                    },
+                )
         },
     );
     generate_contract("BalancerV2WeightedPool");

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -127,6 +127,23 @@ fn main() {
                 },
             )
     });
+    generate_contract_with_config(
+        "BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory",
+        |builder| {
+            builder
+                .contract_mod_override(
+                    "balancer_v2_no_protocol_fee_liquidity_bootstrapping_pool_factory",
+                )
+                .add_network(
+                    "1",
+                    Network {
+                        address: addr("0x0F3e0c4218b7b0108a3643cFe9D3ec0d4F57c54e"),
+                        // <https://etherscan.io/tx/0x298381e567ff6643d9b32e8e7e9ff0f04a80929dce3e004f6fa1a0104b2b69c3>
+                        deployment_information: Some(DeploymentInformation::BlockNumber(13730248)),
+                    },
+                )
+        },
+    );
     generate_contract("BalancerV2WeightedPool");
     generate_contract_with_config("BalancerV2StablePool", |builder| {
         builder.add_method_alias(

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -13,6 +13,10 @@ include!(concat!(
     env!("OUT_DIR"),
     "/BalancerV2LiquidityBootstrappingPoolFactory.rs"
 ));
+include!(concat!(
+    env!("OUT_DIR"),
+    "/BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory.rs"
+));
 include!(concat!(env!("OUT_DIR"), "/BalancerV2StablePool.rs"));
 include!(concat!(env!("OUT_DIR"), "/BalancerV2StablePoolFactory.rs"));
 include!(concat!(env!("OUT_DIR"), "/BalancerV2Vault.rs"));
@@ -112,11 +116,15 @@ mod tests {
         }
         for network in &[1, 4] {
             assert_has_deployment_address!(BalancerV2Vault for *network);
+            assert_has_deployment_address!(BalancerV2LiquidityBootstrappingPoolFactory for *network);
             assert_has_deployment_address!(BalancerV2WeightedPoolFactory for *network);
             assert_has_deployment_address!(BalancerV2WeightedPool2TokensFactory for *network);
             assert_has_deployment_address!(BalancerV2StablePoolFactory for *network);
             assert_has_deployment_address!(UniswapV2Factory for *network);
             assert_has_deployment_address!(UniswapV2Router02 for *network);
+        }
+        for network in &[1] {
+            assert_has_deployment_address!(BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory for *network);
         }
         for network in &[100] {
             assert_has_deployment_address!(HoneyswapFactory for *network);

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -117,14 +117,12 @@ mod tests {
         for network in &[1, 4] {
             assert_has_deployment_address!(BalancerV2Vault for *network);
             assert_has_deployment_address!(BalancerV2LiquidityBootstrappingPoolFactory for *network);
+            assert_has_deployment_address!(BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory for *network);
             assert_has_deployment_address!(BalancerV2WeightedPoolFactory for *network);
             assert_has_deployment_address!(BalancerV2WeightedPool2TokensFactory for *network);
             assert_has_deployment_address!(BalancerV2StablePoolFactory for *network);
             assert_has_deployment_address!(UniswapV2Factory for *network);
             assert_has_deployment_address!(UniswapV2Router02 for *network);
-        }
-        for network in &[1] {
-            assert_has_deployment_address!(BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory for *network);
         }
         for network in &[100] {
             assert_has_deployment_address!(HoneyswapFactory for *network);

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -152,7 +152,7 @@ arg_enum! {
 
 impl BalancerFactoryKind {
     /// Returns all supported Balancer factory kinds.
-    pub fn all(chain_id: u64) -> Vec<Self> {
+    pub fn all() -> Vec<Self> {
         // take advantage of the auto-generated `::variants()` associated
         // function so we don't have to keep updating this method with new kinds
         // as they get added. Slightly inefficient.
@@ -161,11 +161,6 @@ impl BalancerFactoryKind {
             .map(|name| {
                 name.parse()
                     .expect("generated variant name did not parse successfully")
-            })
-            .filter(|kind| match (kind, chain_id) {
-                (BalancerFactoryKind::NoProtocolFeeLiquidityBootstrapping, 4) => false,
-                (_, 1 | 4) => true,
-                _ => false,
             })
             .collect()
     }
@@ -376,13 +371,7 @@ mod tests {
 
     #[test]
     fn enumerates_all_balancer_factory_kinds() {
-        assert!(!BalancerFactoryKind::all(1).is_empty());
-    }
-
-    #[test]
-    fn filters_out_no_protocol_fee_liquidity_bootstrapping_pool_for_rinkeby() {
-        assert!(!BalancerFactoryKind::all(4)
-            .contains(&BalancerFactoryKind::NoProtocolFeeLiquidityBootstrapping));
+        assert!(!BalancerFactoryKind::all().is_empty());
     }
 
     #[tokio::test]
@@ -403,7 +392,7 @@ mod tests {
                     web3,
                     pool_initializer,
                     Arc::new(token_infos),
-                    BalancerFactoryKind::all(chain_id),
+                    BalancerFactoryKind::all(),
                 )
                 .await
                 .unwrap(),

--- a/crates/shared/src/sources/balancer_v2/pools.rs
+++ b/crates/shared/src/sources/balancer_v2/pools.rs
@@ -9,6 +9,7 @@
 
 pub mod common;
 pub mod liquidity_bootstrapping;
+pub mod no_protocol_fee_liquidity_bootstrapping;
 pub mod stable;
 pub mod weighted;
 pub mod weighted_2token;

--- a/crates/shared/src/sources/balancer_v2/pools/liquidity_bootstrapping.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/liquidity_bootstrapping.rs
@@ -1,4 +1,4 @@
-//! Module implementing two-token weighted pool specific indexing logic.
+//! Module implementing liquidity bootstrapping pool specific indexing logic.
 
 pub use super::weighted::{PoolState, TokenState};
 use super::{common, FactoryIndexing, PoolIndexing};

--- a/crates/shared/src/sources/balancer_v2/pools/no_protocol_fee_liquidity_bootstrapping.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/no_protocol_fee_liquidity_bootstrapping.rs
@@ -18,7 +18,9 @@ impl FactoryIndexing for BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactor
     type PoolState = PoolState;
 
     async fn specialize_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
-        as_liquidity_bootstrapping_factory(self).specialize_pool_info(pool).await
+        as_liquidity_bootstrapping_factory(self)
+            .specialize_pool_info(pool)
+            .await
     }
 
     fn fetch_pool_state(
@@ -28,7 +30,12 @@ impl FactoryIndexing for BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactor
         batch: &mut Web3CallBatch,
         block: BlockId,
     ) -> BoxFuture<'static, Result<Option<Self::PoolState>>> {
-        as_liquidity_bootstrapping_factory(self).fetch_pool_state(pool_info, common_pool_state, batch, block)
+        as_liquidity_bootstrapping_factory(self).fetch_pool_state(
+            pool_info,
+            common_pool_state,
+            batch,
+            block,
+        )
     }
 }
 

--- a/crates/shared/src/sources/balancer_v2/pools/no_protocol_fee_liquidity_bootstrapping.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/no_protocol_fee_liquidity_bootstrapping.rs
@@ -1,0 +1,42 @@
+//! Module implementing liquidity bootstrapping (with no protocol fees) pool
+//! specific indexing logic.
+
+pub use super::liquidity_bootstrapping::{PoolInfo, PoolState};
+use super::{common, FactoryIndexing};
+use crate::Web3CallBatch;
+use anyhow::Result;
+use contracts::{
+    BalancerV2LiquidityBootstrappingPoolFactory,
+    BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory,
+};
+use ethcontract::BlockId;
+use futures::future::BoxFuture;
+
+#[async_trait::async_trait]
+impl FactoryIndexing for BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory {
+    type PoolInfo = PoolInfo;
+    type PoolState = PoolState;
+
+    async fn specialize_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
+        as_liquidity_bootstrapping_factory(self).specialize_pool_info(pool).await
+    }
+
+    fn fetch_pool_state(
+        &self,
+        pool_info: &Self::PoolInfo,
+        common_pool_state: BoxFuture<'static, common::PoolState>,
+        batch: &mut Web3CallBatch,
+        block: BlockId,
+    ) -> BoxFuture<'static, Result<Option<Self::PoolState>>> {
+        as_liquidity_bootstrapping_factory(self).fetch_pool_state(pool_info, common_pool_state, batch, block)
+    }
+}
+
+fn as_liquidity_bootstrapping_factory(
+    factory: &BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory,
+) -> BalancerV2LiquidityBootstrappingPoolFactory {
+    BalancerV2LiquidityBootstrappingPoolFactory::at(
+        &factory.raw_instance().web3(),
+        factory.address(),
+    )
+}

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -433,7 +433,7 @@ async fn main() {
                 web3.clone(),
                 token_info_fetcher.clone(),
                 args.balancer_factories
-                    .unwrap_or_else(|| BalancerFactoryKind::all(chain_id)),
+                    .unwrap_or_else(BalancerFactoryKind::all),
                 cache_config,
                 current_block_stream.clone(),
                 metrics.clone(),

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -433,7 +433,7 @@ async fn main() {
                 web3.clone(),
                 token_info_fetcher.clone(),
                 args.balancer_factories
-                    .unwrap_or_else(BalancerFactoryKind::all),
+                    .unwrap_or_else(|| BalancerFactoryKind::all(chain_id)),
                 cache_config,
                 current_block_stream.clone(),
                 metrics.clone(),


### PR DESCRIPTION
This PR is a follow up to #1488

Here we add support for the `NoProtocolFeeLiquidityBootstrappingPoolFactory`, which is (as the name suggests) a version of `LiquidityBootstrappingPoolFactory` without protocol fees.

It shares all indexing logic with `LiquidityBootstrappingPoolFactory`, so this PR is mostly just the boiler plate to add the new factory deployment information, as well as factory type for configuring Balancer liquidity to index this pool on startup.

### Test Plan

No new logic. Expanded existing unit test to check deployment information is set in generated contract code.

Manual test results:
```
$ cargo test -p shared -- balancer_fetched_pools_match_subgraph --ignored --nocapture
...
2021-12-22T15:14:34.155Z  WARN shared::sources::balancer_v2::pool_fetching::tests: unknown_pools=[]
test sources::balancer_v2::pool_fetching::tests::balancer_fetched_pools_match_subgraph ... ok
...
```