### PR TITLE
Add latest settlement block to Auction model

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -185,7 +185,6 @@ impl OrderbookServices {
             solvable_orders_cache.clone(),
             Duration::from_secs(600),
             order_validator.clone(),
-            event_updater.clone(),
             Arc::new(NoopMetrics),
         ));
         let maintenance = ServiceMaintenance {

--- a/crates/model/src/auction.rs
+++ b/crates/model/src/auction.rs
@@ -9,11 +9,18 @@ use std::collections::BTreeMap;
 /// A batch auction.
 #[serde_as]
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Auction {
     /// The block that this auction is valid for.
     /// The block number for the auction. Orders and prices are guaranteed to be
     /// valid on this block.
     pub block: u64,
+
+    /// The latest block on which a settlement has been processed.
+    ///
+    /// Note that under certain conditions it is possible for a settlement to
+    /// have been mined as part of [`block`] but not have yet been processed.
+    pub latest_settlement_block: u64,
 
     /// The solvable orders included in the auction.
     pub orders: Vec<Order>,
@@ -41,6 +48,7 @@ mod tests {
         };
         let auction = Auction {
             block: 42,
+            latest_settlement_block: 40,
             orders: vec![order(1), order(2)],
             prices: btreemap! {
                 H160([2; 20]) => U256::from(2),
@@ -52,6 +60,7 @@ mod tests {
             serde_json::to_value(&auction).unwrap(),
             json!({
                 "block": 42,
+                "latestSettlementBlock": 40,
                 "orders": [
                     order(1),
                     order(2),

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -679,6 +679,13 @@ components:
           description: |
             The block number for the auction. Orders and prices are guaranteed to be valid on this
             block. Proposed settlements should be valid for this block as well.
+        latestSettlementBlock:
+          type: integer
+          description: |
+            The latest block on which a settlement has been processed.
+
+            Note that under certain conditions it is possible for a settlement to have been mined as
+            part of `block` but not have yet been processed.
         orders:
           type: array
           items:

--- a/crates/orderbook/src/event_updater.rs
+++ b/crates/orderbook/src/event_updater.rs
@@ -11,14 +11,6 @@ use shared::{
 };
 use tokio::sync::Mutex;
 
-/// A trait for abstracting event updater methods.
-#[async_trait::async_trait]
-pub trait EventUpdating: Send + Sync + 'static {
-    /// Returns the last handled block number. Events are guaranteed to be
-    /// processed up until this block.
-    async fn last_handled_block(&self) -> Option<u64>;
-}
-
 pub struct EventUpdater<Database: EventStoring<ContractEvent>>(
     Mutex<EventHandler<DynWeb3, GPv2SettlementContract, Database>>,
 );
@@ -38,16 +30,6 @@ where
             db,
             start_sync_at_block,
         )))
-    }
-}
-
-#[async_trait::async_trait]
-impl<Database> EventUpdating for EventUpdater<Database>
-where
-    Database: EventStoring<ContractEvent> + Send + Sync + 'static,
-{
-    async fn last_handled_block(&self) -> Option<u64> {
-        self.0.lock().await.last_handled_block()
     }
 }
 

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -618,14 +618,18 @@ async fn main() {
         bad_token_detector,
         native_price_estimator,
         args.enable_presign_orders,
-        solvable_orders_cache,
+        solvable_orders_cache.clone(),
         args.solvable_orders_max_update_age,
         order_validator.clone(),
-        event_updater.clone(),
         metrics.clone(),
     ));
     let mut service_maintainer = ServiceMaintenance {
-        maintainers: vec![database.clone(), event_updater, pool_fetcher],
+        maintainers: vec![
+            database.clone(),
+            event_updater,
+            pool_fetcher,
+            solvable_orders_cache,
+        ],
     };
     if let Some(balancer) = balancer_pool_fetcher {
         service_maintainer.maintainers.push(balancer);

--- a/crates/orderbook/src/solvable_orders.rs
+++ b/crates/orderbook/src/solvable_orders.rs
@@ -91,7 +91,6 @@ impl SolvableOrdersCache {
         self.notify.notify_one();
     }
 
-    /// Returns the last handled block by the solvable order cache.
     /// Manually update solvable orders. Usually called by the background updating task.
     pub async fn update(&self, block: u64) -> Result<()> {
         let min_valid_to = now_in_epoch_seconds() + self.min_order_validity_period.as_secs() as u32;

--- a/crates/solver/src/in_flight_orders.rs
+++ b/crates/solver/src/in_flight_orders.rs
@@ -14,7 +14,9 @@ impl InFlightOrders {
     /// Takes note of the new set of solvable orders and returns the ones that aren't in flight.
     pub fn update_and_filter(&mut self, auction: &mut Auction) {
         // If api has seen block X then trades starting at X + 1 are still in flight.
-        self.in_flight = self.in_flight.split_off(&(auction.block + 1));
+        self.in_flight = self
+            .in_flight
+            .split_off(&(auction.latest_settlement_block + 1));
 
         // TODO - could model inflight_trades as HashMap<OrderUid, Vec<Trade>>
         // https://github.com/gnosis/gp-v2-services/issues/673

--- a/crates/solver/src/in_flight_orders.rs
+++ b/crates/solver/src/in_flight_orders.rs
@@ -74,6 +74,10 @@ mod tests {
 
         auction.block = 1;
         let filtered = update_and_get_filtered_orders(&auction);
+        assert_eq!(filtered.len(), 1);
+
+        auction.latest_settlement_block = 1;
+        let filtered = update_and_get_filtered_orders(&auction);
         assert_eq!(filtered.len(), 2);
     }
 }


### PR DESCRIPTION
This PR fixes a regression introduced with #1655.

Specifically, the `/auction` endpoint assumed that once the `event_updater` had finished processing a new block that the solvable orders cache would have already been updated. However:
- These two components update on different schedules so this is not true - this caused the returned `Auction` model to say it was on block `X` (which, for example, could include a new settlement) even though the solvable orders had not been updated on that block.
- Updates on new blocks are racy. This means that the solvable orders may process block `X` _while_ the event handler is waiting on events for the block from the node, causing the database to still reflect block `X-1` instead, meaning that it did not "truly" update to block `X` as it used stale settlement data and may include filled orders in the `solvable_orders` collection.

This PR does two things:
- Request updating the solvable order cache on each new block. This ensures that user balances are as up to date as possible.
- Re-introduces the `latest_settlement_block` to the `Auction` type as a reliable way to determine which orders may be considered "in flight" or not.

Ultimately, there is a bit of a "data synchronization" issue that is hard to solve here - we get data from two places (current block number and balances from the block chain and settlements from the DB) and they aren't necessarily in sync when updating the solvable orders cache.

Furthermore, #1655 introduced `EventUpdating` for getting the latest handled block. Since we don't use it anymore I went ahead and reverted that part of the change to clean things up a bit.

Note that I didn't bump the API version from `v1/auction` to `v2/auction` since it is still in staging.

### Test Plan

CI and existing unit tests.
