### PR TITLE
Refactor price estimator to return Stream

### DIFF
--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -16,7 +16,7 @@ use model::{
     u256_decimal,
 };
 use serde::{Deserialize, Serialize};
-use shared::price_estimation::{self, PriceEstimating, PriceEstimationError};
+use shared::price_estimation::{self, single_estimate, PriceEstimating, PriceEstimationError};
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, Filter, Rejection};
 
@@ -281,7 +281,7 @@ impl OrderQuoter {
                         quote_request.app_data,
                         quote_request.from,
                     ),
-                    price_estimator.estimate(&query)
+                    single_estimate(price_estimator.as_ref(), &query)
                 )
                 .map_err(FeeError::PriceEstimate)?;
                 let sell_amount_after_fee = sell_amount_before_fee
@@ -336,7 +336,7 @@ impl OrderQuoter {
                         quote_request.app_data,
                         quote_request.from,
                     ),
-                    price_estimator.estimate(&price_estimation_query)
+                    single_estimate(price_estimator.as_ref(), &price_estimation_query)
                 )
                 .map_err(FeeError::PriceEstimate)?;
                 FeeParameters {
@@ -373,7 +373,7 @@ impl OrderQuoter {
                         quote_request.app_data,
                         quote_request.from,
                     ),
-                    price_estimator.estimate(&price_estimation_query)
+                    single_estimate(price_estimator.as_ref(), &price_estimation_query)
                 )
                 .map_err(FeeError::PriceEstimate)?;
                 let sell_amount_after_fee = estimate.out_amount;

