### PR TITLE
Allow coverage CI to fail

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -105,6 +105,8 @@ jobs:
   coverage:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    # Runs on nightly so sometimes fails.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust


### PR DESCRIPTION
Currently we get annoying notifications because the coverage part of CI is failing. The cause is a regression in nightly rust that we cannot fix.
This PR allows the coverage job to fail because it is not important for us, just nice to have.

### Test Plan
see that error notification goes away after this PR

