### PR TITLE
Implement auction endpoint to return prices with solvable orders

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -151,7 +151,7 @@ impl OrderbookServices {
                 fee_factor: 0.,
                 ..Default::default()
             },
-            native_price_estimator,
+            native_price_estimator.clone(),
         ));
         let balance_fetcher = Arc::new(Web3BalanceFetcher::new(
             web3.clone(),
@@ -180,10 +180,12 @@ impl OrderbookServices {
             contracts.gp_settlement.address(),
             db.clone(),
             bad_token_detector,
+            native_price_estimator,
             true,
             solvable_orders_cache.clone(),
             Duration::from_secs(600),
             order_validator.clone(),
+            event_updater.clone(),
         ));
         let maintenance = ServiceMaintenance {
             maintainers: vec![db.clone(), event_updater],

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -80,7 +80,7 @@ pub fn handle_all_routes(
     let post_quote = post_quote::post_quote(quoter)
         .map(|result| (result, "v1/post_quote"))
         .boxed();
-    let get_auction = get_auction::get_auction()
+    let get_auction = get_auction::get_auction(orderbook.clone())
         .map(|result| (result, "v1/auction"))
         .boxed();
 

--- a/crates/orderbook/src/api/get_auction.rs
+++ b/crates/orderbook/src/api/get_auction.rs
@@ -1,14 +1,20 @@
-use super::IntoWarpReply;
-use anyhow::anyhow;
-use std::convert::Infallible;
+use crate::{api::convert_json_response, orderbook::Orderbook};
+use anyhow::Result;
+use std::{convert::Infallible, sync::Arc};
 use warp::{Filter, Rejection};
 
 fn get_auction_request() -> impl Filter<Extract = (), Error = Rejection> + Clone {
     warp::path!("auction").and(warp::get())
 }
 
-pub fn get_auction() -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    get_auction_request().and_then(move || async move {
-        Result::<_, Infallible>::Ok(anyhow!("not yet implemented").into_warp_reply())
+pub fn get_auction(
+    orderbook: Arc<Orderbook>,
+) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
+    get_auction_request().and_then(move || {
+        let orderbook = orderbook.clone();
+        async move {
+            let auction = orderbook.get_auction().await;
+            Result::<_, Infallible>::Ok(convert_json_response(auction))
+        }
     })
 }

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -1,19 +1,28 @@
 use crate::{
     api::order_validation::{OrderValidating, OrderValidator, ValidationError},
     database::orders::{InsertionError, OrderFilter, OrderStoring},
+    event_updater::EventUpdating,
     solvable_orders::{SolvableOrders, SolvableOrdersCache},
 };
 use anyhow::{ensure, Context, Result};
 use chrono::Utc;
-use ethcontract::H256;
+use ethcontract::{H256, U256};
 use model::{
+    auction::Auction,
     order::{Order, OrderCancellation, OrderCreationPayload, OrderStatus, OrderUid},
     signature::SigningScheme,
     DomainSeparator,
 };
 use primitive_types::H160;
-use shared::{bad_token::BadTokenDetecting, metrics::LivenessChecking};
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use shared::{
+    bad_token::BadTokenDetecting, metrics::LivenessChecking,
+    price_estimation::native::NativePriceEstimating,
+};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
 
 #[derive(Debug)]
 pub enum AddOrderResult {
@@ -40,10 +49,12 @@ pub struct Orderbook {
     settlement_contract: H160,
     database: Arc<dyn OrderStoring>,
     bad_token_detector: Arc<dyn BadTokenDetecting>,
+    native_price_estimator: Arc<dyn NativePriceEstimating>,
     enable_presign_orders: bool,
     solvable_orders: Arc<SolvableOrdersCache>,
     solvable_orders_max_update_age: Duration,
     order_validator: Arc<OrderValidator>,
+    event_updater: Arc<dyn EventUpdating>,
 }
 
 impl Orderbook {
@@ -53,20 +64,24 @@ impl Orderbook {
         settlement_contract: H160,
         database: Arc<dyn OrderStoring>,
         bad_token_detector: Arc<dyn BadTokenDetecting>,
+        native_price_estimator: Arc<dyn NativePriceEstimating>,
         enable_presign_orders: bool,
         solvable_orders: Arc<SolvableOrdersCache>,
         solvable_orders_max_update_age: Duration,
         order_validator: Arc<OrderValidator>,
+        event_updater: Arc<dyn EventUpdating>,
     ) -> Self {
         Self {
             domain_separator,
             settlement_contract,
             database,
             bad_token_detector,
+            native_price_estimator,
             enable_presign_orders,
             solvable_orders,
             solvable_orders_max_update_age,
             order_validator,
+            event_updater,
         }
     }
 
@@ -194,6 +209,24 @@ impl Orderbook {
         Ok(solvable_orders)
     }
 
+    pub async fn get_auction(&self) -> Result<Auction> {
+        let last_handled_block = self.event_updater.last_handled_block().await;
+        let solvable_orders = self.get_solvable_orders().await?;
+
+        let block = last_handled_block.unwrap_or(solvable_orders.latest_settlement_block);
+        let (orders, prices) = filter_tokens_without_native_prices(
+            solvable_orders.orders,
+            &*self.native_price_estimator,
+        )
+        .await;
+
+        Ok(Auction {
+            block,
+            orders,
+            prices,
+        })
+    }
+
     pub async fn get_user_orders(
         &self,
         owner: &H160,
@@ -243,13 +276,58 @@ fn set_available_balances(orders: &mut [Order], cache: &SolvableOrdersCache) {
     }
 }
 
+async fn filter_tokens_without_native_prices(
+    mut orders: Vec<Order>,
+    native_price_estimator: &dyn NativePriceEstimating,
+) -> (Vec<Order>, BTreeMap<H160, U256>) {
+    let traded_tokens = orders
+        .iter()
+        .flat_map(|order| {
+            [
+                order.order_creation.sell_token,
+                order.order_creation.buy_token,
+            ]
+        })
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let prices = native_price_estimator
+        .estimate_native_prices(&traded_tokens)
+        .await
+        .into_iter()
+        .zip(traded_tokens)
+        .filter_map(|(price, token)| match price {
+            Ok(price) => Some((token, to_normalized_price(price))),
+            Err(err) => {
+                tracing::warn!(?token, ?err, "error estimating native token price");
+                None
+            }
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    orders.retain(|order| {
+        prices.contains_key(&order.order_creation.sell_token)
+            && prices.contains_key(&order.order_creation.buy_token)
+    });
+
+    (orders, prices)
+}
+
+fn to_normalized_price(price: f64) -> U256 {
+    U256::from_f64_lossy(price * 1e18)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use ethcontract::H160;
     use futures::FutureExt;
+    use maplit::{btreemap, hashset};
     use model::order::OrderBuilder;
-    use shared::bad_token::list_based::ListBasedDetector;
+    use shared::{
+        bad_token::list_based::ListBasedDetector,
+        price_estimation::{native::MockNativePriceEstimating, PriceEstimationError},
+    };
 
     #[test]
     fn filter_unsupported_tokens_() {
@@ -276,5 +354,73 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(result, &orders[1..2]);
+    }
+
+    #[test]
+    fn computes_u256_prices_normalized_to_1e18() {
+        assert_eq!(
+            to_normalized_price(0.5),
+            U256::from(500_000_000_000_000_000_u128)
+        );
+    }
+
+    #[tokio::test]
+    async fn filters_tokens_without_native_prices() {
+        let token1 = H160([1; 20]);
+        let token2 = H160([2; 20]);
+        let token3 = H160([3; 20]);
+
+        let orders = vec![
+            OrderBuilder::default()
+                .with_sell_token(token1)
+                .with_buy_token(token2)
+                .build(),
+            OrderBuilder::default()
+                .with_sell_token(token2)
+                .with_buy_token(token3)
+                .build(),
+            OrderBuilder::default()
+                .with_sell_token(token1)
+                .with_buy_token(token3)
+                .build(),
+        ];
+        let prices = btreemap! {
+            token1 => 0.5,
+            token3 => 2.0,
+        };
+
+        let mut native_price_estimator = MockNativePriceEstimating::new();
+        native_price_estimator
+            .expect_estimate_native_prices()
+            // deal with undeterministic ordering of `HashSet`.
+            .withf(move |tokens| {
+                tokens.iter().cloned().collect::<HashSet<_>>() == hashset!(token1, token2, token3)
+            })
+            .returning({
+                let prices = prices.clone();
+                move |tokens| {
+                    tokens
+                        .iter()
+                        .map(|token| {
+                            prices
+                                .get(token)
+                                .copied()
+                                .ok_or(PriceEstimationError::NoLiquidity)
+                        })
+                        .collect()
+                }
+            });
+
+        let (filtered_orders, prices) =
+            filter_tokens_without_native_prices(orders.clone(), &native_price_estimator).await;
+
+        assert_eq!(filtered_orders, [orders[2].clone()]);
+        assert_eq!(
+            prices,
+            btreemap! {
+                token1 => U256::from(500_000_000_000_000_000_u128),
+                token3 => U256::from(2_000_000_000_000_000_000_u128),
+            }
+        );
     }
 }

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -369,6 +369,7 @@ mod tests {
         let token1 = H160([1; 20]);
         let token2 = H160([2; 20]);
         let token3 = H160([3; 20]);
+        let token4 = H160([4; 20]);
 
         let orders = vec![
             OrderBuilder::default()
@@ -383,6 +384,10 @@ mod tests {
                 .with_sell_token(token1)
                 .with_buy_token(token3)
                 .build(),
+            OrderBuilder::default()
+                .with_sell_token(token2)
+                .with_buy_token(token4)
+                .build(),
         ];
         let prices = btreemap! {
             token1 => 0.5,
@@ -394,7 +399,8 @@ mod tests {
             .expect_estimate_native_prices()
             // deal with undeterministic ordering of `HashSet`.
             .withf(move |tokens| {
-                tokens.iter().cloned().collect::<HashSet<_>>() == hashset!(token1, token2, token3)
+                tokens.iter().cloned().collect::<HashSet<_>>()
+                    == hashset!(token1, token2, token3, token4)
             })
             .returning({
                 let prices = prices.clone();

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -214,11 +214,9 @@ impl Orderbook {
         let solvable_orders = self.get_solvable_orders().await?;
 
         let block = last_handled_block.unwrap_or(solvable_orders.latest_settlement_block);
-        let (orders, prices) = filter_tokens_without_native_prices(
-            solvable_orders.orders,
-            &*self.native_price_estimator,
-        )
-        .await;
+        let (orders, prices) =
+            get_orders_with_native_prices(solvable_orders.orders, &*self.native_price_estimator)
+                .await;
 
         Ok(Auction {
             block,
@@ -276,7 +274,7 @@ fn set_available_balances(orders: &mut [Order], cache: &SolvableOrdersCache) {
     }
 }
 
-async fn filter_tokens_without_native_prices(
+async fn get_orders_with_native_prices(
     mut orders: Vec<Order>,
     native_price_estimator: &dyn NativePriceEstimating,
 ) -> (Vec<Order>, BTreeMap<H160, U256>) {
@@ -418,7 +416,7 @@ mod tests {
             });
 
         let (filtered_orders, prices) =
-            filter_tokens_without_native_prices(orders.clone(), &native_price_estimator).await;
+            get_orders_with_native_prices(orders.clone(), &native_price_estimator).await;
 
         assert_eq!(filtered_orders, [orders[2].clone()]);
         assert_eq!(

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -318,11 +318,11 @@ fn to_normalized_price(price: f64) -> Option<U256> {
     // in the token that it is estimating and not in ETH. This means that we
     // need to invert the price in order for it to be correct.
     let price_in_eth = 1e18 / price;
-    if price_in_eth < 1. || price_in_eth >= uint_max {
-        return None;
+    if price_in_eth.is_normal() && price_in_eth >= 1. && price_in_eth < uint_max {
+        Some(U256::from_f64_lossy(price_in_eth))
+    } else {
+        None
     }
-
-    Some(U256::from_f64_lossy(price_in_eth))
 }
 
 #[cfg(test)]

--- a/crates/shared/src/event_handling.rs
+++ b/crates/shared/src/event_handling.rs
@@ -83,6 +83,10 @@ where
         &self.store
     }
 
+    pub fn last_handled_block(&self) -> Option<u64> {
+        self.last_handled_block
+    }
+
     async fn event_block_range(&self) -> Result<RangeInclusive<BlockNumber>> {
         // Instead of using only the most recent event block from the db we also store the last
         // handled block in self so that during long times of no events we do not query needlessly


### PR DESCRIPTION
This PR adds an initial implementation for the new `v1/auction` endpoint.

Currently, its mostly a wrapper around the `solvable_orders` API endpoint with a couple of differences:
- The block is reported as the last processed block by the event updater instead of the latest settlement block. This makes the block number closer to "latest" and be a better representation of the block the batch auction is valid for. In case the event handler has not processed any blocks - it returns the block number of the last settlement (as the `v2/solvable_orders` endpoint). This should only happen right on startup so I'm not particularly worried about optimizing the case where no events have been processed.
- We filter out orders for which there are no native prices. Since we use the same native price estimator from the `/quote` endpoint, this shouldn't happen often. Currently, we only log a warning when this happens. I want to change this to bump some metrics to keep track of this a bit better (will do it in a follow up PR).

Things still left to do:
- We no longer need to augment prices in the driver (since, not only do we use the native token estimator which supports more tokens, additionally orders for which there are no native prices shouldn't get added to the orderbook anymore, and finally we also filter the orders before sending them to the driver so augmenting would never really do anything anyway).
- Change the driver to use the `Auction` data from this new endpoint.
- Metrics for filtered orders as mentioned ☝️.

### Test Plan

Added new unit test to verify order filtering logic.

Additionally, did some manual testing. Ran the orderbook locally and [added an order](). Then queried the orderbook's new `auction` endpoint:

<details><summary><code>curl -s http://localhost:8080/api/v1/auction | jq</code></summary>

```
{
  "block": 14210281,
  "orders": [
    {
      "creationDate": "2022-02-15T10:46:21.893840Z",
      "owner": "0xb54872859733a3dfbb2c5401ac68cd9ca84b3cd1",
      "uid": "0x6c85ed0264a62ba594b7edc7b9209b05c15ce6814c4b11fc1ae855be48092471b54872859733a3dfbb2c5401ac68cd9ca84b3cd180000000",
      "availableBalance": "600000000000000000000",
      "executedBuyAmount": "0",
      "executedSellAmount": "0",
      "executedSellAmountBeforeFees": "0",
      "executedFeeAmount": "0",
      "invalidated": false,
      "status": "open",
      "settlementContract": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
      "fullFeeAmount": "9726151661805737984",
      "sellToken": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
      "buyToken": "0x6810e776880c02933d47db1b9fc05908e5386b96",
      "receiver": "0x0000000000000000000000000000000000000000",
      "sellAmount": "590273848338194262016",
      "buyAmount": "11899022238076966313",
      "validTo": 2147483648,
      "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "feeAmount": "9726151661805737984",
      "kind": "sell",
      "partiallyFillable": false,
      "signingScheme": "eip712",
      "signature": "0x8535eb8070a7327406bcf69574bda0c494304354c6a36e00886a8461bf2f57e738830870bff9abd75d243dba3c4999e118da11243c093044fa58812d1fc51ea91b",
      "sellTokenBalance": "erc20",
      "buyTokenBalance": "erc20"
    }
  ],
  "prices": {
    "0x6810e776880c02933d47db1b9fc05908e5386b96": "117755220144748432",
    "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f": "2415672455701688"
  }
}
```

</details>

This trades GNO priced at ~$372.74 for GTC priced at ~$7.66. Given an ETH priced at ~$3,109.71. The prices in the vector make sense (GNO is ~Ξ0.1177 and GTC is ~Ξ0.0024).
