### PR TITLE
Update 1Inch REST API to v4.1

### DIFF
--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -495,7 +495,7 @@ impl OneInchClient for OneInchClientImpl {
     }
 
     async fn get_spender(&self) -> Result<Spender> {
-        let endpoint = format!("v3.0/{}/approve/spender", self.chain_id);
+        let endpoint = format!("v4.1/{}/approve/spender", self.chain_id);
         let url = self
             .base_url
             .join(&endpoint)

--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -171,7 +171,7 @@ pub struct SellOrderQuote {
     pub from_token_amount: U256,
     #[serde(with = "u256_decimal")]
     pub to_token_amount: U256,
-    pub protocols: Vec<Vec<Vec<Protocol>>>,
+    pub protocols: Vec<Vec<Vec<ProtocolRouteSegment>>>,
     pub estimated_gas: u64,
 }
 
@@ -332,7 +332,7 @@ pub struct Swap {
     pub from_token_amount: U256,
     #[serde(with = "u256_decimal")]
     pub to_token_amount: U256,
-    pub protocols: Vec<Vec<Vec<Protocol>>>,
+    pub protocols: Vec<Vec<Vec<ProtocolRouteSegment>>>,
     pub tx: Transaction,
 }
 
@@ -348,7 +348,7 @@ pub struct Token {
 /// Metadata associated with a protocol used for part of a 1Inch swap.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub struct Protocol {
+pub struct ProtocolRouteSegment {
     pub name: String,
     pub part: f64,
     pub from_token_address: H160,
@@ -389,11 +389,11 @@ pub struct Spender {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
-pub struct LiquidiySource {
+pub struct ProtocolInfo {
     pub id: String,
 }
 
-impl From<&str> for LiquidiySource {
+impl From<&str> for ProtocolInfo {
     fn from(id: &str) -> Self {
         Self { id: id.to_string() }
     }
@@ -402,7 +402,7 @@ impl From<&str> for LiquidiySource {
 /// Protocols query response.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct Protocols {
-    pub protocols: Vec<LiquidiySource>,
+    pub protocols: Vec<ProtocolInfo>,
 }
 
 // Mockable version of API Client
@@ -422,7 +422,7 @@ pub trait OneInchClient: Send + Sync {
     async fn get_spender(&self) -> Result<Spender>;
 
     /// Retrieves a list of the on-chain protocols supported by 1Inch.
-    async fn get_protocols(&self) -> Result<Protocols>;
+    async fn get_liquidity_sources(&self) -> Result<Protocols>;
 }
 
 /// 1Inch API Client implementation.
@@ -476,7 +476,7 @@ impl OneInchClient for OneInchClientImpl {
         logged_query(&self.client, url).await
     }
 
-    async fn get_protocols(&self) -> Result<Protocols> {
+    async fn get_liquidity_sources(&self) -> Result<Protocols> {
         let endpoint = format!("v4.1/{}/liquidity-sources", self.chain_id);
         let url = self
             .base_url
@@ -497,7 +497,7 @@ where
 }
 
 #[derive(Debug, Clone)]
-pub struct ProtocolCache(Arc<Mutex<TimedCache<(), Vec<LiquidiySource>>>>);
+pub struct ProtocolCache(Arc<Mutex<TimedCache<(), Vec<ProtocolInfo>>>>);
 
 impl ProtocolCache {
     pub fn new(cache_validity_in_seconds: Duration) -> Self {
@@ -507,12 +507,12 @@ impl ProtocolCache {
         ))))
     }
 
-    pub async fn get_all_protocols(&self, api: &dyn OneInchClient) -> Result<Vec<LiquidiySource>> {
+    pub async fn get_all_protocols(&self, api: &dyn OneInchClient) -> Result<Vec<ProtocolInfo>> {
         if let Some(cached) = self.0.lock().unwrap().cache_get(&()) {
             return Ok(cached.clone());
         }
 
-        let all_protocols = api.get_protocols().await?.protocols;
+        let all_protocols = api.get_liquidity_sources().await?.protocols;
         // In the mean time the cache could have already been populated with new protocols,
         // which we would now overwrite. This is fine.
         self.0.lock().unwrap().cache_set((), all_protocols.clone());
@@ -735,13 +735,13 @@ mod tests {
                 from_token_amount: 1_000_000_000_000_000_000u128.into(),
                 to_token_amount: 501_739_725_821_378_713_485u128.into(),
                 protocols: vec![vec![
-                    vec![Protocol {
+                    vec![ProtocolRouteSegment {
                         name: "WETH".to_owned(),
                         part: 100.,
                         from_token_address: addr!("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
                         to_token_address: testlib::tokens::WETH,
                     }],
-                    vec![Protocol {
+                    vec![ProtocolRouteSegment {
                         name: "UNISWAP_V2".to_owned(),
                         part: 100.,
                         from_token_address: addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
@@ -865,10 +865,10 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn oneinch_protocols() {
+    async fn oneinch_liquidity_sources() {
         let protocols = OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new(), 1)
             .unwrap()
-            .get_protocols()
+            .get_liquidity_sources()
             .await
             .unwrap();
         println!("{:#?}", protocols);
@@ -1020,25 +1020,25 @@ mod tests {
                 from_token_amount: 10_000_000_000_000_000u128.into(),
                 to_token_amount: 8_387_323_826_205_172u128.into(),
                 protocols: vec![vec![vec![
-                    Protocol {
+                    ProtocolRouteSegment {
                         name: "CURVE_V2_EURT_2_ASSET".to_owned(),
                         part: 20.,
                         from_token_address: addr!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
                         to_token_address: addr!("dac17f958d2ee523a2206206994597c13d831ec7"),
                     },
-                    Protocol {
+                    ProtocolRouteSegment {
                         name: "CURVE_V2_XAUT_2_ASSET".to_owned(),
                         part: 20.,
                         from_token_address: addr!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
                         to_token_address: addr!("dac17f958d2ee523a2206206994597c13d831ec7"),
                     },
-                    Protocol {
+                    ProtocolRouteSegment {
                         name: "CURVE".to_owned(),
                         part: 20.,
                         from_token_address: addr!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
                         to_token_address: addr!("dac17f958d2ee523a2206206994597c13d831ec7"),
                     },
-                    Protocol {
+                    ProtocolRouteSegment {
                         name: "SHELL".to_owned(),
                         part: 40.,
                         from_token_address: addr!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
@@ -1112,7 +1112,7 @@ mod tests {
     #[tokio::test]
     async fn allowing_all_protocols_will_not_use_api() {
         let mut api = MockOneInchClient::new();
-        api.expect_get_protocols().times(0);
+        api.expect_get_liquidity_sources().times(0);
         let allowed_protocols = ProtocolCache::default()
             .get_allowed_protocols(&Vec::default(), &api)
             .await;
@@ -1123,7 +1123,7 @@ mod tests {
     async fn allowed_protocols_get_cached() {
         let mut api = MockOneInchClient::new();
         // only 1 API call when calling get_allowed_protocols 2 times
-        api.expect_get_protocols().times(1).returning(|| {
+        api.expect_get_liquidity_sources().times(1).returning(|| {
             Ok(Protocols {
                 protocols: vec!["PMM1".into(), "UNISWAP_V3".into()],
             })

--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -2,6 +2,8 @@
 //!
 //! For more information on the HTTP API, consult:
 //! <https://docs.1inch.io/docs/aggregation-protocol/api/swagger>
+//! Although there is no documentation about API v4.1, it exists and is identical to v4.0 except it
+//! uses EIP 1559 gas prices.
 use crate::solver_utils::{deserialize_prefixed_hex, Slippage};
 use anyhow::{ensure, Context, Result};
 use cached::{Cached, TimedCache};
@@ -120,7 +122,7 @@ pub struct SellOrderQuoteQuery {
 
 impl SellOrderQuoteQuery {
     fn into_url(self, base_url: &Url, chain_id: u64) -> Url {
-        let endpoint = format!("v4.0/{}/quote", chain_id);
+        let endpoint = format!("v4.1/{}/quote", chain_id);
         let mut url = base_url
             .join(&endpoint)
             .expect("unexpectedly invalid URL segment");
@@ -938,7 +940,7 @@ mod tests {
 
         assert_eq!(
             url.as_str(),
-            "https://api.1inch.exchange/v4.0/1/quote\
+            "https://api.1inch.exchange/v4.1/1/quote\
                 ?fromTokenAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000"
@@ -967,7 +969,7 @@ mod tests {
 
         assert_eq!(
             url.as_str(),
-            "https://api.1inch.exchange/v4.0/1/quote\
+            "https://api.1inch.exchange/v4.1/1/quote\
                 ?fromTokenAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000\

--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -29,8 +29,8 @@ impl OneInchPriceEstimator {
             .get_sell_order_quote(SellOrderQuoteQuery::with_default_options(
                 query.sell_token,
                 query.buy_token,
-                query.in_amount,
                 allowed_protocols,
+                query.in_amount,
             ))
             .await
             .map_err(PriceEstimationError::Other)?;

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -295,7 +295,7 @@ mod tests {
             .expect_get_approval()
             .returning(|_, _, _| Ok(Approval::AllowanceSufficient));
 
-        client.expect_get_protocols().returning(|| {
+        client.expect_get_liquidity_sources().returning(|| {
             Ok(Protocols {
                 protocols: vec!["GoodProtocol".into(), "BadProtocol".into()],
             })

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -306,7 +306,7 @@ mod tests {
             })
         });
         client.expect_get_swap().times(1).returning(|query| {
-            assert_eq!(query.common.protocols, Some(vec!["GoodProtocol".into()]));
+            assert_eq!(query.quote.protocols, Some(vec!["GoodProtocol".into()]));
             Ok(RestResponse::Ok(Swap {
                 from_token_amount: 100.into(),
                 to_token_amount: 100.into(),


### PR DESCRIPTION
Fixes #1560

We have been using 1Inch API v3.0 for quite a while. There isn't even any documentation online available anymore.
Upgrading to v4.1 makes it easier to reason about changes in the future and also offers some new parameters to configure quotes and swaps.
Note that  I'm not able to find any documentation about v4.1 specifically but I got confirmation from the 1Inch team that v4.0 and v4.1 are equivalent except that v4.1 is using EIP-1559 gas prices instead of the old gas prices.

The `/swap` endpoint got some new parameters and `/protocols` became `/liquidity-sources`.

### Test Plan
Update existing tests
Added new test parsing the response from `/liquidity-sources`

### Release notes
Use 1Inch API v4.1 instead of v3.0
