### PR TITLE
fixed nonce too low error

### DIFF
--- a/crates/solver/src/settlement_submission/submitter/common.rs
+++ b/crates/solver/src/settlement_submission/submitter/common.rs
@@ -66,7 +66,9 @@ where
                 .into()
             }),
             Output::Failure(body) => {
-                if body.error.message.contains("invalid nonce") {
+                if body.error.message.contains("invalid nonce")
+                    || body.error.message.contains("nonce too low")
+                {
                     Err(SubmitApiError::InvalidNonce)
                 } else if body
                     .error


### PR DESCRIPTION
Error `SubmitApiError::InvalidNonce` is received from private networks (Flashbots, Eden) in cases when their network node is aware of a new block containing our mined tx before our node is. If we resend the tx in the meantime, this error is received.

In this case, Flashbots answers with "invalid nonce" while Eden aswers with "nonce too low", but it is the same error.