### PR TITLE
submit settlement to multiple targets at the same time

### DIFF
--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -226,12 +226,12 @@ async fn eth_integration(web3: Web3) {
             gas_price_cap: f64::MAX,
             max_confirm_time: Duration::from_secs(120),
             retry_interval: Duration::from_secs(5),
-            transaction_strategy: solver::settlement_submission::TransactionStrategy::CustomNodes(
+            transaction_strategy: vec![solver::settlement_submission::TransactionStrategy::CustomNodes(
                 StrategyArgs {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     additional_tip: 0.0,
                 },
-            ),
+            )],
         },
         1_000_000_000_000_000_000_u128.into(),
         10,

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -226,12 +226,12 @@ async fn eth_integration(web3: Web3) {
             gas_price_cap: f64::MAX,
             max_confirm_time: Duration::from_secs(120),
             retry_interval: Duration::from_secs(5),
-            transaction_strategy: vec![solver::settlement_submission::TransactionStrategy::CustomNodes(
-                StrategyArgs {
+            transaction_strategy: vec![
+                solver::settlement_submission::TransactionStrategy::CustomNodes(StrategyArgs {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     additional_tip: 0.0,
-                },
-            )],
+                }),
+            ],
         },
         1_000_000_000_000_000_000_u128.into(),
         10,

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -231,12 +231,12 @@ async fn onchain_settlement(web3: Web3) {
             gas_price_cap: f64::MAX,
             max_confirm_time: Duration::from_secs(120),
             retry_interval: Duration::from_secs(5),
-            transaction_strategy: vec![solver::settlement_submission::TransactionStrategy::CustomNodes(
-                StrategyArgs {
+            transaction_strategy: vec![
+                solver::settlement_submission::TransactionStrategy::CustomNodes(StrategyArgs {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     additional_tip: 0.0,
-                },
-            )],
+                }),
+            ],
         },
         1_000_000_000_000_000_000_u128.into(),
         10,

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -231,12 +231,12 @@ async fn onchain_settlement(web3: Web3) {
             gas_price_cap: f64::MAX,
             max_confirm_time: Duration::from_secs(120),
             retry_interval: Duration::from_secs(5),
-            transaction_strategy: solver::settlement_submission::TransactionStrategy::CustomNodes(
+            transaction_strategy: vec![solver::settlement_submission::TransactionStrategy::CustomNodes(
                 StrategyArgs {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     additional_tip: 0.0,
                 },
-            ),
+            )],
         },
         1_000_000_000_000_000_000_u128.into(),
         10,

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -220,12 +220,12 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             gas_price_cap: f64::MAX,
             max_confirm_time: Duration::from_secs(120),
             retry_interval: Duration::from_secs(5),
-            transaction_strategy: solver::settlement_submission::TransactionStrategy::CustomNodes(
+            transaction_strategy: vec![solver::settlement_submission::TransactionStrategy::CustomNodes(
                 StrategyArgs {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     additional_tip: 0.0,
                 },
-            ),
+            )],
         },
         1_000_000_000_000_000_000_u128.into(),
         10,

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -220,12 +220,12 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             gas_price_cap: f64::MAX,
             max_confirm_time: Duration::from_secs(120),
             retry_interval: Duration::from_secs(5),
-            transaction_strategy: vec![solver::settlement_submission::TransactionStrategy::CustomNodes(
-                StrategyArgs {
+            transaction_strategy: vec![
+                solver::settlement_submission::TransactionStrategy::CustomNodes(StrategyArgs {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     additional_tip: 0.0,
-                },
-            )],
+                }),
+            ],
         },
         1_000_000_000_000_000_000_u128.into(),
         10,

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -189,12 +189,12 @@ async fn smart_contract_orders(web3: Web3) {
             gas_price_cap: f64::MAX,
             max_confirm_time: Duration::from_secs(120),
             retry_interval: Duration::from_secs(5),
-            transaction_strategy: solver::settlement_submission::TransactionStrategy::CustomNodes(
+            transaction_strategy: vec![solver::settlement_submission::TransactionStrategy::CustomNodes(
                 StrategyArgs {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     additional_tip: 0.0,
                 },
-            ),
+            )],
         },
         1_000_000_000_000_000_000_u128.into(),
         10,

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -189,12 +189,12 @@ async fn smart_contract_orders(web3: Web3) {
             gas_price_cap: f64::MAX,
             max_confirm_time: Duration::from_secs(120),
             retry_interval: Duration::from_secs(5),
-            transaction_strategy: vec![solver::settlement_submission::TransactionStrategy::CustomNodes(
-                StrategyArgs {
+            transaction_strategy: vec![
+                solver::settlement_submission::TransactionStrategy::CustomNodes(StrategyArgs {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     additional_tip: 0.0,
-                },
-            )],
+                }),
+            ],
         },
         1_000_000_000_000_000_000_u128.into(),
         10,

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -171,12 +171,12 @@ async fn vault_balances(web3: Web3) {
             gas_price_cap: f64::MAX,
             max_confirm_time: Duration::from_secs(120),
             retry_interval: Duration::from_secs(5),
-            transaction_strategy: solver::settlement_submission::TransactionStrategy::CustomNodes(
+            transaction_strategy: vec![solver::settlement_submission::TransactionStrategy::CustomNodes(
                 StrategyArgs {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     additional_tip: 0.0,
                 },
-            ),
+            )],
         },
         1_000_000_000_000_000_000_u128.into(),
         10,

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -171,12 +171,12 @@ async fn vault_balances(web3: Web3) {
             gas_price_cap: f64::MAX,
             max_confirm_time: Duration::from_secs(120),
             retry_interval: Duration::from_secs(5),
-            transaction_strategy: vec![solver::settlement_submission::TransactionStrategy::CustomNodes(
-                StrategyArgs {
+            transaction_strategy: vec![
+                solver::settlement_submission::TransactionStrategy::CustomNodes(StrategyArgs {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     additional_tip: 0.0,
-                },
-            )],
+                }),
+            ],
         },
         1_000_000_000_000_000_000_u128.into(),
         10,

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -65,8 +65,9 @@ pub struct TransactionHandle {
     pub tx_hash: H256,
 }
 
