### PR TITLE
Pin nightly to older version to re-enable coverage

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -108,11 +108,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
-        run: rustup toolchain install nightly-2022-01-13 --component llvm-tools-preview
+        run: rustup toolchain install nightly-2022-01-14 --component llvm-tools-preview
       - name: Install cargo-llvm-cov
-        run: curl -LsSf https://github.com/taiki-e/cargo-llvm-cov/releases/latest/download/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
+        uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+        run: cargo +nightly-2022-01-14 llvm-cov --all-features --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -108,7 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
-        run: rustup toolchain install nightly --component llvm-tools-preview
+        run: rustup toolchain install nightly-2022-01-13 --component llvm-tools-preview
       - name: Install cargo-llvm-cov
         run: curl -LsSf https://github.com/taiki-e/cargo-llvm-cov/releases/latest/download/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
       - name: Generate code coverage


### PR DESCRIPTION
This PR pins nightly to `2022-01-14` to fix the coverage report.

It appears to be an issue with the nightly compiler (at least that is what is suggested in the `cargo-llvm-cov` project issues page). I created an issue so we don't forget to switch( back eventually #1588 (this also contains a link to the issue in the `cargo-llvm-cov` project for reference).

This PR also introduces a small unrelated change: the [recommended way to install `cargo-llvm-cov` is to use a dedicated Github action](https://github.com/taiki-e/cargo-llvm-cov#continuous-integration), so this PR also changes the workflow to use it instead of the manual install it was doing previously.

### Test Plan

CI
