### PR TITLE
Add `/quote` parameter to get fast prices instead of optimal prices

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -532,6 +532,10 @@ components:
       description: Where should the buy token be transfered to?
       type: string
       enum: [ erc20, internal ]
+    PriceQuality:
+      description: How good should the price estimate be?
+      type: string
+      enum: [ fast, optimal ]
     OrderStatus:
       description: The current order status
       type: string
@@ -928,6 +932,9 @@ components:
               default: "erc20"
             from:
               $ref: "#/components/schemas/Address"
+            priceQuality:
+              $ref: "#/components/schemas/PriceQuality"
+              default: "optimal"
           required:
             - sellToken
             - buyToken

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -4,7 +4,7 @@ use crate::{
         order_validation::{OrderValidating, PreOrderData, ValidationError},
         IntoWarpReply,
     },
-    fee::{FeeData, MinFeeCalculating},
+    fee::{FeeData, MinFeeCalculating, PriceQuality},
 };
 use anyhow::Result;
 use chrono::{DateTime, Utc};
@@ -37,6 +37,8 @@ pub struct OrderQuoteRequest {
     sell_token_balance: SellTokenSource,
     #[serde(default)]
     buy_token_balance: BuyTokenDestination,
+    #[serde(default)]
+    price_quality: PriceQuality,
 }
 
 impl From<&OrderQuoteRequest> for PreOrderData {
@@ -426,6 +428,7 @@ mod tests {
                 "appData": "0x9090909090909090909090909090909090909090909090909090909090909090",
                 "partiallyFillable": false,
                 "buyTokenBalance": "internal",
+                "priceQuality": "optimal"
             }))
             .unwrap(),
             OrderQuoteRequest {
@@ -441,6 +444,7 @@ mod tests {
                 partially_fillable: false,
                 sell_token_balance: SellTokenSource::Erc20,
                 buy_token_balance: BuyTokenDestination::Internal,
+                price_quality: PriceQuality::Optimal
             }
         );
     }
@@ -458,6 +462,7 @@ mod tests {
                 "appData": "0x9090909090909090909090909090909090909090909090909090909090909090",
                 "partiallyFillable": false,
                 "sellTokenBalance": "external",
+                "priceQuality": "fast"
             }))
             .unwrap(),
             OrderQuoteRequest {
@@ -473,6 +478,7 @@ mod tests {
                 partially_fillable: false,
                 sell_token_balance: SellTokenSource::External,
                 buy_token_balance: BuyTokenDestination::Erc20,
+                price_quality: PriceQuality::Fast
             }
         );
     }
@@ -505,6 +511,7 @@ mod tests {
                 partially_fillable: false,
                 sell_token_balance: SellTokenSource::Erc20,
                 buy_token_balance: BuyTokenDestination::Erc20,
+                price_quality: Default::default()
             }
         );
     }

--- a/crates/orderbook/src/fee.rs
+++ b/crates/orderbook/src/fee.rs
@@ -4,6 +4,7 @@ use futures::future::TryFutureExt;
 use gas_estimation::GasPriceEstimating;
 use model::{app_id::AppId, order::OrderKind};
 use primitive_types::{H160, U256};
