### PR TITLE
Clean up cli arguments

### DIFF
--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -208,6 +208,9 @@ struct Arguments {
     /// The 1Inch REST API URL to use.
     #[structopt(long, env, default_value = "https://api.1inch.exchange/")]
     one_inch_url: Url,
+
+    #[clap(long, env, default_value = "Baseline", arg_enum, use_delimiter = true)]
+    price_estimators: Vec<PriceEstimatorType>,
 }
 
 pub async fn database_metrics(metrics: Arc<Metrics>, database: Postgres) -> ! {
@@ -462,7 +465,6 @@ async fn main() {
         )
     };
     let price_estimators = args
-        .shared
         .price_estimators
         .iter()
         .map(|estimator| -> (String, Box<dyn PriceEstimating>) {

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -199,16 +199,6 @@ struct Arguments {
     #[clap(long, default_value = "1000")]
     price_estimator_cache_size: usize,
 
-    /// The list of disabled 1Inch protocols. By default, the `PMM1` protocol
-    /// (representing a private market maker) is disabled as it seems to
-    /// produce invalid swaps.
-    #[clap(long, env, default_value = "PMM1", use_delimiter = true)]
-    disabled_one_inch_protocols: Vec<String>,
-
-    /// The 1Inch REST API URL to use.
-    #[structopt(long, env, default_value = "https://api.1inch.exchange/")]
-    one_inch_url: Url,
-
     #[clap(long, env, default_value = "Baseline", arg_enum, use_delimiter = true)]
     price_estimators: Vec<PriceEstimatorType>,
 }
@@ -528,11 +518,11 @@ async fn main() {
                     PriceEstimatorType::OneInch => Box::new(instrumented_and_cached(
                         Box::new(OneInchPriceEstimator::new(
                             Arc::new(OneInchClientImpl::new(
-                                args.one_inch_url.clone(),
+                                args.shared.one_inch_url.clone(),
                                 client.clone(),
                                 chain_id,
                             ).unwrap()),
-                            args.disabled_one_inch_protocols.clone()
+                            args.shared.disabled_one_inch_protocols.clone()
                         )),
                         &estimator.name(),
                     ))

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -1,7 +1,6 @@
 //! Contains command line arguments and related helpers that are shared between the binaries.
 use crate::{
     gas_price_estimation::GasEstimatorType,
-    price_estimation::PriceEstimatorType,
     sources::{balancer_v2::BalancerFactoryKind, BaselineSource},
 };
 use anyhow::{ensure, Result};
@@ -111,9 +110,6 @@ pub struct Arguments {
     /// price by 1% if built transactions don't actually get executed.
     #[clap(long, env, default_value = "ParaSwapPool4", use_delimiter = true)]
     pub disabled_paraswap_dexs: Vec<String>,
-
-    #[clap(long, env, default_value = "Baseline", arg_enum, use_delimiter = true)]
-    pub price_estimators: Vec<PriceEstimatorType>,
 
     #[clap(long, env)]
     pub zeroex_url: Option<String>,

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -130,6 +130,16 @@ pub struct Arguments {
     /// supported Balancer V2 factory kinds if not specified.
     #[clap(long, env, arg_enum, ignore_case = true, use_delimiter = true)]
     pub balancer_factories: Option<Vec<BalancerFactoryKind>>,
+
+    /// The list of disabled 1Inch protocols. By default, the `PMM1` protocol
+    /// (representing a private market maker) is disabled as it seems to
+    /// produce invalid swaps.
+    #[clap(long, env, default_value = "PMM1", use_delimiter = true)]
+    pub disabled_one_inch_protocols: Vec<String>,
+
+    /// The 1Inch REST API URL to use.
+    #[structopt(long, env, default_value = "https://api.1inch.exchange/")]
+    pub one_inch_url: Url,
 }
 
 pub fn parse_unbounded_factor(s: &str) -> Result<f64> {

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -158,12 +158,6 @@ struct Arguments {
     )]
     min_order_size_one_inch: U256,
 
-    /// The list of disabled 1Inch protocols. By default, the `PMM1` protocol
-    /// (representing a private market maker) is disabled as it seems to
-    /// produce invalid swaps.
-    #[clap(long, env, default_value = "PMM1", use_delimiter = true)]
-    disabled_one_inch_protocols: Vec<String>,
-
     /// The list of tokens our settlement contract is willing to buy when settling trades
     /// without external liquidity
     #[clap(
@@ -289,10 +283,6 @@ struct Arguments {
     /// but at the same time we don't restrict solutions sizes too much
     #[clap(long, env, default_value = "15000000")]
     simulation_gas_limit: u128,
-
-    /// The 1Inch REST API URL to use.
-    #[structopt(long, env, default_value = "https://api.1inch.exchange/")]
-    one_inch_url: Url,
 }
 
 #[derive(Copy, Clone, Debug, clap::ArgEnum)]
@@ -546,7 +536,7 @@ async fn main() {
         network_name.to_string(),
         chain_id,
         args.min_order_size_one_inch,
-        args.disabled_one_inch_protocols,
+        args.shared.disabled_one_inch_protocols,
         args.paraswap_slippage_bps,
         args.shared.disabled_paraswap_dexs,
         args.shared.paraswap_partner,
@@ -556,7 +546,7 @@ async fn main() {
         args.zeroex_slippage_bps,
         args.shared.quasimodo_uses_internal_buffers,
         args.shared.mip_uses_internal_buffers,
-        args.one_inch_url,
+        args.shared.one_inch_url,
     )
     .expect("failure creating solvers");
     let liquidity_collector = LiquidityCollector {


### PR DESCRIPTION
Removed `--price-estimator` argument from solver binary (we always instantiate the BaselineEstimator)
Moved `--disabled-one-inch-protocols` and `--one-inch-url` into shared arguments

### Test Plan
Manual test
