### PR TITLE
Add price estimator for 1Inch

### DIFF
--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -295,11 +295,8 @@ impl IntoWarpReply for PriceEstimationError {
                 StatusCode::BAD_REQUEST,
             ),
             Self::UnsupportedOrderType => with_status(
-                error(
-                    "UnsupportedOrderType",
-                    "Can not estimate price for this order type",
-                ),
-                StatusCode::BAD_REQUEST,
+                internal_error(anyhow::anyhow!("UnsupportedOrderType").context("price_estimation")),
+                StatusCode::INTERNAL_SERVER_ERROR,
             ),
             Self::Other(err) => with_status(
                 internal_error(err.context("price_estimation")),

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -294,6 +294,13 @@ impl IntoWarpReply for PriceEstimationError {
                 error("ZeroAmount", "Please use non-zero amount field"),
                 StatusCode::BAD_REQUEST,
             ),
+            Self::UnsupportedOrderType => with_status(
+                error(
+                    "UnsupportedOrderType",
+                    "Can not estimate price for this order type",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
             Self::Other(err) => with_status(
                 internal_error(err.context("price_estimation")),
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -518,11 +518,11 @@ async fn main() {
                         &estimator.name(),
                     )),
                     PriceEstimatorType::OneInch => Box::new(instrumented_and_cached(
-                            Box::new(OneInchPriceEstimator::new(
-                                Arc::new(OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, client.clone()).unwrap()),
-                                args.disabled_one_inch_protocols.clone()
-                            )),
-                            &estimator.name(),
+                        Box::new(OneInchPriceEstimator::new(
+                            Arc::new(OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, client.clone()).unwrap()),
+                            args.disabled_one_inch_protocols.clone()
+                        )),
+                        &estimator.name(),
                     ))
                 },
             )

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -197,6 +197,12 @@ struct Arguments {
     /// The maximum number of price estimates that will be cached.
     #[structopt(long, default_value = "1000")]
     price_estimator_cache_size: usize,
+
+    /// The list of disabled 1Inch protocols. By default, the `PMM1` protocol
+    /// (representing a private market maker) is disabled as it seems to
+    /// produce invalid swaps.
+    #[structopt(long, env, default_value = "PMM1", use_delimiter = true)]
+    disabled_one_inch_protocols: Vec<String>,
 }
 
 pub async fn database_metrics(metrics: Arc<Metrics>, database: Postgres) -> ! {
@@ -511,10 +517,11 @@ async fn main() {
                         }),
                         &estimator.name(),
                     )),
-                    PriceEstimatorType::OneInch => Box::new(instrumented(
-                            Box::new(OneInchPriceEstimator {
-                                api: Arc::new(OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, client.clone()).unwrap())
-                            }),
+                    PriceEstimatorType::OneInch => Box::new(instrumented_and_cached(
+                            Box::new(OneInchPriceEstimator::new(
+                                Arc::new(OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, client.clone()).unwrap()),
+                                args.disabled_one_inch_protocols.clone()
+                            )),
                             &estimator.name(),
                     ))
                 },

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -20,6 +20,8 @@ use orderbook::{
     verify_deployed_contract_constants,
 };
 use primitive_types::H160;
+use shared::oneinch_api::OneInchClientImpl;
+use shared::price_estimation::oneinch::OneInchPriceEstimator;
 use shared::price_estimation::quasimodo::QuasimodoPriceEstimator;
 use shared::price_estimation::sanitized::SanitizedPriceEstimator;
 use shared::price_estimation::zeroex::ZeroExPriceEstimator;
@@ -509,6 +511,12 @@ async fn main() {
                         }),
                         &estimator.name(),
                     )),
+                    PriceEstimatorType::OneInch => Box::new(instrumented(
+                            Box::new(OneInchPriceEstimator {
+                                api: Arc::new(OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, client.clone()).unwrap())
+                            }),
+                            &estimator.name(),
+                    ))
                 },
             )
         })

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -3,6 +3,7 @@ pub mod cached;
 pub mod competition;
 pub mod gas;
 pub mod instrumented;
