### PR TITLE
return early from transaction submission if reverted or canceled

### DIFF
--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -120,7 +120,7 @@ impl SolutionSubmitter {
                 let (result, _index, rest) = futures::future::select_all(futures).await;
                 match result {
                     Ok(receipt) => return Ok(receipt),
-                    Err(err) if rest.is_empty() => {
+                    Err(err) if rest.is_empty() || err.is_transaction_mined() => {
                         return Err(err);
                     }
                     Err(_) => {
@@ -176,6 +176,16 @@ impl SubmissionError {
             }
             SubmissionError::SimulationRevert(None) => anyhow!("transaction simulation reverted"),
             SubmissionError::Other(err) => err,
+        }
+    }
+
+    pub fn is_transaction_mined(&self) -> bool {
+        match self {
+            SubmissionError::SimulationRevert(_) => false,
+            SubmissionError::Revert => true,
+            SubmissionError::Timeout => false,
+            SubmissionError::Canceled => true,
+            SubmissionError::Other(_) => false,
         }
     }
 }


### PR DESCRIPTION
In case of `Revert` or `Cancel` error type, we definitely know what happened -> transaction is mined. There is no need to wait for other futures.

This prevents racing when, for example, we have two submissions running at the same time, first one finishes with `Revert` error while other detects change in nonce, but does not detect mined transaction because it has a different set of submitted transaction hashes, therefore it returns `SimulationRevert`. In this case, we want `Revert` as a final error.