### PR TITLE
Include release notes section to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,11 @@
-[Optional] 
-Fixes #issue
-
-*<Context of what this change does, why it is needed and how it is accomplished>*
+Describe context of what this change does,
+why it is needed and how it is accomplished
 
 ### Test Plan
-*<Explain how you and a reviewer have/intend to test this change>*
+
+Explain how you and a reviewer have/intend to test this change.
+
+### Release notes
+
+Optionally add notes, suggestions and warnings for the releaser.
+They will be included in the release changelog.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
-Describe context of what this change does,
-why it is needed and how it is accomplished
+Fixes #issue.
+
+Describe context of what this change does, why it is needed and how it is accomplished
 
 ### Test Plan
 
@@ -7,5 +8,4 @@ Explain how you and a reviewer have/intend to test this change.
 
 ### Release notes
 
-Optionally add notes, suggestions and warnings for the releaser.
-They will be included in the release changelog.
+Optionally add notes, suggestions and warnings for the releaser. They will be included in the release changelog.


### PR DESCRIPTION
I'm working on a new script for generating changelogs. It will parse commit messages and extract contents of the "release notes" section.
