### PR TITLE
Use same parameters for 1Inch swap and quote

### DIFF
--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -71,8 +71,11 @@ impl QuoteAndSwapCommonOptions {
             to_token_address: buy_token,
             amount,
             protocols,
+            // Use at most 2 connector tokens
             complexity_level: Some(Amount::new(2).unwrap()),
+            // Cap swap gas to 750K.
             gas_limit: Some(Amount::new(750_000).unwrap()),
+            // Use only 3 main route for cheaper trades.
             main_route_parts: Some(Amount::new(3).unwrap()),
             parts: Some(Amount::new(3).unwrap()),
         }
@@ -267,6 +270,8 @@ impl SwapQuery {
         Self {
             from_address,
             slippage,
+            // Disable balance/allowance checks, as the settlement contract
+            // does not hold balances to traded tokens.
             disable_estimate: Some(true),
             common: QuoteAndSwapCommonOptions::with_default_options(
                 sell_token, buy_token, protocols, in_amount,

--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -19,25 +19,19 @@ impl OneInchPriceEstimator {
             return Err(PriceEstimationError::UnsupportedOrderType);
         }
 
+        let allowed_protocols = self
+            .protocol_cache
+            .get_allowed_protocols(&self.disabled_protocols, self.api.as_ref())
+            .await?;
+
         let quote = self
             .api
-            .get_sell_order_quote(SellOrderQuoteQuery {
-                from_token_address: query.sell_token,
-                to_token_address: query.buy_token,
-                amount: query.in_amount,
-                protocols: self
-                    .protocol_cache
-                    .get_allowed_protocols(&self.disabled_protocols, self.api.as_ref())
-                    .await?,
-                fee: None,
-                gas_limit: None,
-                connector_tokens: None,
-                complexity_level: None,
-                main_route_parts: None,
-                virtual_parts: None,
-                parts: None,
-                gas_price: None,
-            })
+            .get_sell_order_quote(SellOrderQuoteQuery::with_default_options(
+                query.sell_token,
+                query.buy_token,
+                query.in_amount,
+                allowed_protocols,
+            ))
             .await
             .map_err(PriceEstimationError::Other)?;
 

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -21,8 +21,7 @@ use maplit::hashmap;
 use model::order::OrderKind;
 use reqwest::Client;
 use shared::oneinch_api::{
-    Amount, OneInchClient, OneInchClientImpl, ProtocolCache, RestError, RestResponse, Swap,
-    SwapQuery,
+    OneInchClient, OneInchClientImpl, ProtocolCache, RestError, RestResponse, Swap, SwapQuery,
 };
 use shared::solver_utils::Slippage;
 use shared::Web3;
@@ -97,24 +96,14 @@ impl OneInchSolver {
             .get_approval(order.sell_token, spender.address, order.sell_amount)
             .await?;
 
-        let query = SwapQuery {
-            from_token_address: order.sell_token,
-            to_token_address: order.buy_token,
-            amount: order.sell_amount,
-            from_address: self.settlement_contract.address(),
-            slippage: Slippage::percentage_from_basis_points(MAX_SLIPPAGE_BPS).unwrap(),
+        let query = SwapQuery::with_default_options(
+            order.sell_token,
+            order.buy_token,
+            order.sell_amount,
+            self.settlement_contract.address(),
             protocols,
-            // Disable balance/allowance checks, as the settlement contract
-            // does not hold balances to traded tokens.
-            disable_estimate: Some(true),
-            // Use at most 2 connector tokens
-            complexity_level: Some(Amount::new(2).unwrap()),
-            // Cap swap gas to 750K.
-            gas_limit: Some(750_000),
-            // Use only 3 main route for cheaper trades.
-            main_route_parts: Some(Amount::new(3).unwrap()),
-            parts: Some(Amount::new(3).unwrap()),
-        };
+            Slippage::percentage_from_basis_points(MAX_SLIPPAGE_BPS).unwrap(),
+        );
 
         tracing::debug!("querying 1Inch swap api with {:?}", query);
         let swap = match self.client.get_swap(query).await? {

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -306,7 +306,7 @@ mod tests {
             })
         });
         client.expect_get_swap().times(1).returning(|query| {
-            assert_eq!(query.protocols, Some(vec!["GoodProtocol".into()]));
+            assert_eq!(query.common.protocols, Some(vec!["GoodProtocol".into()]));
             Ok(RestResponse::Ok(Swap {
                 from_token_amount: 100.into(),
                 to_token_amount: 100.into(),


### PR DESCRIPTION
In order for `OneInchPriceEstimator` quotes to be meaningful they need to use the same arguments as the `OneInchSolver` swaps wherever possible. Otherwise the price estimation and the final price could differ quite a bit.
I created a new struct which holds parameters which are common to `/swap` and `/quote` requests. Creating those requests is now done with a function which sets the correct defaults. There is only a single source of truth so no need to manually keep the defaults for `/quote` and `/swap` queries synchronized.

### Test Plan
No new tests