### PR TITLE
Add Metrics to Competition Price Estimator

### DIFF
--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -523,6 +523,16 @@ pub enum OrderKind {
     Sell,
 }
 
+impl OrderKind {
+    /// Returns a the order kind as a string label that can be used in metrics.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Buy => "buy",
+            Self::Sell => "sell",
+        }
+    }
+}
+
 impl Default for OrderKind {
     fn default() -> Self {
         Self::Buy

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -1,6 +1,8 @@
 use super::{Estimate, PriceEstimating, PriceEstimationError, Query};
+use crate::metrics;
 use anyhow::{anyhow, Result};
 use futures::future;
+use model::order::OrderKind;
 use num::BigRational;
 use std::cmp;
 
@@ -55,8 +57,14 @@ impl PriceEstimating for CompetitionPriceEstimator {
                         // The `EstimateData::estimator_name` field is getting
                         // flagged as dead code despited being used in the log
                         // below. Just convince the linter that we use it.
-                        let _ = winning_estimate.estimator_name;
                         tracing::debug!(?query, ?winning_estimate, "winning price estimate");
+                        metrics()
+                            .queries_won
+                            .with_label_values(&[
+                                winning_estimate.estimator_name,
+                                winning_estimate.kind_label(),
+                            ])
+                            .inc();
                         winning_estimate.estimate
                     })
             })
@@ -66,9 +74,20 @@ impl PriceEstimating for CompetitionPriceEstimator {
 
 #[derive(Debug)]
 struct EstimateData<'a> {
+    kind: OrderKind,
     estimator_name: &'a str,
     estimate: Estimate,
     sell_over_buy: BigRational,
+}
+
+impl EstimateData<'_> {
+    /// Returns a label for the estimate's query kind.
+    pub fn kind_label(&self) -> &'static str {
+        match self.kind {
+            OrderKind::Buy => "buy",
+            OrderKind::Sell => "sell",
+        }
+    }
 }
 
 fn fold_price_estimation_result<'a>(
@@ -93,6 +112,7 @@ fn fold_price_estimation_result<'a>(
             .price_in_sell_token_rational(query)
             .ok_or(PriceEstimationError::ZeroAmount)?;
         Ok(EstimateData {
+            kind: query.kind,
             estimator_name,
             estimate,
             sell_over_buy,
@@ -132,6 +152,24 @@ fn join_error(a: PriceEstimationError, b: PriceEstimationError) -> PriceEstimati
         }
         (err @ PriceEstimationError::UnsupportedOrderType, _) => err,
     }
+}
+
+#[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
+#[metric(subsystem = "competition_price_estimator")]
+struct Metrics {
+    /// Number of wins for a particular price estimator and order kind.
+    ///
+    /// Note that the order kind is included in the metric. This is because some
+    /// estimators only support sell orders (e.g. 1Inch) which would skew the
+    /// total metrics. Additionally, this allows us to see how different
+    /// estimators behave for buy vs sell orders.
+    #[metric(labels("estimator_type", "order_kind"))]
+    queries_won: prometheus::CounterVec,
+}
+
+fn metrics() -> &'static Metrics {
+    Metrics::instance(metrics::get_metric_storage_registry())
+        .expect("unexpected error getting metrics instance")
 }
 
 #[cfg(test)]

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -62,7 +62,7 @@ impl PriceEstimating for CompetitionPriceEstimator {
                             .queries_won
                             .with_label_values(&[
                                 winning_estimate.estimator_name,
-                                winning_estimate.kind_label(),
+                                winning_estimate.kind.label(),
                             ])
                             .inc();
                         winning_estimate.estimate
@@ -78,16 +78,6 @@ struct EstimateData<'a> {
     estimator_name: &'a str,
     estimate: Estimate,
     sell_over_buy: BigRational,
-}
-
-impl EstimateData<'_> {
-    /// Returns a label for the estimate's query kind.
-    pub fn kind_label(&self) -> &'static str {
-        match self.kind {
-            OrderKind::Buy => "buy",
-            OrderKind::Sell => "sell",
-        }
-    }
 }
 
 fn fold_price_estimation_result<'a>(


### PR DESCRIPTION
Fixes #1586.

This PR adds metrics or the competition price estimation to show the winner.

I decided to include a label for the price estimator name **and** for the query kind (so `buy` vs `sell`). The decision was driven by the fact that the additional label only has two possible values (so we have twice as many counters now - nothing crazy). Furthermore, it could show how different price estimators fare on buy vs sell orders (which are fundamentally different). This was also driven by the fact that some price estimators (1Inch for example) don't 

### Test Plan

Run the orderbook and checkout the metrics!
```
% curl -s http://localhost:9586/metrics | grep gp_v2_api_competition_price_estimator_queries_won
# HELP gp_v2_api_competition_price_estimator_queries_won Number of wins for a particular price estimator and order kind.
# TYPE gp_v2_api_competition_price_estimator_queries_won counter
gp_v2_api_competition_price_estimator_queries_won{estimator_type="Baseline",order_kind="buy"} 2
gp_v2_api_competition_price_estimator_queries_won{estimator_type="OneInch",order_kind="sell"} 4
```

### Release notes

Additional metrics have been added.
