### PR TITLE
Add ProtocolCache for 1Inch

### DIFF
--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -1,17 +1,16 @@
 use super::gas;
-use crate::oneinch_api::{OneInchClient, RestResponse, SellOrderQuoteQuery};
+use crate::oneinch_api::{OneInchClient, ProtocolCache, RestResponse, SellOrderQuoteQuery};
 use crate::price_estimation::{Estimate, PriceEstimating, PriceEstimationError, Query};
 use anyhow::Result;
-use cached::{Cached, TimedSizedCache};
 use futures::future;
 use model::order::OrderKind;
 use primitive_types::U256;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 pub struct OneInchPriceEstimator {
     api: Arc<dyn OneInchClient>,
     disabled_protocols: Vec<String>,
-    allowed_protocols: Arc<Mutex<TimedSizedCache<Vec<String>, Vec<String>>>>,
+    protocol_cache: ProtocolCache,
 }
 
 impl OneInchPriceEstimator {
@@ -26,7 +25,10 @@ impl OneInchPriceEstimator {
                 from_token_address: query.sell_token,
                 to_token_address: query.buy_token,
                 amount: query.in_amount,
-                protocols: self.get_protocol_argument().await?,
+                protocols: self
+                    .protocol_cache
+                    .get_allowed_protocols(&self.disabled_protocols, self.api.as_ref())
+                    .await?,
                 fee: None,
                 gas_limit: None,
                 connector_tokens: None,
@@ -54,39 +56,8 @@ impl OneInchPriceEstimator {
         Self {
             api,
             disabled_protocols,
-            allowed_protocols: Arc::new(Mutex::new(
-                TimedSizedCache::with_size_and_lifespan_and_refresh(1, 60, false),
-            )),
+            protocol_cache: ProtocolCache::default(),
         }
-    }
-
-    async fn get_protocol_argument(&self) -> Result<Option<Vec<String>>> {
-        if self.disabled_protocols.is_empty() {
-            return Ok(None);
-        }
-
-        if let Some(allowed_protocols) = self
-            .allowed_protocols
-            .lock()
-            .unwrap()
-            .cache_get(&self.disabled_protocols)
-        {
-            return Ok(Some(allowed_protocols.clone()));
-        }
-
-        let current_protocols = self.api.get_protocols().await?.protocols;
-        let allowed_protocols: Vec<String> = current_protocols
-            .into_iter()
-            // linear search through the Vec is okay because it's very small
-            .filter(|protocol| !self.disabled_protocols.contains(protocol))
-            .collect();
-
-        self.allowed_protocols
-            .lock()
-            .unwrap()
-            .cache_set(self.disabled_protocols.clone(), allowed_protocols.clone());
-
-        Ok(Some(allowed_protocols))
     }
 }
 
@@ -242,52 +213,6 @@ mod tests {
             est,
             Err(PriceEstimationError::Other(e)) if e.to_string() == "malformed JSON"
         ));
-    }
-
-    #[tokio::test]
-    async fn filter_out_disabled_protocols_and_cache_them() {
-        let mut one_inch = MockOneInchClient::new();
-        // We are estimating 2 orders but fetch the protocols only once
-        one_inch.expect_get_protocols().times(1).returning(|| {
-            Ok(Protocols {
-                protocols: vec!["PMM1".into(), "UNISWAP_V3".into()],
-            })
-        });
-        one_inch
-            .expect_get_sell_order_quote()
-            .times(2)
-            .withf(|query| {
-                let protocols = query.protocols.as_ref().unwrap();
-                protocols.len() == 1 && protocols[0] == "UNISWAP_V3"
-            })
-            .returning(|_| {
-                Ok(RestResponse::<_>::Ok(SellOrderQuote {
-                    from_token: Token {
-                        address: testlib::tokens::WETH,
-                    },
-                    to_token: Token {
-                        address: testlib::tokens::GNO,
-                    },
-                    to_token_amount: 808_069_760_400_778_577u128.into(),
-                    from_token_amount: 100_000_000_000_000_000u128.into(),
-                    protocols: Vec::default(),
-                    estimated_gas: 189_386,
-                }))
-            });
-
-        let estimator = OneInchPriceEstimator::new(Arc::new(one_inch), vec!["PMM1".to_string()]);
-
-        for _ in 0..=1 {
-            estimator
-                .estimate(&Query {
-                    sell_token: testlib::tokens::WETH,
-                    buy_token: testlib::tokens::GNO,
-                    in_amount: 1_000_000_000_000_000_000u128.into(),
-                    kind: OrderKind::Sell,
-                })
-                .await
-                .unwrap();
-        }
     }
 
     #[tokio::test]

