### PR TITLE
Implemented cancel_submission for Eden and CustomNodes strategies

### DIFF
--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -341,7 +341,7 @@ impl<'a> Submitter<'a> {
 
             match self.submit_api.submit_transaction(method.tx).await {
                 Ok(handle) => {
-                    previous_tx = Some((gas_price, handle.clone()));
+                    previous_tx = Some((gas_price, handle));
                     transactions.push(handle.tx_hash)
                 }
                 Err(err) => match err {

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -65,6 +65,14 @@ pub struct TransactionHandle {
     pub tx_hash: H256,
 }
 
+#[derive(Debug, Clone)]
+pub struct CancelHandle {
+    /// transaction previosly submitted using TransactionSubmitting::submit_transaction()
+    pub submitted_transaction: TransactionHandle,
+    /// empty transaction with the same nonce used for cancelling the previously submitted transaction
+    pub noop_transaction: TransactionBuilder<DynTransport>,
+}
+
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait TransactionSubmitting: Send + Sync {
@@ -74,8 +82,10 @@ pub trait TransactionSubmitting: Send + Sync {
         &self,
         tx: TransactionBuilder<DynTransport>,
     ) -> Result<TransactionHandle, SubmitApiError>;
-    /// Cancels already submitted transaction using the transaction handle
-    async fn cancel_transaction(&self, id: &TransactionHandle) -> Result<()>;
+    /// Cancels already submitted transaction using the cancel handle
+    async fn cancel_transaction(&self, id: &CancelHandle) -> Result<()>;
+    /// Marks previously submitted transaction as outdated and prevents from being mined
+    async fn mark_transaction_outdated(&self, id: &TransactionHandle) -> Result<()>;
 }
 
 /// Gas price estimator specialized for sending transactions to the network
@@ -289,8 +299,16 @@ impl<'a> Submitter<'a> {
             // simulate transaction
 
             if let Err(err) = method.clone().view().call().await {
-                if let Some((_, previous_tx)) = previous_tx.as_ref() {
-                    if let Err(err) = self.submit_api.cancel_transaction(previous_tx).await {
+                if let Some((_, previous_tx)) = previous_tx {
+                    let cancel_handle = CancelHandle {
+                        submitted_transaction: previous_tx,
+                        noop_transaction: self.build_noop_transaction(
+                            &gas_price.bump(3.),
+                            nonce,
+                            gas_limit,
+                        ),
+                    };
+                    if let Err(err) = self.submit_api.cancel_transaction(&cancel_handle).await {
                         tracing::warn!("cancellation failed: {:?}", err);
                     }
                 }
@@ -304,7 +322,7 @@ impl<'a> Submitter<'a> {
                 if gas_price.cap() > previous_gas_price.cap()
                     && gas_price.tip() > previous_gas_price.tip()
                 {
-                    if let Err(err) = self.submit_api.cancel_transaction(previous_tx).await {
+                    if let Err(err) = self.submit_api.mark_transaction_outdated(previous_tx).await {
                         tracing::warn!("cancellation failed: {:?}", err);
                     }
                 } else {
@@ -323,7 +341,7 @@ impl<'a> Submitter<'a> {
 
             match self.submit_api.submit_transaction(method.tx).await {
                 Ok(handle) => {
-                    previous_tx = Some((gas_price, handle));
+                    previous_tx = Some((gas_price, handle.clone()));
                     transactions.push(handle.tx_hash)
                 }
                 Err(err) => match err {
@@ -358,6 +376,27 @@ impl<'a> Submitter<'a> {
             .nonce(nonce)
             .gas(U256::from_f64_lossy(gas_limit))
             .gas_price(gas_price)
+    }
+
+    /// Prepare transaction for simulation
+    fn build_noop_transaction(
+        &self,
+        gas_price: &EstimatedGasPrice,
+        nonce: U256,
+        gas_limit: f64,
+    ) -> TransactionBuilder<DynTransport> {
+        let gas_price = if let Some(eip1559) = gas_price.eip1559 {
+            (eip1559.max_fee_per_gas, eip1559.max_priority_fee_per_gas).into()
+        } else {
+            gas_price.legacy.into()
+        };
+
+        TransactionBuilder::new(self.contract.raw_instance().web3())
+            .from(self.account.clone())
+            .to(self.account.address())
+            .nonce(nonce)
+            .gas_price(gas_price)
+            .gas(U256::from_f64_lossy(gas_limit))
     }
 }
 

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -1,5 +1,8 @@
-use super::super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting};
-use anyhow::Result;
+use super::{
+    super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
+    CancelHandle,
+};
+use anyhow::{anyhow, Result};
 use ethcontract::{
     dyns::DynTransport,
     transaction::{Transaction, TransactionBuilder},
@@ -66,7 +69,14 @@ impl TransactionSubmitting for CustomNodesApi {
         }
     }
 
-    async fn cancel_transaction(&self, _id: &TransactionHandle) -> Result<()> {
+    async fn cancel_transaction(&self, id: &CancelHandle) -> Result<()> {
+        match self.submit_transaction(id.noop_transaction.clone()).await {
+            Ok(_) => Ok(()),
+            Err(err) => Err(anyhow!("{:?}", err)),
+        }
+    }
+
+    async fn mark_transaction_outdated(&self, _id: &TransactionHandle) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/solver/src/settlement_submission/submitter/eden_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/eden_api.rs
@@ -1,7 +1,10 @@
 //! https://docs.edennetwork.io/for-traders/getting-started
 
-use super::super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting};
-use anyhow::Result;
+use super::{
+    super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
+    CancelHandle,
+};
+use anyhow::{anyhow, Result};
 use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder};
 use reqwest::Client;
 
@@ -27,7 +30,20 @@ impl TransactionSubmitting for EdenApi {
         super::common::submit_raw_transaction(self.client.clone(), URL, tx).await
     }
 
-    async fn cancel_transaction(&self, _id: &TransactionHandle) -> Result<()> {
+    async fn cancel_transaction(&self, id: &CancelHandle) -> Result<()> {
+        match super::common::submit_raw_transaction(
+            self.client.clone(),
+            URL,
+            id.noop_transaction.clone(),
+        )
+        .await
+        {
+            Ok(_) => Ok(()),
+            Err(err) => Err(anyhow!("{:?}", err)),
+        }
+    }
+
+    async fn mark_transaction_outdated(&self, _id: &TransactionHandle) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -1,4 +1,7 @@
-use super::super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting};
+use super::{
+    super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
+    CancelHandle,
+};
 use anyhow::Result;
 use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder};
 use reqwest::Client;
@@ -25,7 +28,11 @@ impl TransactionSubmitting for FlashbotsApi {
         super::common::submit_raw_transaction(self.client.clone(), URL, tx).await
     }
 
-    async fn cancel_transaction(&self, _id: &TransactionHandle) -> Result<()> {
+    async fn cancel_transaction(&self, _id: &CancelHandle) -> Result<()> {
+        Ok(())
+    }
+
+    async fn mark_transaction_outdated(&self, _id: &TransactionHandle) -> Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
Yesterday, we tried out the Flashbots+Eden transaction submission strategy on prod and had too many failing transactions.
Based on my analysis, quite a few of them could be prevented by:
1. Lowering the cli argument submission_retry_interval_seconds from 5s to 1-2s in order to detect simulation failure as soon as possible.
2. Cancelling the tx on Eden network by sending a noop transaction with higher gas price to replace the old tx (I was aiming to avoid this during the refactor of submission logic but it seems its inevitable).
3. Bidding for slot on Eden network.

This PR implements point 2.

This PR is not quite clean. Additional effort could be invested to clean it up, but for now I want to test the effects of this change prior to investing more time in further implementation.