### PR TITLE
Use error types instead of result enums for order operations

### DIFF
--- a/crates/orderbook/src/api/create_order.rs
+++ b/crates/orderbook/src/api/create_order.rs
@@ -1,9 +1,9 @@
 use crate::{
     api::{extract_payload, IntoWarpReply},
-    orderbook::{AddOrderResult, Orderbook},
+    orderbook::{AddOrderError, Orderbook},
 };
 use anyhow::Result;
-use model::order::OrderCreationPayload;
+use model::order::{OrderCreationPayload, OrderUid};
 use std::{convert::Infallible, sync::Arc};
 use warp::reply::with_status;
 use warp::{hyper::StatusCode, Filter, Rejection};
@@ -15,22 +15,30 @@ pub fn create_order_request(
         .and(extract_payload())
 }
 
-pub fn create_order_response(result: Result<AddOrderResult>) -> super::ApiReply {
+impl IntoWarpReply for AddOrderError {
+    fn into_warp_reply(self) -> super::ApiReply {
+        match self {
+            Self::OrderValidation(err) => err.into_warp_reply(),
+            Self::UnsupportedSignature => with_status(
+                super::error("UnsupportedSignature", "signing scheme is not supported"),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::DuplicatedOrder => with_status(
+                super::error("DuplicatedOrder", "order already exists"),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::Database(err) => with_status(
+                super::internal_error(anyhow::Error::new(err).context("create_order")),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        }
+    }
+}
+
+pub fn create_order_response(result: Result<OrderUid, AddOrderError>) -> super::ApiReply {
     match result {
-        Ok(AddOrderResult::Added(uid)) => with_status(warp::reply::json(&uid), StatusCode::CREATED),
-        Ok(AddOrderResult::OrderValidation(err)) => err.into_warp_reply(),
-        Ok(AddOrderResult::UnsupportedSignature) => with_status(
-            super::error("UnsupportedSignature", "signing scheme is not supported"),
-            StatusCode::BAD_REQUEST,
-        ),
-        Ok(AddOrderResult::DuplicatedOrder) => with_status(
-            super::error("DuplicatedOrder", "order already exists"),
-            StatusCode::BAD_REQUEST,
-        ),
-        Err(err) => with_status(
-            super::internal_error(err.context("create_order")),
-            StatusCode::INTERNAL_SERVER_ERROR,
-        ),
+        Ok(uid) => with_status(warp::reply::json(&uid), StatusCode::CREATED),
+        Err(err) => err.into_warp_reply(),
     }
 }
 
@@ -78,7 +86,7 @@ mod tests {
     #[tokio::test]
     async fn create_order_response_created() {
         let uid = OrderUid([1u8; 56]);
-        let response = create_order_response(Ok(AddOrderResult::Added(uid))).into_response();
+        let response = create_order_response(Ok(uid)).into_response();
         assert_eq!(response.status(), StatusCode::CREATED);
         let body = response_body(response).await;
         let body: serde_json::Value = serde_json::from_slice(body.as_slice()).unwrap();
@@ -90,7 +98,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_order_response_duplicate() {
-        let response = create_order_response(Ok(AddOrderResult::DuplicatedOrder)).into_response();
+        let response = create_order_response(Err(AddOrderError::DuplicatedOrder)).into_response();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let body = response_body(response).await;
         let body: serde_json::Value = serde_json::from_slice(body.as_slice()).unwrap();


### PR DESCRIPTION
This PR refactors the `add_order` and `cancel_order` orderbook operations to return `Result<_, Error>` instead of `Result<ResultEnum>`.

This is mostly a cleanup and doesn't change any behaviour. The rationale behind the change is that:
- The `Result::Ok(ResultEnum::SomeErrorCondition)` actually represent errors (since they return `4xx` and `5xx` error codes) and it made more sense to me to use error types instead of nested result types.
- Allows for `?` operator to be used in the implementation, simplifying things a bit.

I also noticed when refactoring that the `cancel_order` API endpoint returns `200 OK` with a static string. I think it would be slightly more correct to return `204 No Content` but that is a separate change that I don't want to include here (and may require coordinating with the FE team in case they are relying on the current behaviour).

### Test Plan

Existing unit tests continue to pass.
