### PR TITLE
Configure minimum discounted fee

### DIFF
--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -141,6 +141,14 @@ struct Arguments {
     #[structopt(long, env, default_value = "0")]
     fee_discount: f64,
 
+    /// The minimum value for the discounted fee in the network's native token (i.e. Ether for
+    /// Mainnet).
+    ///
+    /// Note that this minimum is applied BEFORE any multiplicative factors from either
+    /// `--fee-factor` or `--partner-additional-fee-factors` configuration.
+    #[structopt(long, env, default_value = "0")]
+    min_discounted_fee: f64,
+
     /// Gas Fee Factor: 1.0 means cost is forwarded to users alteration, 0.9 means there is a 10%
     /// subsidy, 1.1 means users pay 10% in fees than what we estimate we pay for gas.
     #[structopt(long, env, default_value = "1", parse(try_from_str = shared::arguments::parse_fee_factor))]
@@ -470,6 +478,7 @@ async fn main() {
         native_token_price_estimation_amount,
         FeeSubsidyConfiguration {
             fee_discount: args.fee_discount,
+            min_discounted_fee: args.min_discounted_fee,
             fee_factor: args.fee_factor,
             partner_additional_fee_factors: args.partner_additional_fee_factors,
         },


### PR DESCRIPTION
This PR adds a configuration option for setting a minimum discounted fee amount. We want this because we currently have a flat fee subsidy, and in times of low gas prices, it _can_ happen that we end up with a 0 or negative fee amount after applying this fee discount.

In order to avoid these situations (since free trading is nice for our users but causes a bunch of other problems - like wash trading for example), we add a new configuration option for a lower bound on how much the fee can be discounted.

One quirk about how this was implemented, the amount represents the minimum fee **before** any multiplicative subsidies are applied. The reason for doing this is that:
- It made the code much easier (we already had logic for this, just hard-coded at 0).
- It was unclear to me whether or not we wanted things like the global fee factor and specifically partner fee factors to allow the final subsidized fee to go lower than this (e.g. PMMs should be able to place orders below this minimum right?).

Since I'm not 100% sure about the semantics here, I started a discussion in Slack. Feel free to review the rest of the code in the meantime.

### Test Plan

Adapted unit test for fees being capped at 0 to use a minimum amount.
