### PR TITLE
Track Filtered Solvable Orders

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -8,6 +8,7 @@ use orderbook::{
     database::Postgres,
     event_updater::EventUpdater,
     fee::{FeeSubsidyConfiguration, MinFeeCalculator},
+    metrics::NoopMetrics,
     orderbook::Orderbook,
     solvable_orders::SolvableOrdersCache,
 };
@@ -185,6 +186,7 @@ impl OrderbookServices {
             Duration::from_secs(600),
             order_validator.clone(),
             event_updater.clone(),
+            Arc::new(NoopMetrics),
         ));
         let maintenance = ServiceMaintenance {
             maintainers: vec![db.clone(), event_updater],

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -609,6 +609,7 @@ async fn main() {
         args.solvable_orders_max_update_age,
         order_validator.clone(),
         event_updater.clone(),
+        metrics.clone(),
     ));
     let mut service_maintainer = ServiceMaintenance {
         maintainers: vec![database.clone(), event_updater, pool_fetcher],


### PR DESCRIPTION
This PR does a couple of small things in the hopes of facilitating debugging why orders get filtered out once #1655 gets merged:

- First it adds a new `filtered_solvalbe_orders` metric counter that is incremented for every order that is filtered out because of missing token prices. We can use this to setup Grafana alerts so that we get notified when this happens. Since orders only get added if there are native token prices for it, this _should_ be 0. That being said, it is possible for an order to get added and then later the token liquidity dries up to the point that there is no more native token price.
- Added a log side-effect in the `retain` closure so that debugging which/why orders get filtered out because of missing native token prices is easier.

### Test Plan

CI - no logic changes just minor logging and metrics.