### PR TITLE
Verify that external single order solvers do not violate limit price

### DIFF
--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -4,7 +4,7 @@
 //! single GPv2 order and produce a settlement directly against 1Inch.
 
 use super::{
-    single_order_solver::{SettlementError, SingleOrderSolving},
+    single_order_solver::{execution_respects_order, SettlementError, SingleOrderSolving},
     Auction,
 };
 use crate::{
@@ -109,8 +109,8 @@ impl OneInchSolver {
             RestResponse::Err(error) => return Err((error).into()),
         };
 
-        if !satisfies_limit_price(&swap, &order) {
-            tracing::debug!("Order limit price not respected");
+        if !execution_respects_order(&order, swap.from_token_amount, swap.to_token_amount) {
+            tracing::debug!("execution does not respect order");
             return Ok(None);
         }
 
@@ -126,10 +126,6 @@ impl OneInchSolver {
 
         Ok(Some(settlement))
     }
-}
-
-fn satisfies_limit_price(swap: &Swap, order: &LimitOrder) -> bool {
-    swap.to_token_amount >= order.buy_amount
 }
 
 impl Interaction for Swap {

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -125,6 +125,7 @@ mod tests {
     use crate::liquidity::tests::CapturingSettlementHandler;
     use crate::metrics::NoopMetrics;
     use anyhow::anyhow;
+    use model::order::OrderKind;
     use std::sync::Arc;
 
     #[tokio::test]
@@ -227,5 +228,33 @@ mod tests {
             })
             .await
             .unwrap();
+    }
+
+    #[test]
+    fn execution_respects_order_() {
+        let order = LimitOrder {
+            kind: OrderKind::Sell,
+            sell_amount: 10.into(),
+            buy_amount: 10.into(),
+            ..Default::default()
+        };
+        assert!(execution_respects_order(&order, 10.into(), 11.into(),));
+        assert!(!execution_respects_order(&order, 10.into(), 9.into(),));
+        // Unexpectedly the executed sell amount is less than the real sell order for a fill kill
+        // order but we still get enough buy token.
+        assert!(execution_respects_order(&order, 9.into(), 10.into(),));
+        // Price is respected but order is partially filled.
+        assert!(!execution_respects_order(&order, 9.into(), 9.into(),));
+
+        let order = LimitOrder {
+            kind: OrderKind::Buy,
+            ..order
+        };
+        assert!(execution_respects_order(&order, 9.into(), 10.into(),));
+        assert!(!execution_respects_order(&order, 11.into(), 10.into(),));
+        // Unexpectedly get more buy amount but sell amount is still respected.
+        assert!(execution_respects_order(&order, 10.into(), 11.into(),));
+        // Price is respected but order is partially filled.
+        assert!(!execution_respects_order(&order, 9.into(), 9.into(),));
     }
 }


### PR DESCRIPTION
As on call I was investigating

> 2022-02-15T06:31:09.418Z ERROR solver::settlement: Overflow computing objective value

and could not understand how this could happen.

Eventually I found the following exchange with 0x:
<details>

> 2022-02-15T06:30:55.692Z DEBUG shared::zeroex_api: Querying 0x API: https://gated.api.0x.org/swap/v1/quote?sellToken=0x7ae1d57b58fa6411f32948314badd83583ee0e8c&buyToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&slippagePercentage=0.003&buyAmount=2000000000000000000&affiliateAddress=0x9008D19f58AAbD9eD0D60971565AA8510560ab41&skipValidation=true&intentOnFilling=false

