### PR TITLE
Avoid panic by using saturating_sub

### DIFF
--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -175,7 +175,7 @@ async fn update_most_outdated_prices(
             .estimate_prices_and_update_cache(&tokens_to_update)
             .await;
 
-        tokio::time::sleep(update_interval - now.elapsed()).await;
+        tokio::time::sleep(update_interval.saturating_sub(now.elapsed())).await;
     }
 }
 


### PR DESCRIPTION
If the maintenance cycles takes longer than the `update_interval` simply subtracting the durations would cause a [panic](https://gnosisinc.slack.com/archives/CQZBU9T5J/p1644494303362509).
`saturating_sub` returns a "0" duration in those cases which avoids the panic.

