### PR TITLE
Implement RacingCompetitionPriceEstimator

### DIFF
--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -105,8 +105,8 @@ impl Estimate {
     }
 }
 
-#[mockall::automock]
 #[async_trait::async_trait]
+#[mockall::automock]
 pub trait PriceEstimating: Send + Sync {
     async fn estimate(&self, query: &Query) -> Result<Estimate, PriceEstimationError> {
         self.estimates(std::slice::from_ref(query))

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -125,9 +125,6 @@ fn merge_estimates_from_multiple_estimators(
                     },
                 )
                 .map(|winning_estimate| {
-                    // The `EstimateData::estimator_name` field is getting
-                    // flagged as dead code despited being used in the log
-                    // below. Just convince the linter that we use it.
                     tracing::debug!(?query, ?winning_estimate, "winning price estimate");
                     metrics()
                         .queries_won

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -296,13 +296,13 @@ mod tests {
         let mut first = MockPriceEstimating::new();
         first.expect_estimates().times(1).returning(move |queries| {
             assert_eq!(queries.len(), 5);
-            vec![
+            Box::pin(future::ready(vec![
                 Ok(estimates[0]),
                 Ok(estimates[0]),
                 Ok(estimates[0]),
                 Err(PriceEstimationError::Other(anyhow!(""))),
                 Err(PriceEstimationError::NoLiquidity),
-            ]
+            ]))
         });
         let mut second = MockPriceEstimating::new();
         second
@@ -310,13 +310,13 @@ mod tests {
             .times(1)
             .returning(move |queries| {
                 assert_eq!(queries.len(), 5);
-                vec![
+                Box::pin(future::ready(vec![
                     Err(PriceEstimationError::Other(anyhow!(""))),
                     Ok(estimates[1]),
                     Ok(estimates[1]),
                     Err(PriceEstimationError::Other(anyhow!(""))),
                     Err(PriceEstimationError::UnsupportedToken(H160([0; 20]))),
-                ]
+                ]))
             });
 
         let priority = CompetitionPriceEstimator::new(vec![

--- a/crates/shared/src/price_estimation/instrumented.rs
+++ b/crates/shared/src/price_estimation/instrumented.rs
@@ -79,10 +79,10 @@ mod tests {
             .times(1)
             .withf(move |q| q == queries)
             .returning(|_| {
-                vec![
+                Box::pin(futures::future::ready(vec![
                     Ok(Estimate::default()),
                     Err(PriceEstimationError::Other(anyhow!(""))),
-                ]
+                ]))
             });
 
         let mut metrics = MockMetrics::new();

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -89,10 +89,10 @@ mod tests {
             assert!(queries.len() == 1);
             assert!(queries[0].buy_token.to_low_u64_be() == 7);
             assert!(queries[0].sell_token.to_low_u64_be() == 3);
-            vec![Ok(Estimate {
+            Box::pin(futures::future::ready(vec![Ok(Estimate {
                 out_amount: 123_456_789_000_000_000u128.into(),
                 gas: 0.into(),
-            })]
+            })]))
         });
 
         let native_price_estimator = NativePriceEstimator {
@@ -116,7 +116,9 @@ mod tests {
             assert!(queries.len() == 1);
             assert!(queries[0].buy_token.to_low_u64_be() == 7);
             assert!(queries[0].sell_token.to_low_u64_be() == 2);
-            vec![Err(PriceEstimationError::NoLiquidity)]
+            Box::pin(futures::future::ready(vec![Err(
+                PriceEstimationError::NoLiquidity,
+            )]))
         });
 
         let native_price_estimator = NativePriceEstimator {

--- a/crates/shared/src/price_estimation/priority.rs
+++ b/crates/shared/src/price_estimation/priority.rs
@@ -91,23 +91,23 @@ mod tests {
         let mut first = MockPriceEstimating::new();
         first.expect_estimates().times(1).returning(|queries| {
             assert_eq!(queries.len(), 3);
-            vec![
+            Box::pin(futures::future::ready(vec![
                 Err(PriceEstimationError::Other(anyhow!(""))),
                 Err(PriceEstimationError::UnsupportedToken(
                     H160::from_low_u64_le(2),
                 )),
                 Err(PriceEstimationError::Other(anyhow!(""))),
-            ]
+            ]))
         });
         let mut second = MockPriceEstimating::new();
         second.expect_estimates().times(1).returning(|queries| {
             assert_eq!(queries.len(), 2);
             assert_eq!(queries[0].sell_token, H160::from_low_u64_le(0));
             assert_eq!(queries[1].sell_token, H160::from_low_u64_le(3));
-            vec![
+            Box::pin(futures::future::ready(vec![
                 Err(PriceEstimationError::NoLiquidity),
                 Ok(Estimate::default()),
-            ]
+            ]))
         });
         let third = MockPriceEstimating::new();
 

--- a/crates/shared/src/price_estimation/sanitized.rs
+++ b/crates/shared/src/price_estimation/sanitized.rs
@@ -286,7 +286,7 @@ mod tests {
             .times(1)
             .withf(move |arg: &[Query]| arg.iter().eq(expected_forwarded_queries.iter()))
             .returning(|_| {
-                vec![
+                Box::pin(futures::future::ready(vec![
                     Ok(Estimate {
                         out_amount: 1.into(),
                         gas: 100.into(),
@@ -299,7 +299,7 @@ mod tests {
                         out_amount: 1.into(),
                         gas: U256::MAX,
                     }),
-                ]
+                ]))
             });
 
         let sanitized_estimator = SanitizedPriceEstimator {


### PR DESCRIPTION
Related to: #1359 

Right now it takes quite a bit of time until a user gets a first price estimation for their trade.
Unfortunately it looks as if there is no easy way to speed up price estimation by simply tweaking the query parameters we use. One alternative solution could be to offer a way to get faster but less optimal price estimations. The frontend could request a fast and an optimal price at the same time and show the fast one until the optimal one arrives.

My initial idea was to just put a time limit on the price estimation and use the best result we got so far. This turned out to be problematic because there are no good ways to configure that time limit. Sometimes even our faster estimators take quite a bit of time to find a solution and if we configure the time limit to be high enough to get a result from the fast ones most  of the time, we waste quite a bit on time on average.

Another option which seems to perform better is to let the estimators race each other and return a result early when there is at least a (configurable) number of successful estimates for every query.
This is nicer because it's way simpler to configure a "good" threshold (compared to the time limit solution). I found 2 results to return early quite nice (if all estimators are enabled). Smaller orders usually get estimated by the faster (on average) `Baseline` and `Quasimodo` estimators whereas bigger orders cause `Quasimodo` to return `NoLiquidity` so one of the other "bigger" estimators has to give an estimation instead. But it looks like `Paraswap`, `ZeroEx` and `OneInch` are faster on bigger orders so that cancels our nicely.
Based on some manual tests this would bring "fast" sell order price estimations consistently below 1s (where smaller orders are around 200-500ms and bigger ones around 600-900ms). Big buy orders perform worse because more estimators returns errors.

Notes
- to properly test returning fast results early I had to make the mocked `PriceEstimating` trait return a future instead of a normal value. (This is also closer to the reality)
- a follow up PR is supposed to make the `/quote` endpoint differentiate between "fast" and "optimal" and  actually use the new estimator

### Test Plan
Unit test for correctness of `RacingCompetitionPriceEstimator`
Manual test to see viability of this approach
