### PR TITLE
`NativePriceEstimating` return prices denominated in Ether

### DIFF
--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -97,11 +97,22 @@ impl Estimate {
         amounts_to_price(sell_amount, buy_amount)
     }
 
+    /// The price for the estimate denominated in sell token.
+    ///
     /// The resulting price is how many units of sell_token needs to be sold for one unit of
     /// buy_token (sell_amount / buy_amount).
     pub fn price_in_sell_token_f64(&self, query: &Query) -> f64 {
         let (sell_amount, buy_amount) = self.amounts(query);
         sell_amount.to_f64_lossy() / buy_amount.to_f64_lossy()
+    }
+
+    /// The price of the estimate denominated in buy token.
+    ///
+    /// The resulting price is how many units of buy_token are bought for one unit of
+    /// sell_token (buy_amount / sell_amount).
+    pub fn price_in_buy_token_f64(&self, query: &Query) -> f64 {
+        let (sell_amount, buy_amount) = self.amounts(query);
+        buy_amount.to_f64_lossy() / sell_amount.to_f64_lossy()
     }
 }
 

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -69,7 +69,7 @@ impl NativePriceEstimating for NativePriceEstimator {
             .into_iter()
             .zip(native_token_queries.iter())
             .map(|(estimate, query)| {
-                estimate.map(|estimate| estimate.price_in_sell_token_f64(query))
+                estimate.map(|estimate| estimate.price_in_buy_token_f64(query))
             })
             .collect()
     }
@@ -106,7 +106,7 @@ mod tests {
             .now_or_never()
             .unwrap()
             .unwrap();
-        assert_eq!(price, 0.123456789);
+        assert_eq!(price, 1. / 0.123456789);
     }
 
     #[test]

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -6,8 +6,10 @@ use std::sync::Arc;
 #[mockall::automock]
 #[async_trait::async_trait]
 pub trait NativePriceEstimating: Send + Sync {
-    /// The resulting price is how many units of token needs to be sold for one unit of
-    /// the chain's native token (sell_amount / buy_amount).
+    /// Returns a price estimate for the specified token query.
+    ///
+    /// Prices are denominated in native token (i.e. the amount of native token
+    /// that is needed to buy 1 unit of the specified token).
     async fn estimate_native_price(&self, token: &H160) -> Result<f64, PriceEstimationError> {
         self.estimate_native_prices(std::slice::from_ref(token))
             .await
@@ -16,9 +18,10 @@ pub trait NativePriceEstimating: Send + Sync {
             .unwrap()
     }
 
-    /// The resulting price is how many units of token needs to be sold for one unit of
-    /// the chain's native token (sell_amount / buy_amount).
-    /// Returns one result for each query.
+    /// Returns a price estimate for each query.
+    ///
+    /// Prices are denominated in native token (i.e. the amount of native token
+    /// that is needed to buy 1 unit of the specified token).
     async fn estimate_native_prices(
         &self,
         tokens: &[H160],


### PR DESCRIPTION
This PR changes the `NativePriceEstimating` implementation to return query token prices denominated in native token instead of prices of the native token denominated in query tokens.

I noticed this when implementing #1649 and thought it made slightly more sense to have native token prices be denominated in native token. That is:
```rust
let prices = native_price_estimator.estimate_native_prices([foo, bar]);
```

This will give us a price vector that are in the same unit instead of having a different unit per estimate (meaning that comparisons of prices returned from the request are meaningful):
```rust
prices[0] = price_of_foo_in_eth;
prices[1] = price_of_bar_in_eth;
```

I don't feel strongly about this, it just confused me a bit when implementing `v1/auction` endpoint and wanted to propose this change to see what you all think. I'm also OK with just closing this PR if you don't think its necessary.

### Test Plan

CI and existing unit tests.
