### PR TITLE
Add NativePriceEstimator

### DIFF
--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -133,6 +133,24 @@ pub async fn ensure_token_supported(
     }
 }
 
+#[mockall::automock]
+#[async_trait::async_trait]
+pub trait NativePriceEstimating: Send + Sync {
+    async fn estimate_native_price(&self, token: &H160) -> Result<f64, PriceEstimationError> {
+        self.estimate_native_prices(std::slice::from_ref(token))
+            .await
+            .into_iter()
+            .next()
+            .unwrap()
+    }
+
+    /// Returns one result for each query.
+    async fn estimate_native_prices(
+        &self,
+        tokens: &[H160],
+    ) -> Vec<Result<f64, PriceEstimationError>>;
+}
+
 pub fn amounts_to_price(sell_amount: U256, buy_amount: U256) -> Option<BigRational> {
     if buy_amount.is_zero() {
         return None;

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -97,6 +97,8 @@ impl Estimate {
         amounts_to_price(sell_amount, buy_amount)
     }
 
+    /// The resulting price is how many units of sell_token needs to be sold for one unit of
+    /// buy_token (sell_amount / buy_amount).
     pub fn price_in_sell_token_f64(&self, query: &Query) -> f64 {
         let (sell_amount, buy_amount) = self.amounts(query);
         sell_amount.to_f64_lossy() / buy_amount.to_f64_lossy()
@@ -132,24 +134,6 @@ pub async fn ensure_token_supported(
         }
         Err(err) => Err(PriceEstimationError::Other(err)),
     }
-}
-
-#[mockall::automock]
-#[async_trait::async_trait]
-pub trait NativePriceEstimating: Send + Sync {
-    async fn estimate_native_price(&self, token: &H160) -> Result<f64, PriceEstimationError> {
-        self.estimate_native_prices(std::slice::from_ref(token))
-            .await
-            .into_iter()
-            .next()
-            .unwrap()
-    }
-
-    /// Returns one result for each query.
-    async fn estimate_native_prices(
-        &self,
-        tokens: &[H160],
-    ) -> Vec<Result<f64, PriceEstimationError>>;
 }
 
 pub fn amounts_to_price(sell_amount: U256, buy_amount: U256) -> Option<BigRational> {

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -3,6 +3,7 @@ pub mod cached;
 pub mod competition;
 pub mod gas;
 pub mod instrumented;
+pub mod native;
 pub mod oneinch;
 pub mod paraswap;
 pub mod priority;

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -1,7 +1,29 @@
-use super::{NativePriceEstimating, PriceEstimating, PriceEstimationError, Query};
+use super::{PriceEstimating, PriceEstimationError, Query};
 use model::order::OrderKind;
 use primitive_types::{H160, U256};
 use std::sync::Arc;
+
+#[mockall::automock]
+#[async_trait::async_trait]
+pub trait NativePriceEstimating: Send + Sync {
+    /// The resulting price is how many units of token needs to be sold for one unit of
+    /// the chain's native token (sell_amount / buy_amount).
+    async fn estimate_native_price(&self, token: &H160) -> Result<f64, PriceEstimationError> {
+        self.estimate_native_prices(std::slice::from_ref(token))
+            .await
+            .into_iter()
+            .next()
+            .unwrap()
+    }
+
+    /// The resulting price is how many units of token needs to be sold for one unit of
+    /// the chain's native token (sell_amount / buy_amount).
+    /// Returns one result for each query.
+    async fn estimate_native_prices(
+        &self,
+        tokens: &[H160],
+    ) -> Vec<Result<f64, PriceEstimationError>>;
+}
 
 /// Wrapper around price estimators specialized to estimate a token's price compared to the current
 /// chain's native token.

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -1,0 +1,55 @@
+use super::{NativePriceEstimating, PriceEstimating, PriceEstimationError, Query};
+use model::order::OrderKind;
+use primitive_types::{H160, U256};
+use std::sync::Arc;
+
+/// Wrapper around price estimators specialized to estimate a token's price compared to the current
+/// chain's native token.
+pub struct NativePriceEstimator {
+    inner: Arc<dyn PriceEstimating>,
+    native_token: H160,
+    price_estimation_amount: U256,
+}
+
+impl NativePriceEstimator {
+    pub fn new(
+        inner: Arc<dyn PriceEstimating>,
+        native_token: H160,
+        price_estimation_amount: U256,
+    ) -> Self {
+        Self {
+            inner,
+            native_token,
+            price_estimation_amount,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl NativePriceEstimating for NativePriceEstimator {
+    async fn estimate_native_prices(
+        &self,
+        tokens: &[H160],
+    ) -> Vec<Result<f64, PriceEstimationError>> {
+        let native_token_queries: Vec<_> = tokens
+            .iter()
+            .map(|token| Query {
+                sell_token: *token,
+                buy_token: self.native_token,
+                in_amount: self.price_estimation_amount,
+                kind: OrderKind::Buy,
+            })
+            .collect();
+
+        let estimates = self.inner.estimates(&native_token_queries).await;
+
+        estimates
+            .into_iter()
+            .zip(native_token_queries.iter())
+            .map(|(estimate, query)| {
+                estimate.map(|estimate| estimate.price_in_sell_token_f64(query))
+            })
+            .collect()
+    }
+}
+


### PR DESCRIPTION
Related: #1615

To make it more convenient to estimate prices, I added a new trait `NativePriceEstimating` and a wrapper around `Arc<dyn PriceEstimating` which implements the new trait for the wrapped price estimator.
This component is not yet in use but a follow up PR shall change that and make the `MinFeeCalculator` use it.

### Test Plan
Unit test for new component
