### PR TITLE
change the additional-tip calculation

### DIFF
--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -229,7 +229,8 @@ async fn eth_integration(web3: Web3) {
             transaction_strategies: vec![
                 solver::settlement_submission::TransactionStrategy::CustomNodes(StrategyArgs {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
-                    additional_tip: 0.0,
+                    max_additional_tip: 0.,
+                    additional_tip_percentage_of_max_fee: 0.,
                 }),
             ],
         },

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -234,7 +234,8 @@ async fn onchain_settlement(web3: Web3) {
             transaction_strategies: vec![
                 solver::settlement_submission::TransactionStrategy::CustomNodes(StrategyArgs {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
-                    additional_tip: 0.0,
+                    max_additional_tip: 0.,
+                    additional_tip_percentage_of_max_fee: 0.,
                 }),
             ],
         },

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -223,7 +223,8 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             transaction_strategies: vec![
                 solver::settlement_submission::TransactionStrategy::CustomNodes(StrategyArgs {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
-                    additional_tip: 0.0,
+                    max_additional_tip: 0.,
+                    additional_tip_percentage_of_max_fee: 0.,
                 }),
             ],
         },

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -192,7 +192,8 @@ async fn smart_contract_orders(web3: Web3) {
             transaction_strategies: vec![
                 solver::settlement_submission::TransactionStrategy::CustomNodes(StrategyArgs {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
-                    additional_tip: 0.0,
+                    max_additional_tip: 0.,
+                    additional_tip_percentage_of_max_fee: 0.,
                 }),
             ],
         },

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -174,7 +174,8 @@ async fn vault_balances(web3: Web3) {
             transaction_strategies: vec![
                 solver::settlement_submission::TransactionStrategy::CustomNodes(StrategyArgs {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
-                    additional_tip: 0.0,
+                    max_additional_tip: 0.,
+                    additional_tip_percentage_of_max_fee: 0.,
                 }),
             ],
         },

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -35,7 +35,8 @@ pub struct SolutionSubmitter {
 
 pub struct StrategyArgs {
     pub submit_api: Box<dyn TransactionSubmitting>,
-    pub additional_tip: f64,
+    pub max_additional_tip: f64,
+    pub additional_tip_percentage_of_max_fee: f64,
 }
 pub enum TransactionStrategy {
     Eden(StrategyArgs),
@@ -101,8 +102,9 @@ impl SolutionSubmitter {
                         };
                         let gas_price_estimator = SubmitterGasPriceEstimator {
                             inner: self.gas_price_estimator.as_ref(),
-                            additional_tip: Some(strategy_args.additional_tip),
                             gas_price_cap: self.gas_price_cap,
+                            additional_tip_percentage_of_max_fee: Some(strategy_args.additional_tip_percentage_of_max_fee),
+                            max_additional_tip: Some(strategy_args.max_additional_tip),
                         };
                         let submitter = Submitter::new(
                             &self.contract,
@@ -230,7 +232,8 @@ mod tests {
         fn default() -> Self {
             Self {
                 submit_api: Box::new(MockTransactionSubmitting::new()),
-                additional_tip: Default::default(),
+                max_additional_tip: Default::default(),
+                additional_tip_percentage_of_max_fee: Default::default(),
             }
         }
     }

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -32,9 +32,6 @@ use shared::Web3;
 use std::time::{Duration, Instant};
 use web3::types::{TransactionReceipt, U64};
 
-/// Used for calculating the maximum additional tip based on the current value of max_fee_per_gas
-const MAX_FEE_PER_GAS_PERCENT: f64 = 0.05; //5%
-
 /// Parameters for transaction submitting
 #[derive(Clone, Default)]
 pub struct SubmitterParams {
@@ -103,8 +100,10 @@ pub trait TransactionSubmitting: Send + Sync {
 /// Gas price estimator specialized for sending transactions to the network
 pub struct SubmitterGasPriceEstimator<'a> {
     pub inner: &'a dyn GasPriceEstimating,
-    /// Boost estimated gas price miner tip in order to increase the chances of a transaction being mined
-    pub additional_tip: Option<f64>,
+    /// Additionally increase max_priority_fee_per_gas by percentage of max_fee_per_gas, in order to increase the chances of a transaction being mined
+    pub additional_tip_percentage_of_max_fee: Option<f64>,
+    /// Maximum max_priority_fee_per_gas additional increase
+    pub max_additional_tip: Option<f64>,
     /// Maximum max_fee_per_gas to pay for a transaction
     pub gas_price_cap: f64,
 }
@@ -120,10 +119,13 @@ impl GasPriceEstimating for SubmitterGasPriceEstimator<'_> {
             Ok(mut gas_price) if gas_price.cap() <= self.gas_price_cap => {
                 // boost miner tip to increase our chances of being included in a block
                 if let Some(ref mut eip1559) = gas_price.eip1559 {
-                    eip1559.max_priority_fee_per_gas += self
-                        .additional_tip
-                        .unwrap_or_default()
-                        .min(eip1559.max_fee_per_gas * MAX_FEE_PER_GAS_PERCENT);
+                    eip1559.max_priority_fee_per_gas +=
+                        self.max_additional_tip.unwrap_or_default().min(
+                            eip1559.max_fee_per_gas
+                                * self
+                                    .additional_tip_percentage_of_max_fee
+                                    .unwrap_or_default(),
+                        );
                 }
                 Ok(gas_price)
             }
@@ -514,8 +516,9 @@ mod tests {
         .unwrap();
         let gas_price_estimator = SubmitterGasPriceEstimator {
             inner: &gas_price_estimator,
-            additional_tip: Some(3.0),
+            max_additional_tip: Some(3.0),
             gas_price_cap: 100e9,
+            additional_tip_percentage_of_max_fee: Some(0.05),
         };
 
         let settlement = Settlement::new(Default::default());


### PR DESCRIPTION
Alex noticed that with the current network conditions (gas price ~ 50Gwei) we might be overpaying the Flashbots, giving them fixed 7Gwei tip increase.

This PR aims at lowering the additional tip in low gas price network conditions.
