### PR TITLE
Deprecate `EthAwareMinFeeCalculator`

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -7,7 +7,7 @@ use orderbook::{
     api::post_quote::OrderQuoter,
     database::Postgres,
     event_updater::EventUpdater,
-    fee::{EthAwareMinFeeCalculator, FeeSubsidyConfiguration},
+    fee::{FeeSubsidyConfiguration, MinFeeCalculator},
     orderbook::Orderbook,
     solvable_orders::SolvableOrdersCache,
 };
@@ -141,10 +141,9 @@ impl OrderbookServices {
             contracts.weth.address(),
             1_000_000_000_000_000_000_u128.into(),
         ));
-        let fee_calculator = Arc::new(EthAwareMinFeeCalculator::new(
+        let fee_calculator = Arc::new(MinFeeCalculator::new(
             price_estimator.clone(),
             gas_estimator,
-            contracts.weth.address(),
             db.clone(),
             bad_token_detector.clone(),
             FeeSubsidyConfiguration {

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -12,7 +12,7 @@ use orderbook::{
     api::{order_validation::OrderValidator, post_quote::OrderQuoter},
     database::{self, orders::OrderFilter, Postgres},
     event_updater::EventUpdater,
-    fee::{EthAwareMinFeeCalculator, FeeSubsidyConfiguration},
+    fee::{FeeSubsidyConfiguration, MinFeeCalculator},
     gas_price::InstrumentedGasEstimator,
     metrics::Metrics,
     orderbook::Orderbook,
@@ -540,10 +540,9 @@ async fn main() {
         Some(args.native_price_cache_max_update_size),
     );
 
-    let fee_calculator = Arc::new(EthAwareMinFeeCalculator::new(
+    let fee_calculator = Arc::new(MinFeeCalculator::new(
         price_estimator.clone(),
         gas_price_estimator,
-        native_token.address(),
         database.clone(),
         bad_token_detector.clone(),
         FeeSubsidyConfiguration {


### PR DESCRIPTION
This PR removes the `orderbook::fee::{EthAdapter, EthAwareMinFeeCalculator}` types. Follow up to #1656.

These types existed for computing minimum order fees for orders taking the `BUY_ETH_ADDRESS` marker value for the `buy_token` into account. However, this is no longer needed since the `SanitizingPriceEstimator` already does this for us **and** adds a gas amount to compensate for the WETH unwrap cost.

With this change, we should still continue supporting native token buy orders as before (i.e. orders where `buy_token == BUY_ETH_ADDRESS`) while charging a small premium on the fee to account for the WETH unwrap interaction that the solvers need to perform.

One downside to this is that we can't take advantage of the cached fee measurement entry in the database between ETH and WETH orders with the same amounts. One alternative would be to also include logic in the `impl MinFeeCalculating for EthAdapter` implementation to add the WETH unwrap gas premium. That being said I slightly prefer the solution here as it removes the necessity of having multiple components aware of `native_token` for the purpose of normalizing `buy_token` for estimates.

### Test Plan

Existing CI - just removed some code. The E2E test that buys ETH should verify that this change does not cause any regressions.

You can also see that it still works with the `/quote` API:
```
% curl -s \
  -X POST \
  -H 'Content-Type: application/json' \
  --data '@-' \
  'http://localhost:8080/api/v1/quote' \
  <<JSON | jq '.quote | { sellAmount, buyAmount, feeAmount }'
{
  "from": "0x0001020304050607080910111213141516171819",
  "sellToken": "0xba100000625a3754423978a60c9317c58a424e3d",
  "buyToken": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
  "receiver": "0x0000000000000000000000000000000000000000",
  "buyAmountAfterFee": "1000000000000000000",
  "validTo": 2147483648,
  "appData": "0xe9f29ae547955463ed535162aefee525d8d309571a2b18bc26086c8c35d781eb",
  "kind": "buy",
  "partiallyFillable": false,
  "sellTokenBalance": "external",
  "buyTokenBalance": "erc20"
}
JSON

{
  "sellAmount": "200274328056010037013",
  "buyAmount": "1000000000000000000",
  "feeAmount": "3736440792904630784"
}
```