--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -91,7 +91,7 @@ impl PriceEstimating for OneInchPriceEstimator {
 mod tests {
     use super::*;
     use crate::oneinch_api::{
-        MockOneInchClient, OneInchClientImpl, Protocols, RestError, SellOrderQuote, Token,
+        MockOneInchClient, OneInchClientImpl, RestError, SellOrderQuote, Token,
     };
     use reqwest::Client;
 

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -21,14 +21,12 @@ use maplit::hashmap;
 use model::order::OrderKind;
 use reqwest::Client;
 use shared::oneinch_api::{
-    Amount, OneInchClient, OneInchClientImpl, RestError, RestResponse, Swap, SwapQuery,
+    Amount, OneInchClient, OneInchClientImpl, ProtocolCache, RestError, RestResponse, Swap,
+    SwapQuery,
 };
 use shared::solver_utils::Slippage;
 use shared::Web3;
-use std::{
-    collections::HashSet,
-    fmt::{self, Display, Formatter},
-};
+use std::fmt::{self, Display, Formatter};
 
 /// A GPv2 solver that matches GP **sell** orders to direct 1Inch swaps.
 #[derive(Derivative)]
@@ -36,11 +34,12 @@ use std::{
 pub struct OneInchSolver {
     account: Account,
     settlement_contract: GPv2Settlement,
-    disabled_protocols: HashSet<String>,
+    disabled_protocols: Vec<String>,
     #[derivative(Debug = "ignore")]
     client: Box<dyn OneInchClient>,
     #[derivative(Debug = "ignore")]
     allowance_fetcher: Box<dyn AllowanceManaging>,
+    protocol_cache: ProtocolCache,
 }
 
 impl From<RestError> for SettlementError {
@@ -80,29 +79,12 @@ impl OneInchSolver {
                 client,
             )?),
             allowance_fetcher: Box::new(AllowanceManager::new(web3, settlement_address)),
+            protocol_cache: ProtocolCache::default(),
         })
     }
 }
 
 impl OneInchSolver {
-    /// Gets the list of supported protocols for the 1Inch solver.
-    async fn supported_protocols(&self) -> Result<Option<Vec<String>>> {
-        let protocols = if self.disabled_protocols.is_empty() {
-            None
-        } else {
-            Some(
-                self.client
-                    .get_protocols()
-                    .await?
-                    .protocols
-                    .into_iter()
-                    .filter(|protocol| !self.disabled_protocols.contains(protocol))
-                    .collect(),
-            )
-        };
-        Ok(protocols)
-    }
-
     /// Settles a single sell order against a 1Inch swap using the specified protocols.
     async fn settle_order_with_protocols(
         &self,
@@ -187,7 +169,10 @@ impl SingleOrderSolving for OneInchSolver {
             // 1Inch only supports sell orders
             return Ok(None);
         }
-        let protocols = self.supported_protocols().await?;
+        let protocols = self
+            .protocol_cache
+            .get_allowed_protocols(&self.disabled_protocols, self.client.as_ref())
+            .await?;
         self.settle_order_with_protocols(order, protocols).await
     }
 
@@ -214,7 +199,6 @@ mod tests {
     use crate::test::account;
     use contracts::{GPv2Settlement, WETH9};
     use ethcontract::{Web3, H160, U256};
-    use maplit::hashset;
     use mockall::{predicate::*, Sequence};
     use model::order::{Order, OrderCreation, OrderKind};
     use shared::oneinch_api::{MockOneInchClient, Protocols, Spender};
@@ -232,9 +216,10 @@ mod tests {
         OneInchSolver {
             account: account(),
             settlement_contract,
-            disabled_protocols: HashSet::new(),
+            disabled_protocols: Vec::default(),
             client: Box::new(client),
             allowance_fetcher: Box::new(allowance_fetcher),
+            protocol_cache: ProtocolCache::default(),
         }
     }
 
@@ -253,15 +238,6 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
-    }
-
-    #[tokio::test]
-    async fn returns_none_when_no_protocols_are_disabled() {
-        let protocols = dummy_solver(MockOneInchClient::new(), MockAllowanceManaging::new())
-            .supported_protocols()
-            .await
-            .unwrap();
-        assert!(protocols.is_none());
     }
 
     #[tokio::test]
@@ -361,7 +337,7 @@ mod tests {
         });
 
         let solver = OneInchSolver {
-            disabled_protocols: hashset!["BadProtocol".to_string(), "VeryBadProtocol".to_string()],
+            disabled_protocols: vec!["BadProtocol".to_string(), "VeryBadProtocol".to_string()],
             ..dummy_solver(client, allowance_fetcher)
         };
 


### PR DESCRIPTION
The `OneInchPriceEstimator` and `OneInchSolver` need to disable certain protocols (`PMM1`) because they can lead to wrong settlements.
To not duplicate the code responsible for limiting the protocols, I added `ProtocolCache` to `oneinch_api.rs` and made both structs us it.

This PR introduces caching to the `OneInchSolver` but it shouldn't be a big deal. 1Inch doesn't change the supported protocols on a regular basis, so having a small delay (at most 1 minute) until `OneInchSolver` is able to utilize new protocols can not lead to many suboptimal solutions.

### Test Plan
Unit tests for `ProtocolCache`
