### PR TITLE
Update 1Inch API to v4.1

### DIFF
--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -57,6 +57,16 @@ pub struct QuoteAndSwapCommonOptions {
     pub main_route_parts: Option<Amount<1, 50>>,
     /// Limit maximum number of parts each main route part can be split into.
     pub parts: Option<Amount<1, 100>>,
+    /// This percentage of from_token_address token amount will be sent
+    /// to referrer_address. The rest will be used as input for the swap.
+    /// min: 0, max: 3, default: 0
+    pub fee: Option<f64>,
+    /// Gas price in smallest divisible unit. default: "fast" from network
+    pub gas_price: Option<U256>,
+    /// Limit the number of virtual split parts. default: 50
+    pub virtual_parts: Option<Amount<1, 500>>,
+    /// Which tokens should be used for intermediate trading hops.
+    pub connector_tokens: Option<Vec<H160>>,
 }
 
 impl QuoteAndSwapCommonOptions {
@@ -78,6 +88,10 @@ impl QuoteAndSwapCommonOptions {
             // Use only 3 main route for cheaper trades.
             main_route_parts: Some(Amount::new(3).unwrap()),
             parts: Some(Amount::new(3).unwrap()),
+            fee: None,
+            gas_price: None,
+            virtual_parts: None,
+            connector_tokens: None,
         }
     }
 }
@@ -211,13 +225,24 @@ pub struct SwapQuery {
     pub slippage: Slippage,
     /// Flag to disable checks of the required quantities.
     pub disable_estimate: Option<bool>,
+    /// Receiver of destination currency. default: from_address
+    pub dest_receiver: Option<H160>,
+    /// Who is referring this swap to 1Inch.
+    pub referrer_address: Option<H160>,
+    /// Should Chi of from_token_address be burnt to compensate for gas.
+    /// default: false
+    pub burn_chi: Option<bool>,
+    /// If true, the algorithm can cancel part of the route, if the rate has become
+    /// less attractive. Unswapped tokens will return to the from_address
+    /// default: true
+    pub allow_partial_fill: Option<bool>,
     pub common: QuoteAndSwapCommonOptions,
 }
 
 impl SwapQuery {
     /// Encodes the swap query as
     fn into_url(self, base_url: &Url, chain_id: u64) -> Url {
-        let endpoint = format!("v3.0/{}/swap", chain_id);
+        let endpoint = format!("v4.1/{}/swap", chain_id);
         let mut url = base_url
             .join(&endpoint)
             .expect("unexpectedly invalid URL segment");
@@ -255,6 +280,43 @@ impl SwapQuery {
             url.query_pairs_mut()
                 .append_pair("parts", &parts.to_string());
         }
+        if let Some(dest_receiver) = self.dest_receiver {
+            url.query_pairs_mut()
+                .append_pair("destReceiver", &addr2str(dest_receiver));
+        }
+        if let Some(referrer_address) = self.referrer_address {
+            url.query_pairs_mut()
+                .append_pair("referrerAddress", &addr2str(referrer_address));
+        }
+        if let Some(fee) = self.common.fee {
+            url.query_pairs_mut().append_pair("fee", &fee.to_string());
+        }
+        if let Some(gas_price) = self.common.gas_price {
+            url.query_pairs_mut()
+                .append_pair("gasPrice", &gas_price.to_string());
+        }
+        if let Some(burn_chi) = self.burn_chi {
+            url.query_pairs_mut()
+                .append_pair("burnChi", &burn_chi.to_string());
+        }
+        if let Some(allow_partial_fill) = self.allow_partial_fill {
+            url.query_pairs_mut()
+                .append_pair("allowPartialFill", &allow_partial_fill.to_string());
+        }
+        if let Some(virtual_parts) = self.common.virtual_parts {
+            url.query_pairs_mut()
+                .append_pair("virtualParts", &virtual_parts.to_string());
+        }
+        if let Some(connector_tokens) = self.common.connector_tokens {
+            url.query_pairs_mut().append_pair(
+                "connectorTokens",
+                &connector_tokens
+                    .into_iter()
+                    .map(addr2str)
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
+        }
 
         url
     }
@@ -276,6 +338,10 @@ impl SwapQuery {
             common: QuoteAndSwapCommonOptions::with_default_options(
                 sell_token, buy_token, protocols, in_amount,
             ),
+            dest_receiver: None,
+            referrer_address: None,
+            burn_chi: None,
+            allow_partial_fill: Some(false),
         }
     }
 }
@@ -338,7 +404,9 @@ pub struct Transaction {
     #[serde(with = "u256_decimal")]
     pub value: U256,
     #[serde(with = "u256_decimal")]
-    pub gas_price: U256,
+    pub max_fee_per_gas: U256,
+    #[serde(with = "u256_decimal")]
+    pub max_priority_fee_per_gas: U256,
     pub gas: u64,
 }
 
@@ -349,7 +417,8 @@ impl std::fmt::Debug for Transaction {
             .field("to", &self.to)
             .field("data", &format_args!("0x{}", hex::encode(&self.data)))
             .field("value", &self.value)
-            .field("gas_price", &self.gas_price)
+            .field("max_fee_per_gas", &self.max_fee_per_gas)
+            .field("max_priority_fee_per_gas", &self.max_priority_fee_per_gas)
             .field("gas", &self.gas)
             .finish()
     }
