### PR TITLE
Revert 1Inch API update

### DIFF
--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -2,8 +2,6 @@
 //!
 //! For more information on the HTTP API, consult:
 //! <https://docs.1inch.io/docs/aggregation-protocol/api/swagger>
-//! Although there is no documentation about API v4.1, it exists and is identical to v4.0 except it
-//! uses EIP 1559 gas prices.
 use crate::solver_utils::{deserialize_prefixed_hex, Slippage};
 use anyhow::{ensure, Context, Result};
 use cached::{Cached, TimedCache};
@@ -42,7 +40,7 @@ impl<const MIN: usize, const MAX: usize> Display for Amount<MIN, MAX> {
 }
 
 #[derive(Debug, Clone)]
-pub struct SellOrderQuoteQuery {
+pub struct QuoteAndSwapCommonOptions {
     /// Contract address of a token to sell.
     pub from_token_address: H160,
     /// Contract address of a token to buy.
@@ -59,83 +57,10 @@ pub struct SellOrderQuoteQuery {
     pub main_route_parts: Option<Amount<1, 50>>,
     /// Limit maximum number of parts each main route part can be split into.
     pub parts: Option<Amount<1, 100>>,
-    /// This percentage of from_token_address token amount will be sent
-    /// to referrer_address. The rest will be used as input for the swap.
-    /// min: 0, max: 3, default: 0
-    pub fee: Option<f64>,
-    /// Gas price in smallest divisible unit. default: "fast" from network
-    pub gas_price: Option<U256>,
-    /// Limit the number of virtual split parts. default: 50
-    pub virtual_parts: Option<Amount<1, 500>>,
-    /// Which tokens should be used for intermediate trading hops.
-    pub connector_tokens: Option<Vec<H160>>,
 }
 
-// The `Display` implementation for `H160` unfortunately does not print
-// the full address and instead uses ellipsis (e.g. "0xeeee…eeee"). This
-// helper just works around that.
-fn addr2str(addr: H160) -> String {
-    format!("{:?}", addr)
-}
-
-impl SellOrderQuoteQuery {
-    fn into_url(self, base_url: &Url, chain_id: u64) -> Url {
-        let endpoint = format!("v4.1/{}/quote", chain_id);
-        let mut url = base_url
-            .join(&endpoint)
-            .expect("unexpectedly invalid URL segment");
-
-        url.query_pairs_mut()
-            .append_pair("fromTokenAddress", &addr2str(self.from_token_address))
-            .append_pair("toTokenAddress", &addr2str(self.to_token_address))
-            .append_pair("amount", &self.amount.to_string());
-
-        if let Some(protocols) = self.protocols {
-            url.query_pairs_mut()
-                .append_pair("protocols", &protocols.join(","));
-        }
-        if let Some(fee) = self.fee {
-            url.query_pairs_mut().append_pair("fee", &fee.to_string());
-        }
-        if let Some(gas_limit) = self.gas_limit {
-            url.query_pairs_mut()
-                .append_pair("gasLimit", &gas_limit.to_string());
-        }
-        if let Some(connector_tokens) = self.connector_tokens {
-            url.query_pairs_mut().append_pair(
-                "connectorTokens",
-                &connector_tokens
-                    .into_iter()
-                    .map(addr2str)
-                    .collect::<Vec<_>>()
-                    .join(","),
-            );
-        }
-        if let Some(complexity_level) = self.complexity_level {
-            url.query_pairs_mut()
-                .append_pair("complexityLevel", &complexity_level.to_string());
-        }
-        if let Some(main_route_parts) = self.main_route_parts {
-            url.query_pairs_mut()
-                .append_pair("mainRouteParts", &main_route_parts.to_string());
-        }
-        if let Some(virtual_parts) = self.virtual_parts {
-            url.query_pairs_mut()
-                .append_pair("virtualParts", &virtual_parts.to_string());
-        }
-        if let Some(parts) = self.parts {
-            url.query_pairs_mut()
-                .append_pair("parts", &parts.to_string());
-        }
-        if let Some(gas_price) = self.gas_price {
-            url.query_pairs_mut()
-                .append_pair("gasPrice", &gas_price.to_string());
-        }
-
-        url
-    }
-
-    pub fn with_default_options(
+impl QuoteAndSwapCommonOptions {
+    fn with_default_options(
         sell_token: H160,
         buy_token: H160,
         protocols: Option<Vec<String>>,
@@ -153,10 +78,106 @@ impl SellOrderQuoteQuery {
             // Use only 3 main route for cheaper trades.
             main_route_parts: Some(Amount::new(3).unwrap()),
             parts: Some(Amount::new(3).unwrap()),
+        }
+    }
+}
+
+// The `Display` implementation for `H160` unfortunately does not print
+// the full address and instead uses ellipsis (e.g. "0xeeee…eeee"). This
+// helper just works around that.
+fn addr2str(addr: H160) -> String {
+    format!("{:?}", addr)
+}
+
+/// A query to get a quote for a sell order with 1Inch.
+#[derive(Clone, Debug)]
+pub struct SellOrderQuoteQuery {
+    /// Percentage how much of the from_token_address amount should be sent to the referrer
+    /// address. Values: [0, 3], Default 0.0
+    pub fee: Option<f64>,
+    /// Which tokens should be used for intermediate trading hops.
+    pub connector_tokens: Option<Vec<H160>>,
+    /// Limit the number of virtual split parts.
+    pub virtual_parts: Option<Amount<1, 500>>,
+    /// Gas price in smallest divisible unit. Default: "fast" from network
+    pub gas_price: Option<U256>,
+    pub common: QuoteAndSwapCommonOptions,
+}
+
+impl SellOrderQuoteQuery {
+    fn into_url(self, base_url: &Url, chain_id: u64) -> Url {
+        let endpoint = format!("v4.0/{}/quote", chain_id);
+        let mut url = base_url
+            .join(&endpoint)
+            .expect("unexpectedly invalid URL segment");
+
+        url.query_pairs_mut()
+            .append_pair(
+                "fromTokenAddress",
+                &addr2str(self.common.from_token_address),
+            )
+            .append_pair("toTokenAddress", &addr2str(self.common.to_token_address))
+            .append_pair("amount", &self.common.amount.to_string());
+
+        if let Some(protocols) = self.common.protocols {
+            url.query_pairs_mut()
+                .append_pair("protocols", &protocols.join(","));
+        }
+        if let Some(fee) = self.fee {
+            url.query_pairs_mut().append_pair("fee", &fee.to_string());
+        }
+        if let Some(gas_limit) = self.common.gas_limit {
+            url.query_pairs_mut()
+                .append_pair("gasLimit", &gas_limit.to_string());
+        }
+        if let Some(connector_tokens) = self.connector_tokens {
+            url.query_pairs_mut().append_pair(
+                "connectorTokens",
+                &connector_tokens
+                    .into_iter()
+                    .map(addr2str)
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
+        }
+        if let Some(complexity_level) = self.common.complexity_level {
+            url.query_pairs_mut()
+                .append_pair("complexityLevel", &complexity_level.to_string());
+        }
+        if let Some(main_route_parts) = self.common.main_route_parts {
+            url.query_pairs_mut()
+                .append_pair("mainRouteParts", &main_route_parts.to_string());
+        }
+        if let Some(virtual_parts) = self.virtual_parts {
+            url.query_pairs_mut()
+                .append_pair("virtualParts", &virtual_parts.to_string());
+        }
+        if let Some(parts) = self.common.parts {
+            url.query_pairs_mut()
+                .append_pair("parts", &parts.to_string());
+        }
+        if let Some(gas_price) = self.gas_price {
+            url.query_pairs_mut()
+                .append_pair("gasPrice", &gas_price.to_string());
+        }
+
+        url
+    }
+
+    pub fn with_default_options(
+        sell_token: H160,
+        buy_token: H160,
+        in_amount: U256,
+        protocols: Option<Vec<String>>,
+    ) -> Self {
+        Self {
             fee: None,
-            gas_price: None,
-            virtual_parts: None,
             connector_tokens: None,
+            virtual_parts: None,
+            gas_price: None,
+            common: QuoteAndSwapCommonOptions::with_default_options(
+                sell_token, buy_token, protocols, in_amount,
+            ),
         }
     }
 }
@@ -171,7 +192,7 @@ pub struct SellOrderQuote {
     pub from_token_amount: U256,
     #[serde(with = "u256_decimal")]
     pub to_token_amount: U256,
-    pub protocols: Vec<Vec<Vec<ProtocolRouteSegment>>>,
+    pub protocols: Vec<Vec<Vec<Protocol>>>,
     pub estimated_gas: u64,
 }
 
@@ -190,35 +211,27 @@ pub struct SwapQuery {
     pub slippage: Slippage,
     /// Flag to disable checks of the required quantities.
     pub disable_estimate: Option<bool>,
-    /// Receiver of destination currency. default: from_address
-    pub dest_receiver: Option<H160>,
-    /// Who is referring this swap to 1Inch.
-    pub referrer_address: Option<H160>,
-    /// Should Chi of from_token_address be burnt to compensate for gas.
-    /// default: false
-    pub burn_chi: Option<bool>,
-    /// If true, the algorithm can cancel part of the route, if the rate has become
-    /// less attractive. Unswapped tokens will return to the from_address
-    /// default: true
-    pub allow_partial_fill: Option<bool>,
-    pub quote: SellOrderQuoteQuery,
+    pub common: QuoteAndSwapCommonOptions,
 }
 
 impl SwapQuery {
     /// Encodes the swap query as
     fn into_url(self, base_url: &Url, chain_id: u64) -> Url {
-        let endpoint = format!("v4.1/{}/swap", chain_id);
+        let endpoint = format!("v3.0/{}/swap", chain_id);
         let mut url = base_url
             .join(&endpoint)
             .expect("unexpectedly invalid URL segment");
         url.query_pairs_mut()
-            .append_pair("fromTokenAddress", &addr2str(self.quote.from_token_address))
-            .append_pair("toTokenAddress", &addr2str(self.quote.to_token_address))
-            .append_pair("amount", &self.quote.amount.to_string())
+            .append_pair(
+                "fromTokenAddress",
+                &addr2str(self.common.from_token_address),
+            )
+            .append_pair("toTokenAddress", &addr2str(self.common.to_token_address))
+            .append_pair("amount", &self.common.amount.to_string())
             .append_pair("fromAddress", &addr2str(self.from_address))
             .append_pair("slippage", &self.slippage.to_string());
 
-        if let Some(protocols) = self.quote.protocols {
+        if let Some(protocols) = self.common.protocols {
             url.query_pairs_mut()
                 .append_pair("protocols", &protocols.join(","));
         }
@@ -226,58 +239,21 @@ impl SwapQuery {
             url.query_pairs_mut()
                 .append_pair("disableEstimate", &disable_estimate.to_string());
         }
-        if let Some(complexity_level) = self.quote.complexity_level {
+        if let Some(complexity_level) = self.common.complexity_level {
             url.query_pairs_mut()
                 .append_pair("complexityLevel", &complexity_level.to_string());
         }
-        if let Some(gas_limit) = self.quote.gas_limit {
+        if let Some(gas_limit) = self.common.gas_limit {
             url.query_pairs_mut()
                 .append_pair("gasLimit", &gas_limit.to_string());
         }
-        if let Some(main_route_parts) = self.quote.main_route_parts {
+        if let Some(main_route_parts) = self.common.main_route_parts {
             url.query_pairs_mut()
                 .append_pair("mainRouteParts", &main_route_parts.to_string());
         }
-        if let Some(parts) = self.quote.parts {
+        if let Some(parts) = self.common.parts {
             url.query_pairs_mut()
                 .append_pair("parts", &parts.to_string());
-        }
-        if let Some(dest_receiver) = self.dest_receiver {
-            url.query_pairs_mut()
-                .append_pair("destReceiver", &addr2str(dest_receiver));
-        }
-        if let Some(referrer_address) = self.referrer_address {
-            url.query_pairs_mut()
-                .append_pair("referrerAddress", &addr2str(referrer_address));
-        }
-        if let Some(fee) = self.quote.fee {
-            url.query_pairs_mut().append_pair("fee", &fee.to_string());
-        }
-        if let Some(gas_price) = self.quote.gas_price {
-            url.query_pairs_mut()
-                .append_pair("gasPrice", &gas_price.to_string());
-        }
-        if let Some(burn_chi) = self.burn_chi {
-            url.query_pairs_mut()
-                .append_pair("burnChi", &burn_chi.to_string());
-        }
-        if let Some(allow_partial_fill) = self.allow_partial_fill {
-            url.query_pairs_mut()
-                .append_pair("allowPartialFill", &allow_partial_fill.to_string());
-        }
-        if let Some(virtual_parts) = self.quote.virtual_parts {
-            url.query_pairs_mut()
-                .append_pair("virtualParts", &virtual_parts.to_string());
-        }
-        if let Some(connector_tokens) = self.quote.connector_tokens {
-            url.query_pairs_mut().append_pair(
-                "connectorTokens",
-                &connector_tokens
-                    .into_iter()
-                    .map(addr2str)
-                    .collect::<Vec<_>>()
-                    .join(","),
-            );
         }
 
         url
@@ -297,13 +273,9 @@ impl SwapQuery {
             // Disable balance/allowance checks, as the settlement contract
             // does not hold balances to traded tokens.
             disable_estimate: Some(true),
-            quote: SellOrderQuoteQuery::with_default_options(
+            common: QuoteAndSwapCommonOptions::with_default_options(
                 sell_token, buy_token, protocols, in_amount,
             ),
-            dest_receiver: None,
-            referrer_address: None,
-            burn_chi: None,
-            allow_partial_fill: Some(false),
         }
     }
 }
@@ -332,7 +304,7 @@ pub struct Swap {
     pub from_token_amount: U256,
     #[serde(with = "u256_decimal")]
     pub to_token_amount: U256,
-    pub protocols: Vec<Vec<Vec<ProtocolRouteSegment>>>,
+    pub protocols: Vec<Vec<Vec<Protocol>>>,
     pub tx: Transaction,
 }
 
@@ -348,7 +320,7 @@ pub struct Token {
 /// Metadata associated with a protocol used for part of a 1Inch swap.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub struct ProtocolRouteSegment {
+pub struct Protocol {
     pub name: String,
     pub part: f64,
     pub from_token_address: H160,
@@ -388,21 +360,10 @@ pub struct Spender {
     pub address: H160,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
-pub struct ProtocolInfo {
-    pub id: String,
-}
-
-impl From<&str> for ProtocolInfo {
-    fn from(id: &str) -> Self {
-        Self { id: id.to_string() }
-    }
-}
-
 /// Protocols query response.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct Protocols {
-    pub protocols: Vec<ProtocolInfo>,
+    pub protocols: Vec<String>,
 }
 
 // Mockable version of API Client
@@ -422,7 +383,7 @@ pub trait OneInchClient: Send + Sync {
     async fn get_spender(&self) -> Result<Spender>;
 
     /// Retrieves a list of the on-chain protocols supported by 1Inch.
-    async fn get_liquidity_sources(&self) -> Result<Protocols>;
+    async fn get_protocols(&self) -> Result<Protocols>;
 }
 
 /// 1Inch API Client implementation.
@@ -468,7 +429,7 @@ impl OneInchClient for OneInchClientImpl {
     }
 
     async fn get_spender(&self) -> Result<Spender> {
-        let endpoint = format!("v4.1/{}/approve/spender", self.chain_id);
+        let endpoint = format!("v3.0/{}/approve/spender", self.chain_id);
         let url = self
             .base_url
             .join(&endpoint)
@@ -476,8 +437,8 @@ impl OneInchClient for OneInchClientImpl {
         logged_query(&self.client, url).await
     }
 
-    async fn get_liquidity_sources(&self) -> Result<Protocols> {
-        let endpoint = format!("v4.1/{}/liquidity-sources", self.chain_id);
+    async fn get_protocols(&self) -> Result<Protocols> {
+        let endpoint = format!("v3.0/{}/protocols", self.chain_id);
         let url = self
             .base_url
             .join(&endpoint)
@@ -497,7 +458,7 @@ where
 }
 
 #[derive(Debug, Clone)]
-pub struct ProtocolCache(Arc<Mutex<TimedCache<(), Vec<ProtocolInfo>>>>);
+pub struct ProtocolCache(Arc<Mutex<TimedCache<(), Vec<String>>>>);
 
 impl ProtocolCache {
     pub fn new(cache_validity_in_seconds: Duration) -> Self {
@@ -507,12 +468,12 @@ impl ProtocolCache {
         ))))
     }
 
-    pub async fn get_all_protocols(&self, api: &dyn OneInchClient) -> Result<Vec<ProtocolInfo>> {
+    pub async fn get_all_protocols(&self, api: &dyn OneInchClient) -> Result<Vec<String>> {
         if let Some(cached) = self.0.lock().unwrap().cache_get(&()) {
             return Ok(cached.clone());
         }
 
-        let all_protocols = api.get_liquidity_sources().await?.protocols;
+        let all_protocols = api.get_protocols().await?.protocols;
         // In the mean time the cache could have already been populated with new protocols,
         // which we would now overwrite. This is fine.
         self.0.lock().unwrap().cache_set((), all_protocols.clone());
@@ -534,8 +495,7 @@ impl ProtocolCache {
             .await?
             .into_iter()
             // linear search through the slice is okay because it's very small
-            .filter(|protocol| !disabled_protocols.contains(&protocol.id))
-            .map(|protocol| protocol.id)
+            .filter(|protocol| !disabled_protocols.contains(protocol))
             .collect();
 
         Ok(Some(allowed_protocols))
@@ -582,7 +542,7 @@ mod tests {
             from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
             slippage: Slippage::percentage_from_basis_points(50).unwrap(),
             disable_estimate: None,
-            quote: SellOrderQuoteQuery {
+            common: QuoteAndSwapCommonOptions {
                 from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
                 to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
                 amount: 1_000_000_000_000_000_000u128.into(),
@@ -591,21 +551,13 @@ mod tests {
                 gas_limit: None,
                 main_route_parts: None,
                 parts: None,
-                fee: None,
-                gas_price: None,
-                virtual_parts: None,
-                connector_tokens: None,
             },
-            dest_receiver: None,
-            referrer_address: None,
-            burn_chi: None,
-            allow_partial_fill: None,
         }
         .into_url(&base_url, 1);
 
         assert_eq!(
             url.as_str(),
-            "https://api.1inch.exchange/v4.1/1/swap\
+            "https://api.1inch.exchange/v3.0/1/swap\
                 ?fromTokenAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000\
@@ -621,33 +573,18 @@ mod tests {
             from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
             slippage: Slippage::percentage_from_basis_points(50).unwrap(),
             disable_estimate: Some(true),
-            quote: SellOrderQuoteQuery {
-                from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-                to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
-                protocols: Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
-                amount: 1_000_000_000_000_000_000u128.into(),
-                complexity_level: Some(Amount::new(2).unwrap()),
-                gas_limit: Some(Amount::new(133700).unwrap()),
-                main_route_parts: Some(Amount::new(28).unwrap()),
-                parts: Some(Amount::new(42).unwrap()),
-                fee: Some(1.5),
-                gas_price: Some(100_000.into()),
-                virtual_parts: Some(Amount::new(10).unwrap()),
-                connector_tokens: Some(vec![
-                    addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
-                    addr!("6810e776880c02933d47db1b9fc05908e5386b96"),
-                ]),
-            },
-            burn_chi: Some(false),
-            allow_partial_fill: Some(false),
-            dest_receiver: Some(addr!("41111a111217dc0aa78b774fa6a738024120c302")),
-            referrer_address: Some(addr!("41111a111217dc0aa78b774fa6a738024120c302")),
+            common: QuoteAndSwapCommonOptions::with_default_options(
+                addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+                addr!("111111111117dc0aa78b770fa6a738034120c302"),
+                Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
+                1_000_000_000_000_000_000u128.into(),
+            ),
         }
         .into_url(&base_url, 1);
 
         assert_eq!(
             url.as_str(),
-            "https://api.1inch.exchange/v4.1/1/swap\
+            "https://api.1inch.exchange/v3.0/1/swap\
                 ?fromTokenAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000\
@@ -656,18 +593,9 @@ mod tests {
                 &protocols=WETH%2CUNISWAP_V3\
                 &disableEstimate=true\
                 &complexityLevel=2\
-                &gasLimit=133700\
-                &mainRouteParts=28\
-                &parts=42\
-                &destReceiver=0x41111a111217dc0aa78b774fa6a738024120c302\
-                &referrerAddress=0x41111a111217dc0aa78b774fa6a738024120c302\
-                &fee=1.5\
-                &gasPrice=100000\
-                &burnChi=false\
-                &allowPartialFill=false\
-                &virtualParts=10\
-                &connectorTokens=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2%2C\
-                    0x6810e776880c02933d47db1b9fc05908e5386b96"
+                &gasLimit=750000\
+                &mainRouteParts=3\
+                &parts=3",
         );
     }
 
@@ -735,13 +663,13 @@ mod tests {
                 from_token_amount: 1_000_000_000_000_000_000u128.into(),
                 to_token_amount: 501_739_725_821_378_713_485u128.into(),
                 protocols: vec![vec![
-                    vec![ProtocolRouteSegment {
+                    vec![Protocol {
                         name: "WETH".to_owned(),
                         part: 100.,
                         from_token_address: addr!("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
                         to_token_address: testlib::tokens::WETH,
                     }],
-                    vec![ProtocolRouteSegment {
+                    vec![Protocol {
                         name: "UNISWAP_V2".to_owned(),
                         part: 100.,
                         from_token_address: addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
@@ -811,16 +739,12 @@ mod tests {
                 from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
                 slippage: Slippage::percentage_from_basis_points(50).unwrap(),
                 disable_estimate: None,
-                quote: SellOrderQuoteQuery::with_default_options(
+                common: QuoteAndSwapCommonOptions::with_default_options(
                     addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
                     addr!("111111111117dc0aa78b770fa6a738034120c302"),
                     None,
                     1_000_000_000_000_000_000u128.into(),
                 ),
-                burn_chi: None,
-                allow_partial_fill: None,
-                dest_receiver: None,
-                referrer_address: None,
             })
             .await
             .unwrap();
@@ -836,27 +760,12 @@ mod tests {
                 from_address: addr!("4e608b7da83f8e9213f554bdaa77c72e125529d0"),
                 slippage: Slippage::percentage_from_basis_points(50).unwrap(),
                 disable_estimate: Some(true),
-                quote: SellOrderQuoteQuery {
-                    from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-                    to_token_address: addr!("a3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2"),
-                    protocols: Some(vec!["WETH".to_string(), "UNISWAP_V2".to_string()]),
-                    amount: 100_000_000_000_000_000_000u128.into(),
-                    complexity_level: Some(Amount::new(2).unwrap()),
-                    gas_limit: Some(Amount::new(750_000).unwrap()),
-                    main_route_parts: Some(Amount::new(3).unwrap()),
-                    parts: Some(Amount::new(3).unwrap()),
-                    fee: Some(1.5),
-                    gas_price: Some(100_000.into()),
-                    connector_tokens: Some(vec![
-                        addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
-                        addr!("6810e776880c02933d47db1b9fc05908e5386b96"),
-                    ]),
-                    virtual_parts: Some(Amount::new(10).unwrap()),
-                },
-                dest_receiver: Some(addr!("9008D19f58AAbD9eD0D60971565AA8510560ab41")),
-                referrer_address: Some(addr!("9008D19f58AAbD9eD0D60971565AA8510560ab41")),
-                burn_chi: Some(false),
-                allow_partial_fill: Some(false),
+                common: QuoteAndSwapCommonOptions::with_default_options(
+                    addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+                    addr!("a3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2"),
+                    Some(vec!["WETH".to_string(), "UNISWAP_V2".to_string()]),
+                    100_000_000_000_000_000_000u128.into(),
+                ),
             })
             .await
             .unwrap();
@@ -865,10 +774,10 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn oneinch_liquidity_sources() {
+    async fn oneinch_protocols() {
         let protocols = OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new(), 1)
             .unwrap()
-            .get_liquidity_sources()
+            .get_protocols()
             .await
             .unwrap();
         println!("{:#?}", protocols);
@@ -889,24 +798,26 @@ mod tests {
     fn sell_order_quote_query_serialization() {
         let base_url = Url::parse("https://api.1inch.exchange/").unwrap();
         let url = SellOrderQuoteQuery {
-            from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-            to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
-            amount: 1_000_000_000_000_000_000u128.into(),
-            protocols: None,
-            complexity_level: None,
-            gas_limit: None,
-            main_route_parts: None,
-            parts: None,
             fee: None,
-            gas_price: None,
-            virtual_parts: None,
             connector_tokens: None,
+            virtual_parts: None,
+            gas_price: None,
+            common: QuoteAndSwapCommonOptions {
+                from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+                to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
+                amount: 1_000_000_000_000_000_000u128.into(),
+                protocols: None,
+                complexity_level: None,
+                gas_limit: None,
+                main_route_parts: None,
+                parts: None,
+            },
         }
         .into_url(&base_url, 1);
 
         assert_eq!(
             url.as_str(),
-            "https://api.1inch.exchange/v4.1/1/quote\
+            "https://api.1inch.exchange/v4.0/1/quote\
                 ?fromTokenAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000"
@@ -917,10 +828,6 @@ mod tests {
     fn sell_order_quote_query_serialization_optional_parameters() {
         let base_url = Url::parse("https://api.1inch.exchange/").unwrap();
         let url = SellOrderQuoteQuery {
-            from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-            to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
-            protocols: Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
-            amount: 1_000_000_000_000_000_000u128.into(),
             fee: Some(0.5),
             connector_tokens: Some(vec![
                 addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
@@ -928,16 +835,18 @@ mod tests {
             ]),
             virtual_parts: Some(Amount::new(42).unwrap()),
             gas_price: Some(200_000.into()),
-            complexity_level: Some(Amount::new(2).unwrap()),
-            gas_limit: Some(Amount::new(750_000).unwrap()),
-            main_route_parts: Some(Amount::new(3).unwrap()),
-            parts: Some(Amount::new(3).unwrap()),
+            common: QuoteAndSwapCommonOptions::with_default_options(
+                addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+                addr!("111111111117dc0aa78b770fa6a738034120c302"),
+                Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
+                1_000_000_000_000_000_000u128.into(),
+            ),
         }
         .into_url(&base_url, 1);
 
         assert_eq!(
             url.as_str(),
-            "https://api.1inch.exchange/v4.1/1/quote\
+            "https://api.1inch.exchange/v4.0/1/quote\
                 ?fromTokenAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000\
@@ -1020,25 +929,25 @@ mod tests {
                 from_token_amount: 10_000_000_000_000_000u128.into(),
                 to_token_amount: 8_387_323_826_205_172u128.into(),
                 protocols: vec![vec![vec![
-                    ProtocolRouteSegment {
+                    Protocol {
                         name: "CURVE_V2_EURT_2_ASSET".to_owned(),
                         part: 20.,
                         from_token_address: addr!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
                         to_token_address: addr!("dac17f958d2ee523a2206206994597c13d831ec7"),
                     },
-                    ProtocolRouteSegment {
+                    Protocol {
                         name: "CURVE_V2_XAUT_2_ASSET".to_owned(),
                         part: 20.,
                         from_token_address: addr!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
                         to_token_address: addr!("dac17f958d2ee523a2206206994597c13d831ec7"),
                     },
-                    ProtocolRouteSegment {
+                    Protocol {
                         name: "CURVE".to_owned(),
                         part: 20.,
                         from_token_address: addr!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
                         to_token_address: addr!("dac17f958d2ee523a2206206994597c13d831ec7"),
                     },
-                    ProtocolRouteSegment {
+                    Protocol {
                         name: "SHELL".to_owned(),
                         part: 40.,
                         from_token_address: addr!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
@@ -1071,12 +980,18 @@ mod tests {
     async fn oneinch_sell_order_quote() {
         let swap = OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new(), 1)
             .unwrap()
-            .get_sell_order_quote(SellOrderQuoteQuery::with_default_options(
-                addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-                addr!("111111111117dc0aa78b770fa6a738034120c302"),
-                None,
-                1_000_000_000_000_000_000u128.into(),
-            ))
+            .get_sell_order_quote(SellOrderQuoteQuery {
+                fee: None,
+                connector_tokens: None,
+                virtual_parts: None,
+                gas_price: None,
+                common: QuoteAndSwapCommonOptions::with_default_options(
+                    addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+                    addr!("111111111117dc0aa78b770fa6a738034120c302"),
+                    None,
+                    1_000_000_000_000_000_000u128.into(),
+                ),
+            })
             .await
             .unwrap();
         println!("{:#?}", swap);
@@ -1088,10 +1003,6 @@ mod tests {
         let swap = OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new(), 1)
             .unwrap()
             .get_sell_order_quote(SellOrderQuoteQuery {
-                from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-                to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
-                protocols: Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
-                amount: 1_000_000_000_000_000_000u128.into(),
                 fee: Some(0.5),
                 connector_tokens: Some(vec![
                     addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
@@ -1099,10 +1010,12 @@ mod tests {
                 ]),
                 virtual_parts: Some(Amount::new(42).unwrap()),
                 gas_price: Some(200_000.into()),
-                complexity_level: Some(Amount::new(3).unwrap()),
-                gas_limit: Some(Amount::new(750_000).unwrap()),
-                main_route_parts: Some(Amount::new(2).unwrap()),
-                parts: Some(Amount::new(2).unwrap()),
+                common: QuoteAndSwapCommonOptions::with_default_options(
+                    addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+                    addr!("111111111117dc0aa78b770fa6a738034120c302"),
+                    Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
+                    1_000_000_000_000_000_000u128.into(),
+                ),
             })
             .await
             .unwrap();
@@ -1112,7 +1025,7 @@ mod tests {
     #[tokio::test]
     async fn allowing_all_protocols_will_not_use_api() {
         let mut api = MockOneInchClient::new();
-        api.expect_get_liquidity_sources().times(0);
+        api.expect_get_protocols().times(0);
         let allowed_protocols = ProtocolCache::default()
             .get_allowed_protocols(&Vec::default(), &api)
             .await;
@@ -1123,7 +1036,7 @@ mod tests {
     async fn allowed_protocols_get_cached() {
         let mut api = MockOneInchClient::new();
         // only 1 API call when calling get_allowed_protocols 2 times
-        api.expect_get_liquidity_sources().times(1).returning(|| {
+        api.expect_get_protocols().times(1).returning(|| {
             Ok(Protocols {
                 protocols: vec!["PMM1".into(), "UNISWAP_V3".into()],
             })
@@ -1147,42 +1060,5 @@ mod tests {
     fn creation_fails_on_unsupported_chain() {
         let api = OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new(), 2);
         assert!(api.is_err());
-    }
-
-    #[test]
-    fn deserialize_liquidity_sources_response() {
-        let swap = serde_json::from_str::<Protocols>(
-            r#"{
-                "protocols": [
-                    {
-                      "id": "PMMX",
-                      "title": "LiqPool X",
-                      "img": "https://api.1inch.io/pmm.png"
-                    },
-                    {
-                      "id": "UNIFI",
-                      "title": "Unifi",
-                      "img": "https://api.1inch.io/unifi.png"
-                    }
-                ]
-            }"#,
-        )
-        .unwrap();
-
-        assert_eq!(
-            swap,
-            Protocols {
-                protocols: vec!["PMMX".into(), "UNIFI".into()]
-            }
-        );
-
-        let swap_error = serde_json::from_str::<Protocols>(
-            r#"{
-                "statusCode":500,
-                "description":"Internal server error"
-            }"#,
-        );
-
-        assert!(swap_error.is_err());
     }
 }

--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -29,8 +29,8 @@ impl OneInchPriceEstimator {
             .get_sell_order_quote(SellOrderQuoteQuery::with_default_options(
                 query.sell_token,
                 query.buy_token,
-                allowed_protocols,
                 query.in_amount,
+                allowed_protocols,
             ))
             .await
             .map_err(PriceEstimationError::Other)?;

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -295,7 +295,7 @@ mod tests {
             .expect_get_approval()
             .returning(|_, _, _| Ok(Approval::AllowanceSufficient));
 
-        client.expect_get_liquidity_sources().returning(|| {
+        client.expect_get_protocols().returning(|| {
             Ok(Protocols {
                 protocols: vec!["GoodProtocol".into(), "BadProtocol".into()],
             })
@@ -306,7 +306,7 @@ mod tests {
             })
         });
         client.expect_get_swap().times(1).returning(|query| {
-            assert_eq!(query.quote.protocols, Some(vec!["GoodProtocol".into()]));
+            assert_eq!(query.common.protocols, Some(vec!["GoodProtocol".into()]));
             Ok(RestResponse::Ok(Swap {
                 from_token_amount: 100.into(),
                 to_token_amount: 100.into(),


### PR DESCRIPTION
Updating the 1Inch API lead to some parsing errors. Quickly fixing those parsing errors lead to some settlement simulation failures. It's not yet clear to me what's causing those.
Let's revert the API update until all problems have been ironed out because I'm not sure how long it would take to find the cause.