+pub mod oneinch;
 pub mod paraswap;
 pub mod priority;
 pub mod quasimodo;

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -25,6 +25,7 @@ arg_enum! {
         Paraswap,
         ZeroEx,
         Quasimodo,
+        OneInch,
     }
 }
 

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -45,6 +45,9 @@ pub enum PriceEstimationError {
     #[error("Zero Amount")]
     ZeroAmount,
 
+    #[error("Unsupported Order Type")]
+    UnsupportedOrderType,
+
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -55,6 +58,7 @@ impl Clone for PriceEstimationError {
             Self::UnsupportedToken(token) => Self::UnsupportedToken(*token),
             Self::NoLiquidity => Self::NoLiquidity,
             Self::ZeroAmount => Self::ZeroAmount,
+            Self::UnsupportedOrderType => Self::UnsupportedOrderType,
             Self::Other(err) => Self::Other(crate::clone_anyhow_error(err)),
         }
     }

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -118,8 +118,8 @@ fn join_error(a: PriceEstimationError, b: PriceEstimationError) -> PriceEstimati
     // - ZeroAmount
     // - UnsupportedToken
     // - NoLiquidity
-    // - UnsupportedOrderType
     // - Other
+    // - UnsupportedOrderType
     match (a, b) {
         (err @ PriceEstimationError::ZeroAmount, _)
         | (_, err @ PriceEstimationError::ZeroAmount) => err,
@@ -127,9 +127,10 @@ fn join_error(a: PriceEstimationError, b: PriceEstimationError) -> PriceEstimati
         | (_, err @ PriceEstimationError::UnsupportedToken(_)) => err,
         (err @ PriceEstimationError::NoLiquidity, _)
         | (_, err @ PriceEstimationError::NoLiquidity) => err,
-        (err @ PriceEstimationError::UnsupportedOrderType, _)
-        | (_, err @ PriceEstimationError::UnsupportedOrderType) => err,
-        (err @ PriceEstimationError::Other(_), _) => err,
+        (err @ PriceEstimationError::Other(_), _) | (_, err @ PriceEstimationError::Other(_)) => {
+            err
+        }
+        (err @ PriceEstimationError::UnsupportedOrderType, _) => err,
     }
 }
 

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -118,6 +118,7 @@ fn join_error(a: PriceEstimationError, b: PriceEstimationError) -> PriceEstimati
     // - ZeroAmount
     // - UnsupportedToken
     // - NoLiquidity
+    // - UnsupportedOrderType
     // - Other
     match (a, b) {
         (err @ PriceEstimationError::ZeroAmount, _)
@@ -126,6 +127,8 @@ fn join_error(a: PriceEstimationError, b: PriceEstimationError) -> PriceEstimati
         | (_, err @ PriceEstimationError::UnsupportedToken(_)) => err,
         (err @ PriceEstimationError::NoLiquidity, _)
         | (_, err @ PriceEstimationError::NoLiquidity) => err,
+        (err @ PriceEstimationError::UnsupportedOrderType, _)
+        | (_, err @ PriceEstimationError::UnsupportedOrderType) => err,
         (err @ PriceEstimationError::Other(_), _) => err,
     }
 }

