### PR TITLE
change default value for parameter submission_retry_interval_seconds

### DIFF
--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -242,7 +242,7 @@ struct Arguments {
     /// Amount of time to wait before retrying to submit the tx to the ethereum network
     #[clap(
         long,
-        default_value = "5",
+        default_value = "2",
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
     submission_retry_interval_seconds: Duration,


### PR DESCRIPTION
We have been running with this setting for a while on staging, and since everything is ok, I want to make this change permanent.

Also, this change will affect prod (currently the value on prod is 5).

Also, after this PR is merged I will remove the parameter from our gitlab staging repo.
