### PR TITLE
Use zeroex liquidity in http solver

### DIFF
--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -198,6 +198,7 @@ async fn eth_integration(web3: Web3) {
     let liquidity_collector = LiquidityCollector {
         uniswap_like_liquidity: vec![uniswap_liquidity],
         balancer_v2_liquidity: None,
+        zeroex_liquidity: None,
     };
     let network_id = web3.net().version().await.unwrap();
     let mut driver = solver::driver::Driver::new(

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -203,6 +203,7 @@ async fn onchain_settlement(web3: Web3) {
     let liquidity_collector = LiquidityCollector {
         uniswap_like_liquidity: vec![uniswap_liquidity],
         balancer_v2_liquidity: None,
+        zeroex_liquidity: None,
     };
     let network_id = web3.net().version().await.unwrap();
     let mut driver = solver::driver::Driver::new(

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -184,6 +184,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
     let liquidity_collector = LiquidityCollector {
         uniswap_like_liquidity: vec![uniswap_liquidity],
         balancer_v2_liquidity: None,
+        zeroex_liquidity: None,
     };
     let network_id = web3.net().version().await.unwrap();
     let market_makable_token_list = TokenList::new(maplit::hashmap! {

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -161,6 +161,7 @@ async fn smart_contract_orders(web3: Web3) {
     let liquidity_collector = LiquidityCollector {
         uniswap_like_liquidity: vec![uniswap_liquidity],
         balancer_v2_liquidity: None,
+        zeroex_liquidity: None,
     };
     let network_id = web3.net().version().await.unwrap();
     let mut driver = solver::driver::Driver::new(

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -142,6 +142,7 @@ async fn vault_balances(web3: Web3) {
     let liquidity_collector = LiquidityCollector {
         uniswap_like_liquidity: vec![uniswap_liquidity],
         balancer_v2_liquidity: None,
+        zeroex_liquidity: None,
     };
     let network_id = web3.net().version().await.unwrap();
     let mut driver = solver::driver::Driver::new(

--- a/crates/shared/src/http_solver/gas_model.rs
+++ b/crates/shared/src/http_solver/gas_model.rs
@@ -15,8 +15,12 @@ impl GasModel {
         }
     }
 
-    pub fn order_cost(&self) -> CostModel {
+    pub fn gp_order_cost(&self) -> CostModel {
         self.cost_for_gas(GAS_PER_ORDER.into())
+    }
+
+    pub fn zeroex_order_cost(&self) -> CostModel {
+        self.cost_for_gas(GAS_PER_ZEROEX_ORDER.into())
     }
 
     pub fn uniswap_cost(&self) -> CostModel {

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -32,6 +32,11 @@ pub struct OrderModel {
     pub is_liquidity_order: bool,
     #[serde(default)]
     pub mandatory: bool,
+    /// Signals if the order will be executed as an atomic unit. In that case the order's
+    /// preconditions have to be met for it to be executed successfully. This is different from the
+    /// usual user provided orders because those can be batched together and it's only relevant if
+    /// the pre- and post conditions are met after the complete batch got executed.
+    pub has_atomic_execution: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -299,6 +304,7 @@ mod tests {
             },
             is_liquidity_order: false,
             mandatory: false,
+            has_atomic_execution: false,
         };
         let constant_product_pool_model = AmmModel {
             parameters: AmmParameters::ConstantProduct(ConstantProductPoolParameters {
@@ -418,6 +424,7 @@ mod tests {
                 "token": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
               },
               "mandatory": false,
+              "has_atomic_execution": false
             },
           },
           "amms": {

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -175,6 +175,8 @@ pub struct ExecutedOrderModel {
     pub exec_buy_amount: U256,
     pub cost: Option<CostModel>,
     pub fee: Option<FeeModel>,
+    // Orders which need to be executed in a specific order have an `exec_plan` (e.g. 0x limit orders)
+    pub exec_plan: Option<ExecutionPlanCoordinatesModel>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/crates/shared/src/price_estimation/gas.rs
+++ b/crates/shared/src/price_estimation/gas.rs
@@ -46,8 +46,8 @@ pub static GAS_PER_ORDER: u64 = 66_315;
 pub static GAS_PER_UNISWAP: u64 = 94_696;
 
 /// lower bound for execution of one trade on zeroex
-// estimated with https://dune.xyz/queries/492900/933779
-pub static GAS_PER_ZEROEX_ORDER: u64 = 134_563;
+// estimated with https://dune.xyz/queries/536616
+pub static GAS_PER_ZEROEX_ORDER: u64 = 157_300;
 
 /// lower bound for executing one trade on balancer
 ///

--- a/crates/shared/src/price_estimation/gas.rs
+++ b/crates/shared/src/price_estimation/gas.rs
@@ -45,6 +45,10 @@ pub static GAS_PER_ORDER: u64 = 66_315;
 /// lower bound for executing one trade on uniswap
 pub static GAS_PER_UNISWAP: u64 = 94_696;
 
+/// lower bound for execution of one trade on zeroex
+// TODO this is currently a placeholder and needs to be replaced with the real value
+pub static GAS_PER_ZEROEX_ORDER: u64 = 94_696;
+
 /// lower bound for executing one trade on balancer
 ///
 /// Taken from a sample of two swaps

--- a/crates/shared/src/price_estimation/gas.rs
+++ b/crates/shared/src/price_estimation/gas.rs
@@ -46,8 +46,8 @@ pub static GAS_PER_ORDER: u64 = 66_315;
 pub static GAS_PER_UNISWAP: u64 = 94_696;
 
 /// lower bound for execution of one trade on zeroex
-// TODO this is currently a placeholder and needs to be replaced with the real value
-pub static GAS_PER_ZEROEX_ORDER: u64 = 94_696;
+// estimated with https://dune.xyz/queries/492900/933779
+pub static GAS_PER_ZEROEX_ORDER: u64 = 134_563;
 
 /// lower bound for executing one trade on balancer
 ///

--- a/crates/shared/src/price_estimation/quasimodo.rs
+++ b/crates/shared/src/price_estimation/quasimodo.rs
@@ -97,6 +97,7 @@ impl QuasimodoPriceEstimator {
                 },
                 is_liquidity_order: false,
                 mandatory: true,
+                has_atomic_execution: false,
             },
         };
 

--- a/crates/shared/src/sources.rs
+++ b/crates/shared/src/sources.rs
@@ -29,11 +29,18 @@ pub enum BaselineSource {
     BalancerV2,
     Baoswap,
     Swapr,
+    ZeroEx,
 }
 
 pub fn defaults_for_chain(chain_id: u64) -> Result<Vec<BaselineSource>> {
     Ok(match chain_id {
-        1 | 4 => vec![
+        1 => vec![
+            BaselineSource::UniswapV2,
+            BaselineSource::SushiSwap,
+            BaselineSource::BalancerV2,
+            BaselineSource::ZeroEx,
+        ],
+        4 => vec![
             BaselineSource::UniswapV2,
             BaselineSource::SushiSwap,
             BaselineSource::BalancerV2,
@@ -63,6 +70,7 @@ pub async fn uniswap_like_liquidity_sources(
             BaselineSource::Baoswap => baoswap::get_liquidity_source(web3).await?,
             BaselineSource::Swapr => swapr::get_liquidity_source(web3).await?,
             BaselineSource::BalancerV2 => continue,
+            BaselineSource::ZeroEx => continue,
         };
 
         liquidity_sources.insert(*source, liquidity_source);

--- a/crates/solver/src/interactions.rs
+++ b/crates/solver/src/interactions.rs
@@ -4,8 +4,10 @@ pub mod block_coinbase;
 mod erc20;
 mod uniswap_v2;
 mod weth;
+pub mod zeroex;
 
 pub use balancer_v2::BalancerSwapGivenOutInteraction;
 pub use erc20::Erc20ApproveInteraction;
 pub use uniswap_v2::UniswapInteraction;
 pub use weth::UnwrapWethInteraction;
+pub use zeroex::ZeroExInteraction;

--- a/crates/solver/src/interactions/zeroex.rs
+++ b/crates/solver/src/interactions/zeroex.rs
@@ -12,7 +12,7 @@ pub struct ZeroExInteraction {
 
 impl Interaction for ZeroExInteraction {
     fn encode(&self) -> Vec<EncodedInteraction> {
-        let method = self.zeroex.fill_limit_order(
+        let method = self.zeroex.fill_or_kill_limit_order(
             (
                 self.order.maker_token,
                 self.order.taker_token,

--- a/crates/solver/src/interactions/zeroex.rs
+++ b/crates/solver/src/interactions/zeroex.rs
@@ -6,7 +6,7 @@ use shared::zeroex_api::Order;
 #[derive(Clone, Debug)]
 pub struct ZeroExInteraction {
     pub order: Order,
-    pub executed_amount: u128,
+    pub taker_token_fill_amount: u128,
     pub zeroex: IZeroEx,
 }
 
@@ -33,7 +33,7 @@ impl Interaction for ZeroExInteraction {
                 Bytes(self.order.signature.r.0),
                 Bytes(self.order.signature.s.0),
             ),
-            self.executed_amount,
+            self.taker_token_fill_amount,
         );
         let calldata = method.tx.data.expect("no calldata").0;
         vec![(self.zeroex.address(), 0.into(), Bytes(calldata))]

--- a/crates/solver/src/interactions/zeroex.rs
+++ b/crates/solver/src/interactions/zeroex.rs
@@ -12,7 +12,7 @@ pub struct ZeroExInteraction {
 
 impl Interaction for ZeroExInteraction {
     fn encode(&self) -> Vec<EncodedInteraction> {
-        let method = self.zeroex.fill_or_kill_limit_order(
+        let method = self.zeroex.fill_limit_order(
             (
                 self.order.maker_token,
                 self.order.taker_token,

--- a/crates/solver/src/interactions/zeroex.rs
+++ b/crates/solver/src/interactions/zeroex.rs
@@ -1,0 +1,41 @@
+use crate::{encoding::EncodedInteraction, settlement::Interaction};
+use contracts::IZeroEx;
+use ethcontract::Bytes;
+use shared::zeroex_api::Order;
+
+#[derive(Clone, Debug)]
+pub struct ZeroExInteraction {
+    pub order: Order,
+    pub executed_amount: u128,
+    pub zeroex: IZeroEx,
+}
+
+impl Interaction for ZeroExInteraction {
+    fn encode(&self) -> Vec<EncodedInteraction> {
+        let method = self.zeroex.fill_or_kill_limit_order(
+            (
+                self.order.maker_token,
+                self.order.taker_token,
+                self.order.maker_amount,
+                self.order.taker_amount,
+                self.order.taker_token_fee_amount,
+                self.order.maker,
+                self.order.taker,
+                self.order.sender,
+                self.order.fee_recipient,
+                Bytes(self.order.pool.0),
+                self.order.expiry,
+                self.order.salt,
+            ),
+            (
+                self.order.signature.signature_type,
+                self.order.signature.v,
+                Bytes(self.order.signature.r.0),
+                Bytes(self.order.signature.s.0),
+            ),
+            self.executed_amount,
+        );
+        let calldata = method.tx.data.expect("no calldata").0;
+        vec![(self.zeroex.address(), 0.into(), Bytes(calldata))]
+    }
+}

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -64,6 +64,12 @@ where
     fn encode(&self, execution: L::Execution, encoder: &mut SettlementEncoder) -> Result<()>;
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Exchange {
+    GnosisProtocol,
+    ZeroEx,
+}
+
 /// Basic limit sell and buy orders
 #[derive(Clone)]
 #[cfg_attr(test, derive(Derivative))]
@@ -88,11 +94,7 @@ pub struct LimitOrder {
     pub is_liquidity_order: bool,
     #[cfg_attr(test, derivative(PartialEq = "ignore"))]
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
-    /// Signals if the order will be executed as an atomic unit. In that case the order's
-    /// preconditions have to be met for it to be executed successfully. This is different from the
-    /// usual user provided orders because those can be batched together and it's only relevant if
-    /// the pre- and post conditions are met after the complete batch got executed.
-    pub has_atomic_execution: bool,
+    pub exchange: Exchange,
 }
 
 impl std::fmt::Debug for LimitOrder {
@@ -143,7 +145,7 @@ impl Default for LimitOrder {
             settlement_handling: tests::CapturingSettlementHandler::arc(),
             is_liquidity_order: false,
             id: Default::default(),
-            has_atomic_execution: false,
+            exchange: Exchange::GnosisProtocol,
         }
     }
 }

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -88,6 +88,11 @@ pub struct LimitOrder {
     pub is_liquidity_order: bool,
     #[cfg_attr(test, derivative(PartialEq = "ignore"))]
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
+    /// Signals if the order will be executed as an atomic unit. In that case the order's
+    /// preconditions have to be met for it to be executed successfully. This is different from the
+    /// usual user provided orders because those can be batched together and it's only relevant if
+    /// the pre- and post conditions are met after the complete batch got executed.
+    pub has_atomic_execution: bool,
 }
 
 impl std::fmt::Debug for LimitOrder {
@@ -138,6 +143,7 @@ impl Default for LimitOrder {
             settlement_handling: tests::CapturingSettlementHandler::arc(),
             is_liquidity_order: false,
             id: Default::default(),
+            has_atomic_execution: false,
         }
     }
 }

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -2,6 +2,7 @@ pub mod balancer_v2;
 pub mod order_converter;
 pub mod slippage;
 pub mod uniswap_v2;
+pub mod zeroex;
 
 use crate::settlement::SettlementEncoder;
 use anyhow::Result;
@@ -29,6 +30,7 @@ pub enum Liquidity {
     ConstantProduct(ConstantProductOrder),
     BalancerWeighted(WeightedProductOrder),
     BalancerStable(StablePoolOrder),
+    LimitOrder(LimitOrder),
 }
 
 impl Liquidity {
@@ -38,6 +40,9 @@ impl Liquidity {
             Liquidity::ConstantProduct(amm) => vec![amm.tokens],
             Liquidity::BalancerWeighted(amm) => token_pairs(&amm.reserves),
             Liquidity::BalancerStable(amm) => token_pairs(&amm.reserves),
+            Liquidity::LimitOrder(order) => TokenPair::new(order.sell_token, order.buy_token)
+                .map(|pair| vec![pair])
+                .unwrap_or_default(),
         }
     }
 }

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -58,6 +58,7 @@ impl OrderConverter {
                 scaled_unsubsidized_fee_amount: scaled_fee_amount,
                 is_liquidity_order,
             }),
+            has_atomic_execution: false,
         })
     }
 }

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -1,4 +1,4 @@
-use super::{LimitOrder, SettlementHandling};
+use super::{Exchange, LimitOrder, SettlementHandling};
 use crate::{interactions::UnwrapWethInteraction, settlement::SettlementEncoder};
 use anyhow::Result;
 use contracts::WETH9;
@@ -58,7 +58,7 @@ impl OrderConverter {
                 scaled_unsubsidized_fee_amount: scaled_fee_amount,
                 is_liquidity_order,
             }),
-            has_atomic_execution: false,
+            exchange: Exchange::GnosisProtocol,
         })
     }
 }

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -1,0 +1,73 @@
+use super::SettlementHandling;
+use crate::interactions::ZeroExInteraction;
+use crate::liquidity::{LimitOrder, Liquidity};
+use crate::settlement::SettlementEncoder;
+use anyhow::Result;
+use contracts::IZeroEx;
+use model::order::OrderKind;
+use primitive_types::U256;
+use shared::zeroex_api::{Order, OrderRecord, OrdersQuery, ZeroExApi};
+use std::sync::Arc;
+
+pub struct ZeroExLiquidity {
+    pub api: Arc<dyn ZeroExApi>,
+    pub zeroex: IZeroEx,
+}
+
+impl ZeroExLiquidity {
+    pub async fn get_liquidity(&self) -> Result<Vec<Liquidity>> {
+        Ok(self
+            .api
+            .get_orders(&OrdersQuery::default())
+            .await?
+            .into_iter()
+            .filter_map(|record| self.record_into_liquidity(record))
+            .collect())
+    }
+
+    /// Turns 0x OrderRecord into liquidity which solvers can use.
+    fn record_into_liquidity(&self, record: OrderRecord) -> Option<Liquidity> {
+        let sell_amount: U256 = record.remaining_maker_amount().ok()?.into();
+        if sell_amount.is_zero() || record.metadata.remaining_fillable_taker_amount == 0 {
+            // filter out orders with 0 amounts to prevent errors in the solver
+            return None;
+        }
+
+        let limit_order = LimitOrder {
+            id: hex::encode(&record.metadata.order_hash.0),
+            sell_token: record.order.maker_token,
+            buy_token: record.order.taker_token,
+            sell_amount,
+            buy_amount: record.metadata.remaining_fillable_taker_amount.into(),
+            kind: OrderKind::Buy,
+            partially_fillable: true,
+            unscaled_subsidized_fee: U256::zero(),
+            scaled_unsubsidized_fee: U256::zero(),
+            is_liquidity_order: true,
+            settlement_handling: Arc::new(OrderSettlementHandler {
+                order: record.order,
+                zeroex: self.zeroex.clone(),
+            }),
+        };
+        Some(Liquidity::LimitOrder(limit_order))
+    }
+}
+
+struct OrderSettlementHandler {
+    order: Order,
+    zeroex: IZeroEx,
+}
+
+impl SettlementHandling<LimitOrder> for OrderSettlementHandler {
+    fn encode(&self, executed_amount: U256, encoder: &mut SettlementEncoder) -> Result<()> {
+        if executed_amount > u128::MAX.into() {
+            anyhow::bail!("0x only supports executed amounts of size u128");
+        }
+        encoder.append_to_execution_plan(ZeroExInteraction {
+            executed_amount: executed_amount.as_u128(),
+            order: self.order.clone(),
+            zeroex: self.zeroex.clone(),
+        });
+        Ok(())
+    }
+}

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -64,7 +64,7 @@ impl SettlementHandling<LimitOrder> for OrderSettlementHandler {
             anyhow::bail!("0x only supports executed amounts of size u128");
         }
         encoder.append_to_execution_plan(ZeroExInteraction {
-            executed_amount: executed_amount.as_u128(),
+            taker_token_fill_amount: executed_amount.as_u128(),
             order: self.order.clone(),
             zeroex: self.zeroex.clone(),
         });

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -48,6 +48,7 @@ impl ZeroExLiquidity {
                 order: record.order,
                 zeroex: self.zeroex.clone(),
             }),
+            has_atomic_execution: true,
         };
         Some(Liquidity::LimitOrder(limit_order))
     }

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -1,6 +1,6 @@
 use super::SettlementHandling;
 use crate::interactions::ZeroExInteraction;
-use crate::liquidity::{LimitOrder, Liquidity};
+use crate::liquidity::{Exchange, LimitOrder, Liquidity};
 use crate::settlement::SettlementEncoder;
 use anyhow::Result;
 use contracts::IZeroEx;
@@ -48,7 +48,7 @@ impl ZeroExLiquidity {
                 order: record.order,
                 zeroex: self.zeroex.clone(),
             }),
-            has_atomic_execution: true,
+            exchange: Exchange::ZeroEx,
         };
         Some(Liquidity::LimitOrder(limit_order))
     }

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -280,6 +280,10 @@ struct Arguments {
     /// but at the same time we don't restrict solutions sizes too much
     #[clap(long, env, default_value = "15000000")]
     simulation_gas_limit: u128,
+
+    /// Controls whether 0x limit orders will be used as additional liquidity.
+    #[clap(long, env)]
+    with_zeroex_liquidity: bool,
 }
 
 #[derive(Copy, Clone, Debug, clap::ArgEnum)]
@@ -522,7 +526,7 @@ async fn main() {
     )
     .expect("failure creating solvers");
 
-    let zeroex_liquidity = if chain_id == 1 {
+    let zeroex_liquidity = if args.with_zeroex_liquidity {
         Some(ZeroExLiquidity {
             api: zeroex_api,
             zeroex: contracts::IZeroEx::deployed(&web3).await.unwrap(),

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -280,10 +280,6 @@ struct Arguments {
     /// but at the same time we don't restrict solutions sizes too much
     #[clap(long, env, default_value = "15000000")]
     simulation_gas_limit: u128,
-
-    /// Controls whether 0x limit orders will be used as additional liquidity.
-    #[clap(long, env)]
-    with_zeroex_liquidity: bool,
 }
 
 #[derive(Copy, Clone, Debug, clap::ArgEnum)]
@@ -526,7 +522,7 @@ async fn main() {
     )
     .expect("failure creating solvers");
 
-    let zeroex_liquidity = if args.with_zeroex_liquidity {
+    let zeroex_liquidity = if chain_id == 1 {
         Some(ZeroExLiquidity {
             api: zeroex_api,
             zeroex: contracts::IZeroEx::deployed(&web3).await.unwrap(),

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -522,7 +522,7 @@ async fn main() {
     )
     .expect("failure creating solvers");
 
-    let zeroex_liquidity = if chain_id == 1 {
+    let zeroex_liquidity = if baseline_sources.contains(&BaselineSource::ZeroEx) {
         Some(ZeroExLiquidity {
             api: zeroex_api,
             zeroex: contracts::IZeroEx::deployed(&web3).await.unwrap(),
@@ -694,6 +694,7 @@ async fn build_amm_artifacts(
                 .expect("couldn't load deployed Swapr router")
                 .address(),
             BaselineSource::BalancerV2 => continue,
+            BaselineSource::ZeroEx => continue,
         };
         res.push(UniswapLikeLiquidity::new(
             IUniswapLikeRouter::at(&web3, router_address),

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -25,7 +25,7 @@ use solver::{
     driver::Driver,
     liquidity::{
         balancer_v2::BalancerV2Liquidity, order_converter::OrderConverter,
-        uniswap_v2::UniswapLikeLiquidity,
+        uniswap_v2::UniswapLikeLiquidity, zeroex::ZeroExLiquidity,
     },
     liquidity_collector::LiquidityCollector,
     metrics::Metrics,
@@ -514,16 +514,27 @@ async fn main() {
         args.shared.paraswap_partner,
         client.clone(),
         metrics.clone(),
-        zeroex_api,
+        zeroex_api.clone(),
         args.zeroex_slippage_bps,
         args.shared.quasimodo_uses_internal_buffers,
         args.shared.mip_uses_internal_buffers,
         args.shared.one_inch_url,
     )
     .expect("failure creating solvers");
+
+    let zeroex_liquidity = if chain_id == 1 {
+        Some(ZeroExLiquidity {
+            api: zeroex_api,
+            zeroex: contracts::IZeroEx::deployed(&web3).await.unwrap(),
+        })
+    } else {
+        None
+    };
+
     let liquidity_collector = LiquidityCollector {
         uniswap_like_liquidity,
         balancer_v2_liquidity,
+        zeroex_liquidity,
     };
     let market_makable_token_list =
         TokenList::from_url(&args.market_makable_token_list, chain_id, client.clone())

--- a/crates/solver/src/solver/baseline_solver.rs
+++ b/crates/solver/src/solver/baseline_solver.rs
@@ -144,6 +144,7 @@ impl BaselineSolver {
                             // TODO - https://github.com/gnosis/gp-v2-services/issues/1074
                             tracing::debug!("Excluded stable pool from baseline solving.")
                         }
+                        Liquidity::LimitOrder(_) => {}
                     }
                     amm_map
                 });

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -246,7 +246,7 @@ fn order_models(
                     cost,
                     is_liquidity_order: order.is_liquidity_order,
                     mandatory: false,
-                    has_atomic_execution: matches!(order.exchange, Exchange::ZeroEx),
+                    has_atomic_execution: !matches!(order.exchange, Exchange::GnosisProtocol),
                 },
             ))
         })

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -373,19 +373,10 @@ impl Solver for HttpSolver {
         if orders.is_empty() {
             return Ok(Vec::new());
         };
-        let prices = external_prices.clone().into_http_solver_prices();
-        orders.extend(
-            liquidity
-                .iter()
-                .filter_map(|liquidity| match liquidity {
-                    Liquidity::LimitOrder(order) => Some(order.clone()),
-                    _ => None,
-                })
-                .filter(|order| {
-                    prices.get(&order.sell_token).is_some()
-                        && prices.get(&order.buy_token).is_some()
-                }),
-        );
+        orders.extend(liquidity.iter().filter_map(|liquidity| match liquidity {
+            Liquidity::LimitOrder(order) => Some(order.clone()),
+            _ => None,
+        }));
 
         let (model, context) = {
             let mut guard = self.instance_cache.lock().await;

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -4,7 +4,7 @@ pub mod settlement;
 use self::settlement::SettlementContext;
 use crate::{
     interactions::allowances::AllowanceManaging,
-    liquidity::{LimitOrder, Liquidity},
+    liquidity::{Exchange, LimitOrder, Liquidity},
     settlement::{external_prices::ExternalPrices, Settlement},
     solver::{Auction, Solver},
 };
@@ -228,6 +228,11 @@ fn order_models(
                 return None;
             }
 
+            let cost = match order.exchange {
+                Exchange::GnosisProtocol => gas_model.gp_order_cost(),
+                Exchange::ZeroEx => gas_model.zeroex_order_cost(),
+            };
+
             Some((
                 index,
                 OrderModel {
@@ -238,10 +243,10 @@ fn order_models(
                     allow_partial_fill: order.partially_fillable,
                     is_sell_order: matches!(order.kind, OrderKind::Sell),
                     fee: order_fee(order),
-                    cost: gas_model.order_cost(),
+                    cost,
                     is_liquidity_order: order.is_liquidity_order,
                     mandatory: false,
-                    has_atomic_execution: order.has_atomic_execution,
+                    has_atomic_execution: matches!(order.exchange, Exchange::ZeroEx),
                 },
             ))
         })

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -241,6 +241,7 @@ fn order_models(
                     cost: gas_model.order_cost(),
                     is_liquidity_order: order.is_liquidity_order,
                     mandatory: false,
+                    has_atomic_execution: order.has_atomic_execution,
                 },
             ))
         })

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -149,6 +149,8 @@ impl IntermediateSettlement {
                         Liquidity::BalancerStable(liquidity) => {
                             settlement.with_liquidity(liquidity, execution)?
                         }
+                        // This sort of liquidity gets used elsewhere
+                        Liquidity::LimitOrder(_) => {}
                     };
                 }
                 Execution::ExecutionCustomInteraction(interaction_data) => {

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -42,15 +42,50 @@ pub async fn convert_settlement(
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 enum Execution {
-    ExecutionAmm(Box<ExecutedAmm>),
-    ExecutionCustomInteraction(Box<InteractionData>),
+    Amm(Box<ExecutedAmm>),
+    CustomInteraction(Box<InteractionData>),
+    LimitOrder(Box<ExecutedLimitOrder>),
 }
 
 impl Execution {
     fn coordinates(&self) -> Option<ExecutionPlanCoordinatesModel> {
         match self {
-            Execution::ExecutionAmm(executed_amm) => executed_amm.exec_plan.clone(),
-            Execution::ExecutionCustomInteraction(interaction) => interaction.exec_plan.clone(),
+            Execution::Amm(executed_amm) => executed_amm.exec_plan.clone(),
+            Execution::CustomInteraction(interaction) => interaction.exec_plan.clone(),
+            Execution::LimitOrder(order) => order.exec_plan.clone(),
+        }
+    }
+
+    fn add_to_settlement(&self, settlement: &mut Settlement) -> Result<()> {
+        use Execution::*;
+
+        match self {
+            LimitOrder(order) => settlement.with_liquidity(&order.order, order.executed_amount()),
+            Amm(executed_amm) => {
+                let execution = AmmOrderExecution {
+                    input: executed_amm.input,
+                    output: executed_amm.output,
+                };
+                match &executed_amm.order {
+                    Liquidity::ConstantProduct(liquidity) => {
+                        settlement.with_liquidity(liquidity, execution)
+                    }
+                    Liquidity::BalancerWeighted(liquidity) => {
+                        settlement.with_liquidity(liquidity, execution)
+                    }
+                    Liquidity::BalancerStable(liquidity) => {
+                        settlement.with_liquidity(liquidity, execution)
+                    }
+                    // This sort of liquidity gets used elsewhere
+                    Liquidity::LimitOrder(_) => Ok(()),
+                }
+            }
+            CustomInteraction(interaction_data) => {
+                settlement
+                    .encoder
+                    .append_to_execution_plan(*interaction_data.clone());
+                Ok(())
+            }
         }
     }
 }
@@ -58,16 +93,18 @@ impl Execution {
 // An intermediate representation between SettledBatchAuctionModel and Settlement useful for doing
 // the error checking up front and then working with a more convenient representation.
 struct IntermediateSettlement {
-    executed_limit_orders: Vec<ExecutedLimitOrder>,
     approvals: Vec<Approval>,
     executions: Vec<Execution>, // executions are sorted by execution coordinate.
     prices: HashMap<H160, U256>,
 }
 
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 struct ExecutedLimitOrder {
     order: LimitOrder,
     executed_buy_amount: U256,
     executed_sell_amount: U256,
+    exec_plan: Option<ExecutionPlanCoordinatesModel>,
 }
 
 impl ExecutedLimitOrder {
@@ -102,17 +139,17 @@ impl IntermediateSettlement {
     ) -> Result<Self> {
         let executed_limit_orders =
             match_prepared_and_settled_orders(context.orders, settled.orders)?;
-        let executions_amm = match_prepared_and_settled_amms(context.liquidity, settled.amms)?;
-        let executions_interactions = settled
-            .interaction_data
-            .into_iter()
-            .map(|x| Execution::ExecutionCustomInteraction(Box::new(x)))
-            .collect();
-        let executions = merge_and_order_executions(executions_amm, executions_interactions)?;
         let prices = match_settled_prices(executed_limit_orders.as_slice(), settled.prices)?;
         let approvals = compute_approvals(allowance_manager, settled.approvals).await?;
-        Ok(Self {
+        let executions_amm = match_prepared_and_settled_amms(context.liquidity, settled.amms)?;
+
+        let executions = merge_and_order_executions(
+            executions_amm,
+            settled.interaction_data,
             executed_limit_orders,
+        );
+
+        Ok(Self {
             executions,
             prices,
             approvals,
@@ -121,9 +158,6 @@ impl IntermediateSettlement {
 
     fn into_settlement(self) -> Result<Settlement> {
         let mut settlement = Settlement::new(self.prices);
-        for order in self.executed_limit_orders {
-            settlement.with_liquidity(&order.order, order.executed_amount())?;
-        }
 
         // Make sure to always add approval interactions **before** any
         // interactions from the execution plan - the execution plan typically
@@ -132,34 +166,10 @@ impl IntermediateSettlement {
             settlement.encoder.append_to_execution_plan(approval);
         }
 
-        for execution in self.executions {
-            match execution {
-                Execution::ExecutionAmm(executed_amm) => {
-                    let execution = AmmOrderExecution {
-                        input: executed_amm.input,
-                        output: executed_amm.output,
-                    };
-                    match &executed_amm.order {
-                        Liquidity::ConstantProduct(liquidity) => {
-                            settlement.with_liquidity(liquidity, execution)?
-                        }
-                        Liquidity::BalancerWeighted(liquidity) => {
-                            settlement.with_liquidity(liquidity, execution)?
-                        }
-                        Liquidity::BalancerStable(liquidity) => {
-                            settlement.with_liquidity(liquidity, execution)?
-                        }
-                        // This sort of liquidity gets used elsewhere
-                        Liquidity::LimitOrder(_) => {}
-                    };
-                }
-                Execution::ExecutionCustomInteraction(interaction_data) => {
-                    settlement
-                        .encoder
-                        .append_to_execution_plan(*interaction_data);
-                }
-            }
+        for execution in &self.executions {
+            execution.add_to_settlement(&mut settlement)?;
         }
+
         Ok(settlement)
     }
 }
@@ -181,6 +191,7 @@ fn match_prepared_and_settled_orders(
                 order: prepared.clone(),
                 executed_buy_amount: settled.exec_buy_amount,
                 executed_sell_amount: settled.exec_sell_amount,
+                exec_plan: settled.exec_plan,
             })
         })
         .collect()
@@ -189,13 +200,13 @@ fn match_prepared_and_settled_orders(
 fn match_prepared_and_settled_amms(
     prepared_amms: Vec<Liquidity>,
     settled_amms: HashMap<usize, UpdatedAmmModel>,
-) -> Result<Vec<Execution>> {
+) -> Result<Vec<ExecutedAmm>> {
     settled_amms
         .into_iter()
         .filter(|(_, settled)| settled.is_non_trivial())
         .flat_map(|(index, settled)| settled.execution.into_iter().map(move |exec| (index, exec)))
         .map(|(index, settled)| {
-            Ok(Execution::ExecutionAmm(Box::new(ExecutedAmm {
+            Ok(ExecutedAmm {
                 order: prepared_amms
                     .get(index)
                     .ok_or_else(|| anyhow!("Invalid AMM {}", index))?
@@ -203,19 +214,33 @@ fn match_prepared_and_settled_amms(
                 input: (settled.buy_token, settled.exec_buy_amount),
                 output: (settled.sell_token, settled.exec_sell_amount),
                 exec_plan: settled.exec_plan,
-            })))
+            })
         })
-        .collect::<Result<Vec<Execution>>>()
+        .collect()
 }
 
 fn merge_and_order_executions(
-    mut executions_amms: Vec<Execution>,
-    mut interactions: Vec<Execution>,
-) -> Result<Vec<Execution>> {
-    interactions.append(&mut executions_amms);
+    executions_amms: Vec<ExecutedAmm>,
+    interactions: Vec<InteractionData>,
+    orders: Vec<ExecutedLimitOrder>,
+) -> Vec<Execution> {
+    let mut executions: Vec<_> = executions_amms
+        .into_iter()
+        .map(|amm| Execution::Amm(Box::new(amm)))
+        .chain(
+            interactions
+                .into_iter()
+                .map(|interaction| Execution::CustomInteraction(Box::new(interaction))),
+        )
+        .chain(
+            orders
+                .into_iter()
+                .map(|order| Execution::LimitOrder(Box::new(order))),
+        )
+        .collect();
     // executions with optional execution plan will be executed first
-    interactions.sort_by_key(|a| a.coordinates());
-    Ok(interactions)
+    executions.sort_by_key(|execution| execution.coordinates());
+    executions
 }
 
 fn match_settled_prices(
@@ -362,6 +387,7 @@ mod tests {
             exec_sell_amount: 7.into(),
             cost: Default::default(),
             fee: Default::default(),
+            exec_plan: None,
         };
         let updated_uniswap = UpdatedAmmModel {
             execution: vec![ExecutedAmmModel {
@@ -673,13 +699,12 @@ mod tests {
         )
         .unwrap();
 
-        let prepared_amms =
-            match_prepared_and_settled_amms(liquidity, solution_response.amms).unwrap();
-        let executions = merge_and_order_executions(prepared_amms, Vec::new()).unwrap();
+        let amms = match_prepared_and_settled_amms(liquidity, solution_response.amms).unwrap();
+        let executions = merge_and_order_executions(amms, vec![], vec![]);
         assert_eq!(
             executions,
             vec![
-                Execution::ExecutionAmm(Box::new(ExecutedAmm {
+                Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::BalancerWeighted(wpo),
                     input: (token_c, U256::from(996570293625184642u128)),
                     output: (token_b, U256::from(354009510372384890u128)),
@@ -688,7 +713,7 @@ mod tests {
                         position: 0u32,
                     }),
                 })),
-                Execution::ExecutionAmm(Box::new(ExecutedAmm {
+                Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::ConstantProduct(cpo_0),
                     input: (token_b, U256::from(354009510372389956u128)),
                     output: (token_a, U256::from(932415220613609833982u128)),
@@ -697,7 +722,7 @@ mod tests {
                         position: 1u32,
                     }),
                 })),
-                Execution::ExecutionAmm(Box::new(ExecutedAmm {
+                Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::ConstantProduct(cpo_1),
                     input: (token_c, U256::from(2)),
                     output: (token_b, U256::from(1)),
@@ -706,7 +731,7 @@ mod tests {
                         position: 2u32,
                     }),
                 })),
-                Execution::ExecutionAmm(Box::new(ExecutedAmm {
+                Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::BalancerStable(spo),
                     input: (token_c, U256::from(4)),
                     output: (token_b, U256::from(3)),
@@ -730,31 +755,44 @@ mod tests {
             fee: Ratio::new(3, 1000),
             settlement_handling: CapturingSettlementHandler::arc(),
         };
-        let executions_amms = vec![Execution::ExecutionAmm(Box::new(ExecutedAmm {
+        let executions_amms = vec![ExecutedAmm {
             order: Liquidity::ConstantProduct(cpo_1),
-            input: (token_a, U256::from(2)),
-            output: (token_b, U256::from(1)),
+            input: (token_a, U256::from(2_u8)),
+            output: (token_b, U256::from(1_u8)),
+            exec_plan: Some(ExecutionPlanCoordinatesModel {
+                sequence: 1u32,
+                position: 2u32,
+            }),
+        }];
+        let interactions = vec![InteractionData {
+            target: H160::zero(),
+            value: U256::zero(),
+            call_data: Vec::new(),
+            exec_plan: Some(ExecutionPlanCoordinatesModel {
+                sequence: 1u32,
+                position: 1u32,
+            }),
+        }];
+        let orders = vec![ExecutedLimitOrder {
+            order: Default::default(),
+            executed_buy_amount: U256::zero(),
+            executed_sell_amount: U256::zero(),
             exec_plan: None,
-        }))];
-        let interactions = vec![Execution::ExecutionCustomInteraction(Box::new(
-            InteractionData {
-                target: H160::zero(),
-                value: U256::zero(),
-                call_data: Vec::new(),
-                exec_plan: Some(ExecutionPlanCoordinatesModel {
-                    sequence: 1u32,
-                    position: 1u32,
-                }),
-            },
-        ))];
-        let merged_executions =
-            merge_and_order_executions(executions_amms.clone(), interactions.clone()).unwrap();
-        assert_eq!(
-            merged_executions,
-            vec![
-                executions_amms.get(0).unwrap().clone(),
-                interactions.get(0).unwrap().clone()
-            ]
+        }];
+        let merged_executions = merge_and_order_executions(
+            executions_amms.clone(),
+            interactions.clone(),
+            orders.clone(),
+        );
+        assert_eq!(3, merged_executions.len());
+        assert!(
+            matches!(&merged_executions[0], Execution::LimitOrder(order) if order.as_ref() == &orders[0])
+        );
+        assert!(
+            matches!(&merged_executions[1], Execution::CustomInteraction(interaction) if interaction.as_ref() == &interactions[0])
+        );
+        assert!(
+            matches!(&merged_executions[2], Execution::Amm(amm) if amm.as_ref() == &executions_amms[0])
         );
     }
 


### PR DESCRIPTION
Fixes #1663

Added basic machinery to utilize 0x limit orders as liquidity.
For that a new type of liquidity was introduced `Liquidity::LimitOrder(LimitOrder)` which is just a wrapper around our usual `LimitOrder` type.
Also `ZeroExInteraction` was added which just generates call data for `IZeroEx::fillOrKillLimitOrder()` as its encoding strategy.
The http solver takes advantage of the new liquidity limit orders by adding them to the list of solvable orders of the auction.

Note that the Baseline solver does not take advantage of the new liquidity yet.

Whether zeroex limit order should be considered as liquidity can be controlled with the `--baseline-sources` argument. By default the baseline source `ZeroEx` is enabled on mainnet.

### Test Plan
Manual test where I ran the driver locally configured to use quasimodo until a [winning settlement](https://dashboard.tenderly.co/gp-v2/staging/simulator/cac03704-f932-4677-9d28-29c0bddd5c32) was found which included a `ZeroExInteraction`. (call stack includes `fillOrKillLimitOrder()`)

Since multi-0x-hop solutions required another fix I did another manual test to see that way more complex [settlements](https://dashboard.tenderly.co/gp-v2/staging/simulator/df4aa94c-c953-4cff-8c22-38ac78fe85e0) also work.

I didn't add a unit test for generating the call data (as opposed to other interactions) because this is done with a crate which is hopefully properly tested.

### Release notes
Added liquidity of 0x limit orders to quasimodo
