### PR TITLE
Support extra subsidy for cow token owners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,6 +1879,7 @@ dependencies = [
  "assert_approx_eq",
  "async-trait",
  "bigdecimal 0.2.2",
+ "cached",
  "chrono",
  "clap 3.1.0",
  "const_format",

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -1,10 +1,11 @@
 use crate::deploy::Contracts;
-use contracts::{ERC20Mintable, WETH9};
+use contracts::{ERC20Mintable, ERC20, WETH9};
 use ethcontract::{prelude::U256, H160};
 use orderbook::{
     account_balances::Web3BalanceFetcher,
     api::order_validation::OrderValidator,
     api::post_quote::OrderQuoter,
+    cow_subsidy::CowSubsidyImpl,
     database::Postgres,
     event_updater::EventUpdater,
     fee::{FeeSubsidyConfiguration, MinFeeCalculator},
@@ -152,6 +153,10 @@ impl OrderbookServices {
                 ..Default::default()
             },
             native_price_estimator.clone(),
+            Arc::new(CowSubsidyImpl::new(
+                ERC20::at(web3, contracts.weth.address()),
+                0.into(),
+            )),
         ));
         let balance_fetcher = Arc::new(Web3BalanceFetcher::new(
             web3.clone(),

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -156,6 +156,7 @@ impl OrderbookServices {
             Arc::new(CowSubsidyImpl::new(
                 ERC20::at(web3, contracts.weth.address()),
                 0.into(),
+                1.0,
             )),
         ));
         let balance_fetcher = Arc::new(Web3BalanceFetcher::new(

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -45,13 +45,7 @@ impl Default for Order {
             .signature
             .validate(domain, &order.hash_struct())
             .unwrap();
-        Self::from_order_creation(
-            OrderCreation::default(),
-            domain,
-            H160::default(),
-            Default::default(),
-            owner,
-        )
+        Self::from_order_creation(order, domain, H160::default(), Default::default(), owner)
     }
 }
 

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = "1.0"
 assert_approx_eq = "1.1"
 async-trait = "0.1"
 bigdecimal = "0.2"
+cached = { version = "0.30", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 const_format = "0.2"
 contracts = { path = "../contracts" }

--- a/crates/orderbook/src/api/get_fee_info.rs
+++ b/crates/orderbook/src/api/get_fee_info.rs
@@ -59,6 +59,7 @@ pub fn get_fee_info(
                         kind: query.kind,
                     },
                     Default::default(),
+                    None,
                 )
                 .await;
             Result::<_, Infallible>::Ok(convert_json_response(result.map(

--- a/crates/orderbook/src/api/get_fee_info.rs
+++ b/crates/orderbook/src/api/get_fee_info.rs
@@ -59,7 +59,7 @@ pub fn get_fee_info(
                         kind: query.kind,
                     },
                     Default::default(),
-                    None,
+                    Default::default(),
                 )
                 .await;
             Result::<_, Infallible>::Ok(convert_json_response(result.map(

--- a/crates/orderbook/src/api/order_validation.rs
+++ b/crates/orderbook/src/api/order_validation.rs
@@ -321,6 +321,10 @@ impl OrderValidating for OrderValidator {
         domain_separator: &DomainSeparator,
         settlement_contract: H160,
     ) -> Result<(Order, FeeParameters), ValidationError> {
+        let owner = order_creation
+            .signature
+            .validate(domain_separator, &order_creation.hash_struct())
+            .ok_or(ValidationError::InvalidSignature)?;
         let unsubsidized_fee = self
             .fee_validator
             .get_unsubsidized_min_fee(
@@ -335,19 +339,18 @@ impl OrderValidating for OrderValidator {
                 },
                 order_creation.app_data,
                 order_creation.fee_amount,
+                Some(owner),
             )
             .await
             .map_err(|()| ValidationError::InsufficientFee)?;
 
-        let order = match Order::from_order_creation(
+        let order = Order::from_order_creation(
             order_creation,
             domain_separator,
             settlement_contract,
             unsubsidized_fee.amount_in_sell_token(),
-        ) {
-            Some(order) => order,
-            None => return Err(ValidationError::InvalidSignature),
-        };
+            owner,
+        );
 
         self.partial_validate(PreOrderData::from(order.clone()))
             .await
@@ -356,7 +359,6 @@ impl OrderValidating for OrderValidator {
         if order_creation.buy_amount.is_zero() || order_creation.sell_amount.is_zero() {
             return Err(ValidationError::ZeroAmount);
         }
-        let owner = order.order_meta_data.owner;
         if matches!(sender, Some(from) if from != owner) {
             return Err(ValidationError::WrongOwner(owner));
         }
@@ -691,17 +693,17 @@ mod tests {
         fee_calculator
             .expect_get_unsubsidized_min_fee()
             .times(2)
-            .returning(|_, _, _| Ok(Default::default()));
+            .returning(|_, _, _, _| Ok(Default::default()));
         fee_calculator
             .expect_get_unsubsidized_min_fee()
             .times(1)
-            .returning(|_, _, _| Err(()));
+            .returning(|_, _, _, _| Err(()));
         fee_calculator
             .expect_get_unsubsidized_min_fee()
-            .returning(|_, _, _| Ok(Default::default()));
+            .returning(|_, _, _, _| Ok(Default::default()));
         fee_calculator
             .expect_get_unsubsidized_min_fee()
-            .returning(|_, _, _| Ok(Default::default()));
+            .returning(|_, _, _, _| Ok(Default::default()));
         bad_token_detector
             .expect_detect()
             .times(1)
@@ -820,7 +822,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         fee_calculator
             .expect_get_unsubsidized_min_fee()
-            .returning(|_, _, _| Ok(Default::default()));
+            .returning(|_, _, _, _| Ok(Default::default()));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -863,7 +865,7 @@ mod tests {
                 let mut balance_fetcher = MockBalanceFetching::new();
                 fee_calculator
                     .expect_get_unsubsidized_min_fee()
-                    .returning(|_, _, _| Ok(Default::default()));
+                    .returning(|_, _, _, _| Ok(Default::default()));
                 bad_token_detector
                     .expect_detect()
                     .returning(|_| Ok(TokenQuality::Good));

--- a/crates/orderbook/src/api/order_validation.rs
+++ b/crates/orderbook/src/api/order_validation.rs
@@ -339,7 +339,7 @@ impl OrderValidating for OrderValidator {
                 },
                 order_creation.app_data,
                 order_creation.fee_amount,
-                Some(owner),
+                owner,
             )
             .await
             .map_err(|()| ValidationError::InsufficientFee)?;

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -279,6 +279,7 @@ impl OrderQuoter {
                             kind: OrderKind::Sell,
                         },
                         quote_request.app_data,
+                        Some(quote_request.from),
                     ),
                     price_estimator.estimate(&query)
                 )
@@ -333,6 +334,7 @@ impl OrderQuoter {
                             kind: OrderKind::Sell,
                         },
                         quote_request.app_data,
+                        Some(quote_request.from),
                     ),
                     price_estimator.estimate(&price_estimation_query)
                 )
@@ -369,6 +371,7 @@ impl OrderQuoter {
                             kind: OrderKind::Buy,
                         },
                         quote_request.app_data,
+                        Some(quote_request.from),
                     ),
                     price_estimator.estimate(&price_estimation_query)
                 )
@@ -614,7 +617,7 @@ mod tests {
         let expiration = Utc::now();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(move |_, _| Ok((3.into(), expiration)));
+            .returning(move |_, _, _| Ok((3.into(), expiration)));
 
         let fee_calculator = Arc::new(fee_calculator);
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
@@ -658,7 +661,7 @@ mod tests {
         let expiration = Utc::now();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(move |_, _| Ok((3.into(), expiration)));
+            .returning(move |_, _, _| Ok((3.into(), expiration)));
 
         let fee_calculator = Arc::new(fee_calculator);
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
@@ -701,7 +704,7 @@ mod tests {
         let expiration = Utc::now();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(move |_, _| Ok((3.into(), expiration)));
+            .returning(move |_, _, _| Ok((3.into(), expiration)));
 
         let fee_calculator = Arc::new(fee_calculator);
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
@@ -761,7 +764,7 @@ mod tests {
         let mut fee_calculator = MockMinFeeCalculating::new();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(move |_, _| Ok((3.into(), Utc::now())));
+            .returning(move |_, _, _| Ok((3.into(), Utc::now())));
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
             out_amount: 14.into(),
             gas: 1000.into(),

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -279,7 +279,7 @@ impl OrderQuoter {
                             kind: OrderKind::Sell,
                         },
                         quote_request.app_data,
-                        Some(quote_request.from),
+                        quote_request.from,
                     ),
                     price_estimator.estimate(&query)
                 )
@@ -334,7 +334,7 @@ impl OrderQuoter {
                             kind: OrderKind::Sell,
                         },
                         quote_request.app_data,
-                        Some(quote_request.from),
+                        quote_request.from,
                     ),
                     price_estimator.estimate(&price_estimation_query)
                 )
@@ -371,7 +371,7 @@ impl OrderQuoter {
                             kind: OrderKind::Buy,
                         },
                         quote_request.app_data,
-                        Some(quote_request.from),
+                        quote_request.from,
                     ),
                     price_estimator.estimate(&price_estimation_query)
                 )

--- a/crates/orderbook/src/cow_subsidy.rs
+++ b/crates/orderbook/src/cow_subsidy.rs
@@ -1,0 +1,85 @@
+use std::{sync::Mutex, time::Duration};
+
+use anyhow::Result;
+use cached::{Cached, TimedSizedCache};
+use contracts::ERC20;
+use primitive_types::{H160, U256};
+
+const CACHE_SIZE: usize = 10000;
+const CACHE_LIFESPAN: Duration = Duration::from_secs(60 * 60);
+
+/// Check whether a user qualifies for an extra fee subsidy because they own enough cow token.
+#[async_trait::async_trait]
+pub trait CowSubsidy: Send + Sync + 'static {
+    async fn qualifies_for_subsidy(&self, user: H160) -> Result<bool>;
+}
+
+#[derive(Default)]
+pub struct NoopCowSubsidy(pub bool);
+
+#[async_trait::async_trait]
+impl CowSubsidy for NoopCowSubsidy {
+    async fn qualifies_for_subsidy(&self, _: H160) -> Result<bool> {
+        Ok(self.0)
+    }
+}
+
+pub struct CowSubsidyImpl {
+    cow_token: ERC20,
+    threshold: U256,
+    cache: Mutex<TimedSizedCache<H160, bool>>,
+}
+
+#[async_trait::async_trait]
+impl CowSubsidy for CowSubsidyImpl {
+    async fn qualifies_for_subsidy(&self, user: H160) -> Result<bool> {
+        if let Some(qualifies) = self.cache.lock().unwrap().cache_get(&user) {
+            return Ok(*qualifies);
+        }
+        let qualifies = self.qualifies_for_subsidy_uncached(user).await?;
+        self.cache.lock().unwrap().cache_set(user, qualifies);
+        Ok(qualifies)
+    }
+}
+
+impl CowSubsidyImpl {
+    pub fn new(cow_token: ERC20, threshold: U256) -> Self {
+        let cache = TimedSizedCache::with_size_and_lifespan_and_refresh(
+            CACHE_SIZE,
+            CACHE_LIFESPAN.as_secs(),
+            false,
+        );
+        Self {
+            cow_token,
+            threshold,
+            cache: Mutex::new(cache),
+        }
+    }
+
+    async fn qualifies_for_subsidy_uncached(&self, user: H160) -> Result<bool> {
+        let balance = self.cow_token.balance_of(user).call().await?;
+        Ok(balance >= self.threshold)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+    use shared::Web3;
+
+    #[tokio::test]
+    #[ignore]
+    async fn mainnet() {
+        let transport = shared::transport::create_env_test_transport();
+        let web3 = Web3::new(transport);
+        let token = H160(hex!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"));
+        let token = ERC20::at(&web3, token);
+        let subsidy = CowSubsidyImpl::new(token, U256::from_f64_lossy(1e18));
+        for i in 0..2 {
+            let user = H160::from_low_u64_be(i);
+            let result = subsidy.qualifies_for_subsidy(user).await;
+            println!("{:?} {:?}", user, result);
+        }
+    }
+}

--- a/crates/orderbook/src/cow_subsidy.rs
+++ b/crates/orderbook/src/cow_subsidy.rs
@@ -14,16 +14,16 @@ pub trait CowSubsidy: Send + Sync + 'static {
     async fn cow_subsidy_factor(&self, user: H160) -> Result<f64>;
 }
 
-pub struct NoopCowSubsidy(pub f64);
+pub struct FixedCowSubsidy(pub f64);
 
-impl Default for NoopCowSubsidy {
+impl Default for FixedCowSubsidy {
     fn default() -> Self {
         Self(1.0)
     }
 }
 
 #[async_trait::async_trait]
-impl CowSubsidy for NoopCowSubsidy {
+impl CowSubsidy for FixedCowSubsidy {
     async fn cow_subsidy_factor(&self, _: H160) -> Result<f64> {
         Ok(self.0)
     }

--- a/crates/orderbook/src/fee.rs
+++ b/crates/orderbook/src/fee.rs
@@ -466,7 +466,7 @@ mod tests {
     };
     use std::sync::Arc;
 
-    use crate::cow_subsidy::NoopCowSubsidy;
+    use crate::cow_subsidy::FixedCowSubsidy;
 
     use super::*;
 
@@ -494,7 +494,7 @@ mod tests {
                 bad_token_detector: Arc::new(ListBasedDetector::deny_list(Vec::new())),
                 fee_subsidy: Default::default(),
                 native_price_estimator: create_default_native_token_estimator(price_estimator),
-                cow_subsidy: Arc::new(NoopCowSubsidy::default()),
+                cow_subsidy: Arc::new(FixedCowSubsidy::default()),
             }
         }
     }
@@ -641,7 +641,7 @@ mod tests {
             bad_token_detector: Arc::new(ListBasedDetector::deny_list(vec![unsupported_token])),
             fee_subsidy: Default::default(),
             native_price_estimator,
-            cow_subsidy: Arc::new(NoopCowSubsidy::default()),
+            cow_subsidy: Arc::new(FixedCowSubsidy::default()),
         };
 
         // Selling unsupported token
@@ -718,7 +718,7 @@ mod tests {
                 ..Default::default()
             },
             native_price_estimator,
-            cow_subsidy: Arc::new(NoopCowSubsidy(0.5)),
+            cow_subsidy: Arc::new(FixedCowSubsidy(0.5)),
         };
         let (fee, _) = fee_estimator
             .compute_subsidized_min_fee(fee_data, app_data, user)
@@ -743,7 +743,7 @@ mod tests {
             .is_err());
 
         // repeat without user so no extra cow subsidy
-        fee_estimator.cow_subsidy = Arc::new(NoopCowSubsidy(1.0));
+        fee_estimator.cow_subsidy = Arc::new(FixedCowSubsidy(1.0));
         let (fee_2, _) = fee_estimator
             .compute_subsidized_min_fee(fee_data, app_data, user)
             .await
@@ -820,7 +820,7 @@ mod tests {
                 ..Default::default()
             },
             native_price_estimator,
-            cow_subsidy: Arc::new(NoopCowSubsidy::default()),
+            cow_subsidy: Arc::new(FixedCowSubsidy::default()),
         };
 
         let (fee, _) = fee_estimator
@@ -925,7 +925,7 @@ mod tests {
                 ..Default::default()
             },
             native_price_estimator,
-            cow_subsidy: Arc::new(NoopCowSubsidy::default()),
+            cow_subsidy: Arc::new(FixedCowSubsidy::default()),
         };
         let (fee, _) = fee_estimator
             .compute_subsidized_min_fee(fee_data, Default::default(), Default::default())