@@ -551,13 +620,21 @@ mod tests {
                 gas_limit: None,
                 main_route_parts: None,
                 parts: None,
+                fee: None,
+                gas_price: None,
+                virtual_parts: None,
+                connector_tokens: None,
             },
+            dest_receiver: None,
+            referrer_address: None,
+            burn_chi: None,
+            allow_partial_fill: None,
         }
         .into_url(&base_url, 1);
 
         assert_eq!(
             url.as_str(),
-            "https://api.1inch.exchange/v3.0/1/swap\
+            "https://api.1inch.exchange/v4.1/1/swap\
                 ?fromTokenAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000\
@@ -573,18 +650,33 @@ mod tests {
             from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
             slippage: Slippage::percentage_from_basis_points(50).unwrap(),
             disable_estimate: Some(true),
-            common: QuoteAndSwapCommonOptions::with_default_options(
-                addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-                addr!("111111111117dc0aa78b770fa6a738034120c302"),
-                Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
-                1_000_000_000_000_000_000u128.into(),
-            ),
+            common: QuoteAndSwapCommonOptions {
+                from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+                to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
+                protocols: Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
+                amount: 1_000_000_000_000_000_000u128.into(),
+                complexity_level: Some(Amount::new(2).unwrap()),
+                gas_limit: Some(Amount::new(133700).unwrap()),
+                main_route_parts: Some(Amount::new(28).unwrap()),
+                parts: Some(Amount::new(42).unwrap()),
+                fee: Some(1.5),
+                gas_price: Some(100_000.into()),
+                virtual_parts: Some(Amount::new(10).unwrap()),
+                connector_tokens: Some(vec![
+                    addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+                    addr!("6810e776880c02933d47db1b9fc05908e5386b96"),
+                ]),
+            },
+            burn_chi: Some(false),
+            allow_partial_fill: Some(false),
+            dest_receiver: Some(addr!("41111a111217dc0aa78b774fa6a738024120c302")),
+            referrer_address: Some(addr!("41111a111217dc0aa78b774fa6a738024120c302")),
         }
         .into_url(&base_url, 1);
 
         assert_eq!(
             url.as_str(),
-            "https://api.1inch.exchange/v3.0/1/swap\
+            "https://api.1inch.exchange/v4.1/1/swap\
                 ?fromTokenAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000\
@@ -593,9 +685,18 @@ mod tests {
                 &protocols=WETH%2CUNISWAP_V3\
                 &disableEstimate=true\
                 &complexityLevel=2\
-                &gasLimit=750000\
-                &mainRouteParts=3\
-                &parts=3",
+                &gasLimit=133700\
+                &mainRouteParts=28\
+                &parts=42\
+                &destReceiver=0x41111a111217dc0aa78b774fa6a738024120c302\
+                &referrerAddress=0x41111a111217dc0aa78b774fa6a738024120c302\
+                &fee=1.5\
+                &gasPrice=100000\
+                &burnChi=false\
+                &allowPartialFill=false\
+                &virtualParts=10\
+                &connectorTokens=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2%2C\
+                    0x6810e776880c02933d47db1b9fc05908e5386b96"
         );
     }
 
@@ -644,7 +745,8 @@ mod tests {
                 "to": "0x11111112542d85b3ef69ae05771c2dccff4faa26",
                 "data": "0x2e95b6c800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000000000000000000000000001b1038e63128bd548d0000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000180000000000000003b6d034026aad2da94c59524ac0d93f6d6cbf9071d7086f2",
                 "value": "1000000000000000000",
-                "gasPrice": "154110000000",
+                "maxFeePerGas": "123865303708",
+                "maxPriorityFeePerGas": "2000000000",
                 "gas": 143297
               }
             }"#,
@@ -690,7 +792,8 @@ mod tests {
                     )
                     .unwrap(),
                     value: 1_000_000_000_000_000_000u128.into(),
-                    gas_price: 154_110_000_000u128.into(),
+                    max_fee_per_gas: 123_865_303_708u128.into(),
+                    max_priority_fee_per_gas: 2_000_000_000u128.into(),
                     gas: 143297,
                 },
             })
@@ -745,6 +848,10 @@ mod tests {
                     None,
                     1_000_000_000_000_000_000u128.into(),
                 ),
+                burn_chi: None,
+                allow_partial_fill: None,
+                dest_receiver: None,
+                referrer_address: None,
             })
             .await
             .unwrap();
@@ -760,12 +867,27 @@ mod tests {
                 from_address: addr!("4e608b7da83f8e9213f554bdaa77c72e125529d0"),
                 slippage: Slippage::percentage_from_basis_points(50).unwrap(),
                 disable_estimate: Some(true),
-                common: QuoteAndSwapCommonOptions::with_default_options(
-                    addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-                    addr!("a3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2"),
-                    Some(vec!["WETH".to_string(), "UNISWAP_V2".to_string()]),
-                    100_000_000_000_000_000_000u128.into(),
-                ),
+                common: QuoteAndSwapCommonOptions {
+                    from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+                    to_token_address: addr!("a3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2"),
+                    protocols: Some(vec!["WETH".to_string(), "UNISWAP_V2".to_string()]),
+                    amount: 100_000_000_000_000_000_000u128.into(),
+                    complexity_level: Some(Amount::new(2).unwrap()),
+                    gas_limit: Some(Amount::new(750_000).unwrap()),
+                    main_route_parts: Some(Amount::new(3).unwrap()),
+                    parts: Some(Amount::new(3).unwrap()),
+                    fee: Some(1.5),
+                    gas_price: Some(100_000.into()),
+                    connector_tokens: Some(vec![
+                        addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+                        addr!("6810e776880c02933d47db1b9fc05908e5386b96"),
+                    ]),
+                    virtual_parts: Some(Amount::new(10).unwrap()),
+                },
+                dest_receiver: Some(addr!("9008D19f58AAbD9eD0D60971565AA8510560ab41")),
+                referrer_address: Some(addr!("9008D19f58AAbD9eD0D60971565AA8510560ab41")),
+                burn_chi: Some(false),
+                allow_partial_fill: Some(false),
             })
             .await
             .unwrap();
