### PR TITLE
Use BufferingPriceEstimator

### DIFF
--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -17,9 +17,13 @@ use anyhow::Result;
 use ethcontract::{H160, U256};
 use model::order::OrderKind;
 use num::BigRational;
+use std::{
+    cmp::{Eq, PartialEq},
+    hash::Hash,
+};
 use thiserror::Error;
 
-#[derive(Copy, Clone, Debug, clap::ArgEnum)]
+#[derive(Copy, Clone, Debug, clap::ArgEnum, Hash, Eq, PartialEq)]
 #[clap(rename_all = "verbatim")]
 pub enum PriceEstimatorType {
     Baseline,

--- a/crates/shared/src/price_estimation/buffered.rs
+++ b/crates/shared/src/price_estimation/buffered.rs
@@ -119,7 +119,7 @@ impl PriceEstimating for BufferingPriceEstimator {
             in_flight_requests.extend(
                 new_requests
                     .iter()
-                    .map(|(query, fut)| (*query, fut.downgrade().unwrap())),
+                    .map(|(query, fut)| (*query, fut.downgrade().expect("future completed"))),
             );
 
             (active_requests, new_requests)

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -7,19 +7,20 @@ use model::order::OrderKind;
 use num::BigRational;
 use std::cmp;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 
 /// Price estimator that pulls estimates from various sources
 /// and competes on the best price. Returns a price estimation
 /// early if there is a configurable number of successful estimates
 /// for every query or if all price sources returned an estimate.
 pub struct RacingCompetitionPriceEstimator {
-    inner: Vec<(String, Box<dyn PriceEstimating>)>,
+    inner: Vec<(String, Arc<dyn PriceEstimating>)>,
     successful_results_for_early_return: NonZeroUsize,
 }
 
 impl RacingCompetitionPriceEstimator {
     pub fn new(
-        inner: Vec<(String, Box<dyn PriceEstimating>)>,
+        inner: Vec<(String, Arc<dyn PriceEstimating>)>,
         successful_results_for_early_return: NonZeroUsize,
     ) -> Self {
         assert!(!inner.is_empty());
@@ -85,7 +86,7 @@ pub struct CompetitionPriceEstimator {
 }
 
 impl CompetitionPriceEstimator {
-    pub fn new(inner: Vec<(String, Box<dyn PriceEstimating>)>) -> Self {
+    pub fn new(inner: Vec<(String, Arc<dyn PriceEstimating>)>) -> Self {
         let number_of_estimators =
             NonZeroUsize::new(inner.len()).expect("Vec of estimators should not be empty.");
         Self {
@@ -311,8 +312,8 @@ mod tests {
             });
 
         let priority = CompetitionPriceEstimator::new(vec![
-            ("first".to_owned(), Box::new(first)),
-            ("second".to_owned(), Box::new(second)),
+            ("first".to_owned(), Arc::new(first)),
+            ("second".to_owned(), Arc::new(second)),
         ]);
 
         let result = priority.estimates(&queries).await;
@@ -394,9 +395,9 @@ mod tests {
 
         let racing = RacingCompetitionPriceEstimator::new(
             vec![
-                ("first".to_owned(), Box::new(first)),
-                ("second".to_owned(), Box::new(second)),
-                ("third".to_owned(), Box::new(third)),
+                ("first".to_owned(), Arc::new(first)),
+                ("second".to_owned(), Arc::new(second)),
+                ("third".to_owned(), Arc::new(third)),
             ],
             NonZeroUsize::new(1).unwrap(),
         );


### PR DESCRIPTION
Follow up to #1677

In order to let the `optimal` and `fast` price estimators profit from each others work the different estimator hierarchies need to use the same base estimator instances wrapped in a `BufferedPriceEstimator`.
I added `get_or_create_base_estimator()` which stores newly created `Arc<dyn PriceEstimating>` in a map. If someone requests an estimator which already has an instance they will receive a cloned shared pointer to the original.

This change also required that the `RacingCompetitionPriceEstimator` stores `Arc<dyn PriceEstimating>` instead of `Box<dyn PriceEstimating>`.

### Test Plan
Manual test: Requesting a `fast` and `optimal` price quote right after another resulted in a single 1Inch `/quote` request.