### PR TITLE
changed eden additional tip

### DIFF
--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -207,7 +207,7 @@ struct Arguments {
     #[structopt(
         long,
         env,
-        default_value = "3",
+        default_value = "0",
         parse(try_from_str = shared::arguments::wei_from_gwei)
     )]
     additional_eden_tip: f64,


### PR DESCRIPTION
Additional tip is used to increase the chances of our tx being mined by Eden Network, by additionally boosting the gas_price calculated by our gas price estimator.

Now, we set this value to 0 since we will stake Eden tokens with our solver accounts and achieve priority this way.
Leaving it at 3gwei seems like a waste of funds.

I want to leave this option to exist so we could boost some solver accounts that don't want to stake Eden (currently all solver accounts are ours and we can control the staking).

Note: Don't merge this PR before the airdrop is done for all stag/prod solver accounts.