### PR TITLE
Create price estimator cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "cached"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2bc2fd249a24a9cdd4276f3a3e0461713271ab63b0e9e656e200e8e21c8c927"
+dependencies = [
+ "hashbrown",
+ "once_cell",
+]
+
+[[package]]
 name = "cast"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2554,6 +2564,7 @@ dependencies = [
  "assert_approx_eq",
  "async-trait",
  "atty",
+ "cached",
  "chrono",
  "contracts",
  "derivative",

--- a/crates/orderbook/src/metrics.rs
+++ b/crates/orderbook/src/metrics.rs
@@ -30,6 +30,7 @@ pub struct Metrics {
     /// Gas estimate metrics
     gas_price: Gauge,
     price_estimates: IntCounterVec,
+    price_estimator_cache: IntCounterVec,
 }
 
 impl Metrics {
@@ -61,7 +62,6 @@ impl Metrics {
             "Number of cache hits in the pool fetcher cache.",
         )?;
         registry.register(Box::new(pool_cache_hits.clone()))?;
-
         let pool_cache_misses = IntCounter::new(
             "pool_cache_misses",
             "Number of cache misses in the pool fetcher cache.",
@@ -85,6 +85,15 @@ impl Metrics {
         )?;
         registry.register(Box::new(price_estimates.clone()))?;
 
+        let price_estimator_cache = IntCounterVec::new(
+            Opts::new(
+                "price_estimator_cache",
+                "Price estimator cache hit/miss counter.",
+            ),
+            &["estimator_type", "result"],
+        )?;
+        registry.register(Box::new(price_estimates.clone()))?;
+
         Ok(Self {
             api_requests,
             db_table_row_count,
@@ -94,6 +103,7 @@ impl Metrics {
             database_queries,
             gas_price,
             price_estimates,
+            price_estimator_cache,
         })
     }
 
@@ -154,6 +164,17 @@ impl BalancerPoolCacheMetrics for Metrics {
         // liquidity sources in the future, for now just use the same counters.
         self.pool_cache_hits.inc_by(cache_hits as u64);
         self.pool_cache_misses.inc_by(cache_misses as u64);
+    }
+}
+
+impl shared::price_estimation::cached::Metrics for Metrics {
+    fn price_estimator_cache(&self, name: &str, misses: usize, hits: usize) {
+        self.price_estimator_cache
+            .with_label_values(&[name, "misses"])
+            .inc_by(misses as u64);
+        self.price_estimator_cache
+            .with_label_values(&[name, "hits"])
+            .inc_by(hits as u64);
     }
 }
 

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0"
 assert_approx_eq = "1.1"
 async-trait = "0.1"
 atty = "0.2"
+cached = { version = "0.26", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 contracts = { path = "../contracts" }
 derivative = "2.2"

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -1,4 +1,5 @@
 pub mod baseline;
+pub mod cached;
 pub mod competition;
 pub mod gas;
 pub mod instrumented;
@@ -59,7 +60,7 @@ impl Clone for PriceEstimationError {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 pub struct Query {
     pub sell_token: H160,
     pub buy_token: H160,

--- a/crates/shared/src/price_estimation/cached.rs
+++ b/crates/shared/src/price_estimation/cached.rs
@@ -1,0 +1,107 @@
+use super::{Estimate, PriceEstimating, PriceEstimationError, Query};
+use cached::{Cached, TimedSizedCache};
+use std::{sync::Mutex, time::Duration};
+
+/// Price estimator wrapper that caches Ok results for some time.
+pub struct CachingPriceEstimator {
+    inner: Box<dyn PriceEstimating>,
+    cache: Mutex<TimedSizedCache<Query, Estimate>>,
+}
+
+impl CachingPriceEstimator {
+    pub fn new(inner: Box<dyn PriceEstimating>, max_age: Duration, max_size: usize) -> Self {
+        Self {
+            inner,
+            cache: Mutex::new(TimedSizedCache::with_size_and_lifespan_and_refresh(
+                max_size,
+                max_age.as_secs(),
+                false,
+            )),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl PriceEstimating for CachingPriceEstimator {
+    async fn estimates(&self, queries: &[Query]) -> Vec<Result<Estimate, PriceEstimationError>> {
+        let mut cached: Vec<Option<Estimate>> = Vec::with_capacity(queries.len());
+        let mut missing: Vec<Query> = Vec::new();
+
+        {
+            let mut cache = self.cache.lock().unwrap();
+            for query in queries {
+                match cache.cache_get(query) {
+                    Some(estimate) => {
+                        cached.push(Some(*estimate));
+                    }
+                    None => {
+                        cached.push(None);
+                        missing.push(*query);
+                    }
+                }
+            }
+        }
+
+        let inner_results = self.inner.estimates(&missing).await;
+        {
+            let mut cache = self.cache.lock().unwrap();
+            for (query, result) in missing.iter().zip(inner_results.iter()) {
+                if let Ok(estimate) = result {
+                    cache.cache_set(*query, *estimate);
+                }
+            }
+        }
+
+        let mut inner_results = inner_results.into_iter();
+        cached
+            .into_iter()
+            .map(|r| match r {
+                Some(estimate) => Ok(estimate),
+                // unwrap because None count == inner_results.len()
+                None => inner_results.next().unwrap(),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::MockPriceEstimating;
+    use super::*;
+    use futures::FutureExt;
+    use primitive_types::H160;
+
+    #[test]
+    fn cache_is_used() {
+        let query = |u: u64| Query {
+            sell_token: H160::from_low_u64_be(u),
+            ..Default::default()
+        };
+        let mut inner = MockPriceEstimating::new();
+        inner.expect_estimates().times(1).returning(|queries| {
+            assert!(queries.len() == 1);
+            assert!(queries[0].sell_token.to_low_u64_be() == 0);
+            vec![Ok(Estimate {
+                out_amount: 0.into(),
+                gas: 0.into(),
+            })]
+        });
+        inner.expect_estimates().times(1).returning(|queries| {
+            assert!(queries.len() == 1);
+            assert!(queries[0].sell_token.to_low_u64_be() == 1);
+            vec![Ok(Estimate {
+                out_amount: 1.into(),
+                gas: 0.into(),
+            })]
+        });
+        let cache = CachingPriceEstimator::new(Box::new(inner), Duration::from_secs(1), 10);
+        let result = cache.estimates(&[query(0)]).now_or_never().unwrap();
+        assert!(result[0].as_ref().unwrap().out_amount == 0.into());
+        let result = cache
+            .estimates(&[query(1), query(0)])
+            .now_or_never()
+            .unwrap();
+        assert!(result[0].as_ref().unwrap().out_amount == 1.into());
+        assert!(result[1].as_ref().unwrap().out_amount == 0.into());
+    }
+}


### PR DESCRIPTION
Part of https://github.com/gnosis/gp-v2-services/issues/1533 .

This is a generic price estimation cache that we can use to wrap the external price estimation apis.

I initially implemented the cache myself but decided on using a dependency that already implements what we want and feels well made.

In a follow up PR I would change the Paraswap and 0x estimators to use the cache.

### Test Plan
unit test