--- a/crates/orderbook/src/fee.rs
+++ b/crates/orderbook/src/fee.rs
@@ -7,8 +7,8 @@ use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
 use shared::{
     bad_token::BadTokenDetecting,
-    price_estimation::native::NativePriceEstimating,
     price_estimation::{self, ensure_token_supported, PriceEstimating, PriceEstimationError},
+    price_estimation::{native::NativePriceEstimating, single_estimate},
 };
 use std::{
     collections::HashMap,
@@ -266,7 +266,7 @@ impl MinFeeCalculator {
             self.gas_estimator
                 .estimate()
                 .map_err(PriceEstimationError::from),
-            self.price_estimator.estimate(&buy_token_query),
+            single_estimate(self.price_estimator.as_ref(), &buy_token_query),
             self.native_price_estimator
                 .estimate_native_price(&fee_data.sell_token)
         )?;

--- a/crates/shared/src/price_estimation/priority.rs
+++ b/crates/shared/src/price_estimation/priority.rs
@@ -1,5 +1,7 @@
-use super::{Estimate, PriceEstimating, PriceEstimationError, Query};
-use anyhow::Result;
+use crate::price_estimation::{
+    old_estimator_to_stream, vec_estimates, PriceEstimateResult, PriceEstimating,
+    PriceEstimationError, Query,
+};
 
 /// Tries inner price estimators in order for queries failing with PriceEstimationError::Other.
 /// Successes, UnsupportedToken or NoLiquidity errors are not retried.
@@ -12,26 +14,14 @@ impl PriorityPriceEstimator {
         assert!(!inner.is_empty());
         Self { inner }
     }
-}
-
-fn log_errors(results: &[Result<Estimate, PriceEstimationError>], estimator_index: usize) {
-    for result in results {
-        if let Err(err) = result {
-            tracing::warn!(%estimator_index, ?err, "priority price estimator failed");
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl PriceEstimating for PriorityPriceEstimator {
-    async fn estimates(&self, queries: &[Query]) -> Vec<Result<Estimate, PriceEstimationError>> {
+    async fn estimates_(&self, queries: &[Query]) -> Vec<PriceEstimateResult> {
         debug_assert!(queries.iter().all(|query| {
             query.buy_token != model::order::BUY_ETH_ADDRESS
                 && query.sell_token != model::order::BUY_ETH_ADDRESS
                 && query.sell_token != query.buy_token
         }));
 
-        let mut results = self.inner[0].estimates(queries).await;
+        let mut results = vec_estimates(self.inner[0].as_ref(), queries).await;
         log_errors(&results, 0);
         for (i, inner) in (&self.inner[1..]).iter().enumerate() {
             let retry_indexes = results
@@ -47,7 +37,7 @@ impl PriceEstimating for PriorityPriceEstimator {
                 .iter()
                 .map(|index| queries[*index])
                 .collect::<Vec<_>>();
-            let retry_results = inner.estimates(&retry_queries).await;
+            let retry_results = vec_estimates(inner.as_ref(), &retry_queries).await;
             log_errors(&retry_results, i + 1);
             for (index, result) in retry_indexes.into_iter().zip(retry_results) {
                 results[index] = result;
@@ -57,11 +47,29 @@ impl PriceEstimating for PriorityPriceEstimator {
     }
 }
 
+fn log_errors(results: &[PriceEstimateResult], estimator_index: usize) {
+    for result in results {
+        if let Err(err) = result {
+            tracing::warn!(%estimator_index, ?err, "priority price estimator failed");
+        }
+    }
+}
+
+impl PriceEstimating for PriorityPriceEstimator {
+    fn estimates<'a>(
+        &'a self,
+        queries: &'a [Query],
+    ) -> futures::stream::BoxStream<'_, (usize, PriceEstimateResult)> {
+        old_estimator_to_stream(self.estimates_(queries))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::price_estimation::MockPriceEstimating;
+    use crate::price_estimation::{Estimate, MockPriceEstimating};
     use anyhow::anyhow;
+    use futures::StreamExt;
     use model::order::OrderKind;
     use primitive_types::H160;
 
@@ -91,30 +99,34 @@ mod tests {
         let mut first = MockPriceEstimating::new();
         first.expect_estimates().times(1).returning(|queries| {
             assert_eq!(queries.len(), 3);
-            Box::pin(futures::future::ready(vec![
+            futures::stream::iter([
                 Err(PriceEstimationError::Other(anyhow!(""))),
                 Err(PriceEstimationError::UnsupportedToken(
                     H160::from_low_u64_le(2),
                 )),
                 Err(PriceEstimationError::Other(anyhow!(""))),
-            ]))
+            ])
+            .enumerate()
+            .boxed()
         });
         let mut second = MockPriceEstimating::new();
         second.expect_estimates().times(1).returning(|queries| {
             assert_eq!(queries.len(), 2);
             assert_eq!(queries[0].sell_token, H160::from_low_u64_le(0));
             assert_eq!(queries[1].sell_token, H160::from_low_u64_le(3));
-            Box::pin(futures::future::ready(vec![
+            futures::stream::iter([
                 Err(PriceEstimationError::NoLiquidity),
                 Ok(Estimate::default()),
-            ]))
+            ])
+            .enumerate()
+            .boxed()
         });
         let third = MockPriceEstimating::new();
 
         let priority =
             PriorityPriceEstimator::new(vec![Box::new(first), Box::new(second), Box::new(third)]);
 
-        let result = priority.estimates(&queries).await;
+        let result = vec_estimates(&priority, &queries).await;
         assert_eq!(result.len(), 3);
         assert!(matches!(result[0], Err(PriceEstimationError::NoLiquidity)));
         assert!(matches!(


### PR DESCRIPTION
This allows estimators to make results available as they come in which gives them and their user more flexibility in how they want to handle multiple requests.

This is motivated by #1689 where we want to try to get as many estimates as possible in some time interval. After a bunch of testing and back and forth I decided the long term cleanest way to implement this would require this change.

To keep the commit reasonably short I introduce the new trait function in `price_estimation.rs` and several helper functions that allow existing code to keep working mostly as before. Then most price estimator implementations and uses are naively replaced with these helper functions.

In follow ups I will
- Change NativePriceEstimator to be Stream based.
- See if there are smarter PriceEstimating implementations possible for the more complicated buffered, competition, instrumented estimators.
- Make use of the streaming in `solvable_orders.rs` to fix #1689 .

### Test Plan

Existing tests in CI