+use serde::{Deserialize, Serialize};
 use shared::{
     bad_token::BadTokenDetecting,
     price_estimation::native::NativePriceEstimating,
@@ -15,6 +16,19 @@ use std::{
 };
 
 pub type Measurement = (U256, DateTime<Utc>);
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum PriceQuality {
+    Fast,
+    Optimal,
+}
+
+impl Default for PriceQuality {
+    fn default() -> Self {
+        Self::Optimal
+    }
+}
 
 /// Fee subsidy configuration.
 ///


### PR DESCRIPTION
Related to: #1359 

This PR adds the `priceQuality` query parameter to the `/quote` endpoint. It determines whether the price estimation should be `fast` or `optimal`. To not change the behavior by accident the default for `priceQuality` is `optimal`.

If the `OrderQuoter` handles a `fast` estimate request it forwards it to a `MinFeeCalculator` which uses  a  `RacingCompetitionPriceEstimator` internally. `optimal` requests get handled by the same components as before.

To configure how many successful price estimates the `RacingCompetitionPriceEstimator` needs to return a result early I added a CLI argument:
```
--fast-price-estimation-results-required <FAST_PRICE_ESTIMATION_RESULTS_REQUIRED>
            How many successful price estimates for each order will cause a fast price estimation to
            return its result early. The bigger the value the more the fast price estimation
            performs like the optimal price estimation. It's possible to pass values greater than
            the total number of enabled estimators but that will not have any further effect

            [default: 2]
```


### Test Plan
CI

Manual test:
Ran `orderbook` with: `cargo run --bin orderbook -- --node-url https://mainnet.infura.io/v3/<API_KEY> --skip-trace-api true   --quasimodo-solver-url <URL> --price-estimators Baseline,OneInch,Quasimodo,ZeroEx,Paraswap --fast-price-estimation-results-required 2`

Requested `fast` estimate:
```
time curl 'http://localhost:8080/api/v1/quote' -X POST -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:97.0) Gecko/20100101 Firefox/97.0' -H 'Accept: */*' -H 'Accept-Language: en-US,en;q=0.5' -H 'Accept-Encoding: gzip, deflate' -H 'Content-Type: application/json' -H 'Origin: https://bafybeias5x3tgdshkhj5umriqze2wioy5mjw4fdo2zzp2sl4pacq7rnwtm.ipfs.infura-ipfs.io' -H 'Connection: keep-alive' -H 'Sec-Fetch-Dest: empty' -H 'Sec-Fetch-Mode: cors' -H 'Sec-Fetch-Site: cross-site' --data-raw '{"sellToken":"0x6810e776880c02933d47db1b9fc05908e5386b96","buyToken":"0x1f9840a85d5af5bf1d1762f925bdaddc4201f984","receiver":"0x0000000000000000000000000000000000000000","validTo":2147483648,"appData":"0x0000000000000000000000000000000000000000000000000000000000000000","kind":"sell","partiallyFillable":false,"sellTokenBalance":"erc20","buyTokenBalance":"erc20","sellAmountBeforeFee":"2152080757633961000","from":"0x1a015AD600829D8b288BF3C50B9f557A2C12e9ca","priceQuality":"fast"}'
{"quote":{"sellToken":"0x6810e776880c02933d47db1b9fc05908e5386b96","buyToken":"0x1f9840a85d5af5bf1d1762f925bdaddc4201f984","receiver":"0x0000000000000000000000000000000000000000","sellAmount":"2017231869592956456","buyAmount":"68329075216910194413","validTo":2147483648,"appData":"0x0000000000000000000000000000000000000000000000000000000000000000","feeAmount":"134848888041004544","kind":"sell","partiallyFillable":false,"sellTokenBalance":"erc20","buyTokenBalance":"erc20"},"from":"0x1a015ad600829d8b288bf3c50b9f557a2c12e9ca","expiration":"2022-02-16T12:50:27.137302Z"}
0.00s user 0.01s system 3% cpu 0.298 total
```

Requested `optimal` estimate:
```
time curl 'http://localhost:8080/api/v1/quote' -X POST -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:97.0) Gecko/20100101 Firefox/97.0' -H 'Accept: */*' -H 'Accept-Language: en-US,en;q=0.5' -H 'Accept-Encoding: gzip, deflate' -H 'Content-Type: application/json' -H 'Origin: https://bafybeias5x3tgdshkhj5umriqze2wioy5mjw4fdo2zzp2sl4pacq7rnwtm.ipfs.infura-ipfs.io' -H 'Connection: keep-alive' -H 'Sec-Fetch-Dest: empty' -H 'Sec-Fetch-Mode: cors' -H 'Sec-Fetch-Site: cross-site' --data-raw '{"sellToken":"0x6810e776880c02933d47db1b9fc05908e5386b96","buyToken":"0x1f9840a85d5af5bf1d1762f925bdaddc4201f984","receiver":"0x0000000000000000000000000000000000000000","validTo":2147483648,"appData":"0x0000000000000000000000000000000000000000000000000000000000000000","kind":"sell","partiallyFillable":false,"sellTokenBalance":"erc20","buyTokenBalance":"erc20","sellAmountBeforeFee":"2052080757633961000","from":"0x1a015AD600829D8b288BF3C50B9f557A2C12e9ca","priceQuality":"optimal"}'
{"quote":{"sellToken":"0x6810e776880c02933d47db1b9fc05908e5386b96","buyToken":"0x1f9840a85d5af5bf1d1762f925bdaddc4201f984","receiver":"0x0000000000000000000000000000000000000000","sellAmount":"1917231869592956456","buyAmount":"64942085553522342762","validTo":2147483648,"appData":"0x0000000000000000000000000000000000000000000000000000000000000000","feeAmount":"134848888041004544","kind":"sell","partiallyFillable":false,"sellTokenBalance":"erc20","buyTokenBalance":"erc20"},"from":"0x1a015ad600829d8b288bf3c50b9f557a2c12e9ca","expiration":"2022-02-16T12:50:15.460611Z"}
0.01s user 0.01s system 1% cpu 1.322 total
```

### Release notes
Added `priceQuality` parameter to `/quote` endpoint.
