### PR TITLE
Use resolver 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = ["crates/*"]
 
 [patch.crates-io]


### PR DESCRIPTION
For 2021 edition this defaults to 2 for individual crates but not for
workspaces.

You can read more about this here https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html . Basically this forces us to specify the right features in some cases instead of the code accidentally compiling because a required feature gets enabled from somewhere else.
There is no immediate reason to enable it. I just recently learned it isn't the default for workspaces.

### Test Plan
CI
