### PR TITLE
Do not use join_all in 1Inch price estimator

### DIFF
--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -2,7 +2,6 @@ use super::gas;
 use crate::oneinch_api::{OneInchClient, ProtocolCache, RestResponse, SellOrderQuoteQuery};
 use crate::price_estimation::{Estimate, PriceEstimating, PriceEstimationError, Query};
 use anyhow::Result;
-use futures::future;
 use model::order::OrderKind;
 use primitive_types::U256;
 use std::sync::Arc;
@@ -72,12 +71,11 @@ impl PriceEstimating for OneInchPriceEstimator {
             a SanitizedPriceEstimator"
         );
 
-        future::join_all(
-            queries
-                .iter()
-                .map(|query| async move { self.estimate(query).await }),
-        )
-        .await
+        let mut results = Vec::with_capacity(queries.len());
+        for query in queries {
+            results.push(self.estimate(query).await);
+        }
+        results
     }
 }
 

--- a/crates/shared/src/price_estimation/paraswap.rs
+++ b/crates/shared/src/price_estimation/paraswap.rs
@@ -83,8 +83,7 @@ impl PriceEstimating for ParaswapPriceEstimator {
             .into_iter()
             .collect::<Vec<_>>();
         let token_infos = self.token_info.get_token_infos(&tokens).await;
-        // TODO: concurrency?
-        let mut results = Vec::new();
+        let mut results = Vec::with_capacity(queries.len());
         for query in queries {
             results.push(self.estimate_(query, &token_infos).await);
         }

--- a/crates/shared/src/price_estimation/zeroex.rs
+++ b/crates/shared/src/price_estimation/zeroex.rs
@@ -53,7 +53,6 @@ impl PriceEstimating for ZeroExPriceEstimator {
         }));
 
         let mut results = Vec::with_capacity(queries.len());
-
         for query in queries {
             results.push(self.estimate(query).await);
         }


### PR DESCRIPTION
The `estimates` functions is meant to allow more efficient estimating
when the estimator can evalute several queries together as is the case
for the baseline estimator.
For the external estimators whose api only allows single estimates at a
time there is no such efficiency gain. The 1inch estimator was
nonetheless doing all price estimation calls in parallel. This is
problematic when there are a large amount of queries as it would likely
look like a DOS to their backend.
For now I decided to ensure that all of the external estimators work the same way.
In the future we could decide to allow some fixed level of
parallelness like max 3 requests at the same time.

Related to https://github.com/gnosis/gp-v2-services/pull/1619
