### PR TITLE
Support Wrapping Native Asset In Sanitized Estimator

### DIFF
--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -135,7 +135,7 @@ async fn eth_integration(web3: Web3) {
     assert_eq!(fee_buy_eth.status(), 200);
     // Eth is only supported as the buy token
     let fee_invalid_token = estimate_fee(BUY_ETH_ADDRESS, token.address()).await;
-    assert_eq!(fee_invalid_token.status(), 404);
+    assert_eq!(fee_invalid_token.status(), 400);
 
     // Place Orders
     assert_ne!(weth.address(), BUY_ETH_ADDRESS);

--- a/crates/shared/src/price_estimation/gas.rs
+++ b/crates/shared/src/price_estimation/gas.rs
@@ -52,4 +52,8 @@ pub static GAS_PER_UNISWAP: u64 = 94_696;
 /// https://etherscan.io/tx/0x1c345a6da1edb2bba953685a4cf85f6a0d967ac751f8c5b518578c5fd20a7c96
 pub static GAS_PER_BALANCER_SWAP: u64 = 120_000;
 
+/// Median gas used for unwrapping portion of WETH.
 pub static GAS_PER_WETH_UNWRAP: u64 = 14_192;
+
+/// Median gas used for wrapping WETH for the first time.
+pub static GAS_PER_WETH_WRAP: u64 = 24_038;

--- a/crates/shared/src/price_estimation/sanitized.rs
+++ b/crates/shared/src/price_estimation/sanitized.rs
@@ -1,6 +1,6 @@
 use super::{Estimate, PriceEstimating, PriceEstimationError, Query};
 use crate::bad_token::{BadTokenDetecting, TokenQuality};
-use crate::price_estimation::gas::GAS_PER_WETH_UNWRAP;
+use crate::price_estimation::gas::{GAS_PER_WETH_UNWRAP, GAS_PER_WETH_WRAP};
 use anyhow::Result;
 use model::order::BUY_ETH_ADDRESS;
 use primitive_types::H160;
@@ -19,7 +19,7 @@ type EstimationResult = Result<Estimate, PriceEstimationError>;
 
 enum EstimationProgress<'a> {
     TrivialSolution(EstimationResult),
-    AwaitingEthEstimation(&'a Query),
+    AwaitingEthEstimation(&'a Query, u64),
     AwaitingErc20Estimation,
 }
 
@@ -102,9 +102,6 @@ impl PriceEstimating for SanitizedPriceEstimator {
         let all_estimates = queries
             .iter()
             .map(|query| {
-                if query.sell_token == BUY_ETH_ADDRESS {
-                    return TrivialSolution(Err(PriceEstimationError::NoLiquidity));
-                }
                 if let Some(err) = token_quality_errors.get(&query.buy_token) {
                     return TrivialSolution(Err(err.clone()));
                 }
@@ -131,6 +128,15 @@ impl PriceEstimating for SanitizedPriceEstimator {
                     tracing::debug!(?query, ?estimation, "generate trivial unwrap estimation");
                     return TrivialSolution(Ok(estimation));
                 }
+                if query.sell_token == BUY_ETH_ADDRESS && query.buy_token == self.native_token {
+                    let estimation = Estimate {
+                        out_amount: query.in_amount,
+                        gas: GAS_PER_WETH_WRAP.into(),
+                    };
+
+                    tracing::debug!(?query, ?estimation, "generate trivial wrap estimation");
+                    return TrivialSolution(Ok(estimation));
+                }
 
                 if query.sell_token != self.native_token && query.buy_token == BUY_ETH_ADDRESS {
                     let sanitized_query = Query {
@@ -141,11 +147,26 @@ impl PriceEstimating for SanitizedPriceEstimator {
                     tracing::debug!(
                         ?query,
                         ?sanitized_query,
-                        "estimate price for wrapped native asset"
+                        "estimate price for buying native asset"
                     );
 
                     difficult_queries.push(sanitized_query);
-                    return AwaitingEthEstimation(query);
+                    return AwaitingEthEstimation(query, GAS_PER_WETH_UNWRAP);
+                }
+                if query.sell_token == BUY_ETH_ADDRESS && query.buy_token != self.native_token {
+                    let sanitized_query = Query {
+                        sell_token: self.native_token,
+                        ..*query
+                    };
+
+                    tracing::debug!(
+                        ?query,
+                        ?sanitized_query,
+                        "estimate price for selling native asset"
+                    );
+
+                    difficult_queries.push(sanitized_query);
+                    return AwaitingEthEstimation(query, GAS_PER_WETH_WRAP);
                 }
 
                 difficult_queries.push(*query);
@@ -168,20 +189,20 @@ impl PriceEstimating for SanitizedPriceEstimator {
                 AwaitingErc20Estimation => difficult_estimates
                     .next()
                     .expect("there is a result for every forwarded query"),
-                AwaitingEthEstimation(query) => {
+                AwaitingEthEstimation(query, weth_op_gas) => {
                     let mut final_estimation = difficult_estimates
                         .next()
                         .expect("there is a result for every forwarded query")?;
                     final_estimation.gas = final_estimation
                         .gas
-                        .checked_add(GAS_PER_WETH_UNWRAP.into())
+                        .checked_add(weth_op_gas.into())
                         .ok_or(anyhow::anyhow!(
-                            "cost of unwrapping ETH would overflow gas price"
+                            "cost of converting native asset would overflow gas price"
                         ))?;
                     tracing::debug!(
                         ?query,
                         ?final_estimation,
-                        "added cost of unwrapping WETH to price estimation"
+                        "added cost of converting native asset to price estimation"
                     );
                     Ok(final_estimation)
                 }
@@ -245,6 +266,15 @@ mod tests {
                 in_amount: U256::MAX,
                 kind: OrderKind::Buy,
             },
+            // `sanitized_estimator` will replace `sell_token` with `native_token` before querying
+            // `wrapped_estimator`.
+            // `sanitized_estimator` will add cost of wrapping ETH to Estimate.
+            Query {
+                sell_token: BUY_ETH_ADDRESS,
+                buy_token: H160::from_low_u64_le(1),
+                in_amount: 1.into(),
+                kind: OrderKind::Buy,
+            },
             // Can be estimated by `sanitized_estimator` because `buy_token` and `sell_token` are identical.
             Query {
                 sell_token: H160::from_low_u64_le(1),
@@ -252,10 +282,24 @@ mod tests {
                 in_amount: 1.into(),
                 kind: OrderKind::Sell,
             },
+            // Can be estimated by `sanitized_estimator` because both tokens are the native token.
+            Query {
+                sell_token: BUY_ETH_ADDRESS,
+                buy_token: BUY_ETH_ADDRESS,
+                in_amount: 1.into(),
+                kind: OrderKind::Sell,
+            },
             // Can be estimated by `sanitized_estimator` because it is a native token unwrap.
             Query {
                 sell_token: native_token,
                 buy_token: BUY_ETH_ADDRESS,
+                in_amount: 1.into(),
+                kind: OrderKind::Sell,
+            },
+            // Can be estimated by `sanitized_estimator` because it is a native token wrap.
+            Query {
+                sell_token: BUY_ETH_ADDRESS,
+                buy_token: native_token,
                 in_amount: 1.into(),
                 kind: OrderKind::Sell,
             },
@@ -273,13 +317,6 @@ mod tests {
                 in_amount: 1.into(),
                 kind: OrderKind::Buy,
             },
-            // Will throw `NoLiquidity` error in `sanitized_estimator`.
-            Query {
-                sell_token: BUY_ETH_ADDRESS,
-                buy_token: H160::from_low_u64_le(1),
-                in_amount: 1.into(),
-                kind: OrderKind::Buy,
-            },
         ];
 
         let expected_forwarded_queries = [
@@ -294,6 +331,11 @@ mod tests {
                 // SanitizedPriceEstimator replaces ETH buy token with native token
                 buy_token: native_token,
                 ..queries[2]
+            },
+            Query {
+                // SanitizedPriceEstimator replaces ETH sell token with native token
+                sell_token: native_token,
+                ..queries[3]
             },
         ];
 
@@ -316,6 +358,10 @@ mod tests {
                         out_amount: 1.into(),
                         gas: U256::MAX,
                     }),
+                    Ok(Estimate {
+                        out_amount: 1.into(),
+                        gas: 100.into(),
+                    }),
                 ]))
             });
 
@@ -326,7 +372,7 @@ mod tests {
         };
 
         let result = sanitized_estimator.estimates(&queries).await;
-        assert_eq!(result.len(), 8);
+        assert_eq!(result.len(), 10);
         assert_eq!(
             result[0].as_ref().unwrap(),
             &Estimate {
@@ -340,41 +386,60 @@ mod tests {
                 out_amount: 1.into(),
                 //sanitized_estimator will add ETH_UNWRAP_COST to the gas of any
                 //Query with ETH as the buy_token.
-                gas: U256::from(GAS_PER_WETH_UNWRAP)
-                    .checked_add(100.into())
-                    .unwrap()
+                gas: U256::from(GAS_PER_WETH_UNWRAP + 100),
             }
         );
         assert!(matches!(
             result[2].as_ref().unwrap_err(),
             PriceEstimationError::Other(err)
-                if err.to_string() == "cost of unwrapping ETH would overflow gas price",
+                if err.to_string() == "cost of converting native asset would overflow gas price",
         ));
         assert_eq!(
             result[3].as_ref().unwrap(),
             &Estimate {
                 out_amount: 1.into(),
-                gas: 0.into()
+                //sanitized_estimator will add ETH_WRAP_COST to the gas of any
+                //Query with ETH as the sell_token.
+                gas: U256::from(GAS_PER_WETH_WRAP + 100),
             }
         );
         assert_eq!(
             result[4].as_ref().unwrap(),
             &Estimate {
                 out_amount: 1.into(),
+                gas: 0.into()
+            }
+        );
+        assert_eq!(
+            result[5].as_ref().unwrap(),
+            &Estimate {
+                out_amount: 1.into(),
+                gas: 0.into()
+            }
+        );
+        assert_eq!(
+            result[6].as_ref().unwrap(),
+            &Estimate {
+                out_amount: 1.into(),
+                // Sanitized estimator will report a 1:1 estimate when unwrapping native token.
                 gas: GAS_PER_WETH_UNWRAP.into()
             }
         );
+        assert_eq!(
+            result[7].as_ref().unwrap(),
+            &Estimate {
+                out_amount: 1.into(),
+                // Sanitized estimator will report a 1:1 estimate when wrapping native token.
+                gas: GAS_PER_WETH_WRAP.into()
+            }
+        );
         assert!(matches!(
-            result[5].as_ref().unwrap_err(),
+            result[8].as_ref().unwrap_err(),
             PriceEstimationError::UnsupportedToken(_)
         ));
         assert!(matches!(
-            result[6].as_ref().unwrap_err(),
+            result[9].as_ref().unwrap_err(),
             PriceEstimationError::UnsupportedToken(_)
-        ));
-        assert!(matches!(
-            result[7].as_ref().unwrap_err(),
-            PriceEstimationError::NoLiquidity
         ));
     }
 }


### PR DESCRIPTION
This PR add support for wrapping native asset (i.e. `sell_token = BUY_ETH_ADDRESS` queries) to the `SanitizedPriceEsimator`.

The main motivation for this PR is to unblock #1649, which currently is failing the native token E2E test. The reason that PR effectively changes the services to use `estimated_prices` computed by `NativePriceEstimating` component - which doesn't support `0xeee..eee` (i.e. `BUY_ETH_ADDRESS`). This is because, under the hood, we use a `SanitizedPriceEsimator` to compute token prices, and it automatically rejects queries where `sell_token == BUY_ETH_ADDRESS`.

There are two straight-forward ways of fixing this issue that I could think of:
1. Lift the restriction on `sell_token == BUY_ETH_ADDRESS` queries in `SanitizedPriceEsimator` (Note that this is not an issue at an API level since we now reject orders and quotes where `sell_token == BUY_ETH_ADDRESS` with a specialized error since #1664 ).
2. Automatically add an entry for `prices[BUY_ETH_ADDRESS] = 1e18` before filtering orders that don't have token prices.

The reason I went for 1. is that, conceptually, it makes sense to be able to estimate conversions from the native asset to another token using our price estimator (even if the contracts don't support such orders). One example of where this can, conceptually, make sense is if we have an interaction that swaps an ERC20 for ETH and **not** WETH (for example Uniswap V1 - although in practice there is absolutely no liquidity there) and then we need some way to convert the ETH to some other token. This way, the price estimator would be able to give us a price estimate for such a conversion (regardless of whether or not CowSwap supports such orders).

That being said, I am OK with going for option 2. as well, WDYT?

Regarding the implementation - it is a little verbose and am not 100% happy with how the code turned out (it seemed nicer before 😛). I couldn't figure out anything cleaver to reduce some of the duplicated code across wrap and unwrap paths.

### Test Plan

Added more cases for new logic in existing unit test.
