### PR TITLE
Change default transaction strategy to PublicMempool

### DIFF
--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -197,7 +197,7 @@ struct Arguments {
     #[structopt(
         long,
         env,
-        default_value = "Flashbots,Eden",
+        default_value = "PublicMempool",
         possible_values = &TransactionStrategyArg::variants(),
         case_insensitive = true,
         use_delimiter = true)]


### PR DESCRIPTION
This PR changes the default transaction strategy to `PublicMempool`. The rational behind this change is that this is the only strategy that works on all supported networks (Mainnet, Rinkeby, xDai, Ganache) without any additional configuration.

### Test Plan

```
$ cargo run -p solver -- \
  --node-url $NODE_URL \
  --solver-account $SOLVER_ACCOUNT \
  | grep -C1 'PublicMempool'
    transaction_strategy: [
        PublicMempool,
    ],
```
