### PR TITLE
update cargo lock for gp-gas-estimation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,7 +1066,7 @@ dependencies = [
 [[package]]
 name = "gas-estimation"
 version = "0.1.0"
-source = "git+https://github.com/gnosis/gp-gas-estimation.git?tag=v0.4.4#5c7928fef84fd797fe66da735e52361d5fa6ca01"
+source = "git+https://github.com/gnosis/gp-gas-estimation.git?tag=v0.4.4#1a3f898cfe3aeac1ff54f632559fb2773db10079"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
Updated only cargo lock file, since v0.4.4 tag is reused for newer commit hash.

Fixes https://github.com/gnosis/gp-gas-estimation/pull/28