### PR TITLE
add possibility to disable strategies

### DIFF
--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -45,6 +45,8 @@ pub enum SettlementSubmissionOutcome {
     Revert,
     /// Submission timed-out while waiting for the transaction to get mined.
     Timeout,
+    /// Submission disabled
+    Disabled,
     /// A transaction failed to be submitted or, in the case of private network
     /// submission, the blockchain state changed and the transaction is no
     /// longer valid.
@@ -320,6 +322,7 @@ impl SolverMetrics for Metrics {
             SettlementSubmissionOutcome::Success => "success",
             SettlementSubmissionOutcome::Revert => "revert",
             SettlementSubmissionOutcome::Timeout => "timeout",
+            SettlementSubmissionOutcome::Disabled => "disabled",
             SettlementSubmissionOutcome::Failure => "failure",
         };
         self.settlement_submissions

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -256,6 +256,11 @@ impl Settlement {
         let merged = self.encoder.merge(other.encoder)?;
         Ok(Self { encoder: merged })
     }
+
+    // Move to a separate struct to enable caching the result?
+    pub fn mev_extractable(&self) -> bool {
+        todo!()
+    }
 }
 
 impl From<Settlement> for EncodedSettlement {

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -1,10 +1,14 @@
-use super::super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting};
+use super::{
+    super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
+    SubmissionLoopStatus,
+};
 use anyhow::Result;
 use ethcontract::{
     dyns::DynTransport,
     transaction::{Transaction, TransactionBuilder},
 };
 use futures::FutureExt;
+use gas_estimation::EstimatedGasPrice;
 use shared::Web3;
 
 #[derive(Clone)]
@@ -68,5 +72,9 @@ impl TransactionSubmitting for CustomNodesApi {
 
     async fn cancel_transaction(&self, _id: &TransactionHandle) -> Result<()> {
         Ok(())
+    }
+
+    fn submission_status(&self, _gas_price: &EstimatedGasPrice) -> SubmissionLoopStatus {
+        SubmissionLoopStatus::Enabled
     }
 }

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -1,6 +1,10 @@
-use super::super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting};
+use super::{
+    super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
+    SubmissionLoopStatus,
+};
 use anyhow::Result;
 use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder};
+use gas_estimation::EstimatedGasPrice;
 use reqwest::Client;
 
 const URL: &str = "https://rpc.flashbots.net";
@@ -27,5 +31,9 @@ impl TransactionSubmitting for FlashbotsApi {
 
     async fn cancel_transaction(&self, _id: &TransactionHandle) -> Result<()> {
         Ok(())
+    }
+
+    fn submission_status(&self, _gas_price: &EstimatedGasPrice) -> SubmissionLoopStatus {
+        SubmissionLoopStatus::Enabled
     }
 }


### PR DESCRIPTION
This PR implements task 4 from: https://github.com/gnosis/gp-v2-services/issues/1407

The idea is following:
1. All transaction strategies that are considered are received on program start up (`transaction_strategy` argument)
2. For each submission loop (one specific settlement) disable some of the strategies before entering the submission loop (for example, we know if settlement is MEV extractable before starting the submission loop)
2. For each loop inside submission loop, additionally disable/reenable some of the strategies based on some dynamically changed parameters (for example, if effective gas price becomes > 500gwei, disable Eden network temporarily)
