### PR TITLE
Add new Auction model type

### DIFF
--- a/crates/model/src/auction.rs
+++ b/crates/model/src/auction.rs
@@ -1,0 +1,70 @@
+//! Module defining a batch auction.
+
+use crate::{order::Order, u256_decimal::DecimalU256};
+use primitive_types::{H160, U256};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use std::collections::BTreeMap;
+
+/// A batch auction.
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct Auction {
+    /// The block that this auction is valid for.
+    /// The block number for the auction. Orders and prices are guaranteed to be
+    /// valid on this block.
+    pub block: u64,
+
+    /// The solvable orders included in the auction.
+    pub orders: Vec<Order>,
+
+    /// The reference prices for all traded tokens in the auction.
+    #[serde_as(as = "BTreeMap<_, DecimalU256>")]
+    pub prices: BTreeMap<H160, U256>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::order::{OrderMetaData, OrderUid};
+    use maplit::btreemap;
+    use serde_json::json;
+
+    #[test]
+    fn roundtrips_auction() {
+        let order = |uid_byte: u8| Order {
+            order_meta_data: OrderMetaData {
+                uid: OrderUid([uid_byte; 56]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let auction = Auction {
+            block: 42,
+            orders: vec![order(1), order(2)],
+            prices: btreemap! {
+                H160([2; 20]) => U256::from(2),
+                H160([1; 20]) => U256::from(1),
+            },
+        };
+
+        assert_eq!(
+            serde_json::to_value(&auction).unwrap(),
+            json!({
+                "block": 42,
+                "orders": [
+                    order(1),
+                    order(2),
+                ],
+                "prices": {
+                    "0x0101010101010101010101010101010101010101": "1",
+                    "0x0202020202020202020202020202020202020202": "2",
+                },
+            }),
+        );
+        assert_eq!(
+            serde_json::from_value::<Auction>(serde_json::to_value(&auction).unwrap()).unwrap(),
+            auction,
+        );
+    }
+}

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -1,6 +1,7 @@
 //! Contains models that are shared between the orderbook and the solver.
 
 pub mod app_id;
+pub mod auction;
 pub mod order;
 pub mod ratio_as_decimal;
 pub mod signature;


### PR DESCRIPTION
This PR just adds a new `Auction` model type (doesn't use it yet). This model will be returned by the new `v1/auction` endpoint that was introduced in #1644 

### Test Plan

New unit test to check serialization/deserialization.
