### PR TITLE
Composed estimator hierarchy for cached native price estimations

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -87,7 +87,7 @@ pub fn uniswap_pair_provider(contracts: &Contracts) -> PairProvider {
 }
 
 pub struct OrderbookServices {
-    pub price_estimator: Arc<SanitizedPriceEstimator<BaselinePriceEstimator>>,
+    pub price_estimator: Arc<SanitizedPriceEstimator>,
     pub maintenance: ServiceMaintenance,
     pub block_stream: CurrentBlockStream,
     pub solvable_orders_cache: Arc<SolvableOrdersCache>,
@@ -126,13 +126,13 @@ impl OrderbookServices {
         let bad_token_detector = Arc::new(ListBasedDetector::deny_list(Vec::new()));
         let base_tokens = Arc::new(BaseTokens::new(contracts.weth.address(), &[]));
         let price_estimator = Arc::new(SanitizedPriceEstimator::new(
-            BaselinePriceEstimator::new(
+            Arc::new(BaselinePriceEstimator::new(
                 Arc::new(pool_fetcher),
                 gas_estimator.clone(),
                 base_tokens.clone(),
                 contracts.weth.address(),
                 1_000_000_000_000_000_000_u128.into(),
-            ),
+            )),
             contracts.weth.address(),
             bad_token_detector.clone(),
         ));

--- a/crates/shared/src/price_estimation/sanitized.rs
+++ b/crates/shared/src/price_estimation/sanitized.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 
 /// Verifies that buy and sell tokens are supported and handles
 /// ETH as buy token appropriately.
-pub struct SanitizedPriceEstimator<T: PriceEstimating> {
-    inner: T,
+pub struct SanitizedPriceEstimator {
+    inner: Arc<dyn PriceEstimating>,
     bad_token_detector: Arc<dyn BadTokenDetecting>,
     native_token: H160,
 }
@@ -23,9 +23,9 @@ enum EstimationProgress<'a> {
     AwaitingErc20Estimation,
 }
 
-impl<T: PriceEstimating> SanitizedPriceEstimator<T> {
+impl SanitizedPriceEstimator {
     pub fn new(
-        inner: T,
+        inner: Arc<dyn PriceEstimating>,
         native_token: H160,
         bad_token_detector: Arc<dyn BadTokenDetecting>,
     ) -> Self {
@@ -70,7 +70,7 @@ impl<T: PriceEstimating> SanitizedPriceEstimator<T> {
 }
 
 #[async_trait::async_trait]
-impl<T: PriceEstimating> PriceEstimating for SanitizedPriceEstimator<T> {
+impl PriceEstimating for SanitizedPriceEstimator {
     // This function will estimate easy queries on its own and forward "difficult" queries to the
     // inner estimator. When the inner estimator did its job, solutions get merged back together
     // while preserving the correct order.
@@ -303,7 +303,7 @@ mod tests {
             });
 
         let sanitized_estimator = SanitizedPriceEstimator {
-            inner: wrapped_estimator,
+            inner: Arc::new(wrapped_estimator),
             bad_token_detector: Arc::new(bad_token_detector),
             native_token,
         };


### PR DESCRIPTION
Since #1619 triggered a discussion about the viability of the approach of composing a new native price estimator entirely from existing components, I wanted to share what I got so far.

The current code already highlights one weird thing with reusing the `CachingPriceEstimator`:
The `CachingPriceEstimator` as well as the task maintaining it in the background need to be parameterized a little bit different but not that different that it would make much sense introducing more CLI arguments for that.

Note creating the new estimator hierarchy is quite verbose but relatively painless in this approach but optimizing the task to maintain the cache in the background further would probably end up quite hacky.