### PR TITLE
Eden and Flashbots Api URL made configurable

### DIFF
--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -203,6 +203,14 @@ struct Arguments {
         use_delimiter = true)]
     transaction_strategy: Vec<TransactionStrategyArg>,
 
+    /// The API endpoint of the Eden network for transaction submission.
+    #[structopt(long, env, default_value = "https://api.edennetwork.io/v1/rpc")]
+    eden_api_url: Url,
+
+    /// The API endpoint of the Flashbots network for transaction submission.
+    #[structopt(long, env, default_value = "https://rpc.flashbots.net")]
+    flashbots_api_url: Url,
+
     /// Additional tip in gwei that we are willing to give to eden above regular gas price estimation
     #[structopt(
         long,
@@ -575,11 +583,15 @@ async fn main() {
                 })
             }
             TransactionStrategyArg::Eden => TransactionStrategy::Eden(StrategyArgs {
-                submit_api: Box::new(EdenApi::new(client.clone())),
+                submit_api: Box::new(
+                    EdenApi::new(client.clone(), args.eden_api_url.clone()).unwrap(),
+                ),
                 additional_tip: args.additional_eden_tip,
             }),
             TransactionStrategyArg::Flashbots => TransactionStrategy::Flashbots(StrategyArgs {
-                submit_api: Box::new(FlashbotsApi::new(client.clone())),
+                submit_api: Box::new(
+                    FlashbotsApi::new(client.clone(), args.flashbots_api_url.clone()).unwrap(),
+                ),
                 additional_tip: args.additional_flashbot_tip,
             }),
             TransactionStrategyArg::CustomNodes => {

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -470,7 +470,7 @@ mod tests {
         let private_key: PrivateKey = std::env::var("PRIVATE_KEY").unwrap().parse().unwrap();
         let account = Account::Offline(private_key, Some(chain_id));
         let contract = crate::get_settlement_contract(&web3).await.unwrap();
-        let flashbots_api = FlashbotsApi::new(Client::new());
+        let flashbots_api = FlashbotsApi::new(Client::new(), "https://rpc.flashbots.net").unwrap();
         let mut header = reqwest::header::HeaderMap::new();
         header.insert(
             "AUTHORIZATION",

--- a/crates/solver/src/settlement_submission/submitter/common.rs
+++ b/crates/solver/src/settlement_submission/submitter/common.rs
@@ -7,13 +7,13 @@ use ethcontract::{
 use futures::FutureExt;
 use jsonrpc_core::Output;
 use primitive_types::H256;
-use reqwest::Client;
+use reqwest::{Client, Url};
 use serde::de::DeserializeOwned;
 
 /// Function for sending raw signed transaction to private networks
 pub async fn submit_raw_transaction(
     client: Client,
-    url: &str,
+    url: Url,
     tx: TransactionBuilder<DynTransport>,
 ) -> Result<TransactionHandle, SubmitApiError> {
     let (raw_signed_transaction, tx_hash) = match tx.build().now_or_never().unwrap().unwrap() {
@@ -32,7 +32,7 @@ pub async fn submit_raw_transaction(
         serde_json::to_string(&body).unwrap_or_else(|err| format!("error: {:?}", err)),
     );
     let response = client
-        .post(url)
+        .post(url.clone())
         .json(&body)
         .send()
         .await
@@ -44,10 +44,10 @@ pub async fn submit_raw_transaction(
 
     let handle = parse_json_rpc_response::<H256>(&body)?;
     tracing::info!(
-        "created transaction with hash: {:?} and handle: {:?}, url: {:?}",
+        "created transaction with hash: {:?} and handle: {:?}, url: {}",
         tx_hash,
         handle,
-        url
+        url.as_str()
     );
     Ok(TransactionHandle { tx_hash, handle })
 }

--- a/crates/solver/src/settlement_submission/submitter/eden_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/eden_api.rs
@@ -4,20 +4,22 @@ use super::{
     super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
     CancelHandle,
 };
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder};
-use reqwest::Client;
-
-const URL: &str = "https://api.edennetwork.io/v1/rpc";
+use reqwest::{Client, IntoUrl, Url};
 
 #[derive(Clone)]
 pub struct EdenApi {
     client: Client,
+    url: Url,
 }
 
 impl EdenApi {
-    pub fn new(client: Client) -> Self {
-        Self { client }
+    pub fn new(client: Client, url: impl IntoUrl) -> Result<Self> {
+        Ok(Self {
+            client,
+            url: url.into_url().context("bad eden url")?,
+        })
     }
 }
 
@@ -27,13 +29,13 @@ impl TransactionSubmitting for EdenApi {
         &self,
         tx: TransactionBuilder<DynTransport>,
     ) -> Result<TransactionHandle, SubmitApiError> {
-        super::common::submit_raw_transaction(self.client.clone(), URL, tx).await
+        super::common::submit_raw_transaction(self.client.clone(), self.url.clone(), tx).await
     }
 
     async fn cancel_transaction(&self, id: &CancelHandle) -> Result<()> {
         match super::common::submit_raw_transaction(
             self.client.clone(),
-            URL,
+            self.url.clone(),
             id.noop_transaction.clone(),
         )
         .await

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -2,20 +2,22 @@ use super::{
     super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
     CancelHandle,
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
 use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder};
-use reqwest::Client;
-
-const URL: &str = "https://rpc.flashbots.net";
+use reqwest::{Client, IntoUrl, Url};
 
 #[derive(Clone)]
 pub struct FlashbotsApi {
     client: Client,
+    url: Url,
 }
 
 impl FlashbotsApi {
-    pub fn new(client: Client) -> Self {
-        Self { client }
+    pub fn new(client: Client, url: impl IntoUrl) -> Result<Self> {
+        Ok(Self {
+            client,
+            url: url.into_url().context("bad flashbots url")?,
+        })
     }
 }
 
@@ -25,7 +27,7 @@ impl TransactionSubmitting for FlashbotsApi {
         &self,
         tx: TransactionBuilder<DynTransport>,
     ) -> Result<TransactionHandle, SubmitApiError> {
-        super::common::submit_raw_transaction(self.client.clone(), URL, tx).await
+        super::common::submit_raw_transaction(self.client.clone(), self.url.clone(), tx).await
     }
 
     async fn cancel_transaction(&self, _id: &CancelHandle) -> Result<()> {


### PR DESCRIPTION
Last 48 hours we have an issue with the submission of the transaction to the Eden network. Their Api endpoint is failing.
Eden crew suggested to try out the different URL. That said, this seems like a convenient time to set these URLs configurable.