### PR TITLE
Make README.md more beginner friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,11 @@ Run an `orderbook` on `localhost:8080` with:
 ```sh
 cargo run --bin orderbook -- \
   --skip-trace-api true \
+  --skip-event-sync \
   --node-url <YOUR_NODE_URL>
 ```
+
+`--skip-event-sync` will skip some work to speed up the initialization process.
 
 `--skip-trace-api true` will make the orderbook compatible with more ethereum nodes. If your node supports `trace_callMany` you can drop this argument.
 
@@ -178,11 +181,11 @@ Run a solver which is connected to an `orderbook` at `localhost:8080` with:
 ```sh
 cargo run -p solver -- \
   --solver-account 0xa6DDBD0dE6B310819b49f680F65871beE85f517e \
-  --baseline-sources UniswapV2,SushiSwap \
+  --transaction-strategy DryRun \
   --node-url <YOUR_NODE_URL>
 ```
 
-Because this command was designed to work with `node-urls` from mainnet and rinkeby it limits the `baseline-sources` to `UniswapV2` and `SushiSwap`. If your `node-url` belongs to mainnet, you can drop this argument all together to get access to all supported `baseline-sources`.
+`--transaction-strategy DryRun` will make the solver only print the solution but not submit it on-chain. This command is absolutely safe and will not use any funds.
 
 The `solver-account` is responsible for signing transactions. Solutions for settlements need to come from an address the settlement contract trusts in order to make the contract actually consider the solution. Adding your personal solver account is quite involved and requires you to get in touch with the team, so we are using this public solver address for now.
 

--- a/README.md
+++ b/README.md
@@ -132,16 +132,18 @@ Due to the RPC calls the services issue `Ganache` is incompatible, so we will us
 1. Install [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)  
 2. Install hardhat with `npm install --save-dev hardhat`  
 3. Create `hardhat.config.js` in the directory you installed `hardhat` in with following content:
