### PR TITLE
Replace structopt with clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,12 +53,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap 3.0.13",
  "model",
  "primitive-types",
  "reqwest",
  "serde",
  "shared",
- "structopt",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "arrayvec"
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byte-slice-cast"
@@ -292,13 +292,39 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
+ "bitflags",
+ "textwrap 0.11.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08799f92c961c7a1cf0cc398a9073da99e21ce388b46372c37f3191f2f3eed3e"
+dependencies = [
  "atty",
  "bitflags",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim",
+ "termcolor",
+ "textwrap 0.14.2",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -374,7 +400,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -404,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -425,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -438,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+checksum = "b979d76c9fcb84dffc80a73f7290da0f83e4c95773494674cb44b76d13a7a110"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -448,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -496,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc6d233563261f8db6ffb83bbaad5a73837a6e6b28868e926337ebbdece0be3"
+checksum = "7de97b894edd5b5bcceef8b78d7da9b75b1d2f2f9a910569d0bde3dd31d84939"
 dependencies = [
  "curl-sys",
  "libc",
@@ -511,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.51+curl-7.80.0"
+version = "0.4.52+curl-7.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d130987e6a6a34fe0889e1083022fa48cd90e6709a84be3fb8dd95801de5af20"
+checksum = "14b8c2d1023ea5fded5b7b892e4b8e95f70038a421126a056761a84246a28971"
 dependencies = [
  "cc",
  "libc",
@@ -526,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -536,23 +562,23 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
 dependencies = [
  "darling_core",
  "quote",
@@ -606,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
  "dirs-sys",
 ]
@@ -675,9 +701,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.29"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
+checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if",
 ]
@@ -822,7 +848,7 @@ dependencies = [
  "ethcontract",
  "hex",
  "mockall 0.10.2",
- "predicates 2.1.0",
+ "predicates 2.1.1",
  "rlp",
 ]
 
@@ -847,6 +873,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
  "backtrace",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -912,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
+checksum = "8da1b8f89c5b5a5b7e59405cfcf0bb9588e5ed19f0b57a4cd542bbba3f164a6d"
 
 [[package]]
 name = "funty"
@@ -1050,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -1060,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1077,9 +1112,9 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "h2"
-version = "0.3.7"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes",
  "fnv",
@@ -1151,6 +1186,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1225,9 +1266,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.15"
+version = "0.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
+checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1317,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1363,9 +1404,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1399,9 +1440,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "0a8d982fa7a96a000f6ec4cfe966de9703eccde29750df2bb8949da91b0e818d"
 
 [[package]]
 name = "libz-sys"
@@ -1482,9 +1523,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
@@ -1569,7 +1610,7 @@ dependencies = [
  "fragile",
  "lazy_static",
  "mockall_derive 0.11.0",
- "predicates 2.1.0",
+ "predicates 2.1.1",
  "predicates-tree",
 ]
 
@@ -1753,11 +1794,20 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
  "libc",
 ]
 
@@ -1804,15 +1854,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.71"
+version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
 dependencies = [
  "autocfg",
  "cc",
@@ -1830,6 +1880,7 @@ dependencies = [
  "async-trait",
  "bigdecimal 0.2.2",
  "chrono",
+ "clap 3.0.13",
  "const_format",
  "contracts",
  "ethcontract",
@@ -1851,7 +1902,6 @@ dependencies = [
  "serde_with",
  "shared",
  "sqlx",
- "structopt",
  "testlib",
  "thiserror",
  "tokio",
@@ -1859,6 +1909,15 @@ dependencies = [
  "url",
  "warp",
  "web3",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1920,18 +1979,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1940,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -1952,9 +2011,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "plotters"
@@ -1986,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "predicates"
@@ -2005,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e5a7689e456ab905c22c2b48225bb921aba7c8dfa58440d68ba13f6222a715"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
  "difflib",
  "float-cmp 0.9.0",
@@ -2019,15 +2078,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338c7be2905b732ae3984a2f40032b5e94fd8f52505b186c7d4d68d193445df7"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -2082,9 +2141,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -2134,9 +2193,9 @@ checksum = "47c327e191621a2158159df97cdbc2e7074bb4e940275e35abf38eb3d2595754"
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -2268,15 +2327,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.7"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bea77bc708afa10e59905c3d4af7c8fd43c9214251673095ff8b14345fcbc5"
+checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
 dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "hyper",
@@ -2334,15 +2394,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "same-file"
@@ -2386,18 +2446,18 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827cb7cce42533829c792fc51b82fbf18b125b45a702ef2c8be77fce65463a7b"
+checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "security-framework"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+checksum = "d09d3c15d814eda1d6a836f2f2b56a6abc1446c8a34351cb3180d3db92ffe4ce"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2408,9 +2468,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+checksum = "e90dd10c41c6bfc633da6e0c659bd25d31e0791e5974ac42970267d59eba87f7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2424,9 +2484,9 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -2443,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2465,9 +2525,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -2476,12 +2536,12 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -2524,9 +2584,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer",
  "cfg-if",
@@ -2566,6 +2626,7 @@ dependencies = [
  "atty",
  "cached",
  "chrono",
+ "clap 3.0.13",
  "contracts",
  "derivative",
  "ethcontract",
@@ -2593,7 +2654,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "structopt",
  "testlib",
  "thiserror",
  "time",
@@ -2623,15 +2683,15 @@ checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
@@ -2659,6 +2719,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "clap 3.0.13",
  "contracts",
  "derivative",
  "derive_more",
@@ -2683,7 +2744,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "shared",
- "structopt",
  "strum",
  "testlib",
  "thiserror",
@@ -2706,9 +2766,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7911b0031a0247af40095838002999c7a52fba29d9739e93326e71a5a1bc9d43"
+checksum = "692749de69603d81e016212199d73a2e14ee20e2def7d7914919e8db5d4d48b9"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2716,9 +2776,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec89bfaca8f7737439bad16d52b07f1ccd0730520d3bf6ae9d069fe4b641fb1"
+checksum = "518be6f6fff5ca76f985d434f9c37f3662af279642acf730388f271dff7b9016"
 dependencies = [
  "ahash",
  "atoi",
@@ -2741,7 +2801,7 @@ dependencies = [
  "hex",
  "hmac",
  "indexmap",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "libc",
  "log",
  "md-5",
@@ -2767,13 +2827,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584866c833511b1a152e87a7ee20dee2739746f60c858b3c5209150bc4b466f5"
+checksum = "38e45140529cf1f90a5e1c2e561500ca345821a1c513652c8f486bbf07407cc8"
 dependencies = [
  "dotenv",
  "either",
- "heck",
+ "heck 0.3.3",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -2785,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1bd069de53442e7a320f525a6d4deb8bb0621ac7a55f7eccbc2b58b57f43d0"
+checksum = "8061cbaa91ee75041514f67a09398c65a64efed72c90151ecd47593bad53da99"
 dependencies = [
  "native-tls",
  "once_cell",
@@ -2813,39 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "strum"
@@ -2862,7 +2892,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -2877,9 +2907,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.82"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2894,13 +2924,13 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -2917,9 +2947,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "testlib"
@@ -2939,6 +2969,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"
@@ -2962,21 +2998,22 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "libc",
+ "num_threads",
  "time-macros",
 ]
 
@@ -3022,9 +3059,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
  "bytes",
  "libc",
@@ -3163,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d81bfa81424cc98cb034b837c985b7a290f592e5b4322f353f94a0ab0f9f594"
+checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
 dependencies = [
  "ansi_term",
  "lazy_static",
@@ -3208,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "uint"
@@ -3297,16 +3334,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
@@ -3363,9 +3394,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3373,9 +3404,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3388,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3400,9 +3431,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3410,9 +3441,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3423,15 +3454,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3540,6 +3571,6 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "4062c749be08d90be727e9c5895371c3a0e49b90ba2b9592dc7afda95cc2b719"

--- a/crates/alerter/Cargo.toml
+++ b/crates/alerter/Cargo.toml
@@ -11,7 +11,7 @@ primitive-types = { version = "0.10" }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 shared = { path = "../shared" }
-structopt = "0.3"
+clap = { version = "3.0", features = ["derive", "env"] }
 tokio = { version = "1.15", features = ["macros", "time"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/crates/alerter/src/main.rs
+++ b/crates/alerter/src/main.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
+use clap::Parser;
 use model::{
     order::{OrderKind, OrderStatus, OrderUid, BUY_ETH_ADDRESS},
     u256_decimal,
@@ -11,7 +12,6 @@ use model::{
 use primitive_types::{H160, U256};
 use reqwest::Client;
 use std::time::{Duration, Instant};
-use structopt::StructOpt;
 use url::Url;
 
 #[derive(Debug, serde::Deserialize, Eq, PartialEq)]
@@ -240,10 +240,10 @@ impl Alerter {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Arguments {
     /// Minimum time without a trade before alerting.
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "600",
@@ -252,7 +252,7 @@ struct Arguments {
     time_without_trade: Duration,
 
     /// Minimum time an order must have been matchable for before alerting.
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "180",
@@ -261,7 +261,7 @@ struct Arguments {
     min_order_age: Duration,
 
     /// Do not repeat the alert more often than this.
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "1800",
@@ -271,16 +271,16 @@ struct Arguments {
 
     /// How many errors in the update loop (fetching solvable orders or querying 0x) in a row
     /// must happen before we alert about them.
-    #[structopt(long, env, default_value = "5")]
+    #[clap(long, env, default_value = "5")]
     errors_in_a_row_before_alert: u32,
 
-    #[structopt(long, env, default_value = "https://protocol-mainnet.gnosis.io")]
+    #[clap(long, env, default_value = "https://protocol-mainnet.gnosis.io")]
     orderbook_api: String,
 }
 
 #[tokio::main]
 async fn main() {
-    let args = Arguments::from_args();
+    let args = Arguments::parse();
     shared::tracing::initialize("alerter=debug", tracing::Level::ERROR.into());
     tracing::info!("running alerter with {:#?}", args);
 

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = "1.0"
 serde_with = { version = "1.11", default-features = false, features = ["macros"] }
 shared= { path = "../shared" }
 sqlx = { version = "0.5", default-features = false, features = ["bigdecimal", "chrono", "macros", "runtime-tokio-native-tls", "postgres"] }
-structopt = "0.3"
+clap = { version = "3.0", features = ["derive", "env"] }
 thiserror = "1.0"
 tokio = { version = "1.15", features = ["macros", "rt-multi-thread", "sync", "time", "signal"] }
 tracing = "0.1"

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -41,7 +41,7 @@ scopeguard = "1.1.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_with = { version = "1.11", default-features = false }
-structopt = { version = "0.3", default-features = false }
+clap = { version = "3.0", features = ["derive", "env"] }
 thiserror = "1.0"
 time = { version = "0.3", features = ["macros"] }
 tokio = { version = "1.15", features = ["macros", "time"] }

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -14,24 +14,24 @@ use std::{
 use tracing::level_filters::LevelFilter;
 use url::Url;
 
-#[derive(Debug, structopt::StructOpt)]
+#[derive(Debug, clap::Parser)]
 pub struct Arguments {
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "warn,orderbook=debug,solver=debug,shared=debug,shared::transport::http=info"
     )]
     pub log_filter: String,
 
-    #[structopt(long, env, default_value = "error", parse(try_from_str))]
+    #[clap(long, env, default_value = "error", parse(try_from_str))]
     pub log_stderr_threshold: LevelFilter,
 
     /// The Ethereum node URL to connect to.
-    #[structopt(long, env, default_value = "http://localhost:8545")]
+    #[clap(long, env, default_value = "http://localhost:8545")]
     pub node_url: Url,
 
     /// Timeout in seconds for all http requests.
-    #[structopt(
+    #[clap(
             long,
             default_value = "10",
             parse(try_from_str = duration_from_seconds),
@@ -44,53 +44,47 @@ pub struct Arguments {
     /// `GasNow`: supports mainnet.
     /// `GnosisSafe`: supports mainnet and rinkeby.
     /// `Web3`: supports every network.
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "Web3",
-        possible_values = &GasEstimatorType::variants(),
-        case_insensitive = true,
+        arg_enum,
+        ignore_case = true,
         use_delimiter = true
     )]
     pub gas_estimators: Vec<GasEstimatorType>,
 
     /// BlockNative requires api key to work. Optional since BlockNative could be skipped in gas estimators.
-    #[structopt(long, env)]
+    #[clap(long, env)]
     pub blocknative_api_key: Option<String>,
 
     /// Base tokens used for finding multi-hop paths between multiple AMMs
     /// Should be the most liquid tokens of the given network.
-    #[structopt(long, env, use_delimiter = true)]
+    #[clap(long, env, use_delimiter = true)]
     pub base_tokens: Vec<H160>,
 
     /// Which Liquidity sources to be used by Price Estimator.
-    #[structopt(
-        long,
-        env,
-        possible_values = &BaselineSource::variants(),
-        case_insensitive = true,
-        use_delimiter = true
-    )]
+    #[clap(long, env, arg_enum, ignore_case = true, use_delimiter = true)]
     pub baseline_sources: Option<Vec<BaselineSource>>,
 
     /// The number of blocks kept in the pool cache.
-    #[structopt(long, env, default_value = "10")]
+    #[clap(long, env, default_value = "10")]
     pub pool_cache_blocks: NonZeroU64,
 
     /// The number of pairs that are automatically updated in the pool cache.
-    #[structopt(long, env, default_value = "4")]
+    #[clap(long, env, default_value = "4")]
     pub pool_cache_maximum_recent_block_age: u64,
 
     /// How often to retry requests in the pool cache.
-    #[structopt(long, env, default_value = "5")]
+    #[clap(long, env, default_value = "5")]
     pub pool_cache_maximum_retries: u32,
 
     /// How long to sleep in seconds between retries in the pool cache.
-    #[structopt(long, env, default_value = "1", parse(try_from_str = duration_from_seconds))]
+    #[clap(long, env, default_value = "1", parse(try_from_str = duration_from_seconds))]
     pub pool_cache_delay_between_retries_seconds: Duration,
 
     /// How often in seconds we poll the node to check if the current block has changed.
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "5",
@@ -101,7 +95,7 @@ pub struct Arguments {
     /// The amount in native tokens atoms to use for price estimation. Should be reasonably large so
     // that small pools do not influence the prices. If not set a reasonable default is used based
     // on network id.
-    #[structopt(
+    #[clap(
         long,
         env,
         parse(try_from_str = U256::from_dec_str)
@@ -109,48 +103,36 @@ pub struct Arguments {
     pub amount_to_estimate_prices_with: Option<U256>,
 
     /// Special partner authentication for Paraswap API (allowing higher rater limits)
-    #[structopt(long, env)]
+    #[clap(long, env)]
     pub paraswap_partner: Option<String>,
 
     /// The list of disabled ParaSwap DEXs. By default, the `ParaSwapPool4`
     /// DEX (representing a private market maker) is disabled as it increases
     /// price by 1% if built transactions don't actually get executed.
-    #[structopt(long, env, default_value = "ParaSwapPool4", use_delimiter = true)]
+    #[clap(long, env, default_value = "ParaSwapPool4", use_delimiter = true)]
     pub disabled_paraswap_dexs: Vec<String>,
 
-    #[structopt(
-        long,
-        env,
-        default_value = "Baseline",
-        possible_values = &PriceEstimatorType::variants(),
-        use_delimiter = true
-    )]
+    #[clap(long, env, default_value = "Baseline", arg_enum, use_delimiter = true)]
     pub price_estimators: Vec<PriceEstimatorType>,
 
-    #[structopt(long, env)]
+    #[clap(long, env)]
     pub zeroex_url: Option<String>,
 
-    #[structopt(long, env)]
+    #[clap(long, env)]
     pub zeroex_api_key: Option<String>,
 
     /// If quasimodo should use internal buffers to improve solution quality.
-    #[structopt(long, env)]
+    #[clap(long, env)]
     pub quasimodo_uses_internal_buffers: bool,
 
     /// If mipsolver should use internal buffers to improve solution quality.
-    #[structopt(long, env)]
+    #[clap(long, env)]
     pub mip_uses_internal_buffers: bool,
 
     /// The Balancer V2 factories to consider for indexing liquidity. Allows
     /// specific pool kinds to be disabled via configuration. Will use all
     /// supported Balancer V2 factory kinds if not specified.
-    #[structopt(
-        long,
-        env,
-        possible_values = &BalancerFactoryKind::variants(),
-        case_insensitive = true,
-        use_delimiter = true
-    )]
+    #[clap(long, env, arg_enum, ignore_case = true, use_delimiter = true)]
     pub balancer_factories: Option<Vec<BalancerFactoryKind>>,
 }
 

--- a/crates/shared/src/gas_price_estimation.rs
+++ b/crates/shared/src/gas_price_estimation.rs
@@ -7,18 +7,16 @@ use gas_estimation::{
 };
 use serde::de::DeserializeOwned;
 use std::sync::{Arc, Mutex};
-use structopt::clap::arg_enum;
 
-arg_enum! {
-    #[derive(Debug)]
-    pub enum GasEstimatorType {
-        EthGasStation,
-        GasNow,
-        GnosisSafe,
-        Web3,
-        BlockNative,
-        Native,
-    }
+#[derive(Copy, Clone, Debug, clap::ArgEnum)]
+#[clap(rename_all = "verbatim")]
+pub enum GasEstimatorType {
+    EthGasStation,
+    GasNow,
+    GnosisSafe,
+    Web3,
+    BlockNative,
+    Native,
 }
 
 #[derive(Clone)]

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -15,18 +15,16 @@ use anyhow::Result;
 use ethcontract::{H160, U256};
 use model::order::OrderKind;
 use num::BigRational;
-use structopt::clap::arg_enum;
 use thiserror::Error;
 
-arg_enum! {
-    #[derive(Debug)]
-    pub enum PriceEstimatorType {
-        Baseline,
-        Paraswap,
-        ZeroEx,
-        Quasimodo,
-        OneInch,
-    }
+#[derive(Copy, Clone, Debug, clap::ArgEnum)]
+#[clap(rename_all = "verbatim")]
+pub enum PriceEstimatorType {
+    Baseline,
+    Paraswap,
+    ZeroEx,
+    Quasimodo,
+    OneInch,
 }
 
 impl PriceEstimatorType {

--- a/crates/shared/src/price_estimation/quasimodo.rs
+++ b/crates/shared/src/price_estimation/quasimodo.rs
@@ -323,6 +323,7 @@ mod tests {
     use crate::token_info::TokenInfoFetcher;
     use crate::transport::http::HttpTransport;
     use crate::Web3;
+    use clap::ArgEnum;
     use ethcontract::dyns::DynTransport;
     use model::order::OrderKind;
     use reqwest::Client;
@@ -403,7 +404,7 @@ mod tests {
             BalancerPoolFetcher::new(
                 chain_id,
                 token_info.clone(),
-                BalancerFactoryKind::all(),
+                BalancerFactoryKind::value_variants(),
                 Default::default(),
                 current_block_stream.clone(),
                 Arc::new(crate::sources::balancer_v2::pool_fetching::NoopBalancerPoolCacheMetrics),

--- a/crates/shared/src/sources.rs
+++ b/crates/shared/src/sources.rs
@@ -18,18 +18,16 @@ use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
-use structopt::clap::arg_enum;
 
-arg_enum! {
-    #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
-    pub enum BaselineSource {
-        UniswapV2,
-        Honeyswap,
-        SushiSwap,
-        BalancerV2,
-        Baoswap,
-        Swapr,
-    }
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, clap::ArgEnum)]
+#[clap(rename_all = "verbatim")]
+pub enum BaselineSource {
+    UniswapV2,
+    Honeyswap,
+    SushiSwap,
+    BalancerV2,
+    Baoswap,
+    Swapr,
 }
 
 pub fn defaults_for_chain(chain_id: u64) -> Result<Vec<BaselineSource>> {

--- a/crates/solver/Cargo.toml
+++ b/crates/solver/Cargo.toml
@@ -41,7 +41,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "1.11", default-features = false }
 shared = { path = "../shared" }
-structopt = "0.3"
+clap = { version = "3.0", features = ["derive", "env"] }
 strum = { version = "0.23", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.15", features = ["macros", "rt-multi-thread", "time", "test-util"] }

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use clap::{ArgEnum, Parser};
 use contracts::{BalancerV2Vault, IUniswapLikeRouter, WETH9};
 use ethcontract::{Account, PrivateKey, H160, U256};
 use reqwest::Url;
@@ -42,41 +43,40 @@ use solver::{
     solver::SolverType,
 };
 use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
-use structopt::{clap::arg_enum, StructOpt};
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Arguments {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     shared: shared::arguments::Arguments,
 
     /// The API endpoint to fetch the orderbook
-    #[structopt(long, env, default_value = "http://localhost:8080")]
+    #[clap(long, env, default_value = "http://localhost:8080")]
     orderbook_url: Url,
 
     /// The API endpoint to call the mip solver
-    #[structopt(long, env, default_value = "http://localhost:8000")]
+    #[clap(long, env, default_value = "http://localhost:8000")]
     mip_solver_url: Url,
 
     /// The API endpoint to call the mip v2 solver
-    #[structopt(long, env, default_value = "http://localhost:8000")]
+    #[clap(long, env, default_value = "http://localhost:8000")]
     quasimodo_solver_url: Url,
 
     /// The API endpoint to call the cow-dex-ag-solver solver
-    #[structopt(long, env, default_value = "http://localhost:8000")]
+    #[clap(long, env, default_value = "http://localhost:8000")]
     cow_dex_ag_solver_url: Url,
 
     /// The API endpoint for the Balancer SOR API for solving.
-    #[structopt(long, env, default_value = "http://localhost:8000")]
+    #[clap(long, env, default_value = "http://localhost:8000")]
     balancer_sor_url: Url,
 
     /// The account used by the driver to sign transactions. This can be either
     /// a 32-byte private key for offline signing, or a 20-byte Ethereum address
     /// for signing with a local node account.
-    #[structopt(long, env, hide_env_values = true)]
+    #[clap(long, env, hide_env_values = true)]
     solver_account: Option<SolverAccountArg>,
 
     /// The target confirmation time in seconds for settlement transactions used to estimate gas price.
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "30",
@@ -90,7 +90,7 @@ struct Arguments {
     /// internal driver error, but can be set to a larger value for running
     /// drivers in dry-run mode to prevent repeatedly settling the same
     /// orders.
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "1",
@@ -99,22 +99,22 @@ struct Arguments {
     settle_interval: Duration,
 
     /// Which type of solver to use
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "Naive,Baseline",
-        possible_values = &SolverType::variants(),
-        case_insensitive = true,
-        use_delimiter = true,
+        arg_enum,
+        ignore_case = true,
+        use_delimiter = true
     )]
     solvers: Vec<SolverType>,
 
     /// Individual accounts for each solver. See `--solver-account` for more
     /// information about configuring accounts.
-    #[structopt(
+    #[clap(
         long,
         env,
-        case_insensitive = true,
+        ignore_case = true,
         use_delimiter = true,
         hide_env_values = true
     )]
@@ -123,7 +123,7 @@ struct Arguments {
     /// A settlement must contain at least one order older than this duration in seconds for it
     /// to be applied.  Larger values delay individual settlements more but have a higher
     /// coincidence of wants chance.
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "30",
@@ -132,15 +132,15 @@ struct Arguments {
     min_order_age: Duration,
 
     /// The port at which we serve our metrics
-    #[structopt(long, env, default_value = "9587", case_insensitive = true)]
+    #[clap(long, env, default_value = "9587")]
     metrics_port: u16,
 
     /// The port at which we serve our metrics
-    #[structopt(long, env, default_value = "5")]
+    #[clap(long, env, default_value = "5")]
     max_merged_settlements: usize,
 
     /// The maximum amount of time in seconds a solver is allowed to take.
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "30",
@@ -150,7 +150,7 @@ struct Arguments {
 
     /// The minimum amount of sell volume (in ETH) that needs to be
     /// traded in order to use the 1Inch solver.
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "5",
@@ -161,12 +161,12 @@ struct Arguments {
     /// The list of disabled 1Inch protocols. By default, the `PMM1` protocol
     /// (representing a private market maker) is disabled as it seems to
     /// produce invalid swaps.
-    #[structopt(long, env, default_value = "PMM1", use_delimiter = true)]
+    #[clap(long, env, default_value = "PMM1", use_delimiter = true)]
     disabled_one_inch_protocols: Vec<String>,
 
     /// The list of tokens our settlement contract is willing to buy when settling trades
     /// without external liquidity
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "https://tokens.coingecko.com/uniswap/all.json"
@@ -174,7 +174,7 @@ struct Arguments {
     market_makable_token_list: String,
 
     /// The maximum gas price in Gwei the solver is willing to pay in a settlement.
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "1500",
@@ -183,36 +183,37 @@ struct Arguments {
     gas_price_cap: f64,
 
     /// The slippage tolerance we apply to the price quoted by Paraswap
-    #[structopt(long, env, default_value = "10")]
+    #[clap(long, env, default_value = "10")]
     paraswap_slippage_bps: u32,
 
     /// The slippage tolerance we apply to the price quoted by zeroEx
-    #[structopt(long, env, default_value = "10")]
+    #[clap(long, env, default_value = "10")]
     zeroex_slippage_bps: u32,
 
     /// How to to submit settlement transactions.
     /// Expected to contain either:
     /// 1. One value equal to TransactionStrategyArg::DryRun or
     /// 2. One or more values equal to any combination of enum variants except TransactionStrategyArg::DryRun
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "PublicMempool",
-        possible_values = &TransactionStrategyArg::variants(),
-        case_insensitive = true,
-        use_delimiter = true)]
+        arg_enum,
+        ignore_case = true,
+        use_delimiter = true
+    )]
     transaction_strategy: Vec<TransactionStrategyArg>,
 
     /// The API endpoint of the Eden network for transaction submission.
-    #[structopt(long, env, default_value = "https://api.edennetwork.io/v1/rpc")]
+    #[clap(long, env, default_value = "https://api.edennetwork.io/v1/rpc")]
     eden_api_url: Url,
 
     /// The API endpoint of the Flashbots network for transaction submission.
-    #[structopt(long, env, default_value = "https://rpc.flashbots.net")]
+    #[clap(long, env, default_value = "https://rpc.flashbots.net")]
     flashbots_api_url: Url,
 
     /// Additional tip in gwei that we are willing to give to eden above regular gas price estimation
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "3",
@@ -222,7 +223,7 @@ struct Arguments {
 
     /// The maximum time in seconds we spend trying to settle a transaction through the ethereum
     /// network before going to back to solving.
-    #[structopt(
+    #[clap(
         long,
         default_value = "120",
         parse(try_from_str = shared::arguments::duration_from_seconds),
@@ -230,7 +231,7 @@ struct Arguments {
     max_submission_seconds: Duration,
 
     /// Additional tip in gwei that we are willing to give to flashbots above regular gas price estimation
-    #[structopt(
+    #[clap(
         long,
         env,
         default_value = "3",
@@ -239,7 +240,7 @@ struct Arguments {
     additional_flashbot_tip: f64,
 
     /// Amount of time to wait before retrying to submit the tx to the ethereum network
-    #[structopt(
+    #[clap(
         long,
         default_value = "5",
         parse(try_from_str = shared::arguments::duration_from_seconds),
@@ -247,23 +248,23 @@ struct Arguments {
     submission_retry_interval_seconds: Duration,
 
     /// The RPC endpoints to use for submitting transaction to a custom set of nodes.
-    #[structopt(long, env, use_delimiter = true)]
+    #[clap(long, env, use_delimiter = true)]
     transaction_submission_nodes: Vec<Url>,
 
     /// The configured addresses whose orders should be considered liquidity
     /// and not to be included in the objective function by the HTTP solver.
-    #[structopt(long, env, use_delimiter = true)]
+    #[clap(long, env, use_delimiter = true)]
     liquidity_order_owners: Vec<H160>,
 
     /// Fee scaling factor for objective value. This controls the constant
     /// factor by which order fees are multiplied with. Setting this to a value
     /// greater than 1.0 makes settlements with negative objective values less
     /// likely, promoting more aggressive merging of single order settlements.
-    #[structopt(long, env, default_value = "1", parse(try_from_str = shared::arguments::parse_unbounded_factor))]
+    #[clap(long, env, default_value = "1", parse(try_from_str = shared::arguments::parse_unbounded_factor))]
     fee_objective_scaling_factor: f64,
 
     /// The maximum number of settlements the driver considers per solver.
-    #[structopt(long, env, default_value = "20")]
+    #[clap(long, env, default_value = "20")]
     max_settlements_per_solver: usize,
 
     /// Factor how much of the WETH buffer should be unwrapped if ETH buffer is not big enough to
@@ -271,25 +272,24 @@ struct Arguments {
     /// Unwrapping a bigger amount will cause fewer unwraps to happen and thereby reduce the cost
     /// of unwraps per settled batch.
     /// Only values in the range [0.0, 1.0] make sense.
-    #[structopt(long, env, default_value = "0.6", parse(try_from_str = shared::arguments::parse_percentage_factor))]
+    #[clap(long, env, default_value = "0.6", parse(try_from_str = shared::arguments::parse_percentage_factor))]
     weth_unwrap_factor: f64,
 
     /// Gas limit for simulations. This parameter is important to set correctly, such that
     /// there are no simulation errors due to: err: insufficient funds for gas * price + value,
     /// but at the same time we don't restrict solutions sizes too much
-    #[structopt(long, env, default_value = "15000000")]
+    #[clap(long, env, default_value = "15000000")]
     simulation_gas_limit: u128,
 }
 
-arg_enum! {
-    #[derive(Debug)]
-    enum TransactionStrategyArg {
-        PublicMempool,
-        Eden,
-        Flashbots,
-        CustomNodes,
-        DryRun,
-    }
+#[derive(Copy, Clone, Debug, clap::ArgEnum)]
+#[clap(rename_all = "verbatim")]
+enum TransactionStrategyArg {
+    PublicMempool,
+    Eden,
+    Flashbots,
+    CustomNodes,
+    DryRun,
 }
 
 #[derive(Debug)]
@@ -327,7 +327,7 @@ impl FromStr for SolverAccountArg {
 
 #[tokio::main]
 async fn main() {
-    let args = Arguments::from_args();
+    let args = Arguments::parse();
     shared::tracing::initialize(
         args.shared.log_filter.as_str(),
         args.shared.log_stderr_threshold,
@@ -443,7 +443,8 @@ async fn main() {
                     token_info_fetcher.clone(),
                     args.shared
                         .balancer_factories
-                        .unwrap_or_else(BalancerFactoryKind::all),
+                        .as_deref()
+                        .unwrap_or_else(BalancerFactoryKind::value_variants),
                     cache_config,
                     current_block_stream.clone(),
                     metrics.clone(),

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -27,7 +27,6 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use structopt::clap::arg_enum;
 use zeroex_solver::ZeroExSolver;
 
 pub mod balancer_sor_solver;
@@ -125,19 +124,18 @@ pub type Solvers = Vec<Arc<dyn Solver>>;
 /// A single settlement and a solver that produced it.
 pub type SettlementWithSolver = (Arc<dyn Solver>, Settlement);
 
-arg_enum! {
-    #[derive(Debug)]
-    pub enum SolverType {
-        Naive,
-        Baseline,
-        Mip,
-        CowDexAg,
-        OneInch,
-        Paraswap,
-        ZeroEx,
-        Quasimodo,
-        BalancerSor,
-    }
+#[derive(Copy, Clone, Debug, clap::ArgEnum)]
+#[clap(rename_all = "verbatim")]
+pub enum SolverType {
+    Naive,
+    Baseline,
+    Mip,
+    CowDexAg,
+    OneInch,
+    Paraswap,
+    ZeroEx,
+    Quasimodo,
+    BalancerSor,
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
Clap has absorbed and succeeded structopt in the newly released v3.

Based on my testing this should be backward compatible but it is easy to accidentally make a mistake that will only show up once this hits staging so I will merge this earliest after Kaffeekraenzchen and stand by to unbreak if needed.

### Test Plan

CI and manual test

