### PR TITLE
Rename Order Types and Fields

### DIFF
--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -153,7 +153,7 @@ async fn eth_integration(web3: Web3) {
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_BUY_ETH_A_PK).unwrap()),
         )
         .build()
-        .order_creation;
+        .creation;
     let placement = client
         .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
         .body(json!(order_buy_eth_a).to_string())
@@ -174,7 +174,7 @@ async fn eth_integration(web3: Web3) {
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_BUY_ETH_B_PK).unwrap()),
         )
         .build()
-        .order_creation;
+        .creation;
     let placement = client
         .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
         .body(json!(order_buy_eth_b).to_string())

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -158,7 +158,7 @@ async fn onchain_settlement(web3: Web3) {
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_A_PK).unwrap()),
         )
         .build()
-        .order_creation;
+        .creation;
     let placement = client
         .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
         .body(json!(order_a).to_string())
@@ -180,7 +180,7 @@ async fn onchain_settlement(web3: Web3) {
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_B_PK).unwrap()),
         )
         .build()
-        .order_creation;
+        .creation;
     let placement = client
         .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
         .body(json!(order_b).to_string())

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -160,7 +160,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_A_PK).unwrap()),
         )
         .build()
-        .order_creation;
+        .creation;
     let placement = client
         .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
         .body(json!(order).to_string())

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -105,7 +105,7 @@ async fn smart_contract_orders(web3: Web3) {
         .with_valid_to(shared::time::now_in_epoch_seconds() + 300)
         .with_presign(trader.address())
         .build()
-        .order_creation;
+        .creation;
     let placement = client
         .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
         .json(&order)
@@ -129,7 +129,7 @@ async fn smart_contract_orders(web3: Web3) {
             .json::<Order>()
             .await
             .unwrap()
-            .order_meta_data
+            .metadata
             .status
     };
 

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -118,7 +118,7 @@ async fn vault_balances(web3: Web3) {
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER).unwrap()),
         )
         .build()
-        .order_creation;
+        .creation;
     let placement = client
         .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
         .body(json!(order).to_string())