--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -1,0 +1,70 @@
+use super::gas;
+use crate::oneinch_api::{OneInchClient, RestResponse, SellOrderQuoteQuery};
+use crate::price_estimation::{Estimate, PriceEstimating, PriceEstimationError, Query};
+use futures::future;
+use model::order::OrderKind;
+use primitive_types::U256;
+use std::sync::Arc;
+
+pub struct OneInchPriceEstimator {
+    pub api: Arc<dyn OneInchClient>,
+}
+
+impl OneInchPriceEstimator {
+    async fn estimate(&self, query: &Query) -> Result<Estimate, PriceEstimationError> {
+        if query.kind == OrderKind::Buy {
+            return Err(PriceEstimationError::UnsupportedOrderType);
+        }
+
+        let quote = self
+            .api
+            .get_sell_order_quote(SellOrderQuoteQuery {
+                from_token_address: query.sell_token,
+                to_token_address: query.buy_token,
+                amount: query.in_amount,
+                protocols: None,
+                fee: None,
+                gas_limit: None,
+                connector_tokens: None,
+                complexity_level: None,
+                main_route_parts: None,
+                virtual_parts: None,
+                parts: None,
+                gas_price: None,
+            })
+            .await
+            .map_err(PriceEstimationError::Other)?;
+
+        match quote {
+            RestResponse::Ok(quote) => Ok(Estimate {
+                out_amount: quote.to_token_amount,
+                gas: U256::from(gas::SETTLEMENT_OVERHEAD) + quote.estimated_gas,
+            }),
+            RestResponse::Err(e) => {
+                Err(PriceEstimationError::Other(anyhow::anyhow!(e.description)))
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl PriceEstimating for OneInchPriceEstimator {
+    async fn estimates(
+        &self,
+        queries: &[Query],
+    ) -> Vec<anyhow::Result<Estimate, PriceEstimationError>> {
+        debug_assert!(queries.iter().all(|query| {
+            query.buy_token != model::order::BUY_ETH_ADDRESS
+                && query.sell_token != model::order::BUY_ETH_ADDRESS
+                && query.sell_token != query.buy_token
+        }));
+
+        future::join_all(
+            queries
+                .iter()
+                .map(|query| async move { self.estimate(query).await }),
+        )
+        .await
+    }
+}
+

--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -96,11 +96,16 @@ impl PriceEstimating for OneInchPriceEstimator {
         &self,
         queries: &[Query],
     ) -> Vec<anyhow::Result<Estimate, PriceEstimationError>> {
-        debug_assert!(queries.iter().all(|query| {
-            query.buy_token != model::order::BUY_ETH_ADDRESS
-                && query.sell_token != model::order::BUY_ETH_ADDRESS
-                && query.sell_token != query.buy_token
-        }), "the hierarchy of price estimators should be set up such that OneInchPriceEstimator is a descendant of SanitizedPriceEstimator");
+        debug_assert!(
+            queries.iter().all(|query| {
+                query.buy_token != model::order::BUY_ETH_ADDRESS
+                    && query.sell_token != model::order::BUY_ETH_ADDRESS
+                    && query.sell_token != query.buy_token
+            }),
+            "the hierarchy of price estimators should be set up \
+            such that OneInchPriceEstimator is a descendant of \
+            a SanitizedPriceEstimator"
+        );
 
         future::join_all(
             queries

--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -100,7 +100,7 @@ impl PriceEstimating for OneInchPriceEstimator {
             query.buy_token != model::order::BUY_ETH_ADDRESS
                 && query.sell_token != model::order::BUY_ETH_ADDRESS
                 && query.sell_token != query.buy_token
-        }));
+        }), "the hierarchy of price estimators should be set up such that OneInchPriceEstimator is a descendant of SanitizedPriceEstimator");
 
         future::join_all(
             queries

--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -68,3 +68,169 @@ impl PriceEstimating for OneInchPriceEstimator {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oneinch_api::{
+        MockOneInchClient, OneInchClientImpl, RestError, SellOrderQuote, Token,
+    };
+    use reqwest::Client;
+
+    #[tokio::test]
+    async fn estimate_sell_order_succeeds() {
+        // How much GNO can you buy for 1 WETH
+        let mut one_inch = MockOneInchClient::new();
+
+        // Response was generated with:
+        //
+        // curl 'https://api.1inch.io/v4.0/1/quote?\
+        //     fromTokenAddress=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&\
+        //     toTokenAddress=0x6810e776880c02933d47db1b9fc05908e5386b96&\
+        //     amount=100000000000000000'
+        one_inch.expect_get_sell_order_quote().return_once(|_| {
+            Ok(RestResponse::<_>::Ok(SellOrderQuote {
+                from_token: Token {
+                    address: testlib::tokens::WETH,
+                },
+                to_token: Token {
+                    address: testlib::tokens::GNO,
+                },
+                to_token_amount: 808_069_760_400_778_577u128.into(),
+                from_token_amount: 100_000_000_000_000_000u128.into(),
+                protocols: Vec::default(),
+                estimated_gas: 189_386,
+            }))
+        });
+
+        let estimator = OneInchPriceEstimator {
+            api: Arc::new(one_inch),
+        };
+
+        let est = estimator
+            .estimate(&Query {
+                sell_token: testlib::tokens::WETH,
+                buy_token: testlib::tokens::GNO,
+                in_amount: 1_000_000_000_000_000_000u128.into(),
+                kind: OrderKind::Sell,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(est.out_amount, 808_069_760_400_778_577u128.into());
+        assert!(est.gas > 189_386.into());
+    }
+
+    #[tokio::test]
+    async fn estimating_buy_order_fails() {
+        let mut one_inch = MockOneInchClient::new();
+
+        one_inch.expect_get_sell_order_quote().times(0);
+
+        let estimator = OneInchPriceEstimator {
+            api: Arc::new(one_inch),
+        };
+
+        let est = estimator
+            .estimate(&Query {
+                sell_token: testlib::tokens::WETH,
+                buy_token: testlib::tokens::GNO,
+                in_amount: 1_000_000_000_000_000_000u128.into(),
+                kind: OrderKind::Buy,
+            })
+            .await;
+
+        assert!(matches!(
+            est,
+            Err(PriceEstimationError::UnsupportedOrderType)
+        ));
+    }
+
+    #[tokio::test]
+    async fn rest_api_errors_get_propagated() {
+        let mut one_inch = MockOneInchClient::new();
+        one_inch
+            .expect_get_sell_order_quote()
+            .times(1)
+            .return_once(|_| {
+                Ok(RestResponse::<SellOrderQuote>::Err(RestError {
+                    status_code: 500,
+                    description: "Internal Server Error".to_string(),
+                }))
+            });
+
+        let estimator = OneInchPriceEstimator {
+            api: Arc::new(one_inch),
+        };
+
+        let est = estimator
+            .estimate(&Query {
+                sell_token: testlib::tokens::WETH,
+                buy_token: testlib::tokens::GNO,
+                in_amount: 1_000_000_000_000_000_000u128.into(),
+                kind: OrderKind::Sell,
+            })
+            .await;
+
+        assert!(matches!(
+            est,
+            Err(PriceEstimationError::Other(e)) if e.to_string() == "Internal Server Error"
+        ));
+    }
+
+    #[tokio::test]
+    async fn request_errors_get_propagated() {
+        let mut one_inch = MockOneInchClient::new();
+        one_inch
+            .expect_get_sell_order_quote()
+            .times(1)
+            .return_once(|_| Err(anyhow::anyhow!("malformed JSON")));
+
+        let estimator = OneInchPriceEstimator {
+            api: Arc::new(one_inch),
+        };
+
+        let est = estimator
+            .estimate(&Query {
+                sell_token: testlib::tokens::WETH,
+                buy_token: testlib::tokens::GNO,
+                in_amount: 1_000_000_000_000_000_000u128.into(),
+                kind: OrderKind::Sell,
+            })
+            .await;
+
+        assert!(matches!(
+            est,
+            Err(PriceEstimationError::Other(e)) if e.to_string() == "malformed JSON"
+        ));
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn real_estimate() {
+        let weth = testlib::tokens::WETH;
+        let gno = testlib::tokens::GNO;
+
+        let estimator = OneInchPriceEstimator {
+            api: Arc::new(
+                OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new()).unwrap(),
+            ),
+        };
+
+        let result = estimator
+            .estimate(&Query {
+                sell_token: weth,
+                buy_token: gno,
+                in_amount: 10u128.pow(18).into(),
+                kind: OrderKind::Sell,
+            })
+            .await;
+
+        dbg!(&result);
+        let estimate = result.unwrap();
+        println!(
+            "1 WETH buys {} GNO, costing {} gas",
+            estimate.out_amount.to_f64_lossy() / 1e18,
+            estimate.gas,
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a price estimator for 1Inch. There are is a caveat, though.
The 1Inch REST API only supports estimating sell orders. Because of that I introduced  `PriceEstimationError::UnsupportedOrderType`.
This PR resolves task 5, 6, 7 of #1529.

### Test Plan
New unit tests:
-estimating sell order succeeds
-estimating buy orders yields new error type
-REST API errors get propagated as `PriceEstimationError::Other`
-other errors from the `OneInchClientImpl` also get propagated as `PriceEstimationError::Other`
-test that disabling 1Inch protocols works and that the required API call is cached
-one ignored test which issues a request to the real 1Inch REST API
