### PR TITLE
Use Settlement Contract's Internal Buffer to Optimize Unwraps

### DIFF
--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -237,6 +237,7 @@ async fn eth_integration(web3: Web3) {
         10,
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),
+        0.0,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -242,6 +242,7 @@ async fn onchain_settlement(web3: Web3) {
         10,
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),
+        0.0,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -231,6 +231,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         10,
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),
+        0.0,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -200,6 +200,7 @@ async fn smart_contract_orders(web3: Web3) {
         10,
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),
+        0.0,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -182,6 +182,7 @@ async fn vault_balances(web3: Web3) {
         10,
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),
+        0.0,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -152,7 +152,7 @@ struct Arguments {
 
     /// Gas Fee Factor: 1.0 means cost is forwarded to users alteration, 0.9 means there is a 10%
     /// subsidy, 1.1 means users pay 10% in fees than what we estimate we pay for gas.
-    #[structopt(long, env, default_value = "1", parse(try_from_str = shared::arguments::parse_fee_factor))]
+    #[structopt(long, env, default_value = "1", parse(try_from_str = shared::arguments::parse_unbounded_percentage_factor))]
     fee_factor: f64,
 
     /// Used to specify additional fee subsidy factor based on app_ids contained in orders.

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -152,7 +152,7 @@ struct Arguments {
 
     /// Gas Fee Factor: 1.0 means cost is forwarded to users alteration, 0.9 means there is a 10%
     /// subsidy, 1.1 means users pay 10% in fees than what we estimate we pay for gas.
-    #[structopt(long, env, default_value = "1", parse(try_from_str = shared::arguments::parse_unbounded_percentage_factor))]
+    #[structopt(long, env, default_value = "1", parse(try_from_str = shared::arguments::parse_unbounded_factor))]
     fee_factor: f64,
 
     /// Used to specify additional fee subsidy factor based on app_ids contained in orders.

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -141,10 +141,10 @@ pub struct Arguments {
     pub mip_uses_internal_buffers: bool,
 }
 
-pub fn parse_unbounded_percentage_factor(s: &str) -> Result<f64> {
-    let percentage_factor = f64::from_str(s)?;
-    ensure!(percentage_factor.is_finite() && percentage_factor >= 0.);
-    Ok(percentage_factor)
+pub fn parse_unbounded_factor(s: &str) -> Result<f64> {
+    let factor = f64::from_str(s)?;
+    ensure!(factor.is_finite() && factor >= 0.);
+    Ok(factor)
 }
 
 pub fn parse_percentage_factor(s: &str) -> Result<f64> {

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -141,10 +141,16 @@ pub struct Arguments {
     pub mip_uses_internal_buffers: bool,
 }
 
-pub fn parse_fee_factor(s: &str) -> Result<f64> {
-    let fee = f64::from_str(s)?;
-    ensure!(fee.is_finite() && fee >= 0.);
-    Ok(fee)
+pub fn parse_unbounded_percentage_factor(s: &str) -> Result<f64> {
+    let percentage_factor = f64::from_str(s)?;
+    ensure!(percentage_factor.is_finite() && percentage_factor >= 0.);
+    Ok(percentage_factor)
+}
+
+pub fn parse_percentage_factor(s: &str) -> Result<f64> {
+    let percentage_factor = f64::from_str(s)?;
+    ensure!(percentage_factor.is_finite() && percentage_factor >= 0. && percentage_factor <= 1.0);
+    Ok(percentage_factor)
 }
 
 pub fn duration_from_seconds(s: &str) -> Result<Duration, ParseFloatError> {

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -59,6 +59,7 @@ pub struct Driver {
     api: OrderBookApi,
     order_converter: OrderConverter,
     in_flight_orders: InFlightOrders,
+    weth_unwrap_factor: f64,
 }
 impl Driver {
     #[allow(clippy::too_many_arguments)]
@@ -83,6 +84,7 @@ impl Driver {
         max_settlements_per_solver: usize,
         api: OrderBookApi,
         order_converter: OrderConverter,
+        weth_unwrap_factor: f64,
     ) -> Self {
         Self {
             settlement_contract,
@@ -107,6 +109,7 @@ impl Driver {
             api,
             order_converter,
             in_flight_orders: InFlightOrders::default(),
+            weth_unwrap_factor,
         }
     }
 

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -500,9 +500,10 @@ impl Driver {
                 winning_settlement
             );
 
-            self.post_processing_pipeline
+            winning_settlement.settlement = self
+                .post_processing_pipeline
                 .optimize_settlement(
-                    &mut winning_settlement.settlement,
+                    winning_settlement.settlement,
                     winning_solver.account().clone(),
                     gas_price,
                 )

--- a/crates/solver/src/lib.rs
+++ b/crates/solver/src/lib.rs
@@ -10,6 +10,7 @@ pub mod metrics;
 pub mod orderbook;
 pub mod pending_transactions;
 pub mod settlement;
+pub mod settlement_post_processing;
 pub mod settlement_simulation;
 pub mod settlement_submission;
 pub mod solver;

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -251,7 +251,7 @@ struct Arguments {
     /// factor by which order fees are multiplied with. Setting this to a value
     /// greater than 1.0 makes settlements with negative objective values less
     /// likely, promoting more aggressive merging of single order settlements.
-    #[structopt(long, env, default_value = "1", parse(try_from_str = shared::arguments::parse_unbounded_percentage_factor))]
+    #[structopt(long, env, default_value = "1", parse(try_from_str = shared::arguments::parse_unbounded_factor))]
     fee_objective_scaling_factor: f64,
 
     /// The maximum number of settlements the driver considers per solver.

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -251,7 +251,7 @@ struct Arguments {
     /// factor by which order fees are multiplied with. Setting this to a value
     /// greater than 1.0 makes settlements with negative objective values less
     /// likely, promoting more aggressive merging of single order settlements.
-    #[structopt(long, env, default_value = "1", parse(try_from_str = shared::arguments::parse_fee_factor))]
+    #[structopt(long, env, default_value = "1", parse(try_from_str = shared::arguments::parse_unbounded_percentage_factor))]
     fee_objective_scaling_factor: f64,
 
     /// The maximum number of settlements the driver considers per solver.
@@ -269,6 +269,14 @@ struct Arguments {
         use_delimiter = true
     )]
     balancer_factories: Option<Vec<BalancerFactoryKind>>,
+
+    /// Factor how much of the WETH buffer should be unwrapped if ETH buffer is not big enough to
+    /// settle ETH buy orders.
+    /// Unwrapping a bigger amount will cause fewer unwraps to happen and thereby reduce the cost
+    /// of unwraps per settled batch.
+    /// Only values in the range [0.0, 1.0] make sense.
+    #[structopt(long, env, default_value = "0.6", parse(try_from_str = shared::arguments::parse_percentage_factor))]
+    weth_unwrap_factor: f64,
 }
 
 arg_enum! {
@@ -627,6 +635,7 @@ async fn main() {
         args.max_settlements_per_solver,
         api,
         order_converter,
+        args.weth_unwrap_factor,
     );
 
     let maintainer = ServiceMaintenance {

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -340,6 +340,24 @@ impl SettlementEncoder {
             None => U256::one().to_big_rational(),
         }
     }
+
+    /// Drops all UnwrapWethInteractions for the given token address.
+    /// This can be used in case the settlement contracts ETH buffer is big enough.
+    pub fn drop_unwrap(&mut self, token: H160) {
+        self.unwraps.retain(|unwrap| unwrap.weth.address() != token);
+    }
+
+    /// Calculates how much of a given token this settlement will unwrap during the execution.
+    pub fn amount_to_unwrap(&mut self, token: H160) -> U256 {
+        self.unwraps.iter().fold(U256::zero(), |sum, unwrap| {
+            if unwrap.weth.address() == token {
+                sum.checked_add(unwrap.amount)
+                    .expect("no settlement would pay out that much ETH at once")
+            } else {
+                sum
+            }
+        })
+    }
 }
 
 #[cfg(test)]

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -348,7 +348,7 @@ impl SettlementEncoder {
     }
 
     /// Calculates how much of a given token this settlement will unwrap during the execution.
-    pub fn amount_to_unwrap(&mut self, token: H160) -> U256 {
+    pub fn amount_to_unwrap(&self, token: H160) -> U256 {
         self.unwraps.iter().fold(U256::zero(), |sum, unwrap| {
             if unwrap.weth.address() == token {
                 sum.checked_add(unwrap.amount)

--- a/crates/solver/src/settlement_post_processing/mod.rs
+++ b/crates/solver/src/settlement_post_processing/mod.rs
@@ -60,6 +60,7 @@ impl PostProcessingPipeline {
                 .map_err(|e| anyhow::anyhow!(e))
         };
 
+        // an error will leave the settlement unmodified
         let _ = optimize_unwrapping(
             settlement,
             &settlement_would_succeed,

--- a/crates/solver/src/settlement_post_processing/mod.rs
+++ b/crates/solver/src/settlement_post_processing/mod.rs
@@ -1,0 +1,74 @@
+pub mod optimize_unwrapping;
+
+use crate::settlement::Settlement;
+use crate::settlement_simulation::simulate_and_estimate_gas_at_current_block;
+use contracts::{GPv2Settlement, WETH9};
+use ethcontract::Account;
+use gas_estimation::EstimatedGasPrice;
+use optimize_unwrapping::optimize_unwrapping;
+use primitive_types::H160;
+use shared::Web3;
+
+pub struct PostProcessingPipeline {
+    web3: Web3,
+    unwrap_factor: f64,
+    settlement_contract: GPv2Settlement,
+    weth: WETH9,
+}
+
+impl PostProcessingPipeline {
+    pub fn new(
+        native_token: H160,
+        web3: Web3,
+        unwrap_factor: f64,
+        settlement_contract: GPv2Settlement,
+    ) -> Self {
+        let weth = WETH9::at(&web3, native_token);
+
+        Self {
+            web3,
+            unwrap_factor,
+            settlement_contract,
+            weth,
+        }
+    }
+
+    pub async fn optimize_settlement(
+        &self,
+        settlement: &mut Settlement,
+        solver_account: Account,
+        gas_price: EstimatedGasPrice,
+    ) {
+        let settlement_would_succeed = |settlement: Settlement| async {
+            let result = simulate_and_estimate_gas_at_current_block(
+                std::iter::once((solver_account.clone(), settlement)),
+                &self.settlement_contract,
+                &self.web3,
+                gas_price,
+            )
+            .await;
+            matches!(result, Ok(results) if results[0].is_ok())
+        };
+
+        let get_weth_balance = || async {
+            // TODO cache the WETH balance if we add more optimizations in the future which need it
+            self.weth
+                .methods()
+                .balance_of(self.settlement_contract.address())
+                .call()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))
+        };
+
+        let _ = optimize_unwrapping(
+            settlement,
+            &settlement_would_succeed,
+            &get_weth_balance,
+            &self.weth,
+            self.unwrap_factor,
+        )
+        .await;
+
+        debug_assert!(settlement_would_succeed(settlement.clone()).await);
+    }
+}

--- a/crates/solver/src/settlement_post_processing/mod.rs
+++ b/crates/solver/src/settlement_post_processing/mod.rs
@@ -35,10 +35,10 @@ impl PostProcessingPipeline {
 
     pub async fn optimize_settlement(
         &self,
-        settlement: &mut Settlement,
+        settlement: Settlement,
         solver_account: Account,
         gas_price: EstimatedGasPrice,
-    ) {
+    ) -> Settlement {
         let settlement_would_succeed = |settlement: Settlement| async {
             let result = simulate_and_estimate_gas_at_current_block(
                 std::iter::once((solver_account.clone(), settlement)),
@@ -61,13 +61,13 @@ impl PostProcessingPipeline {
         };
 
         // an error will leave the settlement unmodified
-        let _ = optimize_unwrapping(
+        optimize_unwrapping(
             settlement,
             &settlement_would_succeed,
             &get_weth_balance,
             &self.weth,
             self.unwrap_factor,
         )
-        .await;
+        .await
     }
 }

--- a/crates/solver/src/settlement_post_processing/mod.rs
+++ b/crates/solver/src/settlement_post_processing/mod.rs
@@ -69,7 +69,5 @@ impl PostProcessingPipeline {
             self.unwrap_factor,
         )
         .await;
-
-        debug_assert!(settlement_would_succeed(settlement.clone()).await);
     }
 }

--- a/crates/solver/src/settlement_post_processing/optimize_unwrapping.rs
+++ b/crates/solver/src/settlement_post_processing/optimize_unwrapping.rs
@@ -57,3 +57,145 @@ where
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interactions::UnwrapWethInteraction;
+    use shared::dummy_contract;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    fn to_wei(base: u128) -> U256 {
+        U256::from(base) * U256::from(10).pow(18.into())
+    }
+
+    fn settlement_with_unwrap(weth: &WETH9, amount: U256) -> Settlement {
+        let mut settlement = Settlement::with_trades(HashMap::default(), Vec::default());
+        if !amount.is_zero() {
+            settlement.encoder.add_unwrap(UnwrapWethInteraction {
+                weth: weth.clone(),
+                amount,
+            });
+        }
+        assert_eq!(amount, settlement.encoder.amount_to_unwrap(weth.address()));
+        settlement
+    }
+
+    #[tokio::test]
+    async fn drop_unwrap_if_eth_buffer_is_big_enough() {
+        let first_optimization_succeeds = |_: Settlement| async { true };
+        let get_weth_balance_succeeds = || async { Ok(U256::zero()) };
+        let weth = dummy_contract!(WETH9, [0x42; 20]);
+
+        let mut settlement = settlement_with_unwrap(&weth, to_wei(1));
+
+        optimize_unwrapping(
+            &mut settlement,
+            &first_optimization_succeeds,
+            &get_weth_balance_succeeds,
+            &weth,
+            0.6,
+        )
+        .await
+        .unwrap();
+
+        // no unwraps left because we pay 1 ETH from our buffer
+        assert_eq!(
+            U256::zero(),
+            settlement.encoder.amount_to_unwrap(weth.address())
+        );
+    }
+
+    #[tokio::test]
+    async fn bulk_convert_if_weth_buffer_is_big_enough() {
+        let successes = Arc::new(Mutex::new(vec![true, false]));
+        let second_optimization_succeeds =
+            |_: Settlement| async { successes.lock().unwrap().pop().unwrap() };
+        let get_weth_balance_succeeds = || async { Ok(to_wei(100)) };
+        let weth = dummy_contract!(WETH9, [0x42; 20]);
+
+        let mut settlement = settlement_with_unwrap(&weth, to_wei(10));
+        let unwrap_factor = 0.6;
+
+        optimize_unwrapping(
+            &mut settlement,
+            &second_optimization_succeeds,
+            &get_weth_balance_succeeds,
+            &weth,
+            unwrap_factor,
+        )
+        .await
+        .unwrap();
+
+        // we unwrap way more than needed to hopefully drop unwraps on the next few settlements
+        assert_eq!(
+            to_wei(60),
+            settlement.encoder.amount_to_unwrap(weth.address())
+        );
+    }
+
+    #[tokio::test]
+    async fn leave_settlement_unchanged_if_buffers_are_too_small_for_optimizations() {
+        // Although we would have enough WETH to cover the ETH payout, we pretend the bulk unwrap
+        // would fail anyway. This can happen if the execution_plan of the settlement also tries to
+        // use the WETH buffer (In this case more than 10 WETH).
+        let no_optimization_succeeds = |_: Settlement| async { false };
+        let get_weth_balance_succeeds = || async { Ok(to_wei(100)) };
+        let weth = dummy_contract!(WETH9, [0x42; 20]);
+
+        let eth_to_unwrap = to_wei(50);
+        let mut settlement = settlement_with_unwrap(&weth, eth_to_unwrap);
+
+        optimize_unwrapping(
+            &mut settlement,
+            &no_optimization_succeeds,
+            &get_weth_balance_succeeds,
+            &weth,
+            0.6,
+        )
+        .await
+        .unwrap();
+
+        // the settlement has been left unchanged
+        assert_eq!(
+            eth_to_unwrap,
+            settlement.encoder.amount_to_unwrap(weth.address())
+        );
+    }
+
+    #[tokio::test]
+    async fn errors_get_propagated_and_leave_settlement_unchanged() {
+        //second optimization would work if the algorithm would get so far
+        let successes = Arc::new(Mutex::new(vec![true, false]));
+        let second_optimization_succeeds =
+            |_: Settlement| async { successes.lock().unwrap().pop().unwrap() };
+
+        let error_message = "can't determine WETH balance";
+        let get_weth_balance_fails = || async { Err(anyhow::anyhow!(error_message)) };
+        let weth = dummy_contract!(WETH9, [0x42; 20]);
+
+        let eth_to_unwrap = to_wei(60);
+        let mut settlement = settlement_with_unwrap(&weth, eth_to_unwrap);
+
+        let optimization_result = optimize_unwrapping(
+            &mut settlement,
+            &second_optimization_succeeds,
+            &get_weth_balance_fails,
+            &weth,
+            0.6,
+        )
+        .await;
+
+        assert_eq!(
+            error_message,
+            optimization_result.as_ref().unwrap_err().to_string(),
+        );
+
+        // settlement had been left unchanged because we encountered an error while optimizing it
+        assert_eq!(
+            eth_to_unwrap,
+            settlement.encoder.amount_to_unwrap(weth.address())
+        );
+    }
+}

--- a/crates/solver/src/settlement_post_processing/optimize_unwrapping.rs
+++ b/crates/solver/src/settlement_post_processing/optimize_unwrapping.rs
@@ -3,6 +3,11 @@ use anyhow::Result;
 use contracts::WETH9;
 use primitive_types::U256;
 
+/// Tries to do one of 2 optimizations.
+/// 1) Drop WETH unwraps and instead pay ETH with the settlment contract's buffer.
+/// 2) Top up settlement contract's ETH buffer by unwrapping way more WETH than this settlement
+///    needs. This will cause the next few settlements to use optimization 1.
+/// If this function returns Err(), the original settlement will not be modified in any way.
 pub async fn optimize_unwrapping<V, VFut, B, BFut>(
     settlement: &mut Settlement,
     settlement_would_succeed: V,

--- a/crates/solver/src/settlement_post_processing/optimize_unwrapping.rs
+++ b/crates/solver/src/settlement_post_processing/optimize_unwrapping.rs
@@ -37,7 +37,7 @@ pub async fn optimize_unwrapping(
     let buffers = buffer_retriever.get_buffers(&[weth.address()]).await;
     let weth_balance = match buffers.get(&weth.address()) {
         Some(Ok(balance)) => *balance,
-        _ => U256::zero(),
+        _ => return settlement,
     };
     let amount_to_unwrap = U256::from_f64_lossy(weth_balance.to_f64_lossy() * unwrap_factor);
 

--- a/crates/solver/src/settlement_post_processing/optimize_unwrapping.rs
+++ b/crates/solver/src/settlement_post_processing/optimize_unwrapping.rs
@@ -1,0 +1,59 @@
+use crate::settlement::Settlement;
+use anyhow::Result;
+use contracts::WETH9;
+use primitive_types::U256;
+
+pub async fn optimize_unwrapping<V, VFut, B, BFut>(
+    settlement: &mut Settlement,
+    settlement_would_succeed: V,
+    get_weth_balance: B,
+    weth: &WETH9,
+    unwrap_factor: f64,
+) -> Result<()>
+where
+    V: Fn(Settlement) -> VFut,
+    VFut: futures::Future<Output = bool>,
+    B: Fn() -> BFut,
+    BFut: futures::Future<Output = Result<U256>>,
+{
+    let required_eth_payout = settlement.encoder.amount_to_unwrap(weth.address());
+    if required_eth_payout.is_zero() {
+        return Ok(());
+    }
+
+    // simulate settlement without unwrap
+    let mut optimized_settlement = settlement.clone();
+    optimized_settlement.encoder.drop_unwrap(weth.address());
+
+    if settlement_would_succeed(optimized_settlement.clone()).await {
+        tracing::debug!("use internal buffer to unwraps");
+        *settlement = optimized_settlement;
+        return Ok(());
+    }
+
+    let weth_balance = get_weth_balance().await?;
+    let amount_to_unwrap = U256::from_f64_lossy(weth_balance.to_f64_lossy() * unwrap_factor);
+
+    if amount_to_unwrap <= required_eth_payout {
+        // if we wouldn't unwrap more than required we can leave the settlement as it is
+        return Ok(());
+    }
+
+    // simulate settlement with way bigger unwrap
+    optimized_settlement
+        .encoder
+        .add_unwrap(crate::interactions::UnwrapWethInteraction {
+            weth: weth.clone(),
+            amount: amount_to_unwrap,
+        });
+
+    if settlement_would_succeed(optimized_settlement.clone()).await {
+        tracing::debug!(
+            ?amount_to_unwrap,
+            "unwrap parts of the settlement contract's WETH buffer"
+        );
+        *settlement = optimized_settlement;
+    }
+
+    Ok(())
+}

--- a/crates/solver/src/settlement_post_processing/optimize_unwrapping.rs
+++ b/crates/solver/src/settlement_post_processing/optimize_unwrapping.rs
@@ -30,7 +30,7 @@ pub async fn optimize_unwrapping(
         .settlement_would_succeed(optimized_settlement.clone())
         .await
     {
-        tracing::debug!("use internal buffer to unwraps");
+        tracing::debug!("use internal buffer for unwraps");
         return optimized_settlement;
     }
 

--- a/crates/solver/src/settlement_post_processing/optimize_unwrapping.rs
+++ b/crates/solver/src/settlement_post_processing/optimize_unwrapping.rs
@@ -20,7 +20,9 @@ pub async fn optimize_unwrapping(
         return settlement;
     }
 
-    // simulate settlement without unwrap
+    // We can't determine how much of the WETH and ETH buffers solvers are using for their
+    // solution. Dropping the unwrap could alter the buffers such that the proposed solution is no
+    // longer possible. That's why a simulation is necessary.
     let mut optimized_settlement = settlement.clone();
     optimized_settlement.encoder.drop_unwrap(weth.address());
 
@@ -52,6 +54,9 @@ pub async fn optimize_unwrapping(
             amount: amount_to_unwrap,
         });
 
+    // We can't determine how much of the WETH and ETH buffers solvers are using for their
+    // solution. Increasing the unwrap could alter the buffers such that the proposed solution is no
+    // longer possible. That's why a simulation is necessary.
     if settlement_simulator
         .settlement_would_succeed(optimized_settlement.clone())
         .await

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -32,7 +32,7 @@ use zeroex_solver::ZeroExSolver;
 
 pub mod balancer_sor_solver;
 mod baseline_solver;
-mod http_solver;
+pub mod http_solver;
 mod naive_solver;
 mod oneinch_solver;
 mod paraswap_solver;


### PR DESCRIPTION
Fixes #1496

This change will cause the internal buffers of the settlement contract to be used for unwraps if somebody buys ETH in a batch.
Before this change, every ETH buy order would result in an unwrap operation during the settlement. With this change we try to buffer unwraps such that we unwrap less frequently. But when we do, we unwrap way more than the current settlement needs so we don't have to unwrap again for a few settlements.
This basically uses the same idea as a `Vec<T>` trying to reduce the number of reallocations when you push elements into it.

If the settlement's unwraps can be paid with the settlement contract's ETH buffer, it does so and simply drops the unwrap operation of the settlement. If that is not possible, the driver computes a WETH amount to unwrap given a user defined factor. If that unwrap would exceed what the current settlement needs, the driver executes the unwrap. If that would NOT yield enough ETH for the settlement, the driver does nothing and leaves the settlement as is which results in the behavior we had before this PR.

The user can define how much of the WETH buffer may be unwrapped by passing `--weth-unwrap-factor` to the solver. This value is supposed to be in the range of [0.0, 1.0]. The unwrap amount is equal to `ETH_BALANCE * weth_unwrap_factor`. I followed the recommendation of 0.6 as the default value like it has been suggested in the linked issue.

For more information about the issue, have a look at the linked issue. It is quite detailed.

### Test Plan
Added unit tests for the algorithm optimizing unwraps.

Did a manual test trading GNO -> ETH on rinkeby without unwraps: https://rinkeby.etherscan.io/tx/0xf326ce6ce3d2da376d233f73d4d9646054eff0d91181825ba6eb8512f98003b5