### PR TITLE
Adjust Swagger URLs to new `cow.fi` Domain

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -3,20 +3,20 @@ info:
   version: 0.0.1
   title: Order Book API
 servers:
-  - url: https://protocol-mainnet.dev.gnosisdev.com
-    description: Mainnet (Staging)
-  - url: https://protocol-mainnet.gnosis.io
-    description: Mainnet (Prod)
-  - url: https://protocol-rinkeby.dev.gnosisdev.com
-    description: Rinkeby (Staging)
-  - url: https://protocol-rinkeby.gnosis.io
-    description: Rinkeby (Prod)
-  - url: https://protocol-xdai.dev.gnosisdev.com
-    description: xDai (Staging)
-  - url: https://protocol-xdai.gnosis.io
-    description: xDai (Prod)
-  - url: http://localhost:8080
-    description: Local
+  - description: Mainnet (Staging)
+    url: https://barn.api.cow.fi/mainnet
+  - description: Mainnet (Prod)
+    url: https://api.cow.fi/mainnet
+  - description: Rinkeby (Staging)
+    url: https://barn.api.cow.fi/rinkeby
+  - description: Rinkeby (Prod)
+    url: https://api.cow.fi/rinkeby
+  - description: xDai (Staging)
+    url: https://barn.api.cow.fi/xdai
+  - description: xDai (Prod)
+    url: https://api.cow.fi/xdai
+  - description: Local
+    url: http://localhost:8080
 paths:
   /api/v1/orders:
     post:

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -11,9 +11,9 @@ servers:
     url: https://barn.api.cow.fi/rinkeby
   - description: Rinkeby (Prod)
     url: https://api.cow.fi/rinkeby
-  - description: xDai (Staging)
+  - description: Gnosis Chain (Staging)
     url: https://barn.api.cow.fi/xdai
-  - description: xDai (Prod)
+  - description: Gnosis Chain (Prod)
     url: https://api.cow.fi/xdai
   - description: Local
     url: http://localhost:8080


### PR DESCRIPTION
This PR adjusts the Swagger URLs to point to our new `cow.fi` domain! 🎉 🐮

I also decided to order the YAML pairs as `descritpion` -> `url` as I found it slightly more intuitive.

### Test Plan

Check it out! https://barn.api.cow.fi/docs/

<img width="423" alt="image" src="https://user-images.githubusercontent.com/4210206/148734847-52be9eeb-1438-4321-aec2-4bf941cd5207.png">



