### PR TITLE
Only do buffer trades, if sell and buy token are trusted

### DIFF
--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -194,6 +194,12 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             name: "Test Coin".into(),
             symbol: "TC".into(),
             decimals: 18,
+        },
+        token_b.address() => Token {
+            address: token_b.address(),
+            name: "Test Coin 2".into(),
+            symbol: "TC 2".into(),
+            decimals: 18,
         }
     });
     let mut driver = solver::driver::Driver::new(

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -212,7 +212,7 @@ impl Driver {
         settlement: &RatedSettlement,
         gas_price: EstimatedGasPrice,
     ) -> Result<bool> {
-        // We want to buy and sell only tokens that we trust. If no list is set, we settle with external liquidity.
+        // We want to only buy and sell tokens that we trust. If no list is set, we settle with external liquidity.
         if !self
             .market_makable_token_list
             .as_ref()


### PR DESCRIPTION
We wanted to keep buffer tokens concentrated in a smaller set of tokens to enable buffer trading.
In order to archive this, we should not trade buffers of trusted tokens into the long-tail of arbitrary tokens. Hence, this PR ensures that both tokens, the buy and sell token are in the trusted token list, if an internal buffer trade is made.

### Test Plan
unit tests