### PR TITLE
Add 1Inch quoting API

### DIFF
--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -37,6 +37,13 @@ impl<const MIN: usize, const MAX: usize> Display for Amount<MIN, MAX> {
     }
 }
 
+// The `Display` implementation for `H160` unfortunately does not print
+// the full address and instead uses ellipsis (e.g. "0xeeee…eeee"). This
+// helper just works around that.
+fn addr2str(addr: H160) -> String {
+    format!("{:?}", addr)
+}
+
 /// A 1Inch API quote query parameters.
 ///
 /// These parameters are currently incomplete, and missing parameters can be
@@ -73,13 +80,6 @@ pub struct SwapQuery {
 impl SwapQuery {
     /// Encodes the swap query as
     fn into_url(self, base_url: &Url) -> Url {
-        // The `Display` implementation for `H160` unfortunately does not print
-        // the full address and instead uses ellipsis (e.g. "0xeeee…eeee"). This
-        // helper just works around that.
-        fn addr2str(addr: H160) -> String {
-            format!("{:?}", addr)
-        }
-
         let mut url = base_url
             .join("v3.0/1/swap")
             .expect("unexpectedly invalid URL segment");


### PR DESCRIPTION
In order to implement a `OneInchPriceEstimator` our `OneInchClient` needs to support the 1Inch quote API.
Unfortunately the [quote API](https://docs.1inch.io/docs/aggregation-protocol/api/quote-params) only supports quoting sell orders so I named the involved types and functions accordingly.
This PR resolves task 3 & 4 of #1529.

### Test Plan
For the new unit tests I tried to cover the same scenarios as the tests for the `swap` API.
- serializing `SellOrderQuoteQuery` only with required parameters set
- serializing `SellOrderQuoteQuery` with all parameters set
- deserializing authentic 1Inch quote response
- deserializing authentic 1Inch error response
- executing an actual quote request only with required parameters set
- executing an actual quote request only with all parameters set
