### PR TITLE
Store gas amount as u64 in price estimator

### DIFF
--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -622,7 +622,7 @@ mod tests {
         let fee_calculator = Arc::new(fee_calculator);
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
             out_amount: 14.into(),
-            gas: 1000.into(),
+            gas: 1000,
         });
         let sell_query = OrderQuoteRequest::new(
             H160::from_low_u64_ne(0),
@@ -666,7 +666,7 @@ mod tests {
         let fee_calculator = Arc::new(fee_calculator);
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
             out_amount: 14.into(),
-            gas: 1000.into(),
+            gas: 1000,
         });
         let sell_query = OrderQuoteRequest::new(
             H160::from_low_u64_ne(0),
@@ -709,7 +709,7 @@ mod tests {
         let fee_calculator = Arc::new(fee_calculator);
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
             out_amount: 20.into(),
-            gas: 1000.into(),
+            gas: 1000,
         });
         let buy_query = OrderQuoteRequest::new(
             H160::from_low_u64_ne(0),
@@ -767,7 +767,7 @@ mod tests {
             .returning(move |_, _, _| Ok((3.into(), Utc::now())));
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
             out_amount: 14.into(),
-            gas: 1000.into(),
+            gas: 1000,
         });
         let mut order_validator = MockOrderValidating::new();
         order_validator

--- a/crates/orderbook/src/fee.rs
+++ b/crates/orderbook/src/fee.rs
@@ -271,7 +271,7 @@ impl MinFeeCalculator {
                 .estimate_native_price(&fee_data.sell_token)
         )?;
         let gas_price = gas_estimate.effective_gas_price();
-        let gas_amount = buy_token_estimate.gas.to_f64_lossy();
+        let gas_amount = buy_token_estimate.gas as f64;
         let fee_parameters = FeeParameters {
             gas_amount,
             gas_price,
@@ -528,7 +528,7 @@ mod tests {
         let gas_price_estimator = Arc::new(FakeGasPriceEstimator(gas_price.clone()));
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
             out_amount: 1.into(),
-            gas: 1.into(),
+            gas: 1,
         });
 
         let time_copy = time.clone();
@@ -590,7 +590,7 @@ mod tests {
         let gas_price_estimator = Arc::new(FakeGasPriceEstimator(gas_price.clone()));
         let price_estimator = Arc::new(FakePriceEstimator(price_estimation::Estimate {
             out_amount: 1.into(),
-            gas: 1.into(),
+            gas: 1,
         }));
 
         let fee_estimator = MinFeeCalculator::new_for_test(
@@ -643,7 +643,7 @@ mod tests {
         ))));
         let price_estimator = Arc::new(FakePriceEstimator(price_estimation::Estimate {
             out_amount: 1.into(),
-            gas: 1000.into(),
+            gas: 1000,
         }));
         let native_price_estimator = create_default_native_token_estimator(price_estimator.clone());
 
@@ -716,7 +716,7 @@ mod tests {
         ))));
         let price_estimator = Arc::new(FakePriceEstimator(price_estimation::Estimate {
             out_amount: 1.into(),
-            gas: 1000.into(),
+            gas: 1000,
         }));
         let native_price_estimator = create_default_native_token_estimator(price_estimator.clone());
         let app_data = AppId([1u8; 32]);