@@ -811,6 +933,10 @@ mod tests {
                 gas_limit: None,
                 main_route_parts: None,
                 parts: None,
+                fee: None,
+                gas_price: None,
+                virtual_parts: None,
+                connector_tokens: None,
             },
         }
         .into_url(&base_url, 1);

--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -42,7 +42,7 @@ impl<const MIN: usize, const MAX: usize> Display for Amount<MIN, MAX> {
 }
 
 #[derive(Debug, Clone)]
-pub struct QuoteAndSwapCommonOptions {
+pub struct SellOrderQuoteQuery {
     /// Contract address of a token to sell.
     pub from_token_address: H160,
     /// Contract address of a token to buy.
@@ -71,8 +71,71 @@ pub struct QuoteAndSwapCommonOptions {
     pub connector_tokens: Option<Vec<H160>>,
 }
 
-impl QuoteAndSwapCommonOptions {
-    fn with_default_options(
+// The `Display` implementation for `H160` unfortunately does not print
+// the full address and instead uses ellipsis (e.g. "0xeeee…eeee"). This
+// helper just works around that.
+fn addr2str(addr: H160) -> String {
+    format!("{:?}", addr)
+}
+
+impl SellOrderQuoteQuery {
+    fn into_url(self, base_url: &Url, chain_id: u64) -> Url {
+        let endpoint = format!("v4.1/{}/quote", chain_id);
+        let mut url = base_url
+            .join(&endpoint)
+            .expect("unexpectedly invalid URL segment");
+
+        url.query_pairs_mut()
+            .append_pair("fromTokenAddress", &addr2str(self.from_token_address))
+            .append_pair("toTokenAddress", &addr2str(self.to_token_address))
+            .append_pair("amount", &self.amount.to_string());
+
+        if let Some(protocols) = self.protocols {
+            url.query_pairs_mut()
+                .append_pair("protocols", &protocols.join(","));
+        }
+        if let Some(fee) = self.fee {
+            url.query_pairs_mut().append_pair("fee", &fee.to_string());
+        }
+        if let Some(gas_limit) = self.gas_limit {
+            url.query_pairs_mut()
+                .append_pair("gasLimit", &gas_limit.to_string());
+        }
+        if let Some(connector_tokens) = self.connector_tokens {
+            url.query_pairs_mut().append_pair(
+                "connectorTokens",
+                &connector_tokens
+                    .into_iter()
+                    .map(addr2str)
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
+        }
+        if let Some(complexity_level) = self.complexity_level {
+            url.query_pairs_mut()
+                .append_pair("complexityLevel", &complexity_level.to_string());
+        }
+        if let Some(main_route_parts) = self.main_route_parts {
+            url.query_pairs_mut()
+                .append_pair("mainRouteParts", &main_route_parts.to_string());
+        }
+        if let Some(virtual_parts) = self.virtual_parts {
+            url.query_pairs_mut()
+                .append_pair("virtualParts", &virtual_parts.to_string());
+        }
+        if let Some(parts) = self.parts {
+            url.query_pairs_mut()
+                .append_pair("parts", &parts.to_string());
+        }
+        if let Some(gas_price) = self.gas_price {
+            url.query_pairs_mut()
+                .append_pair("gasPrice", &gas_price.to_string());
+        }
+
+        url
+    }
+
+    pub fn with_default_options(
         sell_token: H160,
         buy_token: H160,
         protocols: Option<Vec<String>>,
@@ -94,93 +157,6 @@ impl QuoteAndSwapCommonOptions {
             gas_price: None,
             virtual_parts: None,
             connector_tokens: None,
-        }
-    }
-}
-
-// The `Display` implementation for `H160` unfortunately does not print
-// the full address and instead uses ellipsis (e.g. "0xeeee…eeee"). This
-// helper just works around that.
-fn addr2str(addr: H160) -> String {
-    format!("{:?}", addr)
-}
-
-/// A query to get a quote for a sell order with 1Inch.
-#[derive(Clone, Debug)]
-pub struct SellOrderQuoteQuery {
-    pub common: QuoteAndSwapCommonOptions,
-}
-
-impl SellOrderQuoteQuery {
-    fn into_url(self, base_url: &Url, chain_id: u64) -> Url {
-        let endpoint = format!("v4.1/{}/quote", chain_id);
-        let mut url = base_url
-            .join(&endpoint)
-            .expect("unexpectedly invalid URL segment");
-
-        url.query_pairs_mut()
-            .append_pair(
-                "fromTokenAddress",
-                &addr2str(self.common.from_token_address),
-            )
-            .append_pair("toTokenAddress", &addr2str(self.common.to_token_address))
-            .append_pair("amount", &self.common.amount.to_string());
-
-        if let Some(protocols) = self.common.protocols {
-            url.query_pairs_mut()
-                .append_pair("protocols", &protocols.join(","));
-        }
-        if let Some(fee) = self.common.fee {
-            url.query_pairs_mut().append_pair("fee", &fee.to_string());
-        }
-        if let Some(gas_limit) = self.common.gas_limit {
-            url.query_pairs_mut()
-                .append_pair("gasLimit", &gas_limit.to_string());
-        }
-        if let Some(connector_tokens) = self.common.connector_tokens {
-            url.query_pairs_mut().append_pair(
-                "connectorTokens",
-                &connector_tokens
-                    .into_iter()
-                    .map(addr2str)
-                    .collect::<Vec<_>>()
-                    .join(","),
-            );
-        }
-        if let Some(complexity_level) = self.common.complexity_level {
-            url.query_pairs_mut()
-                .append_pair("complexityLevel", &complexity_level.to_string());
-        }
-        if let Some(main_route_parts) = self.common.main_route_parts {
-            url.query_pairs_mut()
-                .append_pair("mainRouteParts", &main_route_parts.to_string());
-        }
-        if let Some(virtual_parts) = self.common.virtual_parts {
-            url.query_pairs_mut()
-                .append_pair("virtualParts", &virtual_parts.to_string());
-        }
-        if let Some(parts) = self.common.parts {
-            url.query_pairs_mut()
-                .append_pair("parts", &parts.to_string());
-        }
-        if let Some(gas_price) = self.common.gas_price {
-            url.query_pairs_mut()
-                .append_pair("gasPrice", &gas_price.to_string());
-        }
-
-        url
-    }
-
-    pub fn with_default_options(
-        sell_token: H160,
-        buy_token: H160,
-        in_amount: U256,
-        protocols: Option<Vec<String>>,
-    ) -> Self {
-        Self {
-            common: QuoteAndSwapCommonOptions::with_default_options(
-                sell_token, buy_token, protocols, in_amount,
-            ),
         }
     }
 }
@@ -225,7 +201,7 @@ pub struct SwapQuery {
     /// less attractive. Unswapped tokens will return to the from_address
     /// default: true
     pub allow_partial_fill: Option<bool>,
-    pub common: QuoteAndSwapCommonOptions,
+    pub quote: SellOrderQuoteQuery,
 }
 
 impl SwapQuery {
@@ -236,16 +212,13 @@ impl SwapQuery {
             .join(&endpoint)
             .expect("unexpectedly invalid URL segment");
         url.query_pairs_mut()
-            .append_pair(
-                "fromTokenAddress",
-                &addr2str(self.common.from_token_address),
-            )
-            .append_pair("toTokenAddress", &addr2str(self.common.to_token_address))
-            .append_pair("amount", &self.common.amount.to_string())
+            .append_pair("fromTokenAddress", &addr2str(self.quote.from_token_address))
+            .append_pair("toTokenAddress", &addr2str(self.quote.to_token_address))
+            .append_pair("amount", &self.quote.amount.to_string())
             .append_pair("fromAddress", &addr2str(self.from_address))
             .append_pair("slippage", &self.slippage.to_string());
 
-        if let Some(protocols) = self.common.protocols {
+        if let Some(protocols) = self.quote.protocols {
             url.query_pairs_mut()
                 .append_pair("protocols", &protocols.join(","));
         }
@@ -253,19 +226,19 @@ impl SwapQuery {
             url.query_pairs_mut()
                 .append_pair("disableEstimate", &disable_estimate.to_string());
         }
-        if let Some(complexity_level) = self.common.complexity_level {
+        if let Some(complexity_level) = self.quote.complexity_level {
             url.query_pairs_mut()
                 .append_pair("complexityLevel", &complexity_level.to_string());
         }
-        if let Some(gas_limit) = self.common.gas_limit {
+        if let Some(gas_limit) = self.quote.gas_limit {
             url.query_pairs_mut()
                 .append_pair("gasLimit", &gas_limit.to_string());
         }
-        if let Some(main_route_parts) = self.common.main_route_parts {
+        if let Some(main_route_parts) = self.quote.main_route_parts {
             url.query_pairs_mut()
                 .append_pair("mainRouteParts", &main_route_parts.to_string());
         }
-        if let Some(parts) = self.common.parts {
+        if let Some(parts) = self.quote.parts {
             url.query_pairs_mut()
                 .append_pair("parts", &parts.to_string());
         }
@@ -277,10 +250,10 @@ impl SwapQuery {
             url.query_pairs_mut()
                 .append_pair("referrerAddress", &addr2str(referrer_address));
         }
-        if let Some(fee) = self.common.fee {
+        if let Some(fee) = self.quote.fee {
             url.query_pairs_mut().append_pair("fee", &fee.to_string());
         }
-        if let Some(gas_price) = self.common.gas_price {
+        if let Some(gas_price) = self.quote.gas_price {
             url.query_pairs_mut()
                 .append_pair("gasPrice", &gas_price.to_string());
         }
@@ -292,11 +265,11 @@ impl SwapQuery {
             url.query_pairs_mut()
                 .append_pair("allowPartialFill", &allow_partial_fill.to_string());
         }
-        if let Some(virtual_parts) = self.common.virtual_parts {
+        if let Some(virtual_parts) = self.quote.virtual_parts {
             url.query_pairs_mut()
                 .append_pair("virtualParts", &virtual_parts.to_string());
         }
-        if let Some(connector_tokens) = self.common.connector_tokens {
+        if let Some(connector_tokens) = self.quote.connector_tokens {
             url.query_pairs_mut().append_pair(
                 "connectorTokens",
                 &connector_tokens
@@ -324,7 +297,7 @@ impl SwapQuery {
             // Disable balance/allowance checks, as the settlement contract
             // does not hold balances to traded tokens.
             disable_estimate: Some(true),
-            common: QuoteAndSwapCommonOptions::with_default_options(
+            quote: SellOrderQuoteQuery::with_default_options(
                 sell_token, buy_token, protocols, in_amount,
             ),
             dest_receiver: None,
@@ -612,7 +585,7 @@ mod tests {
             from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
             slippage: Slippage::percentage_from_basis_points(50).unwrap(),
             disable_estimate: None,
-            common: QuoteAndSwapCommonOptions {
+            quote: SellOrderQuoteQuery {
                 from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
                 to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
                 amount: 1_000_000_000_000_000_000u128.into(),
@@ -651,7 +624,7 @@ mod tests {
             from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
             slippage: Slippage::percentage_from_basis_points(50).unwrap(),
             disable_estimate: Some(true),
-            common: QuoteAndSwapCommonOptions {
+            quote: SellOrderQuoteQuery {
                 from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
                 to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
                 protocols: Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
@@ -843,7 +816,7 @@ mod tests {
                 from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
                 slippage: Slippage::percentage_from_basis_points(50).unwrap(),
                 disable_estimate: None,
-                common: QuoteAndSwapCommonOptions::with_default_options(
+                quote: SellOrderQuoteQuery::with_default_options(
                     addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
                     addr!("111111111117dc0aa78b770fa6a738034120c302"),
                     None,
@@ -868,7 +841,7 @@ mod tests {
                 from_address: addr!("4e608b7da83f8e9213f554bdaa77c72e125529d0"),
                 slippage: Slippage::percentage_from_basis_points(50).unwrap(),
                 disable_estimate: Some(true),
-                common: QuoteAndSwapCommonOptions {
+                quote: SellOrderQuoteQuery {
                     from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
                     to_token_address: addr!("a3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2"),
                     protocols: Some(vec!["WETH".to_string(), "UNISWAP_V2".to_string()]),
@@ -921,20 +894,18 @@ mod tests {
     fn sell_order_quote_query_serialization() {
         let base_url = Url::parse("https://api.1inch.exchange/").unwrap();
         let url = SellOrderQuoteQuery {
-            common: QuoteAndSwapCommonOptions {
-                from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-                to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
-                amount: 1_000_000_000_000_000_000u128.into(),
-                protocols: None,
-                complexity_level: None,
-                gas_limit: None,
-                main_route_parts: None,
-                parts: None,
-                fee: None,
-                gas_price: None,
-                virtual_parts: None,
-                connector_tokens: None,
-            },
+            from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+            to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
+            amount: 1_000_000_000_000_000_000u128.into(),
+            protocols: None,
+            complexity_level: None,
+            gas_limit: None,
+            main_route_parts: None,
+            parts: None,
+            fee: None,
+            gas_price: None,
+            virtual_parts: None,
+            connector_tokens: None,
         }
         .into_url(&base_url, 1);
 
@@ -951,23 +922,21 @@ mod tests {
     fn sell_order_quote_query_serialization_optional_parameters() {
         let base_url = Url::parse("https://api.1inch.exchange/").unwrap();
         let url = SellOrderQuoteQuery {
-            common: QuoteAndSwapCommonOptions {
-                from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-                to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
-                protocols: Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
-                amount: 1_000_000_000_000_000_000u128.into(),
-                fee: Some(0.5),
-                connector_tokens: Some(vec![
-                    addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
-                    addr!("6810e776880c02933d47db1b9fc05908e5386b96"),
-                ]),
-                virtual_parts: Some(Amount::new(42).unwrap()),
-                gas_price: Some(200_000.into()),
-                complexity_level: Some(Amount::new(2).unwrap()),
-                gas_limit: Some(Amount::new(750_000).unwrap()),
-                main_route_parts: Some(Amount::new(3).unwrap()),
-                parts: Some(Amount::new(3).unwrap()),
-            },
+            from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+            to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
+            protocols: Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
+            amount: 1_000_000_000_000_000_000u128.into(),
+            fee: Some(0.5),
+            connector_tokens: Some(vec![
+                addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+                addr!("6810e776880c02933d47db1b9fc05908e5386b96"),
+            ]),
+            virtual_parts: Some(Amount::new(42).unwrap()),
+            gas_price: Some(200_000.into()),
+            complexity_level: Some(Amount::new(2).unwrap()),
+            gas_limit: Some(Amount::new(750_000).unwrap()),
+            main_route_parts: Some(Amount::new(3).unwrap()),
+            parts: Some(Amount::new(3).unwrap()),
         }
         .into_url(&base_url, 1);
 
@@ -1107,14 +1076,12 @@ mod tests {
     async fn oneinch_sell_order_quote() {
         let swap = OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new(), 1)
             .unwrap()
-            .get_sell_order_quote(SellOrderQuoteQuery {
-                common: QuoteAndSwapCommonOptions::with_default_options(
-                    addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-                    addr!("111111111117dc0aa78b770fa6a738034120c302"),
-                    None,
-                    1_000_000_000_000_000_000u128.into(),
-                ),
-            })
+            .get_sell_order_quote(SellOrderQuoteQuery::with_default_options(
+                addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+                addr!("111111111117dc0aa78b770fa6a738034120c302"),
+                None,
+                1_000_000_000_000_000_000u128.into(),
+            ))
             .await
             .unwrap();
         println!("{:#?}", swap);
@@ -1126,23 +1093,21 @@ mod tests {
         let swap = OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new(), 1)
             .unwrap()
             .get_sell_order_quote(SellOrderQuoteQuery {
-                common: QuoteAndSwapCommonOptions {
-                    from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-                    to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
-                    protocols: Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
-                    amount: 1_000_000_000_000_000_000u128.into(),
-                    fee: Some(0.5),
-                    connector_tokens: Some(vec![
-                        addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
-                        addr!("6810e776880c02933d47db1b9fc05908e5386b96"),
-                    ]),
-                    virtual_parts: Some(Amount::new(42).unwrap()),
-                    gas_price: Some(200_000.into()),
-                    complexity_level: Some(Amount::new(3).unwrap()),
-                    gas_limit: Some(Amount::new(750_000).unwrap()),
-                    main_route_parts: Some(Amount::new(2).unwrap()),
-                    parts: Some(Amount::new(2).unwrap()),
-                },
+                from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+                to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
+                protocols: Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
+                amount: 1_000_000_000_000_000_000u128.into(),
+                fee: Some(0.5),
+                connector_tokens: Some(vec![
+                    addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+                    addr!("6810e776880c02933d47db1b9fc05908e5386b96"),
+                ]),
+                virtual_parts: Some(Amount::new(42).unwrap()),
+                gas_price: Some(200_000.into()),
+                complexity_level: Some(Amount::new(3).unwrap()),
+                gas_limit: Some(Amount::new(750_000).unwrap()),
+                main_route_parts: Some(Amount::new(2).unwrap()),
+                parts: Some(Amount::new(2).unwrap()),
             })
             .await
             .unwrap();

--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -108,15 +108,6 @@ fn addr2str(addr: H160) -> String {
 /// A query to get a quote for a sell order with 1Inch.
 #[derive(Clone, Debug)]
 pub struct SellOrderQuoteQuery {
-    /// Percentage how much of the from_token_address amount should be sent to the referrer
-    /// address. Values: [0, 3], Default 0.0
-    pub fee: Option<f64>,
-    /// Which tokens should be used for intermediate trading hops.
-    pub connector_tokens: Option<Vec<H160>>,
-    /// Limit the number of virtual split parts.
-    pub virtual_parts: Option<Amount<1, 500>>,
-    /// Gas price in smallest divisible unit. Default: "fast" from network
-    pub gas_price: Option<U256>,
     pub common: QuoteAndSwapCommonOptions,
 }
 
@@ -139,14 +130,14 @@ impl SellOrderQuoteQuery {
             url.query_pairs_mut()
                 .append_pair("protocols", &protocols.join(","));
         }
-        if let Some(fee) = self.fee {
+        if let Some(fee) = self.common.fee {
             url.query_pairs_mut().append_pair("fee", &fee.to_string());
         }
         if let Some(gas_limit) = self.common.gas_limit {
             url.query_pairs_mut()
                 .append_pair("gasLimit", &gas_limit.to_string());
         }
-        if let Some(connector_tokens) = self.connector_tokens {
+        if let Some(connector_tokens) = self.common.connector_tokens {
             url.query_pairs_mut().append_pair(
                 "connectorTokens",
                 &connector_tokens
@@ -164,7 +155,7 @@ impl SellOrderQuoteQuery {
             url.query_pairs_mut()
                 .append_pair("mainRouteParts", &main_route_parts.to_string());
         }
-        if let Some(virtual_parts) = self.virtual_parts {
+        if let Some(virtual_parts) = self.common.virtual_parts {
             url.query_pairs_mut()
                 .append_pair("virtualParts", &virtual_parts.to_string());
         }
@@ -172,7 +163,7 @@ impl SellOrderQuoteQuery {
             url.query_pairs_mut()
                 .append_pair("parts", &parts.to_string());
         }
-        if let Some(gas_price) = self.gas_price {
+        if let Some(gas_price) = self.common.gas_price {
             url.query_pairs_mut()
                 .append_pair("gasPrice", &gas_price.to_string());
         }
@@ -187,10 +178,6 @@ impl SellOrderQuoteQuery {
         protocols: Option<Vec<String>>,
     ) -> Self {
         Self {
-            fee: None,
-            connector_tokens: None,
-            virtual_parts: None,
-            gas_price: None,
             common: QuoteAndSwapCommonOptions::with_default_options(
                 sell_token, buy_token, protocols, in_amount,
             ),
@@ -934,10 +921,6 @@ mod tests {
     fn sell_order_quote_query_serialization() {
         let base_url = Url::parse("https://api.1inch.exchange/").unwrap();
         let url = SellOrderQuoteQuery {
-            fee: None,
-            connector_tokens: None,
-            virtual_parts: None,
-            gas_price: None,
             common: QuoteAndSwapCommonOptions {
                 from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
                 to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
@@ -968,19 +951,23 @@ mod tests {
     fn sell_order_quote_query_serialization_optional_parameters() {
         let base_url = Url::parse("https://api.1inch.exchange/").unwrap();
         let url = SellOrderQuoteQuery {
-            fee: Some(0.5),
-            connector_tokens: Some(vec![
-                addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
-                addr!("6810e776880c02933d47db1b9fc05908e5386b96"),
-            ]),
-            virtual_parts: Some(Amount::new(42).unwrap()),
-            gas_price: Some(200_000.into()),
-            common: QuoteAndSwapCommonOptions::with_default_options(
-                addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-                addr!("111111111117dc0aa78b770fa6a738034120c302"),
-                Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
-                1_000_000_000_000_000_000u128.into(),
-            ),
+            common: QuoteAndSwapCommonOptions {
+                from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+                to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
+                protocols: Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
+                amount: 1_000_000_000_000_000_000u128.into(),
+                fee: Some(0.5),
+                connector_tokens: Some(vec![
+                    addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+                    addr!("6810e776880c02933d47db1b9fc05908e5386b96"),
+                ]),
+                virtual_parts: Some(Amount::new(42).unwrap()),
+                gas_price: Some(200_000.into()),
+                complexity_level: Some(Amount::new(2).unwrap()),
+                gas_limit: Some(Amount::new(750_000).unwrap()),
+                main_route_parts: Some(Amount::new(3).unwrap()),
+                parts: Some(Amount::new(3).unwrap()),
+            },
         }
         .into_url(&base_url, 1);
 
@@ -1121,10 +1108,6 @@ mod tests {
         let swap = OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new(), 1)
             .unwrap()
             .get_sell_order_quote(SellOrderQuoteQuery {
-                fee: None,
-                connector_tokens: None,
-                virtual_parts: None,
-                gas_price: None,
                 common: QuoteAndSwapCommonOptions::with_default_options(
                     addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
                     addr!("111111111117dc0aa78b770fa6a738034120c302"),
@@ -1143,19 +1126,23 @@ mod tests {
         let swap = OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new(), 1)
             .unwrap()
             .get_sell_order_quote(SellOrderQuoteQuery {
-                fee: Some(0.5),
-                connector_tokens: Some(vec![
-                    addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
-                    addr!("6810e776880c02933d47db1b9fc05908e5386b96"),
-                ]),
-                virtual_parts: Some(Amount::new(42).unwrap()),
-                gas_price: Some(200_000.into()),
-                common: QuoteAndSwapCommonOptions::with_default_options(
-                    addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-                    addr!("111111111117dc0aa78b770fa6a738034120c302"),
-                    Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
-                    1_000_000_000_000_000_000u128.into(),
-                ),
+                common: QuoteAndSwapCommonOptions {
+                    from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+                    to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
+                    protocols: Some(vec!["WETH".to_string(), "UNISWAP_V3".to_string()]),
+                    amount: 1_000_000_000_000_000_000u128.into(),
+                    fee: Some(0.5),
+                    connector_tokens: Some(vec![
+                        addr!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+                        addr!("6810e776880c02933d47db1b9fc05908e5386b96"),
+                    ]),
+                    virtual_parts: Some(Amount::new(42).unwrap()),
+                    gas_price: Some(200_000.into()),
+                    complexity_level: Some(Amount::new(3).unwrap()),
+                    gas_limit: Some(Amount::new(750_000).unwrap()),
+                    main_route_parts: Some(Amount::new(2).unwrap()),
+                    parts: Some(Amount::new(2).unwrap()),
+                },
             })
             .await
             .unwrap();

--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -498,7 +498,7 @@ impl OneInchClient for OneInchClientImpl {
     }
 
     async fn get_spender(&self) -> Result<Spender> {
-        let endpoint = format!("v3.0/{}/approve/spender", self.chain_id);
+        let endpoint = format!("v4.1/{}/approve/spender", self.chain_id);
         let url = self
             .base_url
             .join(&endpoint)

--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -2,6 +2,8 @@
 //!
 //! For more information on the HTTP API, consult:
 //! <https://docs.1inch.io/docs/aggregation-protocol/api/swagger>
+//! Although there is no documentation about API v4.1, it exists and is identical to v4.0 except it
+//! uses EIP 1559 gas prices.
 use crate::solver_utils::{deserialize_prefixed_hex, Slippage};
 use anyhow::{ensure, Context, Result};
 use cached::{Cached, TimedCache};
@@ -120,7 +122,7 @@ pub struct SellOrderQuoteQuery {
 
 impl SellOrderQuoteQuery {
     fn into_url(self, base_url: &Url, chain_id: u64) -> Url {
-        let endpoint = format!("v4.0/{}/quote", chain_id);
+        let endpoint = format!("v4.1/{}/quote", chain_id);
         let mut url = base_url
             .join(&endpoint)
             .expect("unexpectedly invalid URL segment");
@@ -943,7 +945,7 @@ mod tests {
 
         assert_eq!(
             url.as_str(),
-            "https://api.1inch.exchange/v4.0/1/quote\
+            "https://api.1inch.exchange/v4.1/1/quote\
                 ?fromTokenAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000"
@@ -972,7 +974,7 @@ mod tests {
 
         assert_eq!(
             url.as_str(),
-            "https://api.1inch.exchange/v4.0/1/quote\
+            "https://api.1inch.exchange/v4.1/1/quote\
                 ?fromTokenAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000\

--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -431,10 +431,21 @@ pub struct Spender {
     pub address: H160,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+pub struct LiquidiySource {
+    pub id: String,
+}
+
+impl From<&str> for LiquidiySource {
+    fn from(id: &str) -> Self {
+        Self { id: id.to_string() }
+    }
+}
+
 /// Protocols query response.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct Protocols {
-    pub protocols: Vec<String>,
+    pub protocols: Vec<LiquidiySource>,
 }
 
 // Mockable version of API Client
@@ -509,7 +520,7 @@ impl OneInchClient for OneInchClientImpl {
     }
 
     async fn get_protocols(&self) -> Result<Protocols> {
-        let endpoint = format!("v3.0/{}/protocols", self.chain_id);
+        let endpoint = format!("v4.1/{}/liquidity-sources", self.chain_id);
         let url = self
             .base_url
             .join(&endpoint)
@@ -529,7 +540,7 @@ where
 }
 
 #[derive(Debug, Clone)]
-pub struct ProtocolCache(Arc<Mutex<TimedCache<(), Vec<String>>>>);
+pub struct ProtocolCache(Arc<Mutex<TimedCache<(), Vec<LiquidiySource>>>>);
 
 impl ProtocolCache {
     pub fn new(cache_validity_in_seconds: Duration) -> Self {
@@ -539,7 +550,7 @@ impl ProtocolCache {
         ))))
     }
 
-    pub async fn get_all_protocols(&self, api: &dyn OneInchClient) -> Result<Vec<String>> {
+    pub async fn get_all_protocols(&self, api: &dyn OneInchClient) -> Result<Vec<LiquidiySource>> {
         if let Some(cached) = self.0.lock().unwrap().cache_get(&()) {
             return Ok(cached.clone());
         }
@@ -566,7 +577,8 @@ impl ProtocolCache {
             .await?
             .into_iter()
             // linear search through the slice is okay because it's very small
-            .filter(|protocol| !disabled_protocols.contains(protocol))
+            .filter(|protocol| !disabled_protocols.contains(&protocol.id))
+            .map(|protocol| protocol.id)
             .collect();
 
         Ok(Some(allowed_protocols))
@@ -1188,5 +1200,42 @@ mod tests {
     fn creation_fails_on_unsupported_chain() {
         let api = OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new(), 2);
         assert!(api.is_err());
+    }
+
+    #[test]
+    fn deserialize_liquidity_sources_response() {
+        let swap = serde_json::from_str::<Protocols>(
+            r#"{
+                "protocols": [
+                    {
+                      "id": "PMMX",
+                      "title": "LiqPool X",
+                      "img": "https://api.1inch.io/pmm.png"
+                    },
+                    {
+                      "id": "UNIFI",
+                      "title": "Unifi",
+                      "img": "https://api.1inch.io/unifi.png"
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            swap,
+            Protocols {
+                protocols: vec!["PMMX".into(), "UNIFI".into()]
+            }
+        );
+
+        let swap_error = serde_json::from_str::<Protocols>(
+            r#"{
+                "statusCode":500,
+                "description":"Internal server error"
+            }"#,
+        );
+
+        assert!(swap_error.is_err());
     }
 }

--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -29,8 +29,8 @@ impl OneInchPriceEstimator {
             .get_sell_order_quote(SellOrderQuoteQuery::with_default_options(
                 query.sell_token,
                 query.buy_token,
-                query.in_amount,
                 allowed_protocols,
+                query.in_amount,
             ))
             .await
             .map_err(PriceEstimationError::Other)?;

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -295,7 +295,7 @@ mod tests {
             .expect_get_approval()
             .returning(|_, _, _| Ok(Approval::AllowanceSufficient));
 
-        client.expect_get_protocols().returning(|| {
+        client.expect_get_liquidity_sources().returning(|| {
             Ok(Protocols {
                 protocols: vec!["GoodProtocol".into(), "BadProtocol".into()],
             })

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -306,7 +306,7 @@ mod tests {
             })
         });
         client.expect_get_swap().times(1).returning(|query| {
-            assert_eq!(query.common.protocols, Some(vec!["GoodProtocol".into()]));
+            assert_eq!(query.quote.protocols, Some(vec!["GoodProtocol".into()]));
             Ok(RestResponse::Ok(Swap {
                 from_token_amount: 100.into(),
                 to_token_amount: 100.into(),


### PR DESCRIPTION
Fixes #1560

We have been using 1Inch API v3.0 for quite a while. There isn't even any documentation online available anymore.
Upgrading to v4.1 makes it easier to reason about changes in the future and also offers some new parameters to configure quotes and swaps.
Note that I'm not able to find any documentation about v4.1 specifically but I got confirmation from the 1Inch team that v4.0 and v4.1 are equivalent except that v4.1 is using EIP-1559 gas prices instead of the old gas prices.

The /swap endpoint got some new parameters and /protocols became /liquidity-sources.

### Test Plan
Update existing tests
Added new test parsing the response from /liquidity-sources
Manual test run with:
```
cargo run -p solver -- \                        INT ✘  7m 46s    15:12:36 
  --solver-account 0xa6DDBD0dE6B310819b49f680F65871beE85f517e \
  --baseline-sources UniswapV2,SushiSwap \
  --node-url <NODE_URL> \
  --transaction-strategy DryRun \
  --solvers OneInch,Baseline \
  --orderbook-url https://protocol-mainnet.gnosis.io/api/
```

### Release notes
Use 1Inch API v4.1 instead of v3.0
