### PR TITLE
add possibility to disable strategies (copied)

### DIFF
--- a/crates/shared/src/gas_price_estimation.rs
+++ b/crates/shared/src/gas_price_estimation.rs
@@ -102,7 +102,7 @@ pub async fn create_priority_estimator(
     Ok(PriorityGasPriceEstimating::new(estimators))
 }
 
-fn is_mainnet(network_id: &str) -> bool {
+pub fn is_mainnet(network_id: &str) -> bool {
     network_id == "1"
 }
 

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -49,6 +49,8 @@ pub enum SettlementSubmissionOutcome {
     Timeout,
     /// Transaction sucessfully cancelled after simulation revert or timeout
     Cancel,
+    /// Submission disabled
+    Disabled,
 }
 
 pub trait SolverMetrics: Send + Sync {
@@ -322,6 +324,7 @@ impl SolverMetrics for Metrics {
             SettlementSubmissionOutcome::Timeout => "timeout",
             SettlementSubmissionOutcome::Cancel => "cancel",
             SettlementSubmissionOutcome::SimulationRevert => "simulationrevert",
+            SettlementSubmissionOutcome::Disabled => "disabled",
         };
         self.settlement_submissions
             .with_label_values(&[result, solver])

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -51,6 +51,8 @@ pub enum SettlementSubmissionOutcome {
     Cancel,
     /// Submission disabled
     Disabled,
+    /// General message for failures (for example, failing to connect to client node)
+    Failed,
 }
 
 pub trait SolverMetrics: Send + Sync {
@@ -325,6 +327,7 @@ impl SolverMetrics for Metrics {
             SettlementSubmissionOutcome::Cancel => "cancel",
             SettlementSubmissionOutcome::SimulationRevert => "simulationrevert",
             SettlementSubmissionOutcome::Disabled => "disabled",
+            SettlementSubmissionOutcome::Failed => "failed",
         };
         self.settlement_submissions
             .with_label_values(&[result, solver])

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -256,6 +256,11 @@ impl Settlement {
         let merged = self.encoder.merge(other.encoder)?;
         Ok(Self { encoder: merged })
     }
+
+    // Move to a separate struct to enable caching the result?
+    pub fn mev_extractable(&self) -> bool {
+        todo!()
+    }
 }
 
 impl From<Settlement> for EncodedSettlement {

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -259,7 +259,7 @@ impl Settlement {
 
     // Checks if the settlement is safe from MEV extraction
     pub fn mev_safe(&self) -> bool {
-        false
+        true
     }
 }
 

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -257,9 +257,9 @@ impl Settlement {
         Ok(Self { encoder: merged })
     }
 
-    // Move to a separate struct to enable caching the result?
-    pub fn mev_extractable(&self) -> bool {
-        todo!()
+    // Checks if the settlement is safe from MEV extraction
+    pub fn mev_safe(&self) -> bool {
+        false
     }
 }
 

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -90,11 +90,7 @@ impl SolutionSubmitter {
                                     )));
                                 }
                             }
-                            TransactionStrategy::CustomNodes(_) => {
-                                if settlement.mev_extractable() {
-                                    return Err(SubmissionError::Disabled(DisabledReason::CustomNodesDisabledMevExtractable));
-                                }
-                            }
+                            TransactionStrategy::CustomNodes(_) => {}
                             TransactionStrategy::DryRun => unreachable!(),
                         };
 

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -163,7 +163,7 @@ impl SubmissionError {
             Self::Revert => SettlementSubmissionOutcome::Revert,
             Self::Canceled => SettlementSubmissionOutcome::Cancel,
             Self::Disabled(_) => SettlementSubmissionOutcome::Disabled,
-            Self::Other(_) => SettlementSubmissionOutcome::SimulationRevert,
+            Self::Other(_) => SettlementSubmissionOutcome::Failed,
         }
     }
 

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -60,6 +60,18 @@ impl From<anyhow::Error> for SubmitApiError {
     }
 }
 
