### PR TITLE
recover pending transaction from mempool

### DIFF
--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -80,15 +80,16 @@ impl SolutionSubmitter {
                 .iter()
                 .map(|strategy| {
                     async {
-                        match &*strategy {
+                        let try_to_recover_gas_price = match &*strategy {
                             TransactionStrategy::Eden(_) | TransactionStrategy::Flashbots(_) => {
                                 if !matches!(account, Account::Offline(..)) {
                                     return Err(SubmissionError::from(anyhow!(
                                         "Submission to private network requires offline account for signing"
                                     )));
                                 }
+                                false
                             }
-                            TransactionStrategy::CustomNodes(_) => {}
+                            TransactionStrategy::CustomNodes(_) => true,
                             TransactionStrategy::DryRun => unreachable!(),
                         };
 
@@ -98,6 +99,7 @@ impl SolutionSubmitter {
                             gas_estimate,
                             deadline: Some(Instant::now() + self.max_confirm_time),
                             retry_interval: self.retry_interval,
+                            try_to_recover_gas_price,
                         };
                         let gas_price_estimator = SubmitterGasPriceEstimator {
                             inner: self.gas_price_estimator.as_ref(),

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -80,16 +80,15 @@ impl SolutionSubmitter {
                 .iter()
                 .map(|strategy| {
                     async {
-                        let try_to_recover_gas_price = match &*strategy {
+                        match &*strategy {
                             TransactionStrategy::Eden(_) | TransactionStrategy::Flashbots(_) => {
                                 if !matches!(account, Account::Offline(..)) {
                                     return Err(SubmissionError::from(anyhow!(
                                         "Submission to private network requires offline account for signing"
                                     )));
                                 }
-                                false
                             }
-                            TransactionStrategy::CustomNodes(_) => true,
+                            TransactionStrategy::CustomNodes(_) => {},
                             TransactionStrategy::DryRun => unreachable!(),
                         };
 
@@ -99,7 +98,6 @@ impl SolutionSubmitter {
                             gas_estimate,
                             deadline: Some(Instant::now() + self.max_confirm_time),
                             retry_interval: self.retry_interval,
-                            try_to_recover_gas_price,
                         };
                         let gas_price_estimator = SubmitterGasPriceEstimator {
                             inner: self.gas_price_estimator.as_ref(),

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -88,7 +88,7 @@ impl SolutionSubmitter {
                                     )));
                                 }
                             }
-                            TransactionStrategy::CustomNodes(_) => {},
+                            TransactionStrategy::CustomNodes(_) => {}
                             TransactionStrategy::DryRun => unreachable!(),
                         };
 

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -43,8 +43,6 @@ pub struct SubmitterParams {
     pub deadline: Option<Instant>,
     /// Resimulate and resend transaction on every retry_interval seconds
     pub retry_interval: Duration,
-    /// Searches for mempool transaction submitted in previous submission loop
-    pub try_to_recover_gas_price: bool,
 }
 
 #[derive(Debug)]
@@ -515,7 +513,6 @@ mod tests {
             gas_estimate,
             deadline: Some(Instant::now() + Duration::from_secs(90)),
             retry_interval: Duration::from_secs(5),
-            try_to_recover_gas_price: false,
         };
         let result = submitter.submit(settlement, params).await;
         tracing::info!("finished with result {:?}", result);

--- a/crates/solver/src/settlement_submission/submitter/common.rs
+++ b/crates/solver/src/settlement_submission/submitter/common.rs
@@ -66,16 +66,22 @@ where
                 .into()
             }),
             Output::Failure(body) => {
-                if body.error.message.contains("invalid nonce")
-                    || body.error.message.contains("nonce too low")
+                if body.error.message.starts_with("invalid nonce")
+                    || body.error.message.starts_with("nonce too low")
                 {
                     Err(SubmitApiError::InvalidNonce)
                 } else if body
                     .error
                     .message
-                    .contains("Transaction gas price supplied is too low")
+                    .starts_with("Transaction gas price supplied is too low")
                 {
                     Err(SubmitApiError::OpenEthereumTooCheapToReplace)
+                } else if body
+                    .error
+                    .message
+                    .starts_with("replacement transaction underpriced")
+                {
+                    Err(SubmitApiError::ReplacementTransactionUnderpriced)
                 } else {
                     Err(anyhow!("rpc error: {}", body.error).into())
                 }

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -75,8 +75,4 @@ impl TransactionSubmitting for CustomNodesApi {
             Err(err) => Err(anyhow!("{:?}", err)),
         }
     }
-
-    async fn mark_transaction_outdated(&self, _id: &TransactionHandle) -> Result<()> {
-        Ok(())
-    }
 }

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -1,13 +1,17 @@
+use crate::pending_transactions::Fee;
+
 use super::{
     super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
     CancelHandle,
 };
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use ethcontract::{
     dyns::DynTransport,
     transaction::{Transaction, TransactionBuilder},
+    H160, U256,
 };
 use futures::FutureExt;
+use gas_estimation::{EstimatedGasPrice, GasPrice1559};
 use shared::Web3;
 
 #[derive(Clone)]
@@ -73,6 +77,45 @@ impl TransactionSubmitting for CustomNodesApi {
         match self.submit_transaction(id.noop_transaction.clone()).await {
             Ok(_) => Ok(()),
             Err(err) => Err(anyhow!("{:?}", err)),
+        }
+    }
+
+    async fn recover_pending_transaction(
+        &self,
+        web3: &Web3,
+        address: &H160,
+        nonce: U256,
+    ) -> Result<Option<EstimatedGasPrice>> {
+        let transactions = crate::pending_transactions::pending_transactions(web3.transport())
+            .await
+            .context("pending_transactions failed")?;
+        let transaction = match transactions
+            .iter()
+            .find(|transaction| transaction.from == *address && transaction.nonce == nonce)
+        {
+            Some(transaction) => transaction,
+            None => return Ok(None),
+        };
+        match transaction.fee {
+            Fee::Legacy { gas_price } => Ok(Some(EstimatedGasPrice {
+                legacy: gas_price.to_f64_lossy(),
+                ..Default::default()
+            })),
+            Fee::Eip1559 {
+                max_priority_fee_per_gas,
+                max_fee_per_gas,
+            } => Ok(Some(EstimatedGasPrice {
+                eip1559: Some(GasPrice1559 {
+                    max_fee_per_gas: max_fee_per_gas.to_f64_lossy(),
+                    max_priority_fee_per_gas: max_priority_fee_per_gas.to_f64_lossy(),
+                    base_fee_per_gas: crate::pending_transactions::base_fee_per_gas(
+                        web3.transport(),
+                    )
+                    .await?
+                    .to_f64_lossy(),
+                }),
+                ..Default::default()
+            })),
         }
     }
 }

--- a/crates/solver/src/settlement_submission/submitter/eden_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/eden_api.rs
@@ -44,8 +44,4 @@ impl TransactionSubmitting for EdenApi {
             Err(err) => Err(anyhow!("{:?}", err)),
         }
     }
-
-    async fn mark_transaction_outdated(&self, _id: &TransactionHandle) -> Result<()> {
-        Ok(())
-    }
 }

--- a/crates/solver/src/settlement_submission/submitter/eden_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/eden_api.rs
@@ -5,8 +5,10 @@ use super::{
     CancelHandle,
 };
 use anyhow::{anyhow, Context, Result};
-use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder};
+use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder, H160, U256};
+use gas_estimation::EstimatedGasPrice;
 use reqwest::{Client, IntoUrl, Url};
