### PR TITLE
Convert COW subsidy computation error to price estimation error

### DIFF
--- a/crates/orderbook/src/fee.rs
+++ b/crates/orderbook/src/fee.rs
@@ -298,7 +298,12 @@ impl MinFeeCalculating for MinFeeCalculator {
 
         tracing::debug!(?fee_data, ?app_data, ?user, "computing subsidized fee",);
 
-        let cow_factor = self.cow_subsidy.cow_subsidy_factor(user);
+        let cow_factor = async {
+            self.cow_subsidy
+                .cow_subsidy_factor(user)
+                .await
+                .map_err(PriceEstimationError::Other)
+        };
         let unsubsidized_min_fee = async {
             if let Some(past_fee) = self
                 .measurements


### PR DESCRIPTION
I started noticing some error alerts related to price estimates caused by no liquidity. It looks like it is because the async closure around the price estimation future is promoting the `PriceEstimationError` to an `anyhow::Error` which becomes a `PriceEstimationError::Other()` and is treated as an internal server error.

This PR fixes this by explicitly converting the error in the future the price estimation is being joined with into a `PriceEstimationError` so we don't lose error information.

Another "more hardcore" approach would be to try to [`downcast`](https://docs.rs/anyhow/latest/anyhow/struct.Error.html#method.downcast) the `anyhow::Error` in the `From<anyhow::Error> for PriceEstimationError` implementation. This might prevent us from introducing these hard to detect bugs moving forward.

### Test Plan

No alerts for `No liquidity` errors.

Also run the orderbook locally and see we no longer get internal server errors when there is no liquidity (you can, for example try to sell a token that isn't really a token):
```
% curl -s \
  -X POST \
  -H 'Content-Type: application/json' \
  --data '@-' \
  'http://localhost:8080/api/v1/quote' \
  <<JSON | jq
{
  "from": "0x0001020304050607080910111213141516171819",
  "sellToken": "0x1111111111111111111111111111111111111111",
  "buyToken": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
  "receiver": "0x0000000000000000000000000000000000000000",
  "buyAmountAfterFee": "1000000000000000000",
  "validTo": 2147483648,
  "appData": "0xe9f29ae547955463ed535162aefee525d8d309571a2b18bc26086c8c35d781eb",
  "kind": "buy",
  "partiallyFillable": false,
  "sellTokenBalance": "external",
  "buyTokenBalance": "erc20"
}
JSON

{
  "errorType": "NoLiquidity",
  "description": "not enough liquidity"
}
```