+#[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
-pub trait TransactionSubmitting {
+pub trait TransactionSubmitting: Send + Sync {
     /// Submits transation to the specific network (public mempool, eden, flashbots...).
     /// Returns transaction handle
     async fn submit_transaction(
@@ -322,7 +323,6 @@ impl<'a> Submitter<'a> {
 
             match self.submit_api.submit_transaction(method.tx).await {
                 Ok(handle) => {
-                    tracing::info!("created transaction with hash {}", handle.tx_hash);
                     previous_tx = Some((gas_price, handle));
                     transactions.push(handle.tx_hash)
                 }

--- a/crates/solver/src/settlement_submission/submitter/common.rs
+++ b/crates/solver/src/settlement_submission/submitter/common.rs
@@ -43,7 +43,11 @@ pub async fn submit_raw_transaction(
         .map_err(|err| SubmitApiError::Other(err.into()))?;
 
     let handle = parse_json_rpc_response::<H256>(&body)?;
-    tracing::debug!("transaction handle: {}", handle);
+    tracing::info!(
+        "created transaction with hash: {} and handle: {}",
+        tx_hash,
+        handle
+    );
     Ok(TransactionHandle { tx_hash, handle })
 }
 

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -24,6 +24,7 @@ impl TransactionSubmitting for CustomNodesApi {
         &self,
         tx: TransactionBuilder<DynTransport>,
     ) -> Result<TransactionHandle, SubmitApiError> {
+        tracing::info!("sending transaction to custom nodes...");
         let transaction_request = tx.build().now_or_never().unwrap().unwrap();
         let mut futures = self
             .nodes
@@ -45,10 +46,11 @@ impl TransactionSubmitting for CustomNodesApi {
             let (result, _index, rest) = futures::future::select_all(futures).await;
             match result {
                 Ok(tx_hash) => {
+                    tracing::info!("created transaction with hash: {}", tx_hash);
                     return Ok(TransactionHandle {
                         tx_hash,
                         handle: tx_hash,
-                    })
+                    });
                 }
                 Err(err) if rest.is_empty() => {
                     tracing::debug!("error {}", err);

--- a/crates/solver/src/settlement_submission/submitter/eden_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/eden_api.rs
@@ -24,6 +24,7 @@ impl TransactionSubmitting for EdenApi {
         &self,
         tx: TransactionBuilder<DynTransport>,
     ) -> Result<TransactionHandle, SubmitApiError> {
+        tracing::info!("sending transaction to Eden network...");
         super::common::submit_raw_transaction(self.client.clone(), URL, tx).await
     }
 

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -22,6 +22,7 @@ impl TransactionSubmitting for FlashbotsApi {
         &self,
         tx: TransactionBuilder<DynTransport>,
     ) -> Result<TransactionHandle, SubmitApiError> {
+        tracing::info!("sending transaction to Flashbots network...");
         super::common::submit_raw_transaction(self.client.clone(), URL, tx).await
     }
 


### PR DESCRIPTION
This PR implements the task 3 from: https://github.com/gnosis/gp-v2-services/issues/1407

Up until now, we had the option to submit settlements either to public mempool, Flashbots or Eden.
Now, we can submit settlement to multiple targets at the same time.

`transaction_strategy` is now a vector. If it contains `DryRun` option or if it contains several options where `DryRun` is one of them, then `transaction_strategy` is resolved to `DryRun`. In other cases it is resolved to other strategies or combination of other strategies.

Note that, since we support different `additional_tip` for eden and flashbots, submitted transactions to respective networks will have different hash (because `additional_tip` affects the `gas_price` of the submitted transaction). This is not an issue, they cant be both mined since they have the same nonce.

### Test Plan
Manual test with Flashbots and Eden options passed. The plan is to extensively test and monitor the changes on staging.
