### PR TITLE
Detecting failing transactions with receipt.status field.

### DIFF
--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -41,18 +41,14 @@ pub enum SolverRunOutcome {
 pub enum SettlementSubmissionOutcome {
     /// A settlement transaction was mined and included on the blockchain.
     Success,
-    /// A settlement transaction was mined and included on the blockchain with a failed status.
-    MinedFailed,
-    /// A transaction reverted.
+    /// A settlement transaction was mined and included on the blockchain but reverted.
     Revert,
+    /// A transaction reverted in the simulation stage.
+    SimulationRevert,
     /// Submission timed-out while waiting for the transaction to get mined.
     Timeout,
-    /// Transaction sucessfully cancelled after revert or timeout
+    /// Transaction sucessfully cancelled after simulation revert or timeout
     Cancel,
-    /// A transaction failed to be submitted or, in the case of private network
-    /// submission, the blockchain state changed and the transaction is no
-    /// longer valid.
-    Failure,
 }
 
 pub trait SolverMetrics: Send + Sync {
@@ -325,8 +321,7 @@ impl SolverMetrics for Metrics {
             SettlementSubmissionOutcome::Revert => "revert",
             SettlementSubmissionOutcome::Timeout => "timeout",
             SettlementSubmissionOutcome::Cancel => "cancel",
-            SettlementSubmissionOutcome::Failure => "failure",
-            SettlementSubmissionOutcome::MinedFailed => "minedfailed",
+            SettlementSubmissionOutcome::SimulationRevert => "simulationrevert",
         };
         self.settlement_submissions
             .with_label_values(&[result, solver])

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -41,6 +41,8 @@ pub enum SolverRunOutcome {
 pub enum SettlementSubmissionOutcome {
     /// A settlement transaction was mined and included on the blockchain.
     Success,
+    /// A settlement transaction was mined and included on the blockchain with a failed status.
+    MinedFailed,
     /// A transaction reverted.
     Revert,
     /// Submission timed-out while waiting for the transaction to get mined.
@@ -324,6 +326,7 @@ impl SolverMetrics for Metrics {
             SettlementSubmissionOutcome::Timeout => "timeout",
             SettlementSubmissionOutcome::Cancel => "cancel",
             SettlementSubmissionOutcome::Failure => "failure",
+            SettlementSubmissionOutcome::MinedFailed => "minedfailed",
         };
         self.settlement_submissions
             .with_label_values(&[result, solver])

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -45,6 +45,8 @@ pub enum SettlementSubmissionOutcome {
     Revert,
     /// Submission timed-out while waiting for the transaction to get mined.
     Timeout,
+    /// Transaction sucessfully cancelled after revert or timeout
+    Cancel,
     /// A transaction failed to be submitted or, in the case of private network
     /// submission, the blockchain state changed and the transaction is no
     /// longer valid.
@@ -320,6 +322,7 @@ impl SolverMetrics for Metrics {
             SettlementSubmissionOutcome::Success => "success",
             SettlementSubmissionOutcome::Revert => "revert",
             SettlementSubmissionOutcome::Timeout => "timeout",
+            SettlementSubmissionOutcome::Cancel => "cancel",
             SettlementSubmissionOutcome::Failure => "failure",
         };
         self.settlement_submissions

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -139,6 +139,8 @@ pub enum SubmissionError {
     Revert(Option<String>),
     /// The settlement submission timed out.
     Timeout,
+    /// Canceled after revert or timeout
+    Canceled,
     /// An error occured.
     Other(anyhow::Error),
 }
@@ -149,6 +151,7 @@ impl SubmissionError {
         match self {
             Self::Timeout => SettlementSubmissionOutcome::Timeout,
             Self::Revert(_) => SettlementSubmissionOutcome::Revert,
+            Self::Canceled => SettlementSubmissionOutcome::Cancel,
             Self::Other(_) => SettlementSubmissionOutcome::Failure,
         }
     }
@@ -163,6 +166,9 @@ impl SubmissionError {
             SubmissionError::Timeout => anyhow!("transaction did not get mined in time"),
             SubmissionError::Revert(Some(message)) => {
                 anyhow!("transaction reverted with message {}", message)
+            }
+            SubmissionError::Canceled => {
+                anyhow!("transaction cancelled after revert or timeout")
             }
             SubmissionError::Revert(None) => anyhow!("transaction reverted"),
             SubmissionError::Other(err) => err,

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -135,6 +135,8 @@ impl SolutionSubmitter {
 /// An error during settlement submission.
 #[derive(Debug)]
 pub enum SubmissionError {
+    /// Transaction successfully mined but with fail status
+    MinedFailed,
     /// The transaction reverted.
     Revert(Option<String>),
     /// The settlement submission timed out.
@@ -149,6 +151,7 @@ impl SubmissionError {
     /// Returns the outcome for use with metrics.
     pub fn as_outcome(&self) -> SettlementSubmissionOutcome {
         match self {
+            Self::MinedFailed => SettlementSubmissionOutcome::MinedFailed,
             Self::Timeout => SettlementSubmissionOutcome::Timeout,
             Self::Revert(_) => SettlementSubmissionOutcome::Revert,
             Self::Canceled => SettlementSubmissionOutcome::Cancel,
@@ -163,6 +166,7 @@ impl SubmissionError {
     /// `impl<T: Display> From<T> for anyhow::Error`.
     pub fn into_anyhow(self) -> anyhow::Error {
         match self {
+            SubmissionError::MinedFailed => anyhow!("transaction mined as failed"),
             SubmissionError::Timeout => anyhow!("transaction did not get mined in time"),
             SubmissionError::Revert(Some(message)) => {
                 anyhow!("transaction reverted with message {}", message)

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -135,10 +135,10 @@ impl SolutionSubmitter {
 /// An error during settlement submission.
 #[derive(Debug)]
 pub enum SubmissionError {
-    /// Transaction successfully mined but with fail status
-    MinedFailed,
-    /// The transaction reverted.
-    Revert(Option<String>),
+    /// The transaction reverted in the simulation stage.
+    SimulationRevert(Option<String>),
+    /// Transaction successfully mined but reverted
+    Revert,
     /// The settlement submission timed out.
     Timeout,
     /// Canceled after revert or timeout
@@ -151,11 +151,11 @@ impl SubmissionError {
     /// Returns the outcome for use with metrics.
     pub fn as_outcome(&self) -> SettlementSubmissionOutcome {
         match self {
-            Self::MinedFailed => SettlementSubmissionOutcome::MinedFailed,
+            Self::SimulationRevert(_) => SettlementSubmissionOutcome::SimulationRevert,
             Self::Timeout => SettlementSubmissionOutcome::Timeout,
-            Self::Revert(_) => SettlementSubmissionOutcome::Revert,
+            Self::Revert => SettlementSubmissionOutcome::Revert,
             Self::Canceled => SettlementSubmissionOutcome::Cancel,
-            Self::Other(_) => SettlementSubmissionOutcome::Failure,
+            Self::Other(_) => SettlementSubmissionOutcome::SimulationRevert,
         }
     }
 
@@ -166,15 +166,15 @@ impl SubmissionError {
     /// `impl<T: Display> From<T> for anyhow::Error`.
     pub fn into_anyhow(self) -> anyhow::Error {
         match self {
-            SubmissionError::MinedFailed => anyhow!("transaction mined as failed"),
+            SubmissionError::Revert => anyhow!("transaction reverted"),
             SubmissionError::Timeout => anyhow!("transaction did not get mined in time"),
-            SubmissionError::Revert(Some(message)) => {
-                anyhow!("transaction reverted with message {}", message)
+            SubmissionError::SimulationRevert(Some(message)) => {
+                anyhow!("transaction simulation reverted with message {}", message)
             }
             SubmissionError::Canceled => {
                 anyhow!("transaction cancelled after revert or timeout")
             }
-            SubmissionError::Revert(None) => anyhow!("transaction reverted"),
+            SubmissionError::SimulationRevert(None) => anyhow!("transaction simulation reverted"),
             SubmissionError::Other(err) => err,
         }
     }
@@ -191,9 +191,9 @@ impl From<MethodError> for SubmissionError {
         match err.inner {
             ExecutionError::ConfirmTimeout(_) => SubmissionError::Timeout,
             ExecutionError::Failure(_) | ExecutionError::InvalidOpcode => {
-                SubmissionError::Revert(None)
+                SubmissionError::SimulationRevert(None)
             }
-            ExecutionError::Revert(message) => SubmissionError::Revert(message),
+            ExecutionError::Revert(message) => SubmissionError::SimulationRevert(message),
             _ => SubmissionError::Other(
                 anyhow::Error::from(err).context("settlement transaction failed"),
             ),
@@ -210,7 +210,7 @@ mod tests {
     impl PartialEq for SubmissionError {
         fn eq(&self, other: &Self) -> bool {
             match (self, other) {
-                (Self::Revert(left), Self::Revert(right)) => left == right,
+                (Self::SimulationRevert(left), Self::SimulationRevert(right)) => left == right,
                 _ => std::mem::discriminant(self) == std::mem::discriminant(other),
             }
         }
@@ -230,12 +230,15 @@ mod tests {
         for (from, to) in [
             (
                 ExecutionError::Failure(Default::default()),
-                SubmissionError::Revert(None),
+                SubmissionError::SimulationRevert(None),
             ),
-            (ExecutionError::InvalidOpcode, SubmissionError::Revert(None)),
+            (
+                ExecutionError::InvalidOpcode,
+                SubmissionError::SimulationRevert(None),
+            ),
             (
                 ExecutionError::Revert(Some("foo".to_owned())),
-                SubmissionError::Revert(Some("foo".to_owned())),
+                SubmissionError::SimulationRevert(Some("foo".to_owned())),
             ),
             (
                 ExecutionError::ConfirmTimeout(Box::new(

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -433,7 +433,7 @@ fn status(receipt: TransactionReceipt) -> Result<TransactionReceipt, SubmissionE
     if let Some(status) = receipt.status {
         if status == U64::zero() {
             // failing transaction
-            return Err(SubmissionError::Revert(None));
+            return Err(SubmissionError::MinedFailed);
         } else if status == U64::one() && receipt.from == receipt.to.unwrap_or_default() {
             // noop transaction
             return Err(SubmissionError::Canceled);

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -433,7 +433,7 @@ fn status(receipt: TransactionReceipt) -> Result<TransactionReceipt, SubmissionE
     if let Some(status) = receipt.status {
         if status == U64::zero() {
             // failing transaction
-            return Err(SubmissionError::MinedFailed);
+            return Err(SubmissionError::Revert);
         } else if status == U64::one() && receipt.from == receipt.to.unwrap_or_default() {
             // noop transaction
             return Err(SubmissionError::Canceled);

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -30,7 +30,7 @@ use gas_estimation::{EstimatedGasPrice, GasPriceEstimating};
 use primitive_types::{H256, U256};
 use shared::Web3;
 use std::time::{Duration, Instant};
-use web3::types::TransactionReceipt;
+use web3::types::{TransactionReceipt, U64};
 
 /// Parameters for transaction submitting
 #[derive(Clone, Default)]
@@ -84,7 +84,10 @@ pub trait TransactionSubmitting: Send + Sync {
         tx: TransactionBuilder<DynTransport>,
     ) -> Result<TransactionHandle, SubmitApiError>;
     /// Cancels already submitted transaction using the cancel handle
-    async fn cancel_transaction(&self, id: &CancelHandle) -> Result<()>;
+    async fn cancel_transaction(
+        &self,
+        id: &CancelHandle,
+    ) -> Result<TransactionHandle, SubmitApiError>;
     /// Try to find submitted transaction from previous submission loop (in this case we don't have a TransactionHandle)
     async fn recover_pending_transaction(
         &self,
@@ -196,8 +199,12 @@ impl<'a> Submitter<'a> {
 
                 if let Some((transaction, gas_price)) = transactions.last() {
                     let gas_price = gas_price.bump(1.125).ceil();
-                    if let Err(err) = self.cancel_transaction(transaction, &gas_price, nonce).await {
-                        tracing::warn!("cancellation failed: {:?}", err);
+                    match self
+                        .cancel_transaction(transaction, &gas_price, nonce)
+                        .await
+                    {
+                        Ok(handle) => transactions.push((handle, gas_price)),
+                        Err(err) => tracing::warn!("cancellation failed: {:?}", err),
                     }
                 }
                 Ok(None)
@@ -235,8 +242,8 @@ impl<'a> Submitter<'a> {
                     find_mined_transaction(&self.contract.raw_instance().web3(), &transactions)
                         .await
                 {
-                    tracing::info!("found mined transaction {}", receipt.transaction_hash);
-                    return Ok(receipt);
+                    tracing::info!("found mined transaction {:?}", receipt);
+                    return status(receipt);
                 }
                 if Instant::now() + MINED_TX_CHECK_INTERVAL > tx_to_propagate_deadline {
                     break;
@@ -326,11 +333,12 @@ impl<'a> Submitter<'a> {
 
             if let Err(err) = method.clone().view().call().await {
                 if let Some((previous_tx, _)) = transactions.last() {
-                    if let Err(err) = self
+                    match self
                         .cancel_transaction(previous_tx, &gas_price, nonce)
                         .await
                     {
-                        tracing::warn!("cancellation failed: {:?}", err);
+                        Ok(handle) => transactions.push((handle, gas_price)),
+                        Err(err) => tracing::warn!("cancellation failed: {:?}", err),
                     }
                 }
                 return SubmissionError::from(err);
@@ -412,13 +420,27 @@ impl<'a> Submitter<'a> {
         transaction: &TransactionHandle,
         gas_price: &EstimatedGasPrice,
         nonce: U256,
-    ) -> Result<()> {
+    ) -> Result<TransactionHandle, SubmitApiError> {
         let cancel_handle = CancelHandle {
             submitted_transaction: *transaction,
             noop_transaction: self.build_noop_transaction(&gas_price.bump(3.), nonce),
         };
         self.submit_api.cancel_transaction(&cancel_handle).await
     }
+}
+
+fn status(receipt: TransactionReceipt) -> Result<TransactionReceipt, SubmissionError> {
+    if let Some(status) = receipt.status {
+        if status == U64::zero() {
+            // failing transaction
+            return Err(SubmissionError::Revert(None));
+        } else if status == U64::one() && receipt.from == receipt.to.unwrap_or_default() {
+            // noop transaction
+            return Err(SubmissionError::Canceled);
+        }
+    }
+    // successfull transaction
+    Ok(receipt)
 }
 
 /// From a list of potential hashes find one that was mined.

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -4,7 +4,7 @@ use super::{
     super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
     CancelHandle,
 };
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use ethcontract::{
     dyns::DynTransport,
     transaction::{Transaction, TransactionBuilder},
@@ -73,11 +73,11 @@ impl TransactionSubmitting for CustomNodesApi {
         }
     }
 
-    async fn cancel_transaction(&self, id: &CancelHandle) -> Result<()> {
-        match self.submit_transaction(id.noop_transaction.clone()).await {
-            Ok(_) => Ok(()),
-            Err(err) => Err(anyhow!("{:?}", err)),
-        }
+    async fn cancel_transaction(
+        &self,
+        id: &CancelHandle,
+    ) -> Result<TransactionHandle, SubmitApiError> {
+        self.submit_transaction(id.noop_transaction.clone()).await
     }
 
     async fn recover_pending_transaction(

--- a/crates/solver/src/settlement_submission/submitter/eden_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/eden_api.rs
@@ -4,7 +4,7 @@ use super::{
     super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
     CancelHandle,
 };
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder, H160, U256};
 use gas_estimation::EstimatedGasPrice;
 use reqwest::{Client, IntoUrl, Url};
@@ -34,17 +34,16 @@ impl TransactionSubmitting for EdenApi {
         super::common::submit_raw_transaction(self.client.clone(), self.url.clone(), tx).await
     }
 
-    async fn cancel_transaction(&self, id: &CancelHandle) -> Result<()> {
-        match super::common::submit_raw_transaction(
+    async fn cancel_transaction(
+        &self,
+        id: &CancelHandle,
+    ) -> Result<TransactionHandle, SubmitApiError> {
+        super::common::submit_raw_transaction(
             self.client.clone(),
             self.url.clone(),
             id.noop_transaction.clone(),
         )
         .await
-        {
-            Ok(_) => Ok(()),
-            Err(err) => Err(anyhow!("{:?}", err)),
-        }
     }
 
     async fn recover_pending_transaction(

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -32,8 +32,11 @@ impl TransactionSubmitting for FlashbotsApi {
         super::common::submit_raw_transaction(self.client.clone(), self.url.clone(), tx).await
     }
 
-    async fn cancel_transaction(&self, _id: &CancelHandle) -> Result<()> {
-        Ok(())
+    async fn cancel_transaction(
+        &self,
+        id: &CancelHandle,
+    ) -> Result<TransactionHandle, SubmitApiError> {
+        Ok(id.submitted_transaction)
     }
 
     async fn recover_pending_transaction(


### PR DESCRIPTION
This PR fixes https://github.com/gnosis/gp-v2-services/issues/1570

Two important things are added:
1. Up until now, we did not detect failing transaction - in case `Submitter` found a mined transaction, `Submitter` returned `Ok(receipt)` and that was interpreted as `SettlementSubmissionOutcome::Success` in solver metrics. Now, `Submitter` detects failing transactions by inspecting `TransactionReceipt::status` field of the mined transaction.
2. Detection of cancelled transactions. In order to implement this, `noop` cancel transactions also need to be pushed into the `mut Transactions` variable, so their hash could be examined at the end of the `Submitter` logic.