+#[derive(Debug)]
+pub enum SubmissionLoopStatus {
+    Enabled,
+    Disabled(DisabledReason),
+}
+
+#[derive(Debug)]
+pub enum DisabledReason {
+    EdenDisabledNetworkCongested,
+    CustomNodesDisabledMevExtractable,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct TransactionHandle {
     pub handle: H256,
@@ -95,6 +107,8 @@ pub trait TransactionSubmitting: Send + Sync {
         address: &H160,
         nonce: U256,
     ) -> Result<Option<EstimatedGasPrice>>;
+    /// Checks if transaction submitting is enabled at the moment
+    fn submission_status(&self, gas_price: &EstimatedGasPrice) -> SubmissionLoopStatus;
 }
 
 /// Gas price estimator specialized for sending transactions to the network
@@ -324,6 +338,16 @@ impl<'a> Submitter<'a> {
                     continue;
                 }
             };
+
+            // before submitting, check if the currently executing strategy is temporarily disabled
+
+            if let SubmissionLoopStatus::Disabled(reason) =
+                self.submit_api.submission_status(&gas_price)
+            {
+                tracing::debug!("strategy temporarily disabled, reason: {:?}", reason);
+                tokio::time::sleep(params.retry_interval).await;
+                continue;
+            }
 
             // create transaction
 

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -68,7 +68,6 @@ pub enum SubmissionLoopStatus {
 
 #[derive(Debug)]
 pub enum DisabledReason {
-    EdenDisabledNetworkCongested,
     CustomNodesDisabledMevExtractable,
 }
 
@@ -108,7 +107,7 @@ pub trait TransactionSubmitting: Send + Sync {
         nonce: U256,
     ) -> Result<Option<EstimatedGasPrice>>;
     /// Checks if transaction submitting is enabled at the moment
-    fn submission_status(&self, gas_price: &EstimatedGasPrice) -> SubmissionLoopStatus;
+    fn submission_status(&self, settlement: &Settlement) -> SubmissionLoopStatus;
 }
 
 /// Gas price estimator specialized for sending transactions to the network
@@ -342,7 +341,7 @@ impl<'a> Submitter<'a> {
             // before submitting, check if the currently executing strategy is temporarily disabled
 
             if let SubmissionLoopStatus::Disabled(reason) =
-                self.submit_api.submission_status(&gas_price)
+                self.submit_api.submission_status(&settlement)
             {
                 tracing::debug!("strategy temporarily disabled, reason: {:?}", reason);
                 tokio::time::sleep(params.retry_interval).await;

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -43,6 +43,8 @@ pub struct SubmitterParams {
     pub deadline: Option<Instant>,
     /// Resimulate and resend transaction on every retry_interval seconds
     pub retry_interval: Duration,
+    /// Network id (mainnet, rinkeby, gnosis chain)
+    pub network_id: String,
 }
 
 #[derive(Debug)]
@@ -107,7 +109,7 @@ pub trait TransactionSubmitting: Send + Sync {
         nonce: U256,
     ) -> Result<Option<EstimatedGasPrice>>;
     /// Checks if transaction submitting is enabled at the moment
-    fn submission_status(&self, settlement: &Settlement) -> SubmissionLoopStatus;
+    fn submission_status(&self, settlement: &Settlement, network_id: &str) -> SubmissionLoopStatus;
 }
 
 /// Gas price estimator specialized for sending transactions to the network
@@ -340,8 +342,9 @@ impl<'a> Submitter<'a> {
 
             // before submitting, check if the currently executing strategy is temporarily disabled
 
-            if let SubmissionLoopStatus::Disabled(reason) =
-                self.submit_api.submission_status(&settlement)
+            if let SubmissionLoopStatus::Disabled(reason) = self
+                .submit_api
+                .submission_status(&settlement, &params.network_id)
             {
                 tracing::debug!("strategy temporarily disabled, reason: {:?}", reason);
                 tokio::time::sleep(params.retry_interval).await;
@@ -558,6 +561,7 @@ mod tests {
             gas_estimate,
             deadline: Some(Instant::now() + Duration::from_secs(90)),
             retry_interval: Duration::from_secs(5),
+            network_id: "1".to_string(),
         };
         let result = submitter.submit(settlement, params).await;
         tracing::info!("finished with result {:?}", result);

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -68,7 +68,7 @@ pub enum SubmissionLoopStatus {
 
 #[derive(Debug)]
 pub enum DisabledReason {
-    CustomNodesDisabledMevExtractable,
+    MevExtractable,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -2,7 +2,7 @@ use crate::pending_transactions::Fee;
 
 use super::{
     super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
-    CancelHandle,
+    CancelHandle, SubmissionLoopStatus,
 };
 use anyhow::{Context, Result};
 use ethcontract::{
@@ -117,5 +117,9 @@ impl TransactionSubmitting for CustomNodesApi {
                 ..Default::default()
             })),
         }
+    }
+
+    fn submission_status(&self, _gas_price: &EstimatedGasPrice) -> SubmissionLoopStatus {
+        SubmissionLoopStatus::Enabled
     }
 }

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -119,8 +119,9 @@ impl TransactionSubmitting for CustomNodesApi {
         }
     }
 
