### PR TITLE
Add metrics for native price cache hits/misses

### DIFF
--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -533,6 +533,7 @@ async fn main() {
             native_token_price_estimation_amount,
         )),
         args.native_price_cache_max_age_secs,
+        metrics.clone(),
     ));
     native_price_estimator.spawn_maintenance_task(
         Duration::from_secs(1),


### PR DESCRIPTION
To see if the new native price cache is worth it we need to see how many cache hits vs misses there are.
Note that cache misses and hits are not updated during maintenance cycles.
This way we only track how much our users get out of the new cache.

### Test Plan
Manual test
```
curl -s http://localhost:9586/metrics | grep native 
# HELP gp_v2_api_native_price_cache Native price cache hit/miss counter.
# TYPE gp_v2_api_native_price_cache counter
gp_v2_api_native_price_cache{result="hits"} 2
gp_v2_api_native_price_cache{result="misses"} 1
```