-<pre><code>module.exports = {
-        networks: { 
-            hardhat: {
-                initialBaseFeePerGas: 0,
-                accounts: {
-                    accountsBalance: "1000000000000000000000000"
-                }
-            }
-        }
-};</code></pre>
+   ```javascript
+   module.exports = {
+       networks: { 
+           hardhat: {
+               initialBaseFeePerGas: 0,
+               accounts: {
+                   accountsBalance: "1000000000000000000000000"
+               }
+           }
+       }
+   };
+   ```
 4. Run local testnet with `npx hardhat node`
 
 ## Running the Services Locally

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ docker build --tag gp-v2-migrations -f docker/Dockerfile.migration .
 docker run -ti -e FLYWAY_URL="jdbc:postgresql://host.docker.internal/?user="$USER"&password=" -v $PWD/database/sql:/flyway/sql gp-v2-migrations migrate
 ```
 
+In case you run into `java.net.UnknownHostException: host.docker.internal` add `--add-host=host.docker.internal:host-gateway` right after `docker run`.
+
 If you're combining a local postgres installation with docker flyway you have to add to the above `--network host` and change `host.docker.internal` to `localhost`.
 
 - Local [flyway installation](https://flywaydb.org/documentation/usage/commandline/#download-and-installation)

--- a/README.md
+++ b/README.md
@@ -126,11 +126,23 @@ flyway -user=$USER -password="" -locations="filesystem:database/sql/" -url=jdbc:
 
 ### Local Test Network
 
-With a testnet (e.g. [Ganache](https://www.trufflesuite.com/ganache)) running on `localhost:8545` deploy the contracts via:
+In order to run the `e2e` tests you have to have a testnet running locally.
+Due to the RPC calls the services issue `Ganache` is incompatible, so we will use `hardhat`.
 
-```sh
-cd contracts; cargo run --bin deploy --features bin; cd -
-```
+1. Install [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)  
+2. Install hardhat with `npm install --save-dev hardhat`  
+3. Create `hardhat.config.js` in the directory you installed `hardhat` in with following content:
+<pre><code>module.exports = {
+        networks: { 
+            hardhat: {
+                initialBaseFeePerGas: 0,
+                accounts: {
+                    accountsBalance: "1000000000000000000000000"
+                }
+            }
+        }
+};</code></pre>
+4. Run local testnet with `npx hardhat node`
 
 ## Running the services
 

--- a/README.md
+++ b/README.md
@@ -204,4 +204,4 @@ Always make sure that the `solver` and the `orderbook` it connects to are config
 
 ### Frontend
 
-To conveniently submit orders checkout the [GPv2 UI](https://github.com/gnosis/gp-swap-ui) and point it to your local instance.
+To conveniently submit orders checkout the [CowSwap](https://github.com/gnosis/cowswap) frontend and point it to your local instance.

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ cargo run -p solver -- \
 
 `--transaction-strategy DryRun` will make the solver only print the solution but not submit it on-chain. This command is absolutely safe and will not use any funds.
 
-The `solver-account` is responsible for signing transactions. Solutions for settlements need to come from an address the settlement contract trusts in order to make the contract actually consider the solution. Adding your personal solver account is quite involved and requires you to get in touch with the team, so we are using this public solver address for now.
+The `solver-account` is responsible for signing transactions. Solutions for settlements need to come from an address the settlement contract trusts in order to make the contract actually consider the solution. If we pass a public address, like we do here, the solver only pretends to be use it for testing purposes. To actually submit transactions on behalf of a solver account you would have to pass a private key of an account the settlement contract trusts instead. Adding your personal solver account is quite involved and requires you to get in touch with the team, so we are using this public solver address for now.
 
 To make things more interesting and see some real orders you can connect the `solver` to our real `orderbook` service. There are several orderbooks for production and staging environments on different networks. Find the `orderbook-url` corresponding to your `node-url` which suits your purposes and connect your solver to it with `--orderbook-url <URL>`.
 

--- a/crates/contracts/README.md
+++ b/crates/contracts/README.md
@@ -2,26 +2,6 @@
 
 The library part of this crate contains `ethcontract` generated bindings to the smart contracts we use.
 
-## `deploy` Script
-
-A `[[bin]]` script for deploying Gnosis Protocol v2 contracts to a test network.
-This script requires a test node such as Ganache (with at least Istanbul Hardfork) listening on `127.0.0.1:8545`.
-It can be run from the repository root:
-
-```
-$ (cd contracts; cargo run --bin deploy --features bin)
-```
-
-This will generate `$CONTRACT_NAME.addr` files in the `target/deploy` directory.
-The `build.rs` script uses these files to inject test network deployed addresses
-into the generated bindings so `Contract::deployed()` methods work as expected
-for E2E tests when connected to a local network.
-
-Note that the `contracts` crate needs to be re-built after running the `deploy`
-script to generate bindings with the injected test network addresses. This is
-done automatically on `cargo build` by leveraging the `cargo:rerun-if-changed`
-build script feature.
-
 ## `vendor` script
 
 A `[[bin]]` script for vendoring smart contract json artifacts that ethcontract uses to generate its bindings. We keep these in the repository to make the build more deterministic and robust.


### PR DESCRIPTION
When trying to get a `solver` and an `orderbook` up and running just by looking into the `README.md` files I ran into some outdated or missing information.
I now added all the information which I think is required to make starting the services on your machine more beginner friendly.

Changes include:
- Adding fix for flyway docker command which I needed on Linux
- Dropping docs about deleted `deploy` script
- Starting a testnet with `hardhat` instead of `ganache` due to compatibility issues
- Mentioning specific hardhat configuration which is required for e2e tests to pass
- Adding commands running `solver` and `orderbook` which don't show any weird behavior with rinkeby
- Adding a solver address which is needed to run the `solver`

### Test Plan
Manual test