--- a/crates/orderbook/src/lib.rs
+++ b/crates/orderbook/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod account_balances;
 pub mod api;
 pub mod conversions;
+pub mod cow_subsidy;
 pub mod database;
 pub mod event_updater;
 pub mod fee;

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use clap::{ArgEnum, Parser};
-use contracts::{BalancerV2Vault, GPv2Settlement, IUniswapV3Factory, WETH9};
+use contracts::{BalancerV2Vault, GPv2Settlement, IUniswapV3Factory, ERC20, WETH9};
 use ethcontract::errors::DeployError;
 use model::{
     app_id::AppId,
@@ -10,6 +10,7 @@ use model::{
 use orderbook::{
     account_balances::Web3BalanceFetcher,
     api::{order_validation::OrderValidator, post_quote::OrderQuoter},
+    cow_subsidy::{CowSubsidy, CowSubsidyImpl, NoopCowSubsidy},
     database::{self, orders::OrderFilter, Postgres},
     event_updater::EventUpdater,
     fee::{FeeSubsidyConfiguration, MinFeeCalculator},
@@ -178,6 +179,18 @@ struct Arguments {
         parse(try_from_str = parse_partner_fee_factor),
     )]
     partner_additional_fee_factors: HashMap<AppId, f64>,
+
+    /// Fee factor as extra subsidy for cow token owners.
+    #[clap(long, env, default_value = "1", parse(try_from_str = shared::arguments::parse_unbounded_factor))]
+    cow_fee_factor: f64,
+
+    /// Address of the cow token used for extra subsidy.
+    #[clap(long, env)]
+    cow_token_address: Option<H160>,
+
+    /// Minimum cow token threshold to get the extra subsidy.
+    #[clap(long, env, default_value = "0")]
+    cow_threshold: f64,
 
     /// The API endpoint to call the mip v2 solver for price estimation
     #[clap(long, env)]
@@ -584,6 +597,14 @@ async fn main() {
         Some(args.native_price_cache_max_update_size),
     );
 
+    let cow_subsidy = match args.cow_token_address {
+        Some(address) => Arc::new(CowSubsidyImpl::new(
+            ERC20::at(&web3, address),
+            U256::from_f64_lossy(args.cow_threshold),
+        )) as Arc<dyn CowSubsidy>,
+        None => Arc::new(NoopCowSubsidy(false)) as Arc<dyn CowSubsidy>,
+    };
+
     let create_fee_calculator = |price_estimator: Arc<dyn PriceEstimating>| {
         Arc::new(MinFeeCalculator::new(
             price_estimator.clone(),
@@ -595,8 +616,10 @@ async fn main() {
                 min_discounted_fee: args.min_discounted_fee,
                 fee_factor: args.fee_factor,
                 partner_additional_fee_factors: args.partner_additional_fee_factors.clone(),
+                cow_factor: args.cow_fee_factor,
             },
             native_price_estimator.clone(),
+            cow_subsidy.clone(),
         ))
     };
     let fee_calculator = create_fee_calculator(price_estimator.clone());

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -10,7 +10,7 @@ use model::{
 use orderbook::{
     account_balances::Web3BalanceFetcher,
     api::{order_validation::OrderValidator, post_quote::OrderQuoter},
-    cow_subsidy::{CowSubsidy, CowSubsidyImpl, NoopCowSubsidy},
+    cow_subsidy::{CowSubsidy, CowSubsidyImpl, FixedCowSubsidy},
     database::{self, orders::OrderFilter, Postgres},
     event_updater::EventUpdater,
     fee::{FeeSubsidyConfiguration, MinFeeCalculator},
@@ -603,7 +603,7 @@ async fn main() {
             U256::from_f64_lossy(args.cow_threshold),
             args.cow_fee_factor,
         )) as Arc<dyn CowSubsidy>,
-        None => Arc::new(NoopCowSubsidy(1.0)) as Arc<dyn CowSubsidy>,
+        None => Arc::new(FixedCowSubsidy(1.0)) as Arc<dyn CowSubsidy>,
     };
 
     let create_fee_calculator = |price_estimator: Arc<dyn PriceEstimating>| {

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -601,8 +601,9 @@ async fn main() {
         Some(address) => Arc::new(CowSubsidyImpl::new(
             ERC20::at(&web3, address),
             U256::from_f64_lossy(args.cow_threshold),
+            args.cow_fee_factor,
         )) as Arc<dyn CowSubsidy>,
-        None => Arc::new(NoopCowSubsidy(false)) as Arc<dyn CowSubsidy>,
+        None => Arc::new(NoopCowSubsidy(1.0)) as Arc<dyn CowSubsidy>,
     };
 
     let create_fee_calculator = |price_estimator: Arc<dyn PriceEstimating>| {
@@ -616,7 +617,6 @@ async fn main() {
                 min_discounted_fee: args.min_discounted_fee,
                 fee_factor: args.fee_factor,
                 partner_additional_fee_factors: args.partner_additional_fee_factors.clone(),
-                cow_factor: args.cow_fee_factor,
             },
             native_price_estimator.clone(),
             cow_subsidy.clone(),


### PR DESCRIPTION
This is the main work for https://github.com/gnosis/gp-v2-services/issues/1647 . We support configuring the service with an erc20 token and extra subsidy for users that have a minimum balance in this token.

The model is a simple binary yes if the threshold is exceed for multiplying an extra factor. We could extend it with other functions in the future for example to scale the subsidy with the amount held.

I have not yet looked at the actual cow token contract so might need some adjustments with that regard in another PR.

In the default configuration no fee subsidy is given.

### Test Plan

new unit test and new ignored test
