### PR TITLE
Fix Balancer SOR settlement prices for buy orders

### DIFF
--- a/crates/solver/src/solver/balancer_sor_solver.rs
+++ b/crates/solver/src/solver/balancer_sor_solver.rs
@@ -81,20 +81,24 @@ impl SingleOrderSolving for BalancerSorSolver {
             return Ok(None);
         }
 
+        let (quoted_sell_amount, quoted_buy_amount) = match order.kind {
+            OrderKind::Sell => (quote.swap_amount, quote.return_amount),
+            OrderKind::Buy => (quote.return_amount, quote.swap_amount),
+        };
         let (quoted_sell_amount_with_slippage, quoted_buy_amount_with_slippage) = match order.kind {
             OrderKind::Sell => (
-                quote.swap_amount,
-                slippage::amount_minus_max_slippage(quote.return_amount),
+                quoted_sell_amount,
+                slippage::amount_minus_max_slippage(quoted_buy_amount),
             ),
             OrderKind::Buy => (
-                slippage::amount_plus_max_slippage(quote.return_amount),
-                quote.swap_amount,
+                slippage::amount_plus_max_slippage(quoted_sell_amount),
+                quoted_buy_amount,
             ),
         };
 
         let prices = hashmap! {
-            order.sell_token => quote.return_amount,
-            order.buy_token => quote.swap_amount,
+            order.sell_token => quoted_buy_amount,
+            order.buy_token => quoted_sell_amount,
         };
         let approval = self
             .allowance_fetcher
@@ -391,14 +395,18 @@ mod tests {
 
         let result = solver
             .try_settle_order(
-                LimitOrder {
-                    sell_token,
-                    buy_token,
-                    sell_amount,
-                    buy_amount,
-                    kind: OrderKind::Sell,
+                Order {
+                    order_creation: OrderCreation {
+                        sell_token,
+                        buy_token,
+                        sell_amount,
+                        buy_amount,
+                        kind: OrderKind::Sell,
+                        ..Default::default()
+                    },
                     ..Default::default()
-                },
+                }
+                .into(),
                 &Auction {
                     gas_price: 100e9,
                     ..Auction::default()
@@ -409,6 +417,9 @@ mod tests {
             .unwrap()
             .encoder
             .finish();
+
+        assert_eq!(result.tokens, [buy_token, sell_token]);
+        assert_eq!(result.clearing_prices, [sell_amount, buy_amount]);
 
         let Bytes(calldata) = &result.interactions[1][0].2;
         assert_eq!(
@@ -506,14 +517,17 @@ mod tests {
 
         let result = solver
             .try_settle_order(
-                LimitOrder {
-                    sell_token,
-                    buy_token,
-                    sell_amount,
-                    buy_amount,
-                    kind: OrderKind::Buy,
+                Order {
+                    order_creation: OrderCreation {
+                        sell_token,
+                        buy_token,
+                        sell_amount,
+                        buy_amount,
+                        kind: OrderKind::Buy,
+                        ..Default::default()
+                    },
                     ..Default::default()
-                },
+                }.into(),
                 &Auction {
                     gas_price: 100e9,
                     ..Auction::default()
@@ -524,6 +538,9 @@ mod tests {
             .unwrap()
             .encoder
             .finish();
+
+        assert_eq!(result.tokens, [buy_token, sell_token]);
+        assert_eq!(result.clearing_prices, [sell_amount, buy_amount]);
 
         let Bytes(calldata) = &result.interactions[1][0].2;
         assert_eq!(

--- a/crates/solver/src/solver/balancer_sor_solver.rs
+++ b/crates/solver/src/solver/balancer_sor_solver.rs
@@ -527,7 +527,8 @@ mod tests {
                         ..Default::default()
                     },
                     ..Default::default()
-                }.into(),
+                }
+                .into(),
                 &Auction {
                     gas_price: 100e9,
                     ..Auction::default()


### PR DESCRIPTION
This PR fixes an issue I discovered when investigating Balancer SOR solver performance in staging.

Specifically, the SOR API uses `swap_amount` for the amount of tokens for computing the route (so in `sell_token` for sell orders or `buy_token` for buy orders) and `return_amount` for the computed counter amount (so in `buy_token` for sell orders and in `sell_token` for buy orders). However, the `prices` map was always being computed as if `swap_amount` was in `sell_token` and `return_amount` was in `buy_token`, making it only valid for sell orders.

### Test Plan

Added check for prices in unit test. Also, you can run the manual test and see:
```
% cargo test -p solver -- --nocapture --ignored balancer_sor_solver
   Compiling solver v0.1.0 (/Users/nlordell/Developer/gp-v2-services/crates/solver)
    Finished test [unoptimized + debuginfo] target(s) in 5.23s
     Running unittests (target/debug/deps/solver-a7ee0ecc05ab3005)

running 1 test
Found settlement for sell order: Settlement {
    encoder: SettlementEncoder {
        tokens: [
            0x6b175474e89094c44da98b954eedeac495271d0f,
            0xba100000625a3754423978a60c9317c58a424e3d,
        ],
        clearing_prices: {
            0xba100000625a3754423978a60c9317c58a424e3d: 14987080625394634375,
            0x6b175474e89094c44da98b954eedeac495271d0f: 1000000000000000000,
        },
...
}
Found settlement for buy order: Settlement {
    encoder: SettlementEncoder {
        tokens: [
            0x6b175474e89094c44da98b954eedeac495271d0f,
            0xba100000625a3754423978a60c9317c58a424e3d,
        ],
        clearing_prices: {
            0xba100000625a3754423978a60c9317c58a424e3d: 100000000000000000000,
            0x6b175474e89094c44da98b954eedeac495271d0f: 6672445296379216961,
        },
```

Which makes sense given that `0x6b175474e89094c44da98b954eedeac495271d0f` is DAI (so 1$) and 
`0xba100000625a3754423978a60c9317c58a424e3d` is BAL which is roughly worth 15$ ATM:
- For the sell order, the price of BAL is 14.98... and the price of DAI is 1.0 (so BAL is roughly worth 15$)
- For the buy order, the price of BAL is 1.0 and the price of DAI is 0.0667.. (so 1 DAI roughly buys you 0.0667 BAL - noting that 1/15 = 0.06666...)