### PR TITLE
Handle EDEN transaction fee too high errors

### DIFF
--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -55,7 +55,7 @@ pub enum SubmitApiError {
     OpenEthereumTooCheapToReplace, // todo ds safe to remove after dropping OE support
     /// EDEN network will reject transactions where the maximum gas cost in ETH
     /// is over 1.0.
-    TransactionTooExpensive,
+    EdenTransactionTooExpensive,
     Other(anyhow::Error),
 }
 
@@ -437,7 +437,13 @@ impl<'a> Submitter<'a> {
             // execute transaction
 
             match self.submit_api.submit_transaction(method.tx).await {
-                Ok(handle) => transactions.push((handle, gas_price)),
+                Ok(handle) => {
+                    tracing::info!(
+                        submitter = %self.submit_api.name(), ?handle,
+                        "submitted transaction",
+                    );
+                    transactions.push((handle, gas_price));
+                }
                 Err(err) => match err {
                     SubmitApiError::InvalidNonce => {
                         tracing::warn!("submission failed: invalid nonce")
@@ -448,8 +454,8 @@ impl<'a> Submitter<'a> {
                     SubmitApiError::OpenEthereumTooCheapToReplace => {
                         tracing::debug!("submission failed: OE has different replacement rules than our algorithm")
                     }
-                    SubmitApiError::TransactionTooExpensive => {
-                        tracing::warn!("submission failed: transaction too expensive")
+                    SubmitApiError::EdenTransactionTooExpensive => {
+                        tracing::warn!("submission failed: eden transaction too expensive")
                     }
                     SubmitApiError::Other(err) => tracing::error!("submission failed: {}", err),
                 },

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -53,6 +53,9 @@ pub enum SubmitApiError {
     InvalidNonce,
     ReplacementTransactionUnderpriced,
     OpenEthereumTooCheapToReplace, // todo ds safe to remove after dropping OE support
+    /// EDEN network will reject transactions where the maximum gas cost in ETH
+    /// is over 1.0.
+    TransactionTooExpensive,
     Other(anyhow::Error),
 }
 
@@ -444,6 +447,9 @@ impl<'a> Submitter<'a> {
                     }
                     SubmitApiError::OpenEthereumTooCheapToReplace => {
                         tracing::debug!("submission failed: OE has different replacement rules than our algorithm")
+                    }
+                    SubmitApiError::TransactionTooExpensive => {
+                        tracing::warn!("submission failed: transaction too expensive")
                     }
                     SubmitApiError::Other(err) => tracing::error!("submission failed: {}", err),
                 },

--- a/crates/solver/src/settlement_submission/submitter/common.rs
+++ b/crates/solver/src/settlement_submission/submitter/common.rs
@@ -1,88 +1,62 @@
 use super::super::submitter::{SubmitApiError, TransactionHandle};
-use anyhow::{anyhow, Result};
 use ethcontract::{
-    dyns::DynTransport,
+    jsonrpc::types::error::Error as RpcError,
     transaction::{Transaction, TransactionBuilder},
 };
 use futures::FutureExt;
-use jsonrpc_core::Output;
-use primitive_types::H256;
-use reqwest::{Client, Url};
-use serde::de::DeserializeOwned;
+use shared::{Web3, Web3Transport};
+use web3::{api::Namespace, types::Bytes};
 
-/// Function for sending raw signed transaction to private networks
-pub async fn submit_raw_transaction(
-    client: Client,
-    url: Url,
-    tx: TransactionBuilder<DynTransport>,
-) -> Result<TransactionHandle, SubmitApiError> {
-    let (raw_signed_transaction, tx_hash) = match tx.build().now_or_never().unwrap().unwrap() {
-        Transaction::Request(_) => unreachable!("verified offline account was used"),
-        Transaction::Raw { bytes, hash } => (bytes.0, hash),
-    };
-    let tx = format!("0x{}", hex::encode(raw_signed_transaction));
-    let body = serde_json::json!({
-      "jsonrpc": "2.0",
-      "id": 1,
-      "method": "eth_sendRawTransaction",
-      "params": [tx],
-    });
-    let response = client
-        .post(url.clone())
-        .json(&body)
-        .send()
-        .await
-        .map_err(|err| SubmitApiError::Other(err.into()))?;
-    let body = response
-        .text()
-        .await
-        .map_err(|err| SubmitApiError::Other(err.into()))?;
+/// An additonal specialized submitter API for private network transactions.
+#[derive(Clone)]
+pub struct PrivateNetwork(Web3);
 
-    let handle = parse_json_rpc_response::<H256>(&body)?;
-    tracing::info!(
-        "created transaction with hash: {:?} and handle: {:?}, url: {}",
-        tx_hash,
-        handle,
-        url.as_str()
-    );
-    Ok(TransactionHandle { tx_hash, handle })
+impl Namespace<Web3Transport> for PrivateNetwork {
+    fn new(transport: Web3Transport) -> Self {
+        Self(Web3::new(transport))
+    }
+
+    fn transport(&self) -> &Web3Transport {
+        self.0.transport()
+    }
 }
 
-fn parse_json_rpc_response<T>(body: &str) -> Result<T, SubmitApiError>
-where
-    T: DeserializeOwned,
-{
-    match serde_json::from_str::<Output>(body) {
-        Ok(output) => match output {
-            Output::Success(body) => serde_json::from_value::<T>(body.result).map_err(|_| {
-                anyhow!(
-                    "failed conversion to expected type {}",
-                    std::any::type_name::<T>()
-                )
-                .into()
-            }),
-            Output::Failure(body) => {
-                if body.error.message.starts_with("invalid nonce")
-                    || body.error.message.starts_with("nonce too low")
-                {
-                    Err(SubmitApiError::InvalidNonce)
-                } else if body
-                    .error
-                    .message
-                    .starts_with("Transaction gas price supplied is too low")
-                {
-                    Err(SubmitApiError::OpenEthereumTooCheapToReplace)
-                } else if body
-                    .error
-                    .message
-                    .starts_with("replacement transaction underpriced")
-                {
-                    Err(SubmitApiError::ReplacementTransactionUnderpriced)
-                } else {
-                    Err(anyhow!("rpc error: {}", body.error).into())
-                }
-            }
-        },
-        Err(_) => Err(anyhow!("invalid rpc response: {}", body).into()),
+impl PrivateNetwork {
+    /// Function for sending raw signed transaction to private networks
+    pub async fn submit_raw_transaction(
+        &self,
+        tx: TransactionBuilder<Web3Transport>,
+    ) -> Result<TransactionHandle, SubmitApiError> {
+        let (raw_signed_transaction, tx_hash) = match tx.build().now_or_never().unwrap().unwrap() {
+            Transaction::Request(_) => unreachable!("verified offline account was used"),
+            Transaction::Raw { bytes, hash } => (bytes.0, hash),
+        };
+
+        let handle = self
+            .0
+            .eth()
+            .send_raw_transaction(Bytes(raw_signed_transaction))
+            .await
+            .map_err(convert_web3_to_submission_error)?;
+
+        Ok(TransactionHandle { tx_hash, handle })
     }
+}
+
+fn convert_web3_to_submission_error(err: web3::Error) -> SubmitApiError {
+    if let web3::Error::Rpc(RpcError { message, .. }) = &err {
+        if message.starts_with("invalid nonce") || message.starts_with("nonce too low") {
+            return SubmitApiError::InvalidNonce;
+        } else if message.starts_with("Transaction gas price supplied is too low") {
+            return SubmitApiError::OpenEthereumTooCheapToReplace;
+        } else if message.starts_with("replacement transaction underpriced") {
+            return SubmitApiError::ReplacementTransactionUnderpriced;
+        } else if message.contains("tx fee") && message.contains("exceeds the configured cap") {
+            return SubmitApiError::TransactionTooExpensive;
+        }
+    }
+
+    anyhow::Error::new(err)
+        .context("transaction submission error")
+        .into()
 }

--- a/crates/solver/src/settlement_submission/submitter/common.rs
+++ b/crates/solver/src/settlement_submission/submitter/common.rs
@@ -52,7 +52,7 @@ fn convert_web3_to_submission_error(err: web3::Error) -> SubmitApiError {
         } else if message.starts_with("replacement transaction underpriced") {
             return SubmitApiError::ReplacementTransactionUnderpriced;
         } else if message.contains("tx fee") && message.contains("exceeds the configured cap") {
-            return SubmitApiError::TransactionTooExpensive;
+            return SubmitApiError::EdenTransactionTooExpensive;
         }
     }
 

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -2,26 +2,30 @@ use crate::settlement::{Revertable, Settlement};
 
 use super::{
     super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
+    common::PrivateNetwork,
     AdditionalTip, CancelHandle, SubmissionLoopStatus,
 };
 use anyhow::{Context, Result};
-use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder, H160, U256};
+use ethcontract::{transaction::TransactionBuilder, H160, U256};
 use gas_estimation::EstimatedGasPrice;
-use reqwest::{Client, IntoUrl, Url};
-use shared::Web3;
+use reqwest::{Client, IntoUrl};
+use shared::{transport::http::HttpTransport, Web3, Web3Transport};
 
 #[derive(Clone)]
 pub struct FlashbotsApi {
-    client: Client,
-    url: Url,
+    rpc: Web3,
 }
 
 impl FlashbotsApi {
     pub fn new(client: Client, url: impl IntoUrl) -> Result<Self> {
-        Ok(Self {
+        let transport = Web3Transport::new(HttpTransport::new(
             client,
-            url: url.into_url().context("bad flashbots url")?,
-        })
+            url.into_url().context("bad flashbots url")?,
+            "flashbots".to_owned(),
+        ));
+        let rpc = Web3::new(transport);
+
+        Ok(Self { rpc })
     }
 }
 
@@ -29,9 +33,12 @@ impl FlashbotsApi {
 impl TransactionSubmitting for FlashbotsApi {
     async fn submit_transaction(
         &self,
-        tx: TransactionBuilder<DynTransport>,
+        tx: TransactionBuilder<Web3Transport>,
     ) -> Result<TransactionHandle, SubmitApiError> {
-        super::common::submit_raw_transaction(self.client.clone(), self.url.clone(), tx).await
+        self.rpc
+            .api::<PrivateNetwork>()
+            .submit_raw_transaction(tx)
+            .await
     }
 
     async fn cancel_transaction(


### PR DESCRIPTION
This PR adds logic to [handle errors](https://gnosisinc.slack.com/archives/CUD4MUCUF/p1645464295682109) that we were seeing from EDEN network RPC endpoint when the total gas cost (i.e. `gas_limit  max_fee_per_gas`) would exceed their configured cap of 1.0 Ether:
```
Server error: tx fee (1.14 ether) exceeds the configured cap (1.00 ether)
```

Additionally, this PR refactors the `submitter::common` module to implement the `submit_raw_transaction` method as a `web3::api::Namespace` and use the internal Rust `web3` code for doing HTTP requests and parsing JSON RPC responses. The motivation for this was that it was hard for me to debug where the error was originating because we didn't log the HTTP requests and responses like we do for regular transports. Instead of just adding logs, I thought it was better to do the refactor above and just use our current logging `HttpTransport` implementation.

Another small implementation note - I decided against `impl From<web3::Error> for SubmitApiError` since:
- It is only used in one place, so implementing the trait wasn't really necessary
- It is not generally true - the conversion only really makes sense for `web3.eth().send_raw_transaction()` errors so having a function that we need to manually `.map_err(...)` with made a little more sense to me.

### Test Plan

CI. There were no tests for this code to adapt. I can add some around the error conversion if you think it is worth it.