### PR TITLE
Stop inspecting Quasimodo metadata field

### DIFF
--- a/crates/shared/src/price_estimation/quasimodo.rs
+++ b/crates/shared/src/price_estimation/quasimodo.rs
@@ -137,23 +137,6 @@ impl QuasimodoPriceEstimator {
             )
             .await?;
 
-        if let Some(metadata) = settlement.metadata {
-            if !metadata.has_solution.unwrap_or(true) {
-                return match metadata.result.as_deref() {
-                    Some("Infeasible" | "InfeasibleOrUnbounded" | "Unbounded") => {
-                        Err(PriceEstimationError::NoLiquidity)
-                    }
-                    Some(error) => Err(PriceEstimationError::Other(anyhow::anyhow!(
-                        "quasimodo didn't return a solution: {}",
-                        error
-                    ))),
-                    None => Err(PriceEstimationError::Other(anyhow::anyhow!(
-                        "quasimodo didn't return a solution"
-                    ))),
-                };
-            }
-        }
-
         if !settlement.orders.contains_key(&0) {
             return Err(PriceEstimationError::NoLiquidity);
         }


### PR DESCRIPTION
Whether a returned settlement is usable depends on the actual
settlements and not what the metadata fields say. The previous check
caused us to interpret soft errors as hard "other error"s when no
liquidity makes more sense.

### Test Plan

CI, no need for extra unit test
