### PR TITLE
Drop min_order_size_one_inch CLI argument from solver

### DIFF
--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use clap::{ArgEnum, Parser};
 use contracts::{BalancerV2Vault, IUniswapLikeRouter, WETH9};
-use ethcontract::{Account, PrivateKey, H160, U256};
+use ethcontract::{Account, PrivateKey, H160};
 use reqwest::Url;
 use shared::{
     baseline_solver::BaseTokens,
@@ -147,16 +147,6 @@ struct Arguments {
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
     solver_time_limit: Duration,
-
-    /// The minimum amount of sell volume (in ETH) that needs to be
-    /// traded in order to use the 1Inch solver.
-    #[clap(
-        long,
-        env,
-        default_value = "5",
-        parse(try_from_str = shared::arguments::wei_from_base_unit)
-    )]
-    min_order_size_one_inch: U256,
 
     /// The list of tokens our settlement contract is willing to buy when settling trades
     /// without external liquidity
@@ -535,7 +525,6 @@ async fn main() {
         token_info_fetcher,
         network_name.to_string(),
         chain_id,
-        args.min_order_size_one_inch,
         args.shared.disabled_one_inch_protocols,
         args.paraswap_slippage_bps,
         args.shared.disabled_paraswap_dexs,

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -153,7 +153,6 @@ pub fn create(
     token_info_fetcher: Arc<dyn TokenInfoFetching>,
     network_id: String,
     chain_id: u64,
-    min_order_size_one_inch: U256,
     disabled_one_inch_protocols: Vec<String>,
     paraswap_slippage_bps: u32,
     disabled_paraswap_dexs: Vec<String>,
@@ -237,25 +236,18 @@ pub fn create(
                         use_internal_buffers: quasimodo_uses_internal_buffers.into(),
                     },
                 )),
-                SolverType::OneInch => {
-                    let one_inch_solver: SingleOrderSolver<_> = SingleOrderSolver::new(
-                        OneInchSolver::with_disabled_protocols(
-                            account,
-                            web3.clone(),
-                            settlement_contract.clone(),
-                            chain_id,
-                            disabled_one_inch_protocols.clone(),
-                            client.clone(),
-                            one_inch_url.clone(),
-                        )?,
-                        solver_metrics.clone(),
-                    );
-                    // We only want to use 1Inch for high value orders
-                    shared(SellVolumeFilteringSolver::new(
-                        Box::new(one_inch_solver),
-                        min_order_size_one_inch,
-                    ))
-                }
+                SolverType::OneInch => shared(SingleOrderSolver::new(
+                    OneInchSolver::with_disabled_protocols(
+                        account,
+                        web3.clone(),
+                        settlement_contract.clone(),
+                        chain_id,
+                        disabled_one_inch_protocols.clone(),
+                        client.clone(),
+                        one_inch_url.clone(),
+                    )?,
+                    solver_metrics.clone(),
+                )),
                 SolverType::ZeroEx => {
                     let zeroex_solver = ZeroExSolver::new(
                         account,


### PR DESCRIPTION
Fixes #1529

Because 1Inch is now represented in the price estimation and we also have enough solution competition, costly 1Inch settlements should simply loose based on their objective value. We no longer need to manually limit `OneInchSolver` to settlements with a total trading volume bigger than a user specified value.

This PR resolves the final task of the linked issue.

### Test Plan
No tests
