### PR TITLE
Propose new `/auction` endpoint

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -667,7 +667,7 @@ components:
         - $ref: "#/components/schemas/OrderMetaData"
     Auction:
       description: |
-        A batched auction for solving.
+        A batch auction for solving.
       type: object
       properties:
         block:

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -240,6 +240,20 @@ paths:
                   latestSettlementBlock:
                     type: integer
                     description: The block number in which the most recent settlement was observed.
+  /api/v1/auction:
+    get:
+      summary: Gets the current batch auction.
+      description: |
+        The current batch auction that solvers should be solving right now. Includes the list of
+        solvable orders, the block on which the batch was created, as well as prices for all tokens
+        being traded (used for objective value computation).
+      responses:
+        200:
+          description: the auction
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Auction"
   /api/v1/fee:
     get:
       description: |
@@ -651,6 +665,31 @@ components:
       allOf:
         - $ref: "#/components/schemas/OrderCreation"
         - $ref: "#/components/schemas/OrderMetaData"
+    Auction:
+      description: |
+        A batched auction for solving.
+      type: object
+      properties:
+        block:
+          type: integer
+          description: |
+            The block number for the auction. Orders and prices are guaranteed to be valid on this
+            block. Proposed settlements should be valid for this block as well.
+        orders:
+          type: array
+          items:
+            $ref: "#/components/schemas/Order"
+          description: |
+            The solvable orders included in the auction.
+        prices:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/BigUint"
+          description: |
+            The reference prices for all traded tokens in the auction. These prices are used for
+            solution competition for computing surplus and converting fees to native token. Prices
+            are denominated in native token (i.e. 1e18 represents a token that trades one to one
+            with the native token).
     OrderCancellation:
       description: |
         EIP712 signature of struct OrderCancellation { orderUid: bytes } from the order's owner

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -686,10 +686,10 @@ components:
           additionalProperties:
             $ref: "#/components/schemas/BigUint"
           description: |
-            The reference prices for all traded tokens in the auction. These prices are used for
-            solution competition for computing surplus and converting fees to native token. Prices
-            are denominated in native token (i.e. 1e18 represents a token that trades one to one
-            with the native token).
+            The reference prices for all traded tokens in the auction as a mapping from token
+            addresses to a price denominated in native token (i.e. 1e18 represents a token that
+            trades one to one with the native token). These prices are used for solution competition
+            for computing surplus and converting fees to native token.
     OrderCancellation:
       description: |
         EIP712 signature of struct OrderCancellation { orderUid: bytes } from the order's owner

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -1,5 +1,6 @@
 mod cancel_order;
 mod create_order;
+mod get_auction;
 mod get_fee_and_quote;
 mod get_fee_info;
 mod get_markets;
@@ -79,6 +80,9 @@ pub fn handle_all_routes(
     let post_quote = post_quote::post_quote(quoter)
         .map(|result| (result, "v1/post_quote"))
         .boxed();
+    let get_auction = get_auction::get_auction()
+        .map(|result| (result, "v1/auction"))
+        .boxed();
 
     let routes_v1 = warp::path!("api" / "v1" / ..)
         .and(
@@ -106,6 +110,8 @@ pub fn handle_all_routes(
                 .or(get_orders_by_tx)
                 .unify()
                 .or(post_quote)
+                .unify()
+                .or(get_auction)
                 .unify(),
         )
         .untuple_one()

--- a/crates/orderbook/src/api/get_auction.rs
+++ b/crates/orderbook/src/api/get_auction.rs
@@ -1,0 +1,14 @@
+use super::IntoWarpReply;
+use anyhow::anyhow;
+use std::convert::Infallible;
+use warp::{Filter, Rejection};
+
+fn get_auction_request() -> impl Filter<Extract = (), Error = Rejection> + Clone {
+    warp::path!("auction").and(warp::get())
+}
+
+pub fn get_auction() -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
+    get_auction_request().and_then(move || async move {
+        Result::<_, Infallible>::Ok(anyhow!("not yet implemented").into_warp_reply())
+    })
+}


### PR DESCRIPTION
This PR adds an initial version of the `/auction` endpoint to the open API specification for the orderbook service.

This proposes what could be the new `/auction` endpoint that the driver uses for populating getting batches. Currently, it is just `v2/solvable_orders` with the reference prices, but we may decide to add more to it in the future (there was discussion of including baseline liquidity here as well to reduce the amount of work required for new solvers - allowing them to integrate with our public `orderbook` API directly without needing to also run a `driver`).

One thing that we should probably discuss (but not necessarily important for this PR) is whether or not auctions should be sealed (i.e. multiple queries of `/auction` within a small time frame return the exact same data) or continuous (a new auction on each block). For canonical batches - it makes more sense to have them "sealed", but in the general case, I'm slightly leaning towards having them continuous, although this makes solution competition a bit more difficult if we decide to not have it happen in the driver.

### Test Plan

CI - we validate OpenAPI file 🎉.

Added an empty route  always returning 500 - you can try it out with:
```
% curl -s http://localhost:8080/api/v1/auction
{"errorType":"InternalServerError","description":""}
```

And check that the error metrics for it increased!:
```
% curl -s http://localhost:9586/metrics | rg 'gp_v2_api_api_requests_complete' | rg 'v1/auction'
gp_v2_api_api_requests_complete{method="v1/auction",status_code="500"} 1
```
