### PR TITLE
Print earned fee in driver

### DIFF
--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -240,6 +240,7 @@ async fn eth_integration(web3: Web3) {
         create_order_converter(&web3, contracts.weth.address()),
         0.0,
         15000000u128,
+        1.0,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -245,6 +245,7 @@ async fn onchain_settlement(web3: Web3) {
         create_order_converter(&web3, contracts.weth.address()),
         0.0,
         15000000u128,
+        1.0,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -234,6 +234,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         create_order_converter(&web3, contracts.weth.address()),
         0.0,
         15000000u128,
+        1.0,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -203,6 +203,7 @@ async fn smart_contract_orders(web3: Web3) {
         create_order_converter(&web3, contracts.weth.address()),
         0.0,
         15000000u128,
+        1.0,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -185,6 +185,7 @@ async fn vault_balances(web3: Web3) {
         create_order_converter(&web3, contracts.weth.address()),
         0.0,
         15000000u128,
+        1.0,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -635,6 +635,9 @@ components:
         status:
           description: Order status
           $ref: "#/components/schemas/OrderStatus"
+        fullFeeAmount:
+          description: "Amount that the signed fee would be without subsidies"
+          $ref: "#/components/schemas/TokenAmount"
       required:
         - creationTime
         - owner

--- a/crates/solver/src/driver/solver_settlements.rs
+++ b/crates/solver/src/driver/solver_settlements.rs
@@ -18,11 +18,14 @@ pub fn has_user_order(settlement: &Settlement) -> bool {
 // Each individual settlement has an objective value.
 #[derive(Debug, Clone)]
 pub struct RatedSettlement {
+    // Identifies a settlement during a run loop.
+    pub id: usize,
     pub settlement: Settlement,
-    pub surplus: BigRational,     // In wei.
-    pub solver_fees: BigRational, // In wei.
-    pub gas_estimate: U256,       // In gas units.
-    pub gas_price: BigRational,   // In wei per gas unit.
+    pub surplus: BigRational,                 // In wei.
+    pub unscaled_subsidized_fee: BigRational, // In wei.
+    pub scaled_unsubsidized_fee: BigRational, // In wei.
+    pub gas_estimate: U256,                   // In gas units.
+    pub gas_price: BigRational,               // In wei per gas unit.
 }
 
 // Helper function for RatedSettlement to allow unit testing objective value computation
@@ -42,7 +45,7 @@ impl RatedSettlement {
         let gas_estimate = self.gas_estimate.to_big_rational();
         compute_objective_value(
             &self.surplus,
-            &self.solver_fees,
+            &self.scaled_unsubsidized_fee,
             &gas_estimate,
             &self.gas_price,
         )

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -72,14 +72,14 @@ pub struct LimitOrder {
     pub buy_amount: U256,
     pub kind: OrderKind,
     pub partially_fillable: bool,
-    pub fee_amount: U256,
+    pub unscaled_subsidized_fee: U256,
     /// The scaled fee amount that the protocol pretends it is receiving.
     ///
-    /// This is different than the actual order `fee_amount` value in that it
+    /// This is different than the actual signed fee in that it
     /// does not have any subsidies applied and may be scaled by a constant
     /// factor to make matching orders more valuable from an objective value
     /// perspective.
-    pub scaled_fee_amount: U256,
+    pub scaled_unsubsidized_fee: U256,
     pub is_liquidity_order: bool,
     #[cfg_attr(test, derivative(PartialEq = "ignore"))]
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
@@ -126,8 +126,8 @@ impl Default for LimitOrder {
             buy_amount: Default::default(),
             kind: Default::default(),
             partially_fillable: Default::default(),
-            fee_amount: Default::default(),
-            scaled_fee_amount: Default::default(),
+            unscaled_subsidized_fee: Default::default(),
+            scaled_unsubsidized_fee: Default::default(),
             settlement_handling: tests::CapturingSettlementHandler::arc(),
             is_liquidity_order: false,
             id: Default::default(),

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -83,7 +83,6 @@ impl SettlementHandling<LimitOrder> for OrderSettlementHandler {
         let trade = encoder.add_trade(
             self.order.clone(),
             executed_amount,
-            self.order.order_creation.fee_amount,
             self.scaled_unsubsidized_fee_amount,
             self.is_liquidity_order,
         )?;
@@ -227,7 +226,7 @@ pub mod tests {
                     amount: executed_buy_amount,
                 });
                 assert!(encoder
-                    .add_trade(order, executed_amount, scaled_fee_amount, 0.into(), false)
+                    .add_trade(order, executed_amount, scaled_fee_amount, false)
                     .is_ok());
             },
         );
@@ -271,7 +270,7 @@ pub mod tests {
                     .add_token_equivalency(native_token.address(), BUY_ETH_ADDRESS)
                     .unwrap();
                 assert!(encoder
-                    .add_trade(order, executed_amount, 0.into(), 0.into(), false)
+                    .add_trade(order, executed_amount, 0.into(), false)
                     .is_ok());
                 encoder.add_unwrap(UnwrapWethInteraction {
                     weth: native_token,
@@ -318,7 +317,7 @@ pub mod tests {
             executed_amount,
             |encoder| {
                 assert!(encoder
-                    .add_trade(order, executed_amount, 0.into(), 0.into(), false)
+                    .add_trade(order, executed_amount, 0.into(), false)
                     .is_ok());
             },
         );

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -665,6 +665,7 @@ async fn main() {
         order_converter,
         args.weth_unwrap_factor,
         args.simulation_gas_limit,
+        args.fee_objective_scaling_factor,
     );
 
     let maintainer = ServiceMaintenance {

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -18,7 +18,8 @@ pub struct Trade {
     pub sell_token_index: usize,
     pub buy_token_index: usize,
     pub executed_amount: U256,
-    pub scaled_fee_amount: U256,
+    pub unscaled_subsidized_fee: U256,
+    pub scaled_unsubsidized_fee: U256,
     pub is_liquidity_order: bool,
 }
 
@@ -78,7 +79,11 @@ impl Trade {
     /// Returns the scaled unsubsidized fee amount that should be used for
     /// objective value computation.
     pub fn executed_scaled_unsubsidized_fee(&self) -> Option<U256> {
-        self.compute_fee_execution(self.scaled_fee_amount)
+        self.compute_fee_execution(self.scaled_unsubsidized_fee)
+    }
+
+    pub fn executed_unscaled_subsidized_fee(&self) -> Option<U256> {
+        self.compute_fee_execution(self.unscaled_subsidized_fee)
     }
 
     fn compute_fee_execution(&self, fee_amount: U256) -> Option<U256> {
@@ -247,6 +252,23 @@ impl Settlement {
                 let fee_token_price =
                     external_prices.get(&trade.order.order_creation.sell_token)?;
                 Some(trade.executed_scaled_unsubsidized_fee()?.to_big_rational() * fee_token_price)
+            })
+            .sum()
+    }
+
+    // Computes the total scaled unsubsidized fee of all protocol trades (in wei ETH).
+    pub fn total_unscaled_subsidized_fees(
+        &self,
+        external_prices: &HashMap<H160, BigRational>,
+    ) -> BigRational {
+        self.encoder
+            .trades()
+            .iter()
+            .filter(|trade| !trade.is_liquidity_order)
+            .filter_map(|trade| {
+                let fee_token_price =
+                    external_prices.get(&trade.order.order_creation.sell_token)?;
+                Some(trade.executed_unscaled_subsidized_fee()?.to_big_rational() * fee_token_price)
             })
             .sum()
     }
@@ -871,7 +893,7 @@ pub mod tests {
             // Note that the scaled fee amount is different than the order's
             // signed fee amount. This happens for subsidized orders, and when
             // a fee objective scaling factor is configured.
-            scaled_fee_amount: 5.into(),
+            scaled_unsubsidized_fee: 5.into(),
             ..Default::default()
         };
         let trade1 = Trade {
@@ -886,7 +908,7 @@ pub mod tests {
                 ..Default::default()
             },
             executed_amount: 10.into(),
-            scaled_fee_amount: 2.into(),
+            scaled_unsubsidized_fee: 2.into(),
             ..Default::default()
         };
 
@@ -998,7 +1020,7 @@ pub mod tests {
                     },
                     executed_amount: 1.into(),
                     // This is what matters for the objective value
-                    scaled_fee_amount: 42.into(),
+                    scaled_unsubsidized_fee: 42.into(),
                     is_liquidity_order: false,
                     ..Default::default()
                 },
@@ -1016,7 +1038,7 @@ pub mod tests {
                     },
                     executed_amount: 1.into(),
                     // Doesn't count because it is a "liquidity order"
-                    scaled_fee_amount: 1337.into(),
+                    scaled_unsubsidized_fee: 1337.into(),
                     is_liquidity_order: true,
                     ..Default::default()
                 },
@@ -1050,7 +1072,7 @@ pub mod tests {
                     ..Default::default()
                 },
                 executed_amount: 99760667014_u128.into(),
-                scaled_fee_amount: 239332986_u128.into(),
+                scaled_unsubsidized_fee: 239332986_u128.into(),
                 is_liquidity_order: false,
                 ..Default::default()
             }],
@@ -1077,7 +1099,7 @@ pub mod tests {
                         ..Default::default()
                     },
                     executed_amount: 99760667014_u128.into(),
-                    scaled_fee_amount: 239332986_u128.into(),
+                    scaled_unsubsidized_fee: 239332986_u128.into(),
                     is_liquidity_order: false,
                     ..Default::default()
                 },
@@ -1095,7 +1117,7 @@ pub mod tests {
                         ..Default::default()
                     },
                     executed_amount: 99760667014_u128.into(),
-                    scaled_fee_amount: 77577144_u128.into(),
+                    scaled_unsubsidized_fee: 77577144_u128.into(),
                     is_liquidity_order: true,
                     ..Default::default()
                 },

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -18,7 +18,6 @@ pub struct Trade {
     pub sell_token_index: usize,
     pub buy_token_index: usize,
     pub executed_amount: U256,
-    pub unscaled_subsidized_fee: U256,
     pub scaled_unsubsidized_fee: U256,
     pub is_liquidity_order: bool,
 }
@@ -83,7 +82,7 @@ impl Trade {
     }
 
     pub fn executed_unscaled_subsidized_fee(&self) -> Option<U256> {
-        self.compute_fee_execution(self.unscaled_subsidized_fee)
+        self.compute_fee_execution(self.order.order_creation.fee_amount)
     }
 
     fn compute_fee_execution(&self, fee_amount: U256) -> Option<U256> {

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -92,7 +92,6 @@ impl SettlementEncoder {
         &mut self,
         order: Order,
         executed_amount: U256,
-        unscaled_subsidized_fee: U256,
         scaled_unsubsidized_fee: U256,
         is_liquidity_order: bool,
     ) -> Result<TradeExecution> {
@@ -117,7 +116,6 @@ impl SettlementEncoder {
             sell_token_index,
             buy_token_index,
             executed_amount,
-            unscaled_subsidized_fee,
             scaled_unsubsidized_fee,
             is_liquidity_order,
         };
@@ -423,10 +421,10 @@ pub mod tests {
         });
 
         assert!(settlement
-            .add_trade(order0, 1.into(), 1.into(), 0.into(), false)
+            .add_trade(order0, 1.into(), 1.into(), false)
             .is_ok());
         assert!(settlement
-            .add_trade(order1, 1.into(), 0.into(), 0.into(), false)
+            .add_trade(order1, 1.into(), 0.into(), false)
             .is_ok());
     }
 
@@ -516,7 +514,6 @@ pub mod tests {
                 },
                 0.into(),
                 0.into(),
-                0.into(),
                 false,
             )
             .unwrap();
@@ -574,7 +571,7 @@ pub mod tests {
             .build();
         order13.order_meta_data.uid.0[0] = 0;
         encoder0
-            .add_trade(order13, 13.into(), 0.into(), 0.into(), false)
+            .add_trade(order13, 13.into(), 0.into(), false)
             .unwrap();
         encoder0.append_to_execution_plan(NoopInteraction {});
         encoder0.add_unwrap(UnwrapWethInteraction {
@@ -592,7 +589,7 @@ pub mod tests {
             .build();
         order24.order_meta_data.uid.0[0] = 1;
         encoder1
-            .add_trade(order24, 24.into(), 0.into(), 0.into(), false)
+            .add_trade(order24, 24.into(), 0.into(), false)
             .unwrap();
         encoder1.append_to_execution_plan(NoopInteraction {});
         encoder1.add_unwrap(UnwrapWethInteraction {
@@ -667,12 +664,12 @@ pub mod tests {
 
         let mut encoder0 = SettlementEncoder::new(prices.clone());
         encoder0
-            .add_trade(order13.clone(), 13.into(), 0.into(), 0.into(), false)
+            .add_trade(order13.clone(), 13.into(), 0.into(), false)
             .unwrap();
 
         let mut encoder1 = SettlementEncoder::new(prices);
         encoder1
-            .add_trade(order13, 24.into(), 0.into(), 0.into(), false)
+            .add_trade(order13, 24.into(), 0.into(), false)
             .unwrap();
 
         assert!(encoder0.merge(encoder1).is_err());
@@ -692,7 +689,7 @@ pub mod tests {
             .with_buy_amount(11.into())
             .build();
         encoder
-            .add_trade(order_1_3, 4.into(), 0.into(), 0.into(), false)
+            .add_trade(order_1_3, 4.into(), 0.into(), false)
             .unwrap();
 
         let weth = dummy_contract!(WETH9, token(2));

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -92,7 +92,8 @@ impl SettlementEncoder {
         &mut self,
         order: Order,
         executed_amount: U256,
-        scaled_fee_amount: U256,
+        unscaled_subsidized_fee: U256,
+        scaled_unsubsidized_fee: U256,
         is_liquidity_order: bool,
     ) -> Result<TradeExecution> {
         let sell_price = self
@@ -116,7 +117,8 @@ impl SettlementEncoder {
             sell_token_index,
             buy_token_index,
             executed_amount,
-            scaled_fee_amount,
+            unscaled_subsidized_fee,
+            scaled_unsubsidized_fee,
             is_liquidity_order,
         };
         let execution = trade
@@ -421,10 +423,10 @@ pub mod tests {
         });
 
         assert!(settlement
-            .add_trade(order0, 1.into(), 1.into(), false)
+            .add_trade(order0, 1.into(), 1.into(), 0.into(), false)
             .is_ok());
         assert!(settlement
-            .add_trade(order1, 1.into(), 0.into(), false)
+            .add_trade(order1, 1.into(), 0.into(), 0.into(), false)
             .is_ok());
     }
 
@@ -514,6 +516,7 @@ pub mod tests {
                 },
                 0.into(),
                 0.into(),
+                0.into(),
                 false,
             )
             .unwrap();
@@ -571,7 +574,7 @@ pub mod tests {
             .build();
         order13.order_meta_data.uid.0[0] = 0;
         encoder0
-            .add_trade(order13, 13.into(), 0.into(), false)
+            .add_trade(order13, 13.into(), 0.into(), 0.into(), false)
             .unwrap();
         encoder0.append_to_execution_plan(NoopInteraction {});
         encoder0.add_unwrap(UnwrapWethInteraction {
@@ -589,7 +592,7 @@ pub mod tests {
             .build();
         order24.order_meta_data.uid.0[0] = 1;
         encoder1
-            .add_trade(order24, 24.into(), 0.into(), false)
+            .add_trade(order24, 24.into(), 0.into(), 0.into(), false)
             .unwrap();
         encoder1.append_to_execution_plan(NoopInteraction {});
         encoder1.add_unwrap(UnwrapWethInteraction {
@@ -664,12 +667,12 @@ pub mod tests {
 
         let mut encoder0 = SettlementEncoder::new(prices.clone());
         encoder0
-            .add_trade(order13.clone(), 13.into(), 0.into(), false)
+            .add_trade(order13.clone(), 13.into(), 0.into(), 0.into(), false)
             .unwrap();
 
         let mut encoder1 = SettlementEncoder::new(prices);
         encoder1
-            .add_trade(order13, 24.into(), 0.into(), false)
+            .add_trade(order13, 24.into(), 0.into(), 0.into(), false)
             .unwrap();
 
         assert!(encoder0.merge(encoder1).is_err());
@@ -689,7 +692,7 @@ pub mod tests {
             .with_buy_amount(11.into())
             .build();
         encoder
-            .add_trade(order_1_3, 4.into(), 0.into(), false)
+            .add_trade(order_1_3, 4.into(), 0.into(), 0.into(), false)
             .unwrap();
 
         let weth = dummy_contract!(WETH9, token(2));

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -177,7 +177,7 @@ fn map_tokens_for_solver(orders: &[LimitOrder], liquidity: &[Liquidity]) -> Vec<
 
 fn order_fee(order: &LimitOrder) -> FeeModel {
     FeeModel {
-        amount: order.scaled_fee_amount,
+        amount: order.scaled_unsubsidized_fee,
         token: order.sell_token,
     }
 }


### PR DESCRIPTION
Part of https://github.com/gnosis/gp-v2-services/issues/1573

- Store the originally signed fee amount in several place
- Make the distinction clear between that fee (unscaled subsidized) and the scaled unsubsidized fee that is already used
- Log both fees in the driver

This is the minimum data we need to compare settlement transaction cost to expected cost. After we see that this data makes sense we might extend the way it is logged as part of the above issue.

### Test Plan

CI
