### PR TITLE
Cache Quasimodo price estimator

### DIFF
--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -482,7 +482,7 @@ async fn main() {
                         }),
                         &estimator.name(),
                     )),
-                    PriceEstimatorType::Quasimodo => Box::new(instrumented(
+                    PriceEstimatorType::Quasimodo => Box::new(instrumented_and_cached(
                         Box::new(QuasimodoPriceEstimator {
                             api: Arc::new(DefaultHttpSolverApi {
                                 name: "quasimodo-price-estimator",


### PR DESCRIPTION
Just like the other external price estimator we can cache Quasimodo to reduce some stress on it.
Based on conversation on Slack that Quasimodo is under high load.

### Test Plan
CI