> 2022-02-15T06:30:56.354Z DEBUG shared::zeroex_api: Response from 0x API: {"chainId":1,"price":"147052.264902334297684418","guaranteedPrice":"147493.421697041300577472","estimatedPriceImpact":"2.5337","to":"0xdef1c0ded9bec7f1a1670819833240f027b25eff","data":"0x6af479b2000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000300cf9dc4d42af9360410000000000000000000000000000000000000000000000001559b69e3c99d88f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002b7ae1d57b58fa6411f32948314badd83583ee0e8c002710c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000000000000000000000869584cd0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab410000000000000000000000000000000000000000000000ec58c55eff620b48a0","value":"0","gas":"126000","estimatedGas":"126000","gasPrice":"45000000000","protocolFee":"0","minimumProtocolFee":"0","buyTokenAddress":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","sellTokenAddress":"0x7ae1d57b58fa6411f32948314badd83583ee0e8c","buyAmount":"1538461538461538447","sellAmount":"226234253695898917376575","sources":[{"name":"0x","proportion":"0"},{"name":"Uniswap","proportion":"0"},{"name":"Uniswap_V2","proportion":"0"},{"name":"Eth2Dai","proportion":"0"},{"name":"Kyber","proportion":"0"},{"name":"Curve","proportion":"0"},{"name":"Balancer","proportion":"0"},{"name":"Balancer_V2","proportion":"0"},{"name":"Bancor","proportion":"0"},{"name":"mStable","proportion":"0"},{"name":"Mooniswap","proportion":"0"},{"name":"Swerve","proportion":"0"},{"name":"SnowSwap","proportion":"0"},{"name":"SushiSwap","proportion":"0"},{"name":"Shell","proportion":"0"},{"name":"MultiHop","proportion":"0"},{"name":"DODO","proportion":"0"},{"name":"DODO_V2","proportion":"0"},{"name":"CREAM","proportion":"0"},{"name":"LiquidityProvider","proportion":"0"},{"name":"CryptoCom","proportion":"0"},{"name":"Linkswap","proportion":"0"},{"name":"Lido","proportion":"0"},{"name":"MakerPsm","proportion":"0"},{"name":"KyberDMM","proportion":"0"},{"name":"Smoothy","proportion":"0"},{"name":"Component","proportion":"0"},{"name":"Saddle","proportion":"0"},{"name":"xSigma","proportion":"0"},{"name":"Uniswap_V3","proportion":"1"},{"name":"Curve_V2","proportion":"0"},{"name":"ShibaSwap","proportion":"0"},{"name":"Synapse","proportion":"0"}],"orders":[{"makerToken":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","takerToken":"0x7ae1d57b58fa6411f32948314badd83583ee0e8c","makerAmount":"1538461538461538447","takerAmount":"226234253695898917376575","fillData":{"router":"0xe592427a0aece92de3edee1f18e0157c05861564","tokenAddressPath":["0x7ae1d57b58fa6411f32948314badd83583ee0e8c","0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"],"uniswapPath":"0x7ae1d57b58fa6411f32948314badd83583ee0e8c002710c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"},"source":"Uniswap_V3","sourcePathId":"0x1b6352b938195de9d2d72d38bfc0f6fe14e99d9ddebed329265c11ae49dd6cf9","type":0}],"allowanceTarget":"0xdef1c0ded9bec7f1a1670819833240f027b25eff","sellTokenToEthRate":"143326.5157040987654247","buyTokenToEthRate":"1"}

</details>

The original user order here is a buy order with sell amount 2.27e23 and buy amount 2.00e18. We forward this to 0x with a query setting the buy amount to 2.00e18 . The response we get back has sell amount 2.26e23 and buy amount 1.54e18.
The returned buy amount is significantly less than what we asked for in the buy order. This is a problem.
First, we asked for a fill-or-kill order buy order. It does not make sense that the resulting buy amount is less than our input buy amount.
Second, because we assume 0x respects our wish for a fill-or-kill order, the limit price check is simplified to `executed_sell_amount <= order_sell_amount` (for a buy order). This is incorrect if the executed buy amount is not at least as large as the order buy amount.
The first case is benign. Either the settlement will fail to simulate because there is not enough buy token or we will unintentionally use the buffers in the settlement contract.
The second case is malignant. Like in the first case it is possible that we would be unintentionally using the buffers. But here the order limit price has not been respected. We are paying the user their limit price out of our buffers even though the on chain price does not match.

I do not know if this ever really happened. In the case I was investigating the 0x solution did not win the competition or failed to simulate (don't remember which). If the situation occurs we should always see the "Overflow computing objective value" error which is caused by `settlement.rs` `fn (buy|sell)_order_surplus` returning None when the surplus is negative which always happens when the price is not respected.
Note that the error does not cause the settlement to be disregarded, the surplus is treated as 0.

To fix this I changed all single order solvers to use the same validation function which always compares both sell and buy amounts.

### Test Plan

Code still compiles. The new function is simple enough that a test is not useful (but please look at it carefully).