@@ -792,7 +792,7 @@ mod tests {
             out_amount: U256::from_f64_lossy(
                 native_token_price_estimation_amount / sell_token_price,
             ),
-            gas: 1337.into(),
+            gas: 1337,
         }));
         let native_price_estimator = Arc::new(NativePriceEstimator::new(
             price_estimator.clone(),
@@ -925,7 +925,7 @@ mod tests {
         ))));
         let price_estimator = Arc::new(FakePriceEstimator(price_estimation::Estimate {
             out_amount: 1.into(),
-            gas: 9.into(),
+            gas: 9,
         }));
         let native_price_estimator = create_default_native_token_estimator(price_estimator.clone());
         let fee_estimator = MinFeeCalculator {

--- a/crates/shared/src/paraswap_api.rs
+++ b/crates/shared/src/paraswap_api.rs
@@ -189,7 +189,7 @@ pub struct PriceResponse {
     pub dest_amount: U256,
     /// The token transfer proxy address to set an allowance for.
     pub token_transfer_proxy: H160,
-    pub gas_cost: U256,
+    pub gas_cost: u64,
 }
 
 impl<'de> Deserialize<'de> for PriceResponse {
@@ -211,8 +211,8 @@ impl<'de> Deserialize<'de> for PriceResponse {
             #[serde(with = "u256_decimal")]
             dest_amount: U256,
             token_transfer_proxy: H160,
-            #[serde(with = "u256_decimal")]
-            gas_cost: U256,
+            #[serde(with = "serde_with::rust::display_fromstr")]
+            gas_cost: u64,
         }
 
         let parsed = ParsedRaw::deserialize(deserializer)?;

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -85,7 +85,7 @@ pub struct Query {
 pub struct Estimate {
     pub out_amount: U256,
     /// full gas cost when settling this order alone on gp
-    pub gas: U256,
+    pub gas: u64,
 }
 
 impl Estimate {

--- a/crates/shared/src/price_estimation/baseline.rs
+++ b/crates/shared/src/price_estimation/baseline.rs
@@ -73,7 +73,7 @@ impl PriceEstimating for BaselinePriceEstimator {
         let estimate_single = |init: &Init, query: &Query| -> PriceEstimateResult {
             let (gas_price, pools) = init.as_ref().map_err(Clone::clone)?;
             let (path, out_amount) = self.estimate_price_helper(query, true, pools, *gas_price)?;
-            let gas = estimate_gas(path.len()).into();
+            let gas = estimate_gas(path.len());
             Ok(Estimate { out_amount, gas })
         };
         let estimate_all = move |init: Init| {
@@ -558,8 +558,7 @@ mod tests {
             )
             .await
             .unwrap()
-            .gas
-            .as_u64();
+            .gas;
             assert_eq!(intermediate, estimate_gas(3));
             let direct = single_estimate(
                 &estimator,
@@ -572,8 +571,7 @@ mod tests {
             )
             .await
             .unwrap()
-            .gas
-            .as_u64();
+            .gas;
             assert_eq!(direct, estimate_gas(2));
             assert!(direct < intermediate);
         }
@@ -636,7 +634,7 @@ mod tests {
                 .await
                 .unwrap()
                 .gas,
-                estimate_gas(2).into(),
+                estimate_gas(2),
             );
         }
 
@@ -661,7 +659,7 @@ mod tests {
                 .await
                 .unwrap()
                 .gas,
-                estimate_gas(3).into()
+                estimate_gas(3)
             );
         }
     }

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -94,7 +94,7 @@ mod tests {
             assert!(queries[0].sell_token.to_low_u64_be() == 3);
             futures::stream::iter([Ok(Estimate {
                 out_amount: 123_456_789_000_000_000u128.into(),
-                gas: 0.into(),
+                gas: 0,
             })])
             .enumerate()
             .boxed()

--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 use futures::StreamExt;
 use model::order::OrderKind;
-use primitive_types::U256;
 use std::sync::Arc;
 
 pub struct OneInchPriceEstimator {
@@ -40,7 +39,7 @@ impl OneInchPriceEstimator {
         match quote {
             RestResponse::Ok(quote) => Ok(Estimate {
                 out_amount: quote.to_token_amount,
-                gas: U256::from(gas::SETTLEMENT_OVERHEAD) + quote.estimated_gas,
+                gas: gas::SETTLEMENT_OVERHEAD + quote.estimated_gas,
             }),
             RestResponse::Err(e) => {
                 Err(PriceEstimationError::Other(anyhow::anyhow!(e.description)))
@@ -127,7 +126,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(est.out_amount, 808_069_760_400_778_577u128.into());
-        assert!(est.gas > 189_386.into());
+        assert!(est.gas > 189_386);
     }
 
     #[tokio::test]

--- a/crates/shared/src/price_estimation/paraswap.rs
+++ b/crates/shared/src/price_estimation/paraswap.rs
@@ -8,7 +8,7 @@ use crate::{
 use anyhow::{anyhow, Context, Result};
 use futures::StreamExt;
 use model::order::OrderKind;
-use primitive_types::{H160, U256};
+use primitive_types::H160;
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -56,7 +56,7 @@ impl ParaswapPriceEstimator {
                 OrderKind::Buy => response.src_amount,
                 OrderKind::Sell => response.dest_amount,
             },
-            gas: U256::from(gas::SETTLEMENT_OVERHEAD) + response.gas_cost,
+            gas: gas::SETTLEMENT_OVERHEAD + response.gas_cost,
         })
     }
 }

--- a/crates/shared/src/price_estimation/quasimodo.rs
+++ b/crates/shared/src/price_estimation/quasimodo.rs
@@ -146,7 +146,7 @@ impl QuasimodoPriceEstimator {
         for amm in settlement.amms.values() {
             cost += self.extract_cost(&amm.cost)? * amm.execution.len();
         }
-        let gas = (cost / gas_price)
+        let gas = (cost / gas_price).as_u64()
             + INITIALIZATION_COST // Call into contract
             + SETTLEMENT // overhead for entering the `settle()` function
             + ERC20_TRANSFER * 2; // transfer in and transfer out

--- a/crates/shared/src/price_estimation/sanitized.rs
+++ b/crates/shared/src/price_estimation/sanitized.rs
@@ -113,7 +113,7 @@ impl SanitizedPriceEstimator {
                 if query.buy_token == query.sell_token {
                     let estimation = Estimate {
                         out_amount: query.in_amount,
-                        gas: 0.into(),
+                        gas: 0,
                     };
 
                     tracing::debug!(?query, ?estimation, "generate trivial price estimation");
@@ -123,7 +123,7 @@ impl SanitizedPriceEstimator {
                 if query.sell_token == self.native_token && query.buy_token == BUY_ETH_ADDRESS {
                     let estimation = Estimate {
                         out_amount: query.in_amount,
-                        gas: GAS_PER_WETH_UNWRAP.into(),
+                        gas: GAS_PER_WETH_UNWRAP,
                     };
 
                     tracing::debug!(?query, ?estimation, "generate trivial unwrap estimation");
@@ -132,7 +132,7 @@ impl SanitizedPriceEstimator {
                 if query.sell_token == BUY_ETH_ADDRESS && query.buy_token == self.native_token {
                     let estimation = Estimate {
                         out_amount: query.in_amount,
-                        gas: GAS_PER_WETH_WRAP.into(),
+                        gas: GAS_PER_WETH_WRAP,
                     };
 
                     tracing::debug!(?query, ?estimation, "generate trivial wrap estimation");
@@ -192,12 +192,13 @@ impl SanitizedPriceEstimator {
                     let mut final_estimation = difficult_estimates
                         .next()
                         .expect("there is a result for every forwarded query")?;
-                    final_estimation.gas = final_estimation
-                        .gas
-                        .checked_add(weth_op_gas.into())
-                        .ok_or(anyhow::anyhow!(
-                            "cost of converting native asset would overflow gas price"
-                        ))?;
+                    final_estimation.gas =
+                        final_estimation
+                            .gas
+                            .checked_add(weth_op_gas)
+                            .ok_or(anyhow::anyhow!(
+                                "cost of converting native asset would overflow gas price"
+                            ))?;
                     tracing::debug!(
                         ?query,
                         ?final_estimation,
@@ -357,19 +358,19 @@ mod tests {
                 futures::stream::iter([
                     Ok(Estimate {
                         out_amount: 1.into(),
-                        gas: 100.into(),
+                        gas: 100,
                     }),
                     Ok(Estimate {
                         out_amount: 1.into(),
-                        gas: 100.into(),
+                        gas: 100,
                     }),
                     Ok(Estimate {
                         out_amount: 1.into(),
-                        gas: U256::MAX,
+                        gas: u64::MAX,
                     }),
                     Ok(Estimate {
                         out_amount: 1.into(),
-                        gas: 100.into(),
+                        gas: 100,
                     }),
                 ])
                 .enumerate()
@@ -388,7 +389,7 @@ mod tests {
             result[0].as_ref().unwrap(),
             &Estimate {
                 out_amount: 1.into(),
-                gas: 100.into()
+                gas: 100,
             }
         );
         assert_eq!(
@@ -397,7 +398,7 @@ mod tests {
                 out_amount: 1.into(),
                 //sanitized_estimator will add ETH_UNWRAP_COST to the gas of any
                 //Query with ETH as the buy_token.
-                gas: U256::from(GAS_PER_WETH_UNWRAP + 100),
+                gas: GAS_PER_WETH_UNWRAP + 100,
             }
         );
         assert!(matches!(
@@ -411,21 +412,21 @@ mod tests {
                 out_amount: 1.into(),
                 //sanitized_estimator will add ETH_WRAP_COST to the gas of any
                 //Query with ETH as the sell_token.
-                gas: U256::from(GAS_PER_WETH_WRAP + 100),
+                gas: GAS_PER_WETH_WRAP + 100,
             }
         );
         assert_eq!(
             result[4].as_ref().unwrap(),
             &Estimate {
                 out_amount: 1.into(),
-                gas: 0.into()
+                gas: 0,
             }
         );
         assert_eq!(
             result[5].as_ref().unwrap(),
             &Estimate {
                 out_amount: 1.into(),
-                gas: 0.into()
+                gas: 0,
             }
         );
         assert_eq!(
@@ -433,7 +434,7 @@ mod tests {
             &Estimate {
                 out_amount: 1.into(),
                 // Sanitized estimator will report a 1:1 estimate when unwrapping native token.
-                gas: GAS_PER_WETH_UNWRAP.into()
+                gas: GAS_PER_WETH_UNWRAP,
             }
         );
         assert_eq!(
@@ -441,7 +442,7 @@ mod tests {
             &Estimate {
                 out_amount: 1.into(),
                 // Sanitized estimator will report a 1:1 estimate when wrapping native token.
-                gas: GAS_PER_WETH_WRAP.into()
+                gas: GAS_PER_WETH_WRAP,
             }
         );
         assert!(matches!(

--- a/crates/shared/src/price_estimation/zeroex.rs
+++ b/crates/shared/src/price_estimation/zeroex.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 use futures::StreamExt;
 use model::order::OrderKind;
-use primitive_types::U256;
 use std::sync::Arc;
 
 pub struct ZeroExPriceEstimator {
@@ -37,7 +36,7 @@ impl ZeroExPriceEstimator {
                 OrderKind::Buy => swap.price.sell_amount,
                 OrderKind::Sell => swap.price.buy_amount,
             },
-            gas: U256::from(gas::SETTLEMENT_OVERHEAD) + swap.price.estimated_gas,
+            gas: gas::SETTLEMENT_OVERHEAD + swap.price.estimated_gas,
         })
     }
 }
@@ -85,7 +84,7 @@ mod tests {
                     buy_amount: 1110165823572443613u64.into(),
                     allowance_target: addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
                     price: 11.101_658_235_724_436,
-                    estimated_gas: 111000.into(),
+                    estimated_gas: 111000,
                 },
                 ..Default::default()
             })
@@ -109,7 +108,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(est.out_amount, 1110165823572443613u64.into());
-        assert!(est.gas > 111000.into());
+        assert!(est.gas > 111000);
     }
 
     #[tokio::test]
@@ -130,7 +129,7 @@ mod tests {
                     buy_amount: 100000000000000000u64.into(),
                     allowance_target: addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
                     price: 0.089_861_863_531_374_87,
-                    estimated_gas: 111000.into(),
+                    estimated_gas: 111000,
                 },
                 ..Default::default()
             })
@@ -154,7 +153,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(est.out_amount, 8986186353137488u64.into());
-        assert!(est.gas > 111000.into());
+        assert!(est.gas > 111000);
     }
 
     #[tokio::test]

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -248,8 +248,8 @@ pub struct PriceResponse {
     pub allowance_target: H160,
     #[serde(deserialize_with = "deserialize_decimal_f64")]
     pub price: f64,
-    #[serde(with = "u256_decimal")]
-    pub estimated_gas: U256,
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub estimated_gas: u64,
 }
 
 /// A Ox API `swap` response.
@@ -643,7 +643,7 @@ mod tests {
                         buy_amount: U256::from_dec_str("1312100257517027783").unwrap(),
                         allowance_target: crate::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
                         price: 13.121_002_575_170_278_f64,
-                        estimated_gas: 111000.into(),
+                        estimated_gas: 111000,
                     },
                     to: crate::addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
                     data: Bytes(hex::decode(

--- a/crates/solver/src/solver/paraswap_solver.rs
+++ b/crates/solver/src/solver/paraswap_solver.rs
@@ -259,7 +259,7 @@ mod tests {
                 src_amount: 100.into(),
                 dest_amount: 99.into(),
                 token_transfer_proxy: H160([0x42; 20]),
-                gas_cost: 0.into(),
+                gas_cost: 0,
             })
         });
         client
@@ -340,7 +340,7 @@ mod tests {
                 src_amount: 100.into(),
                 dest_amount: 99.into(),
                 token_transfer_proxy,
-                gas_cost: 0.into(),
+                gas_cost: 0,
             })
         });
         client
@@ -432,7 +432,7 @@ mod tests {
                 src_amount: 100.into(),
                 dest_amount: 99.into(),
                 token_transfer_proxy: H160([0x42; 20]),
-                gas_cost: 0.into(),
+                gas_cost: 0,
             })
         });
 


### PR DESCRIPTION
While some gas amounts are technically U256 on chain they are limited in practice to 30e6 which easily fits in u64 or even u32. Working with a native integer type is easier for programmers and faster so this PR converts the price estimator interface to use u64.
This might be followed up with similar conversions in other places.

### Test Plan

CI, existing tests ran some external price estimator tests manually as I changed the serialization type