### PR TITLE
fix logs, return early from submitter if strategy disabled

### DIFF
--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -499,10 +499,10 @@ fn status(receipt: TransactionReceipt) -> Result<TransactionReceipt, SubmissionE
     if let Some(status) = receipt.status {
         if status == U64::zero() {
             // failing transaction
-            return Err(SubmissionError::Revert);
+            return Err(SubmissionError::Revert(receipt.transaction_hash));
         } else if status == U64::one() && receipt.from == receipt.to.unwrap_or_default() {
             // noop transaction
-            return Err(SubmissionError::Canceled);
+            return Err(SubmissionError::Canceled(receipt.transaction_hash));
         }
     }
     // successfull transaction

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -367,8 +367,7 @@ impl<'a> Submitter<'a> {
                         name,
                         reason
                     );
-                    tokio::time::sleep(params.retry_interval).await;
-                    continue;
+                    return SubmissionError::from(anyhow!("strategy temporarily disabled"));
                 }
                 SubmissionLoopStatus::Enabled(AdditionalTip::Off) => {
                     self.gas_price_estimator.with_no_additional_tip()

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -34,7 +34,6 @@ impl TransactionSubmitting for CustomNodesApi {
         &self,
         tx: TransactionBuilder<DynTransport>,
     ) -> Result<TransactionHandle, SubmitApiError> {
-        tracing::info!("sending transaction to custom nodes...");
         let transaction_request = tx.build().now_or_never().unwrap().unwrap();
         let mut futures = self
             .nodes
@@ -56,7 +55,7 @@ impl TransactionSubmitting for CustomNodesApi {
             let (result, _index, rest) = futures::future::select_all(futures).await;
             match result {
                 Ok(tx_hash) => {
-                    tracing::info!("created transaction with hash: {}", tx_hash);
+                    tracing::info!("created transaction with hash: {:?}", tx_hash);
                     return Ok(TransactionHandle {
                         tx_hash,
                         handle: tx_hash,


### PR DESCRIPTION
If a transaction submission strategy is disabled, lets return early from function and avoid the same check every two seconds (and cluttering logs).
When a need for `continue` arises, we will change it easily.

Don't want to introduce a new type of error for this, since it is not really an error, and I also don't see a case where I would want to add this case to metrics to monitor.

Some additional logs polished...