### PR TITLE
Make 1Inch pricing parameters more competive

### DIFF
--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -146,13 +146,12 @@ impl SellOrderQuoteQuery {
             to_token_address: buy_token,
             amount,
             protocols,
-            // Use at most 2 connector tokens
-            complexity_level: Some(Amount::new(2).unwrap()),
-            // Cap swap gas to 750K.
-            gas_limit: Some(Amount::new(750_000).unwrap()),
-            // Use only 3 main route for cheaper trades.
-            main_route_parts: Some(Amount::new(3).unwrap()),
-            parts: Some(Amount::new(3).unwrap()),
+            // Use max value instead of default
+            complexity_level: Some(Amount::new(3).unwrap()),
+            gas_limit: None,
+            // use max value instead of default
+            main_route_parts: Some(Amount::new(50).unwrap()),
+            parts: None,
             fee: None,
             gas_price: None,
             virtual_parts: None,


### PR DESCRIPTION
We no longer need to make sure 1Inch generates low gas cost trading routes.
Especially for big volume trades there often exists a trading route which yields an overall better price even if you consider higher gas costs.
To get the best prices I removed our default arguments which are below the 1Inch default and added values for `complexity_level` and `main_parts` which are bigger than 1Inch's defaults. Those parameters where the only ones which yielded higher prices compared to queries with their default values instead.
Note that growing the solution space by giving more generous query arguments also increases the runtime of the query which will result in higher latency for price estimations.
I tried to measure the runtime regression bu the variance between the runs were quite. Overall the latency regression seems worth the up to ~2% better prices for big volume trades.
The routes generated for smaller volume trades most of the time didn't change with the new parameters.

### Test Plan
Manual test
