### PR TITLE
Disable balance check for presign

### DIFF
--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -96,7 +96,7 @@ impl Order {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct OrderBuilder(Order);
 
 impl OrderBuilder {

--- a/crates/orderbook/src/api/order_validation.rs
+++ b/crates/orderbook/src/api/order_validation.rs
@@ -9,6 +9,7 @@ use model::{
     order::{
         BuyTokenDestination, Order, OrderCreation, OrderKind, SellTokenSource, BUY_ETH_ADDRESS,
     },
+    signature::SigningScheme,
     DomainSeparator,
 };
 use shared::{bad_token::BadTokenDetecting, web3_traits::CodeFetching};
@@ -376,6 +377,11 @@ impl OrderValidating for OrderValidator {
             .await
         {
             Ok(_) => Ok((order, unsubsidized_fee)),
+            Err(TransferSimulationError::InsufficientAllowance)
+                if order.order_creation.signature.scheme() == SigningScheme::PreSign =>
+            {
+                Ok((order, unsubsidized_fee))
+            }
             Err(err) => match err {
                 TransferSimulationError::InsufficientAllowance => {
                     Err(ValidationError::InsufficientAllowance)
@@ -420,7 +426,7 @@ mod tests {
     use super::*;
     use crate::{account_balances::MockBalanceFetching, fee::MockMinFeeCalculating};
     use anyhow::anyhow;
-    use model::order::OrderCreation;
+    use model::{order::OrderCreation, signature::Signature};
     use shared::{
         bad_token::{MockBadTokenDetecting, TokenQuality},
         dummy_contract,
@@ -814,5 +820,69 @@ mod tests {
             order.order_meta_data.full_fee_amount,
             order.order_creation.fee_amount
         );
+    }
+
+    #[tokio::test]
+    async fn allows_missing_allowance_for_presign_orders() {
+        let mut fee_calculator = MockMinFeeCalculating::new();
+        let mut bad_token_detector = MockBadTokenDetecting::new();
+        let mut balance_fetcher = MockBalanceFetching::new();
+        fee_calculator
+            .expect_get_unsubsidized_min_fee()
+            .returning(|_, _, _| Ok(Default::default()));
+        bad_token_detector
+            .expect_detect()
+            .returning(|_| Ok(TokenQuality::Good));
+        balance_fetcher
+            .expect_can_transfer()
+            .returning(|_, _, _, _| Err(TransferSimulationError::InsufficientAllowance));
+        let validator = OrderValidator::new(
+            Box::new(MockCodeFetching::new()),
+            dummy_contract!(WETH9, [0xef; 20]),
+            vec![],
+            Duration::from_secs(1),
+            Arc::new(fee_calculator),
+            Arc::new(bad_token_detector),
+            Arc::new(balance_fetcher),
+        );
+
+        let order = OrderCreation {
+            valid_to: u32::MAX,
+            sell_token: H160::from_low_u64_be(1),
+            sell_amount: 1.into(),
+            buy_token: H160::from_low_u64_be(2),
+            buy_amount: 1.into(),
+            ..Default::default()
+        };
+
+        // In general, orders will return an insufficent allowance error if the
+        // balance fetcher says so.
+        assert!(matches!(
+            validator
+                .validate_and_construct_order(
+                    order.clone(),
+                    None,
+                    &Default::default(),
+                    Default::default()
+                )
+                .await,
+            Err(ValidationError::InsufficientAllowance)
+        ));
+
+        // With an exception for pre-sign orders!
+        assert!(matches!(
+            validator
+                .validate_and_construct_order(
+                    OrderCreation {
+                        signature: Signature::default_with(SigningScheme::PreSign),
+                        ..order
+                    },
+                    None,
+                    &Default::default(),
+                    Default::default()
+                )
+                .await,
+            Ok(_)
+        ));
     }
 }

--- a/crates/orderbook/src/api/order_validation.rs
+++ b/crates/orderbook/src/api/order_validation.rs
@@ -383,11 +383,11 @@ impl OrderValidating for OrderValidator {
             ) if order.order_creation.signature.scheme() == SigningScheme::PreSign => {
                 // We have an exception for pre-sign orders where they do not
                 // require sufficient balance or allowance. The idea, is that
-                // this allows SC orders to place orders bundled with other
-                // transactions that either produce the required balance or set
-                // the allowance. This would, for example, allow a Gnosis Safe
-                // to bundle the pre-signature transaction with a WETH wrap and
-                // WETH approval to the vault relayer contract.
+                // this allows smart contracts to place orders bundled with
+                // other transactions that either produce the required balance
+                // or set the allowance. This would, for example, allow a Gnosis
+                // Safe to bundle the pre-signature transaction with a WETH wrap
+                // and WETH approval to the vault relayer contract.
                 Ok((order, unsubsidized_fee))
             }
             Err(err) => match err {


### PR DESCRIPTION
Fixes #1545 
 
This PR disables balance and allowance check for pre-sign orders.

The rational is that this allows SCs to place orders bundled with other transactions that either produce the required balance or set the allowance. This would, for example, allow a Gnosis Safe to bundle the pre-signature transaction with a WETH wrap and WETH approval to the vault relayer contract. Additionally, this enables the Yearn-team integration mentioned in the issue ☝️ 

### Test Plan

New unit test.