-    fn submission_status(&self, settlement: &Settlement) -> SubmissionLoopStatus {
-        if !settlement.mev_safe() {
+    fn submission_status(&self, settlement: &Settlement, network_id: &str) -> SubmissionLoopStatus {
+        // disable strategy if not mev safe (check done only for mainnet)
+        if !settlement.mev_safe() && shared::gas_price_estimation::is_mainnet(network_id) {
             return SubmissionLoopStatus::Disabled(DisabledReason::MevExtractable);
         }
 

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -121,9 +121,7 @@ impl TransactionSubmitting for CustomNodesApi {
 
     fn submission_status(&self, settlement: &Settlement) -> SubmissionLoopStatus {
         if !settlement.mev_safe() {
-            return SubmissionLoopStatus::Disabled(
-                DisabledReason::CustomNodesDisabledMevExtractable,
-            );
+            return SubmissionLoopStatus::Disabled(DisabledReason::MevExtractable);
         }
 
         SubmissionLoopStatus::Enabled

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -1,8 +1,8 @@
-use crate::pending_transactions::Fee;
+use crate::{pending_transactions::Fee, settlement::Settlement};
 
 use super::{
     super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
-    CancelHandle, SubmissionLoopStatus,
+    CancelHandle, DisabledReason, SubmissionLoopStatus,
 };
 use anyhow::{Context, Result};
 use ethcontract::{
@@ -119,7 +119,13 @@ impl TransactionSubmitting for CustomNodesApi {
         }
     }
 
-    fn submission_status(&self, _gas_price: &EstimatedGasPrice) -> SubmissionLoopStatus {
+    fn submission_status(&self, settlement: &Settlement) -> SubmissionLoopStatus {
+        if !settlement.mev_safe() {
+            return SubmissionLoopStatus::Disabled(
+                DisabledReason::CustomNodesDisabledMevExtractable,
+            );
+        }
+
         SubmissionLoopStatus::Enabled
     }
 }

--- a/crates/solver/src/settlement_submission/submitter/eden_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/eden_api.rs
@@ -57,7 +57,11 @@ impl TransactionSubmitting for EdenApi {
         Ok(None)
     }
 
-    fn submission_status(&self, _settlement: &Settlement) -> SubmissionLoopStatus {
+    fn submission_status(
+        &self,
+        _settlement: &Settlement,
+        _network_id: &str,
+    ) -> SubmissionLoopStatus {
         SubmissionLoopStatus::Enabled
     }
 }

--- a/crates/solver/src/settlement_submission/submitter/eden_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/eden_api.rs
@@ -2,7 +2,7 @@
 
 use super::{
     super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
-    CancelHandle,
+    CancelHandle, DisabledReason, SubmissionLoopStatus,
 };
 use anyhow::{Context, Result};
 use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder, H160, U256};
@@ -53,5 +53,14 @@ impl TransactionSubmitting for EdenApi {
         _nonce: U256,
     ) -> Result<Option<EstimatedGasPrice>> {
         Ok(None)
+    }
+
+    fn submission_status(&self, gas_price: &EstimatedGasPrice) -> SubmissionLoopStatus {
+        if gas_price.effective_gas_price() < 500. {
+            //500 as argument?
+            SubmissionLoopStatus::Enabled
+        } else {
+            SubmissionLoopStatus::Disabled(DisabledReason::EdenDisabledNetworkCongested)
+        }
     }
 }

--- a/crates/solver/src/settlement_submission/submitter/eden_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/eden_api.rs
@@ -1,8 +1,10 @@
 //! https://docs.edennetwork.io/for-traders/getting-started
 
+use crate::settlement::Settlement;
+
 use super::{
     super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
-    CancelHandle, DisabledReason, SubmissionLoopStatus,
+    CancelHandle, SubmissionLoopStatus,
 };
 use anyhow::{Context, Result};
 use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder, H160, U256};
@@ -55,12 +57,7 @@ impl TransactionSubmitting for EdenApi {
         Ok(None)
     }
 
-    fn submission_status(&self, gas_price: &EstimatedGasPrice) -> SubmissionLoopStatus {
-        if gas_price.effective_gas_price() < 500. {
-            //500 as argument?
-            SubmissionLoopStatus::Enabled
-        } else {
-            SubmissionLoopStatus::Disabled(DisabledReason::EdenDisabledNetworkCongested)
-        }
+    fn submission_status(&self, _settlement: &Settlement) -> SubmissionLoopStatus {
+        SubmissionLoopStatus::Enabled
     }
 }

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -50,7 +50,11 @@ impl TransactionSubmitting for FlashbotsApi {
         Ok(None)
     }
 
-    fn submission_status(&self, _settlement: &Settlement) -> SubmissionLoopStatus {
+    fn submission_status(
+        &self,
+        _settlement: &Settlement,
+        _network_id: &str,
+    ) -> SubmissionLoopStatus {
         SubmissionLoopStatus::Enabled
     }
 }

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -1,3 +1,5 @@
+use crate::settlement::Settlement;
+
 use super::{
     super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
     CancelHandle, SubmissionLoopStatus,
@@ -48,7 +50,7 @@ impl TransactionSubmitting for FlashbotsApi {
         Ok(None)
     }
 
-    fn submission_status(&self, _gas_price: &EstimatedGasPrice) -> SubmissionLoopStatus {
+    fn submission_status(&self, _settlement: &Settlement) -> SubmissionLoopStatus {
         SubmissionLoopStatus::Enabled
     }
 }

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -1,6 +1,6 @@
 use super::{
     super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
-    CancelHandle,
+    CancelHandle, SubmissionLoopStatus,
 };
 use anyhow::{Context, Result};
 use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder, H160, U256};
@@ -46,5 +46,9 @@ impl TransactionSubmitting for FlashbotsApi {
         _nonce: U256,
     ) -> Result<Option<EstimatedGasPrice>> {
         Ok(None)
+    }
+
+    fn submission_status(&self, _gas_price: &EstimatedGasPrice) -> SubmissionLoopStatus {
+        SubmissionLoopStatus::Enabled
     }
 }


### PR DESCRIPTION
Copy of https://github.com/gnosis/gp-v2-services/pull/1525 (tried to merge with main and resolve conflicts but got strange build errors)

This PR implements task 4 from: https://github.com/gnosis/gp-v2-services/issues/1407 and also https://github.com/gnosis/gp-v2-services/issues/1538

The point of this PR is to be able to select one or multiple transaction strategies dynamically, based on the different attributes of the Settlement. Right now, the only attribute of interest is if the Settlement is MEV Safe. Additional atributes could be taken into consideration in the future:
1. Disable Eden and CustomNodes if gas price > 500
2. Disable Eden if tx.gas > 1.5M (Eden rpc constraint)
3. ... etc

The idea is following:
1. All transaction strategies that are considered are received on program start up (`transaction_strategy` argument). I expect the default to be Flashbots + Eden + CustomNodes
2. In each submission loop, Settlement is checked if it is MEV Safe (theoretically needs to be checked in every loop, since Ethereum State changes block by block, therefore our Settlement could change from MEV Safe to MEV Unsafe, if for example, Settlement touches the liquidity pool and in the next block large portion of the liquidity is removed from the pool). Based on the result, CustomNodes strategy is enabled(if MEV Safe)/disabled(if not MEV Safe), while Flashbots and Eden are always enabled.

MEV Safe check is the hard part and it will be handled in the following PR.