### PR TITLE
Move 1Inch API from solver crate to shared crate

### DIFF
--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -14,6 +14,7 @@ pub mod http_solver;
 pub mod maintenance;
 pub mod metrics;
 pub mod network;
+pub mod oneinch_api;
 pub mod paraswap_api;
 pub mod price_estimation;
 pub mod recent_block_cache;


### PR DESCRIPTION
This change moves the existing `1Inch` API code from the solver crate to shared to allow a yet to be implemented `1Inch` price estimator to use it. This resolves the first task in #1529.
This PR just moves the code and updates `use` statements accordingly.

### Test Plan
no new tests because the behavior of the code shouldn't have changed