--- a/crates/model/src/auction.rs
+++ b/crates/model/src/auction.rs
@@ -33,14 +33,14 @@ pub struct Auction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::order::{OrderMetaData, OrderUid};
+    use crate::order::{OrderMetadata, OrderUid};
     use maplit::btreemap;
     use serde_json::json;
 
     #[test]
     fn roundtrips_auction() {
         let order = |uid_byte: u8| Order {
-            order_meta_data: OrderMetaData {
+            metadata: OrderMetadata {
                 uid: OrderUid([uid_byte; 56]),
                 ..Default::default()
             },

--- a/crates/orderbook/src/account_balances.rs
+++ b/crates/orderbook/src/account_balances.rs
@@ -18,9 +18,9 @@ pub struct Query {
 impl Query {
     pub fn from_order(o: &Order) -> Self {
         Self {
-            owner: o.order_meta_data.owner,
-            token: o.order_creation.sell_token,
-            source: o.order_creation.sell_token_balance,
+            owner: o.metadata.owner,
+            token: o.creation.sell_token,
+            source: o.creation.sell_token_balance,
         }
     }
 }

--- a/crates/orderbook/src/api/order_validation.rs
+++ b/crates/orderbook/src/api/order_validation.rs
@@ -737,10 +737,7 @@ mod tests {
             .validate_and_construct_order(order, None, &Default::default(), Default::default())
             .await
             .unwrap();
-        assert_eq!(
-            order.order_meta_data.full_fee_amount,
-            order.order_creation.fee_amount
-        );
+        assert_eq!(order.metadata.full_fee_amount, order.creation.fee_amount);
     }
 
     #[tokio::test]
@@ -1023,7 +1020,7 @@ mod tests {
                                         SecretKeyRef::new(&ONE_KEY)
                                     )
                                     .build()
-                                    .order_creation,
+                                    .creation,
                                 None,
                                 &Default::default(),
                                 Default::default()
@@ -1036,10 +1033,7 @@ mod tests {
                 assert!(matches!(
                     validator
                         .validate_and_construct_order(
-                            order
-                                .with_presign(Default::default())
-                                .build()
-                                .order_creation,
+                            order.with_presign(Default::default()).build().creation,
                             None,
                             &Default::default(),
                             Default::default()

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -8,7 +8,7 @@ use futures::{stream::TryStreamExt, FutureExt};
 use model::{
     app_id::AppId,
     order::{
-        BuyTokenDestination, Order, OrderCreation, OrderKind, OrderMetaData, OrderStatus, OrderUid,
+        BuyTokenDestination, Order, OrderCreation, OrderKind, OrderMetadata, OrderStatus, OrderUid,
         SellTokenSource,
     },
     signature::{Signature, SigningScheme},
@@ -231,35 +231,31 @@ async fn insert_order(
                 settlement_contract, sell_token_balance, buy_token_balance, full_fee_amount) \
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19);";
     let receiver = order
-        .order_creation
+        .creation
         .receiver
         .map(|address| address.as_bytes().to_vec());
     sqlx::query(QUERY)
-        .bind(order.order_meta_data.uid.0.as_ref())
-        .bind(order.order_meta_data.owner.as_bytes())
-        .bind(order.order_meta_data.creation_date)
-        .bind(order.order_creation.sell_token.as_bytes())
-        .bind(order.order_creation.buy_token.as_bytes())
+        .bind(order.metadata.uid.0.as_ref())
+        .bind(order.metadata.owner.as_bytes())
+        .bind(order.metadata.creation_date)
+        .bind(order.creation.sell_token.as_bytes())
+        .bind(order.creation.buy_token.as_bytes())
         .bind(receiver)
-        .bind(u256_to_big_decimal(&order.order_creation.sell_amount))
-        .bind(u256_to_big_decimal(&order.order_creation.buy_amount))
-        .bind(order.order_creation.valid_to)
-        .bind(&order.order_creation.app_data.0[..])
-        .bind(u256_to_big_decimal(&order.order_creation.fee_amount))
-        .bind(DbOrderKind::from(order.order_creation.kind))
-        .bind(order.order_creation.partially_fillable)
-        .bind(&*order.order_creation.signature.to_bytes())
-        .bind(DbSigningScheme::from(
-            order.order_creation.signature.scheme(),
-        ))
-        .bind(order.order_meta_data.settlement_contract.as_bytes())
-        .bind(DbSellTokenSource::from(
-            order.order_creation.sell_token_balance,
-        ))
+        .bind(u256_to_big_decimal(&order.creation.sell_amount))
+        .bind(u256_to_big_decimal(&order.creation.buy_amount))
+        .bind(order.creation.valid_to)
+        .bind(&order.creation.app_data.0[..])
+        .bind(u256_to_big_decimal(&order.creation.fee_amount))
+        .bind(DbOrderKind::from(order.creation.kind))
+        .bind(order.creation.partially_fillable)
+        .bind(&*order.creation.signature.to_bytes())
+        .bind(DbSigningScheme::from(order.creation.signature.scheme()))
+        .bind(order.metadata.settlement_contract.as_bytes())
+        .bind(DbSellTokenSource::from(order.creation.sell_token_balance))
         .bind(DbBuyTokenDestination::from(
-            order.order_creation.buy_token_balance,
+            order.creation.buy_token_balance,
         ))
-        .bind(u256_to_big_decimal(&order.order_meta_data.full_fee_amount))
+        .bind(u256_to_big_decimal(&order.metadata.full_fee_amount))
         .execute(transaction)
         .await
         .map(|_| ())
@@ -303,7 +299,7 @@ impl OrderStoring for Postgres {
             .transaction(move |transaction| {
                 async move {
                     insert_order(&order, transaction).await?;
-                    insert_fee(&order.order_meta_data.uid, &fee, transaction).await?;
+                    insert_fee(&order.metadata.uid, &fee, transaction).await?;
                     Ok(())
                 }
                 .boxed()
@@ -567,7 +563,7 @@ impl OrdersQueryRow {
             .ok_or_else(|| anyhow!("sum_fee is not an unsigned integer"))?;
         let executed_sell_amount_before_fees = &executed_sell_amount - &executed_fee_amount;
 
-        let order_meta_data = OrderMetaData {
+        let order_metadata = OrderMetadata {
             creation_date: self.creation_timestamp,
             owner: h160_from_vec(self.owner)?,
             uid: OrderUid(
@@ -611,8 +607,8 @@ impl OrdersQueryRow {
             buy_token_balance: self.buy_token_balance.into(),
         };
         Ok(Order {
-            order_meta_data,
-            order_creation,
+            metadata: order_metadata,
+            creation: order_creation,
         })
     }
 }
@@ -866,7 +862,7 @@ mod tests {
         db.insert_order(&order, Default::default()).await.unwrap();
 
         // Note that order UIDs do not care about the signing scheme.
-        order.order_creation.signature = Signature::default_with(SigningScheme::PreSign);
+        order.creation.signature = Signature::default_with(SigningScheme::PreSign);
         assert!(matches!(
             db.insert_order(&order, Default::default()).await,
             Err(InsertionError::DuplicatedRecord)
@@ -890,11 +886,11 @@ mod tests {
         let query = "SELECT * FROM order_fee_parameters;";
         let (uid, gas_amount, gas_price, sell_token_price): (Vec<u8>, f64, f64, f64) =
             sqlx::query_as(query)
-                .bind(order.order_meta_data.uid.0.as_ref())
+                .bind(order.metadata.uid.0.as_ref())
                 .fetch_one(&db.pool)
                 .await
                 .unwrap();
-        assert_eq!(uid, order.order_meta_data.uid.0.as_ref());
+        assert_eq!(uid, order.metadata.uid.0.as_ref());
         assert_eq!(gas_amount, 1.);
         assert_eq!(gas_price, 2.);
         assert_eq!(sell_token_price, 3.);
@@ -913,7 +909,7 @@ mod tests {
             let filter = OrderFilter::default();
             assert!(db.orders(&filter).await.unwrap().is_empty());
             let order = Order {
-                order_meta_data: OrderMetaData {
+                metadata: OrderMetadata {
                     creation_date: DateTime::<Utc>::from_utc(
                         NaiveDateTime::from_timestamp(1234567890, 0),
                         Utc,
@@ -924,7 +920,7 @@ mod tests {
                     },
                     ..Default::default()
                 },
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: H160::from_low_u64_be(1),
                     buy_token: H160::from_low_u64_be(2),
                     receiver: Some(H160::from_low_u64_be(6)),
@@ -961,15 +957,15 @@ mod tests {
         let order = Order::default();
         db.insert_order(&order, Default::default()).await.unwrap();
         let db_orders = db.orders(&filter).await.unwrap();
-        assert!(!db_orders[0].order_meta_data.invalidated);
+        assert!(!db_orders[0].metadata.invalidated);
 
         let cancellation_time =
             DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(1234567890, 0), Utc);
-        db.cancel_order(&order.order_meta_data.uid, cancellation_time)
+        db.cancel_order(&order.metadata.uid, cancellation_time)
             .await
             .unwrap();
         let db_orders = db.orders(&filter).await.unwrap();
-        assert!(db_orders[0].order_meta_data.invalidated);
+        assert!(db_orders[0].metadata.invalidated);
 
         let query = "SELECT cancellation_timestamp FROM orders;";
         let first_cancellation: CancellationQueryRow =
@@ -987,7 +983,7 @@ mod tests {
             "Expected cancellation times to be different."
         );
 
-        db.cancel_order(&order.order_meta_data.uid, irrelevant_time)
+        db.cancel_order(&order.metadata.uid, irrelevant_time)
             .await
             .unwrap();
         let second_cancellation: CancellationQueryRow =
@@ -1003,13 +999,13 @@ mod tests {
 
         let orders = vec![
             Order {
-                order_meta_data: OrderMetaData {
+                metadata: OrderMetadata {
                     owner: H160::from_low_u64_be(0),
                     uid: OrderUid([0u8; 56]),
                     status: OrderStatus::Expired,
                     ..Default::default()
                 },
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: H160::from_low_u64_be(1),
                     buy_token: H160::from_low_u64_be(2),
                     valid_to: 10,
@@ -1017,13 +1013,13 @@ mod tests {
                 },
             },
             Order {
-                order_meta_data: OrderMetaData {
+                metadata: OrderMetadata {
                     owner: H160::from_low_u64_be(0),
                     uid: OrderUid([1; 56]),
                     status: OrderStatus::Expired,
                     ..Default::default()
                 },
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: H160::from_low_u64_be(1),
                     buy_token: H160::from_low_u64_be(3),
                     valid_to: 11,
@@ -1031,13 +1027,13 @@ mod tests {
                 },
             },
             Order {
-                order_meta_data: OrderMetaData {
+                metadata: OrderMetadata {
                     owner: H160::from_low_u64_be(2),
                     uid: OrderUid([2u8; 56]),
                     status: OrderStatus::Expired,
                     ..Default::default()
                 },
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: H160::from_low_u64_be(1),
                     buy_token: H160::from_low_u64_be(3),
                     valid_to: 12,
@@ -1116,7 +1112,7 @@ mod tests {
         assert_orders(
             &db,
             &OrderFilter {
-                uid: Some(orders[0].order_meta_data.uid),
+                uid: Some(orders[0].metadata.uid),
                 ..Default::default()
             },
             &orders[0..1],
@@ -1131,8 +1127,8 @@ mod tests {
         db.clear().await.unwrap();
 
         let order = Order {
-            order_meta_data: Default::default(),
-            order_creation: OrderCreation {
+            metadata: Default::default(),
+            creation: OrderCreation {
                 kind: OrderKind::Sell,
                 sell_amount: 10.into(),
                 buy_amount: 100.into(),
@@ -1156,10 +1152,7 @@ mod tests {
         };
 
         let order = get_order(true).await.unwrap();
-        assert_eq!(
-            order.order_meta_data.executed_sell_amount,
-            BigUint::from(0u8)
-        );
+        assert_eq!(order.metadata.executed_sell_amount, BigUint::from(0u8));
 
         db.append_events_(vec![(
             EventIndex {
@@ -1167,7 +1160,7 @@ mod tests {
                 log_index: 0,
             },
             Event::Trade(Trade {
-                order_uid: order.order_meta_data.uid,
+                order_uid: order.metadata.uid,
                 sell_amount_including_fee: 3.into(),
                 ..Default::default()
             }),
@@ -1175,10 +1168,7 @@ mod tests {
         .await
         .unwrap();
         let order = get_order(true).await.unwrap();
-        assert_eq!(
-            order.order_meta_data.executed_sell_amount,
-            BigUint::from(3u8)
-        );
+        assert_eq!(order.metadata.executed_sell_amount, BigUint::from(3u8));
 
         db.append_events_(vec![(
             EventIndex {
@@ -1186,7 +1176,7 @@ mod tests {
                 log_index: 0,
             },
             Event::Trade(Trade {
-                order_uid: order.order_meta_data.uid,
+                order_uid: order.metadata.uid,
                 sell_amount_including_fee: 6.into(),
                 ..Default::default()
             }),
@@ -1194,10 +1184,7 @@ mod tests {
         .await
         .unwrap();
         let order = get_order(true).await.unwrap();
-        assert_eq!(
-            order.order_meta_data.executed_sell_amount,
-            BigUint::from(9u8),
-        );
+        assert_eq!(order.metadata.executed_sell_amount, BigUint::from(9u8),);
 
         // The order disappears because it is fully executed.
         db.append_events_(vec![(
@@ -1206,7 +1193,7 @@ mod tests {
                 log_index: 0,
             },
             Event::Trade(Trade {
-                order_uid: order.order_meta_data.uid,
+                order_uid: order.metadata.uid,
                 sell_amount_including_fee: 1.into(),
                 ..Default::default()
             }),
@@ -1217,10 +1204,7 @@ mod tests {
 
         // If we include fully executed orders it is there.
         let order = get_order(false).await.unwrap();
-        assert_eq!(
-            order.order_meta_data.executed_sell_amount,
-            BigUint::from(10u8)
-        );
+        assert_eq!(order.metadata.executed_sell_amount, BigUint::from(10u8));
 
         // Change order type and see that is returned as not fully executed again.
         let query = "UPDATE orders SET kind = 'buy';";
@@ -1240,8 +1224,8 @@ mod tests {
         db.clear().await.unwrap();
 
         let order = Order {
-            order_meta_data: Default::default(),
-            order_creation: OrderCreation {
+            metadata: Default::default(),
+            creation: OrderCreation {
                 kind: OrderKind::Sell,
                 ..Default::default()
             },
@@ -1255,7 +1239,7 @@ mod tests {
                     log_index: 0,
                 },
                 Event::Trade(Trade {
-                    order_uid: order.order_meta_data.uid,
+                    order_uid: order.metadata.uid,
                     sell_amount_including_fee: U256::MAX,
                     ..Default::default()
                 }),
@@ -1274,7 +1258,7 @@ mod tests {
 
         let expected = u256_to_big_uint(&U256::MAX) * BigUint::from(10u8);
         assert!(expected.to_string().len() > 78);
-        assert_eq!(order.order_meta_data.executed_sell_amount, expected);
+        assert_eq!(order.metadata.executed_sell_amount, expected);
     }
 
     #[tokio::test]
@@ -1284,7 +1268,7 @@ mod tests {
         db.clear().await.unwrap();
         let uid = OrderUid([0u8; 56]);
         let order = Order {
-            order_meta_data: OrderMetaData {
+            metadata: OrderMetadata {
                 uid,
                 ..Default::default()
             },
@@ -1348,8 +1332,8 @@ mod tests {
         db.clear().await.unwrap();
 
         let order = Order {
-            order_meta_data: Default::default(),
-            order_creation: OrderCreation {
+            metadata: Default::default(),
+            creation: OrderCreation {
                 sell_amount: 1.into(),
                 buy_amount: 1.into(),
                 signature: Signature::default_with(SigningScheme::PreSign),
@@ -1373,8 +1357,8 @@ mod tests {
                     log_index: 0,
                 },
                 Event::PreSignature(PreSignature {
-                    owner: order.order_meta_data.owner,
-                    order_uid: order.order_meta_data.uid,
+                    owner: order.metadata.owner,
+                    order_uid: order.metadata.uid,
                     signed,
                 }),
             )];
@@ -1444,8 +1428,8 @@ mod tests {
         db.clear().await.unwrap();
 
         let order = Order {
-            order_meta_data: Default::default(),
-            order_creation: OrderCreation {
+            metadata: Default::default(),
+            creation: OrderCreation {
                 kind: OrderKind::Sell,
                 sell_amount: 10.into(),
                 buy_amount: 100.into(),
@@ -1474,7 +1458,7 @@ mod tests {
                 log_index: 0,
             },
             Event::Trade(Trade {
-                order_uid: order.order_meta_data.uid,
+                order_uid: order.metadata.uid,
                 sell_amount_including_fee: 10.into(),
                 ..Default::default()
             }),
@@ -1491,7 +1475,7 @@ mod tests {
                 log_index: 0,
             },
             Event::Invalidation(Invalidation {
-                order_uid: order.order_meta_data.uid,
+                order_uid: order.metadata.uid,
             }),
         )])
         .await
@@ -1509,7 +1493,7 @@ mod tests {
                 log_index: 0,
             },
             Event::Trade(Trade {
-                order_uid: order.order_meta_data.uid,
+                order_uid: order.metadata.uid,
                 sell_amount_including_fee: 5.into(),
                 ..Default::default()
             }),
@@ -1526,20 +1510,20 @@ mod tests {
         db.clear().await.unwrap();
 
         let order0 = Order {
-            order_meta_data: OrderMetaData {
+            metadata: OrderMetadata {
                 uid: OrderUid([1u8; 56]),
                 ..Default::default()
             },
             ..Default::default()
         };
         let order1 = Order {
-            order_meta_data: OrderMetaData {
+            metadata: OrderMetadata {
                 uid: OrderUid([2u8; 56]),
                 ..Default::default()
             },
             ..Default::default()
         };
-        assert!(order0.order_meta_data.uid != order1.order_meta_data.uid);
+        assert!(order0.metadata.uid != order1.metadata.uid);
         db.insert_order(&order0, Default::default()).await.unwrap();
         db.insert_order(&order1, Default::default()).await.unwrap();
 
@@ -1548,8 +1532,8 @@ mod tests {
             async move { db.single_order(uid).await.unwrap() }
         };
 
-        assert!(get_order(&order0.order_meta_data.uid).await.is_some());
-        assert!(get_order(&order1.order_meta_data.uid).await.is_some());
+        assert!(get_order(&order0.metadata.uid).await.is_some());
+        assert!(get_order(&order1.metadata.uid).await.is_some());
         assert!(get_order(&OrderUid::default()).await.is_none());
     }
 
@@ -1560,11 +1544,11 @@ mod tests {
         db.clear().await.unwrap();
         let uid = OrderUid([0u8; 56]);
         let order = Order {
-            order_creation: OrderCreation {
+            creation: OrderCreation {
                 signature: Signature::default_with(SigningScheme::PreSign),
                 ..Default::default()
             },
-            order_meta_data: OrderMetaData {
+            metadata: OrderMetadata {
                 uid,
                 ..Default::default()
             },
@@ -1578,14 +1562,14 @@ mod tests {
             })
             .await
             .unwrap()[0]
-                .order_meta_data
+                .metadata
                 .status
         };
         let block_number = AtomicI64::new(0);
         let insert_presignature = |signed: bool| {
             let db = db.clone();
             let block_number = &block_number;
-            let owner = order.order_meta_data.owner.as_bytes();
+            let owner = order.metadata.owner.as_bytes();
             async move {
                 sqlx::query(
                     "INSERT INTO presignature_events \
@@ -1635,11 +1619,11 @@ mod tests {
         db.clear().await.unwrap();
         let order_uid = |uid: u8| OrderUid([uid; 56]);
         let order = |uid: u8, scheme: SigningScheme| Order {
-            order_creation: OrderCreation {
+            creation: OrderCreation {
                 signature: Signature::default_with(scheme),
                 ..Default::default()
             },
-            order_meta_data: OrderMetaData {
+            metadata: OrderMetadata {
                 uid: order_uid(uid),
                 ..Default::default()
             },
@@ -1689,7 +1673,7 @@ mod tests {
                     .await
                     .unwrap()
                     .into_iter()
-                    .map(|order| order.order_meta_data.uid)
+                    .map(|order| order.metadata.uid)
                     .collect::<Vec<_>>();
                 // Make sure the list is sorted, this makes assertions easier.
                 order_uids.sort_by_key(|uid| uid.0);
@@ -1739,7 +1723,7 @@ mod tests {
 
         let orders = [
             Order {
-                order_meta_data: OrderMetaData {
+                metadata: OrderMetadata {
                     uid: OrderUid::from_integer(3),
                     owner: owners[0],
                     creation_date: datetime(3),
@@ -1748,7 +1732,7 @@ mod tests {
                 ..Default::default()
             },
             Order {
-                order_meta_data: OrderMetaData {
+                metadata: OrderMetadata {
                     uid: OrderUid::from_integer(1),
                     owner: owners[1],
                     creation_date: datetime(2),
@@ -1757,7 +1741,7 @@ mod tests {
                 ..Default::default()
             },
             Order {
-                order_meta_data: OrderMetaData {
+                metadata: OrderMetadata {
                     uid: OrderUid::from_integer(0),
                     owner: owners[0],
                     creation_date: datetime(1),
@@ -1766,7 +1750,7 @@ mod tests {
                 ..Default::default()
             },
             Order {
-                order_meta_data: OrderMetaData {
+                metadata: OrderMetadata {
                     uid: OrderUid::from_integer(2),
                     owner: owners[1],
                     creation_date: datetime(0),
@@ -1804,11 +1788,11 @@ mod tests {
 
         let orders: Vec<Order> = (0..=3)
             .map(|i| Order {
-                order_meta_data: OrderMetaData {
+                metadata: OrderMetadata {
                     uid: OrderUid::from_integer(i),
                     ..Default::default()
                 },
-                order_creation: Default::default(),
+                creation: Default::default(),
             })
             .collect();
 
@@ -1834,7 +1818,7 @@ mod tests {
                         log_index: 1,
                     },
                     Event::Trade(Trade {
-                        order_uid: order.order_meta_data.uid,
+                        order_uid: order.metadata.uid,
                         ..Default::default()
                     }),
                 ),

--- a/crates/orderbook/src/database/trades.rs
+++ b/crates/orderbook/src/database/trades.rs
@@ -122,7 +122,7 @@ mod tests {
     };
     use ethcontract::H256;
     use model::{
-        order::{Order, OrderCreation, OrderMetaData},
+        order::{Order, OrderCreation, OrderMetadata},
         trade::Trade,
     };
     use shared::event_handling::EventIndex;
@@ -173,12 +173,12 @@ mod tests {
         tx_hash: Option<H256>,
     ) -> Trade {
         let order = Order {
-            order_meta_data: OrderMetaData {
+            metadata: OrderMetadata {
                 owner,
                 uid: order_uid,
                 ..Default::default()
             },
-            order_creation: OrderCreation {
+            creation: OrderCreation {
                 ..Default::default()
             },
         };

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -135,7 +135,7 @@ impl Default for OrdersQuery {
 #[derive(Debug, Derivative, Clone, Deserialize, PartialEq)]
 #[derivative(Default)]
 #[serde(rename_all = "camelCase")]
-pub struct OrderMetaData {
+pub struct OrderMetadata {
     #[derivative(Default(value = "chrono::MIN_DATETIME"))]
     pub created_at: DateTime<Utc>,
     pub order_hash: Bytes,
@@ -209,7 +209,7 @@ pub struct Order {
 #[derive(Debug, Default, Clone, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderRecord {
-    pub meta_data: OrderMetaData,
+    pub metadata: OrderMetadata,
     pub order: Order,
 }
 
@@ -401,7 +401,7 @@ fn retain_valid_orders(orders: &mut Vec<OrderRecord>) {
     let now = chrono::offset::Utc::now();
     orders.retain(|order| {
         // only keep orders which are still valid and unique
-        order.order.expiry > now && included_orders.insert(order.meta_data.order_hash.clone())
+        order.order.expiry > now && included_orders.insert(order.metadata.order_hash.clone())
     });
 }
 
@@ -545,7 +545,7 @@ mod tests {
                     expiry: chrono::MIN_DATETIME,
                     ..Default::default()
                 },
-                meta_data: OrderMetaData {
+                metadata: OrderMetadata {
                     // unique order_hash
                     order_hash: [2].into(),
                     ..Default::default()

--- a/crates/solver/src/analytics.rs
+++ b/crates/solver/src/analytics.rs
@@ -21,12 +21,12 @@ pub fn report_matched_but_not_settled(
         .settlement
         .trades()
         .iter()
-        .map(|order_trade| order_trade.trade.order.order_meta_data.uid)
+        .map(|order_trade| order_trade.trade.order.metadata.uid)
         .collect();
     let other_matched_orders: HashSet<_> = alternative_settlements
         .iter()
         .flat_map(|(_, solution)| solution.settlement.trades().to_vec())
-        .map(|order_trade| order_trade.trade.order.order_meta_data.uid)
+        .map(|order_trade| order_trade.trade.order.metadata.uid)
         .collect();
     let matched_but_not_settled: HashSet<_> = other_matched_orders
         .difference(&submitted_orders)
@@ -88,12 +88,10 @@ pub fn report_alternative_settlement_surplus(
         .trades()
         .iter()
         .map(|order_trade| {
-            let sell_token_price =
-                &submitted_prices[&order_trade.trade.order.order_creation.sell_token];
-            let buy_token_price =
-                &submitted_prices[&order_trade.trade.order.order_creation.buy_token];
+            let sell_token_price = &submitted_prices[&order_trade.trade.order.creation.sell_token];
+            let buy_token_price = &submitted_prices[&order_trade.trade.order.creation.buy_token];
             (
-                order_trade.trade.order.order_meta_data.uid,
+                order_trade.trade.order.metadata.uid,
                 SurplusInfo {
                     solver_name: winning_solver.name(),
                     ratio: order_trade
@@ -131,11 +129,9 @@ fn best_surplus_by_order(
         let trades = solution.settlement.trades();
         let clearing_prices = get_prices(&solution.settlement);
         for order_trade in trades {
-            let order_id = order_trade.trade.order.order_meta_data.uid;
-            let sell_token_price =
-                &clearing_prices[&order_trade.trade.order.order_creation.sell_token];
-            let buy_token_price =
-                &clearing_prices[&order_trade.trade.order.order_creation.buy_token];
+            let order_id = order_trade.trade.order.metadata.uid;
+            let sell_token_price = &clearing_prices[&order_trade.trade.order.creation.sell_token];
+            let buy_token_price = &clearing_prices[&order_trade.trade.order.creation.buy_token];
             let surplus = SurplusInfo {
                 solver_name: solver.name(),
                 ratio: order_trade

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -530,7 +530,7 @@ impl Driver {
                     .settlement
                     .trades()
                     .iter()
-                    .map(|t| t.trade.order.order_meta_data.uid);
+                    .map(|t| t.trade.order.metadata.uid);
                 let block = match receipt.block_number {
                     Some(block) => block.as_u64(),
                     None => {
@@ -567,7 +567,7 @@ impl Driver {
 fn is_only_selling_trusted_tokens(settlement: &Settlement, token_list: &TokenList) -> bool {
     !settlement.encoder.trades().iter().any(|order_trade| {
         token_list
-            .get(&order_trade.trade.order.order_creation.sell_token)
+            .get(&order_trade.trade.order.creation.sell_token)
             .is_none()
     })
 }
@@ -643,7 +643,7 @@ mod tests {
         let trade = |token| OrderTrade {
             trade: Trade {
                 order: Order {
-                    order_creation: OrderCreation {
+                    creation: OrderCreation {
                         sell_token: token,
                         ..Default::default()
                     },

--- a/crates/solver/src/driver/solver_settlements.rs
+++ b/crates/solver/src/driver/solver_settlements.rs
@@ -120,16 +120,16 @@ pub fn retain_mature_settlements(
 
                 let contains_valid_trade = settlement.trades().iter().any(|order_trade| {
                     // mature by age
-                    order_trade.trade.order.order_meta_data.creation_date <= settle_orders_older_than
+                    order_trade.trade.order.metadata.creation_date <= settle_orders_older_than
                     // mature by association
-                    || valid_trades.contains(&order_trade.trade.order.order_meta_data.uid)
+                    || valid_trades.contains(&order_trade.trade.order.metadata.uid)
                 });
 
                 if contains_valid_trade {
                     for order_trade in settlement.trades() {
                         // make all orders within this settlement mature by association
                         new_order_added |=
-                            valid_trades.insert(&order_trade.trade.order.order_meta_data.uid);
+                            valid_trades.insert(&order_trade.trade.order.metadata.uid);
                     }
                     valid_settlement_indices.insert(index);
                 }
@@ -157,7 +157,7 @@ mod tests {
     use crate::settlement::{LiquidityOrderTrade, OrderTrade, Trade};
     use chrono::{offset::Utc, DateTime, Duration, Local};
     use maplit::hashmap;
-    use model::order::{Order, OrderCreation, OrderKind, OrderMetaData, OrderUid};
+    use model::order::{Order, OrderCreation, OrderKind, OrderMetadata, OrderUid};
     use num::{BigRational, One as _};
     use primitive_types::{H160, U256};
     use std::collections::HashSet;
@@ -167,7 +167,7 @@ mod tests {
         OrderTrade {
             trade: Trade {
                 order: Order {
-                    order_meta_data: OrderMetaData {
+                    metadata: OrderMetadata {
                         creation_date: created_at,
                         uid: OrderUid([uid; 56]),
                         ..Default::default()
@@ -254,11 +254,11 @@ mod tests {
                 sell_token_index: 0,
                 executed_amount,
                 order: Order {
-                    order_meta_data: OrderMetaData {
+                    metadata: OrderMetadata {
                         uid: uid(uid_),
                         ..Default::default()
                     },
-                    order_creation: OrderCreation {
+                    creation: OrderCreation {
                         sell_token: token0,
                         buy_token: token1,
                         sell_amount: executed_amount,
@@ -291,7 +291,7 @@ mod tests {
             let trades = settlement.trades();
             let uids: HashSet<OrderUid> = trades
                 .iter()
-                .map(|order_trade| order_trade.trade.order.order_meta_data.uid)
+                .map(|order_trade| order_trade.trade.order.metadata.uid)
                 .collect();
             uids.len() == 2 && uids.contains(&uid(2)) && uids.contains(&uid(3))
         }));

--- a/crates/solver/src/in_flight_orders.rs
+++ b/crates/solver/src/in_flight_orders.rs
@@ -29,8 +29,7 @@ impl InFlightOrders {
             .copied()
             .collect::<HashSet<_>>();
         auction.orders.retain(|order| {
-            order.order_creation.partially_fillable
-                || !in_flight.contains(&order.order_meta_data.uid)
+            order.creation.partially_fillable || !in_flight.contains(&order.metadata.uid)
         });
     }
 
@@ -49,10 +48,10 @@ mod tests {
         let mut inflight = InFlightOrders::default();
         inflight.mark_settled_orders(1, [OrderUid::from_integer(0)].into_iter());
         let mut order0 = Order::default();
-        order0.order_meta_data.uid = OrderUid::from_integer(0);
-        order0.order_creation.partially_fillable = true;
+        order0.metadata.uid = OrderUid::from_integer(0);
+        order0.creation.partially_fillable = true;
         let mut order1 = Order::default();
-        order1.order_meta_data.uid = OrderUid::from_integer(1);
+        order1.metadata.uid = OrderUid::from_integer(1);
         let mut auction = Auction {
             block: 0,
             orders: vec![order0, order1],
@@ -68,7 +67,7 @@ mod tests {
         let filtered = update_and_get_filtered_orders(&auction);
         assert_eq!(filtered.len(), 2);
 
-        auction.orders[0].order_creation.partially_fillable = false;
+        auction.orders[0].creation.partially_fillable = false;
         let filtered = update_and_get_filtered_orders(&auction);
         assert_eq!(filtered.len(), 1);
 

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -284,7 +284,7 @@ impl SolverMetrics for Metrics {
 
     fn order_settled(&self, order: &Order, solver: &'static str) {
         let time_to_settlement =
-            chrono::offset::Utc::now().signed_duration_since(order.order_meta_data.creation_date);
+            chrono::offset::Utc::now().signed_duration_since(order.metadata.creation_date);
         self.trade_counter.with_label_values(&[solver]).inc();
         self.order_settlement_time.inc_by(
             time_to_settlement

--- a/crates/solver/src/solver/balancer_sor_solver.rs
+++ b/crates/solver/src/solver/balancer_sor_solver.rs
@@ -316,7 +316,7 @@ mod tests {
         let result = solver
             .try_settle_order(
                 Order {
-                    order_creation: OrderCreation {
+                    creation: OrderCreation {
                         sell_token,
                         buy_token,
                         sell_amount,
@@ -438,7 +438,7 @@ mod tests {
         let result = solver
             .try_settle_order(
                 Order {
-                    order_creation: OrderCreation {
+                    creation: OrderCreation {
                         sell_token,
                         buy_token,
                         sell_amount,
@@ -543,7 +543,7 @@ mod tests {
         let sell_settlement = solver
             .try_settle_order(
                 Order {
-                    order_creation: OrderCreation {
+                    creation: OrderCreation {
                         sell_token: addr!("ba100000625a3754423978a60c9317c58a424e3d"),
                         buy_token: addr!("6b175474e89094c44da98b954eedeac495271d0f"),
                         sell_amount: 1_000_000_000_000_000_000_u128.into(),
@@ -567,7 +567,7 @@ mod tests {
         let buy_settlement = solver
             .try_settle_order(
                 Order {
-                    order_creation: OrderCreation {
+                    creation: OrderCreation {
                         sell_token: addr!("ba100000625a3754423978a60c9317c58a424e3d"),
                         buy_token: addr!("6b175474e89094c44da98b954eedeac495271d0f"),
                         sell_amount: u128::MAX.into(),

--- a/crates/solver/src/solver/naive_solver/multi_order_solver.rs
+++ b/crates/solver/src/solver/naive_solver/multi_order_solver.rs
@@ -280,7 +280,7 @@ fn compute_uniswap_in(
 ///
 fn is_valid_solution(solution: &Settlement) -> bool {
     for order_trade in solution.trades().iter() {
-        let order = &order_trade.trade.order.order_creation;
+        let order = &order_trade.trade.order.creation;
         let buy_token_price = solution
             .clearing_price(order.buy_token)
             .expect("Solution should contain clearing price for buy token");
@@ -591,7 +591,7 @@ mod tests {
         let orders = vec![
             // Unreasonable order a -> b
             Order {
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: to_wei(1),
@@ -605,7 +605,7 @@ mod tests {
             .into(),
             // Reasonable order a -> b
             Order {
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: to_wei(1000),
@@ -619,7 +619,7 @@ mod tests {
             .into(),
             // Reasonable order b -> a
             Order {
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: token_b,
                     buy_token: token_a,
                     sell_amount: to_wei(1000),
@@ -633,7 +633,7 @@ mod tests {
             .into(),
             // Unreasonable order b -> a
             Order {
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: token_b,
                     buy_token: token_a,
                     sell_amount: to_wei(2),
@@ -666,7 +666,7 @@ mod tests {
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
             Order {
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: to_wei(900),
@@ -679,7 +679,7 @@ mod tests {
             }
             .into(),
             Order {
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: token_b,
                     buy_token: token_a,
                     sell_amount: to_wei(900),
@@ -709,7 +709,7 @@ mod tests {
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
             Order {
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: to_wei(10),
@@ -721,7 +721,7 @@ mod tests {
                 ..Default::default()
             },
             Order {
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: token_b,
                     buy_token: token_a,
                     sell_amount: to_wei(10),
@@ -792,7 +792,7 @@ mod tests {
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
             Order {
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: U256::MAX,
@@ -805,7 +805,7 @@ mod tests {
             }
             .into(),
             Order {
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: token_b,
                     buy_token: token_a,
                     sell_amount: 1.into(),
@@ -836,7 +836,7 @@ mod tests {
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
             Order {
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: 70145218378783248142575u128.into(),
@@ -849,7 +849,7 @@ mod tests {
             }
             .into(),
             Order {
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: 900_000_000_000_000u128.into(),
@@ -884,7 +884,7 @@ mod tests {
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
             Order {
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: 9_000_000.into(),
@@ -897,7 +897,7 @@ mod tests {
             }
             .into(),
             Order {
-                order_creation: OrderCreation {
+                creation: OrderCreation {
                     buy_token: token_a,
                     sell_token: token_b,
                     buy_amount: 8_000_001.into(),

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -419,7 +419,7 @@ mod tests {
         let settlement = solver
             .settle_order_with_protocols(
                 Order {
-                    order_creation: OrderCreation {
+                    creation: OrderCreation {
                         sell_token: weth.address(),
                         buy_token: gno,
                         sell_amount: 1_000_000_000_000_000_000u128.into(),

--- a/crates/solver/src/solver/paraswap_solver.rs
+++ b/crates/solver/src/solver/paraswap_solver.rs
@@ -544,7 +544,7 @@ mod tests {
         let settlement = solver
             .try_settle_order(
                 Order {
-                    order_creation: OrderCreation {
+                    creation: OrderCreation {
                         sell_token: weth.address(),
                         buy_token: gno,
                         sell_amount: 1_000_000_000_000_000_000u128.into(),

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -186,7 +186,7 @@ mod tests {
         let settlement = solver
             .try_settle_order(
                 Order {
-                    order_creation: OrderCreation {
+                    creation: OrderCreation {
                         sell_token: weth.address(),
                         buy_token: gno,
                         sell_amount: 1_000_000_000_000_000_000u128.into(),
@@ -227,7 +227,7 @@ mod tests {
         let settlement = solver
             .try_settle_order(
                 Order {
-                    order_creation: OrderCreation {
+                    creation: OrderCreation {
                         sell_token: weth.address(),
                         buy_token: gno,
                         sell_amount: 1_000_000_000_000_000_000u128.into(),


### PR DESCRIPTION
This PR just does some very light cleanup on something that was bothering me (admittedly, more than it should have 🙈).

- Rename `MetaData` to `Metadata`. AFAIK, "metadata" the correct in English so we should not camelCase it as it is a single word. I _think_ "meta-data" is an alternative form, but I don't really ever see it used and when I checked both Oxford and Webster English dictionaries it was spelt as "metadata".
- Rename `meta_data` to `metadata`, same reasoning as ☝️.
- Rename `Order::order_{creation,meta_data}` to `Order::{creation,metadata}`. The reasoning here is that typing `order.order_THING` seems redundant and `order.THING` is just as informative and more succinct. Note that instances of the kind `let order_creation = OrderCreation { .. }` were not changed, as they make sense as-is to me.

### Test Plan

The compiler. There are no code changes beyond renaming type names and fields.
