### PR TITLE
Don't re-index Balancer factories without any pools

### DIFF
--- a/crates/shared/src/sources/balancer_v2/graph_api.rs
+++ b/crates/shared/src/sources/balancer_v2/graph_api.rs
@@ -117,6 +117,15 @@ pub struct RegisteredPools {
 }
 
 impl RegisteredPools {
+    /// Creates an empty collection of registered pools for the specified block
+    /// number.
+    pub fn empty(fetched_block_number: u64) -> Self {
+        Self {
+            fetched_block_number,
+            ..Default::default()
+        }
+    }
+
     /// Groups registered pools by factory addresses.
     pub fn group_by_factory(self) -> HashMap<H160, RegisteredPools> {
         let fetched_block_number = self.fetched_block_number;


### PR DESCRIPTION
With the refactor introduced in https://github.com/gnosis/gp-v2-services/pull/1487, we now attempt to re-index since block 0 Balancer pools for factories that have never created a pool.

For example, if we look at Balancer stable pools on Rinkeby (there has never been one created 😱) we see this:
```
$ cargo run -p solver -- --node-url https://rinkeby.infura.io/v3/$INFURA_PROJECT_ID --orderbook-url https://protocol-rinkeby.gnosis.io --balancer-factories Stable
...
2022-01-05T18:48:54.538Z DEBUG shared::event_handling: updating events in block range Specific(0)..=Latest(9939730)
...
```

Notice that it tries to index all stable pools from blocks 0 to 9939730 (`latest` at the time) even though we know at this point that there aren't any stable pools. This PR fixes this issue and correctly sets the `start_sync_at_block` for the Balancer pool registry in these cases.

Thanks @MartinquaXD for noticing this and bisecting the commit that caused the issue!

### Test Plan

CI + Compiler. Also manually testing out the change we see:
```
$ cargo run -p solver -- --node-url https://rinkeby.infura.io/v3/$INFURA_PROJECT_ID --orderbook-url https://protocol-rinkeby.gnosis.io --balancer-factories Stable
...
2022-01-05T18:57:37.774Z DEBUG shared::event_handling: updating events in block range Specific(9939714)..=Latest(9939765)
...
```