+use shared::Web3;
 
 #[derive(Clone)]
 pub struct EdenApi {
@@ -43,5 +45,14 @@ impl TransactionSubmitting for EdenApi {
             Ok(_) => Ok(()),
             Err(err) => Err(anyhow!("{:?}", err)),
         }
+    }
+
+    async fn recover_pending_transaction(
+        &self,
+        _web3: &Web3,
+        _address: &H160,
+        _nonce: U256,
+    ) -> Result<Option<EstimatedGasPrice>> {
+        Ok(None)
     }
 }

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -3,8 +3,10 @@ use super::{
     CancelHandle,
 };
 use anyhow::{Context, Result};
-use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder};
+use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder, H160, U256};
+use gas_estimation::EstimatedGasPrice;
 use reqwest::{Client, IntoUrl, Url};
+use shared::Web3;
 
 #[derive(Clone)]
 pub struct FlashbotsApi {
@@ -32,5 +34,14 @@ impl TransactionSubmitting for FlashbotsApi {
 
     async fn cancel_transaction(&self, _id: &CancelHandle) -> Result<()> {
         Ok(())
+    }
+
+    async fn recover_pending_transaction(
+        &self,
+        _web3: &Web3,
+        _address: &H160,
+        _nonce: U256,
+    ) -> Result<Option<EstimatedGasPrice>> {
+        Ok(None)
     }
 }

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -33,8 +33,4 @@ impl TransactionSubmitting for FlashbotsApi {
     async fn cancel_transaction(&self, _id: &CancelHandle) -> Result<()> {
         Ok(())
     }
-
-    async fn mark_transaction_outdated(&self, _id: &TransactionHandle) -> Result<()> {
-        Ok(())
-    }
 }


### PR DESCRIPTION
This PR fixes https://github.com/gnosis/gp-v2-services/issues/1583

Notice that this is enabled only for `CustomNodes` strategy at the moment. Eden and Flashbots can't benefit from this change since transactions sent through them are not seen in the public mempool. Flashbots does say they send transactions to public mempool if tx.gas < 41000, however I wasn't able to confirm this.

Additionally, with previous PR https://github.com/gnosis/gp-v2-services/pull/1590 we should receive less error messages of this type. Anyway, in this PR we suppress this type of message by handling it in the `Submitter`. Will continue to monitor these messages in logs.
