### PR TITLE
Use Swapr-specific Pool Reader

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -116,7 +116,7 @@ impl OrderbookServices {
                 maximum_recent_block_age: 4,
                 ..Default::default()
             },
-            Box::new(PoolFetcher::uniswap(pair_provider, web3.clone())),
+            Arc::new(PoolFetcher::uniswap(pair_provider, web3.clone())),
             current_block_stream.clone(),
             Arc::new(NoopPoolCacheMetrics),
         )

--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -604,11 +604,11 @@ mod tests {
 
         let settlement = contracts::GPv2Settlement::deployed(&web3).await.unwrap();
         let uniswap = Arc::new(UniswapLikePairProviderFinder {
-            inner: uniswap_v2::get_pair_provider(&web3).await.unwrap(),
+            inner: uniswap_v2::get_liquidity_source(&web3).await.unwrap().0,
             base_tokens: base_tokens.to_vec(),
         });
         let sushiswap = Arc::new(UniswapLikePairProviderFinder {
-            inner: sushiswap::get_pair_provider(&web3).await.unwrap(),
+            inner: sushiswap::get_liquidity_source(&web3).await.unwrap().0,
             base_tokens: base_tokens.to_vec(),
         });
         let token_cache = TraceCallDetector {

--- a/crates/shared/src/price_estimation/quasimodo.rs
+++ b/crates/shared/src/price_estimation/quasimodo.rs
@@ -299,7 +299,6 @@ mod tests {
     use crate::sources::balancer_v2::BalancerFactoryKind;
     use crate::sources::uniswap_v2;
     use crate::sources::uniswap_v2::pool_cache::NoopPoolCacheMetrics;
-    use crate::sources::uniswap_v2::pool_fetching::PoolFetcher;
     use crate::token_info::TokenInfoFetcher;
     use crate::transport::http::HttpTransport;
     use crate::Web3;
@@ -364,10 +363,7 @@ mod tests {
         let pools = Arc::new(
             PoolCache::new(
                 CacheConfig::default(),
-                Box::new(PoolFetcher::uniswap(
-                    uniswap_v2::get_pair_provider(&web3).await.unwrap(),
-                    web3.clone(),
-                )),
+                uniswap_v2::get_liquidity_source(&web3).await.unwrap().1,
                 current_block_stream(web3.clone(), Duration::from_secs(1))
                     .await
                     .unwrap(),

--- a/crates/shared/src/sources.rs
+++ b/crates/shared/src/sources.rs
@@ -48,25 +48,26 @@ pub fn defaults_for_chain(chain_id: u64) -> Result<Vec<BaselineSource>> {
     })
 }
 
-/// Returns a mapping of baseline sources to their respective pair providers.
-pub async fn pair_providers(
+/// Returns a mapping of UniswapV2-like baseline sources to their respective
+/// pair providers and pool fetchers.
+pub async fn uniswap_like_liquidity_sources(
     web3: &Web3,
     sources: &[BaselineSource],
-) -> Result<HashMap<BaselineSource, PairProvider>> {
-    let mut providers = HashMap::new();
+) -> Result<HashMap<BaselineSource, (PairProvider, Arc<dyn PoolFetching>)>> {
+    let mut liquidity_sources = HashMap::new();
     for source in sources {
-        let provider = match source {
-            BaselineSource::UniswapV2 => uniswap_v2::get_pair_provider(web3).await?,
-            BaselineSource::SushiSwap => sushiswap::get_pair_provider(web3).await?,
-            BaselineSource::Honeyswap => honeyswap::get_pair_provider(web3).await?,
-            BaselineSource::Baoswap => baoswap::get_pair_provider(web3).await?,
-            BaselineSource::Swapr => swapr::get_pair_provider(web3).await?,
+        let liquidity_source = match source {
+            BaselineSource::UniswapV2 => uniswap_v2::get_liquidity_source(web3).await?,
+            BaselineSource::SushiSwap => sushiswap::get_liquidity_source(web3).await?,
+            BaselineSource::Honeyswap => honeyswap::get_liquidity_source(web3).await?,
+            BaselineSource::Baoswap => baoswap::get_liquidity_source(web3).await?,
+            BaselineSource::Swapr => swapr::get_liquidity_source(web3).await?,
             BaselineSource::BalancerV2 => continue,
         };
 
-        providers.insert(*source, provider);
+        liquidity_sources.insert(*source, liquidity_source);
     }
-    Ok(providers)
+    Ok(liquidity_sources)
 }
 
 pub struct PoolAggregator {

--- a/crates/shared/src/sources/baoswap.rs
+++ b/crates/shared/src/sources/baoswap.rs
@@ -16,7 +16,7 @@ mod tests {
     #[tokio::test]
     async fn test_create2_sushiswap() {
         // xDai
-        let xdai_pair_provider = get_pair_provider(&Mock::new(100).web3()).await.unwrap();
+        let (xdai_pair_provider, _) = get_liquidity_source(&Mock::new(100).web3()).await.unwrap();
         let xdai_pair = TokenPair::new(
             addr!("7f7440c5098462f833e123b44b8a03e1d9785bab"),
             addr!("e91D153E0b41518A2Ce8Dd3D7944Fa863463a97d"),

--- a/crates/shared/src/sources/honeyswap.rs
+++ b/crates/shared/src/sources/honeyswap.rs
@@ -16,7 +16,7 @@ mod tests {
     #[tokio::test]
     async fn test_create2_xdai() {
         // https://info.honeyswap.org/pair/0x4505b262dc053998c10685dc5f9098af8ae5c8ad
-        let xdai_pair_provider = get_pair_provider(&Mock::new(100).web3()).await.unwrap();
+        let (xdai_pair_provider, _) = get_liquidity_source(&Mock::new(100).web3()).await.unwrap();
         let xdai_pair = TokenPair::new(
             addr!("71850b7e9ee3f13ab46d67167341e4bdc905eef9"),
             addr!("e91d153e0b41518a2ce8dd3d7944fa863463a97d"),

--- a/crates/shared/src/sources/sushiswap.rs
+++ b/crates/shared/src/sources/sushiswap.rs
@@ -16,7 +16,7 @@ mod tests {
     #[tokio::test]
     async fn test_create2_sushiswap() {
         // https://sushiswap.vision/pair/0x41328fdba556c8c969418ccccb077b7b8d932aa5
-        let mainnet_pair_provider = get_pair_provider(&Mock::new(1).web3()).await.unwrap();
+        let (mainnet_pair_provider, _) = get_liquidity_source(&Mock::new(1).web3()).await.unwrap();
         let mainnet_pair = TokenPair::new(testlib::tokens::GNO, testlib::tokens::WETH).unwrap();
         assert_eq!(
             mainnet_pair_provider.pair_address(&mainnet_pair),
@@ -24,7 +24,7 @@ mod tests {
         );
 
         // Rinkeby
-        let rinkeby_pair_provider = get_pair_provider(&Mock::new(4).web3()).await.unwrap();
+        let (rinkeby_pair_provider, _) = get_liquidity_source(&Mock::new(4).web3()).await.unwrap();
         let rinkeby_pair = TokenPair::new(
             addr!("b98Dd87589e460425Cfb5b535d2402E57579Bf40"),
             addr!("d0593E8bafB8Ec2e70ceb1882617a42cfDFbfEbF"),
@@ -36,7 +36,7 @@ mod tests {
         );
 
         // xDai
-        let xdai_pair_provider = get_pair_provider(&Mock::new(100).web3()).await.unwrap();
+        let (xdai_pair_provider, _) = get_liquidity_source(&Mock::new(100).web3()).await.unwrap();
         let xdai_pair = TokenPair::new(
             addr!("6a023ccd1ff6f2045c3309768ead9e68f978f6e1"),
             addr!("d3d47d5578e55c880505dc40648f7f9307c3e7a8"),

--- a/crates/shared/src/sources/swapr.rs
+++ b/crates/shared/src/sources/swapr.rs
@@ -1,12 +1,13 @@
 //! Swapr baseline liquidity source implementation.
 
-pub mod reader;
+mod reader;
 
 use super::uniswap_v2::macros::impl_uniswap_like_liquidity;
 
 impl_uniswap_like_liquidity! {
     factory: contracts::SwaprFactory,
     init_code_digest: "d306a548755b9295ee49cc729e13ca4a45e00199bbd890fa146da43a50571776",
+    pool_reader: reader::SwaprPoolReader,
 }
 
 #[cfg(test)]
@@ -17,7 +18,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create2_xdai() {
-        let xdai_pair_provider = get_pair_provider(&Mock::new(100).web3()).await.unwrap();
+        let (xdai_pair_provider, _) = get_liquidity_source(&Mock::new(100).web3()).await.unwrap();
         let xdai_pair = TokenPair::new(
             addr!("6A023CCd1ff6F2045C3309768eAd9E68F978f6e1"),
             addr!("e91d153e0b41518a2ce8dd3d7944fa863463a97d"),

--- a/crates/shared/src/sources/uniswap_v2.rs
+++ b/crates/shared/src/sources/uniswap_v2.rs
@@ -21,7 +21,7 @@ mod tests {
     #[tokio::test]
     async fn test_create2_mainnet() {
         // https://info.uniswap.org/pair/0x3e8468f66d30fc99f745481d4b383f89861702c6
-        let mainnet_pair_provider = get_pair_provider(&Mock::new(1).web3()).await.unwrap();
+        let (mainnet_pair_provider, _) = get_liquidity_source(&Mock::new(1).web3()).await.unwrap();
         let mainnet_pair = TokenPair::new(testlib::tokens::GNO, testlib::tokens::WETH).unwrap();
         assert_eq!(
             mainnet_pair_provider.pair_address(&mainnet_pair),
@@ -29,7 +29,7 @@ mod tests {
         );
 
         // Rinkeby
-        let rinkeby_pair_provider = get_pair_provider(&Mock::new(4).web3()).await.unwrap();
+        let (rinkeby_pair_provider, _) = get_liquidity_source(&Mock::new(4).web3()).await.unwrap();
         let rinkeby_pair = TokenPair::new(
             addr!("a7D1C04fAF998F9161fC9F800a99A809b84cfc9D"),
             addr!("c778417e063141139fce010982780140aa0cd5ab"),

--- a/crates/shared/src/sources/uniswap_v2/macros.rs
+++ b/crates/shared/src/sources/uniswap_v2/macros.rs
@@ -5,17 +5,40 @@ macro_rules! impl_uniswap_like_liquidity {
         factory: $factory:ty,
         init_code_digest: $init_code:literal,
     ) => {
+        impl_uniswap_like_liquidity!(
+            factory: $factory,
+            init_code_digest: $init_code,
+            pool_reader: $crate::sources::uniswap_v2::pool_fetching::DefaultPoolReader,
+        );
+    };
+    (
+        factory: $factory:ty,
+        init_code_digest: $init_code:literal,
+        pool_reader: $pool_reader:ty,
+    ) => {
         pub const INIT_CODE_DIGEST: [u8; 32] = ::hex_literal::hex!($init_code);
 
-        /// Creates the pair provider for the specified Web3 instance.
-        pub async fn get_pair_provider(
+        /// Creates the pair provider and pool fetcher for the specified Web3
+        /// instance.
+        pub async fn get_liquidity_source(
             web3: &$crate::Web3,
-        ) -> ::anyhow::Result<$crate::sources::uniswap_v2::pair_provider::PairProvider> {
+        ) -> ::anyhow::Result<(
+            $crate::sources::uniswap_v2::pair_provider::PairProvider,
+            ::std::sync::Arc<dyn $crate::sources::uniswap_v2::pool_fetching::PoolFetching>,
+        )> {
+            use $crate::sources::uniswap_v2::pool_fetching::PoolReading;
+
             let factory = <$factory>::deployed(web3).await?;
-            Ok($crate::sources::uniswap_v2::pair_provider::PairProvider {
+            let provider = $crate::sources::uniswap_v2::pair_provider::PairProvider {
                 factory: factory.address(),
                 init_code_digest: INIT_CODE_DIGEST,
-            })
+            };
+            let fetcher = $crate::sources::uniswap_v2::pool_fetching::PoolFetcher {
+                pool_reader: <$pool_reader>::for_pair_provider(provider.clone(), web3.clone()),
+                web3: web3.clone(),
+            };
+
+            Ok((provider, ::std::sync::Arc::new(fetcher)))
         }
     };
 }

--- a/crates/shared/src/sources/uniswap_v2/pool_cache.rs
+++ b/crates/shared/src/sources/uniswap_v2/pool_cache.rs
@@ -20,7 +20,7 @@ impl PoolCacheMetrics for NoopPoolCacheMetrics {
 }
 
 pub struct PoolCache(
-    RecentBlockCache<TokenPair, Pool, Box<dyn PoolFetching>, Arc<dyn PoolCacheMetrics>>,
+    RecentBlockCache<TokenPair, Pool, Arc<dyn PoolFetching>, Arc<dyn PoolCacheMetrics>>,
 );
 
 impl CacheKey<Pool> for TokenPair {
@@ -34,7 +34,7 @@ impl CacheKey<Pool> for TokenPair {
 }
 
 #[async_trait::async_trait]
-impl CacheFetching<TokenPair, Pool> for Box<dyn PoolFetching> {
+impl CacheFetching<TokenPair, Pool> for Arc<dyn PoolFetching> {
     async fn fetch_values(&self, keys: HashSet<TokenPair>, block: Block) -> Result<Vec<Pool>> {
         self.fetch(keys, block).await
     }
@@ -50,7 +50,7 @@ impl PoolCache {
     /// Creates a new pool cache.
     pub fn new(
         config: CacheConfig,
-        fetcher: Box<dyn PoolFetching>,
+        fetcher: Arc<dyn PoolFetching>,
         block_stream: CurrentBlockStream,
         metrics: Arc<dyn PoolCacheMetrics>,
     ) -> Result<Self> {

--- a/crates/shared/src/sources/uniswap_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v2/pool_fetching.rs
@@ -30,7 +30,9 @@ pub trait PoolFetching: Send + Sync {
 }
 
 /// Trait for abstracting the on-chain reading logic for pool state.
-pub trait PoolReading: Send + Sync {
+pub trait PoolReading: Sized + Send + Sync {
+    fn for_pair_provider(pair_provider: PairProvider, web3: Web3) -> Self;
+
     /// Read the pool state for the specified token pair.
     ///
     /// The caller specifies a Web3 call back to queue RPC requests into as well
@@ -231,6 +233,13 @@ pub struct DefaultPoolReader {
 }
 
 impl PoolReading for DefaultPoolReader {
+    fn for_pair_provider(pair_provider: PairProvider, web3: Web3) -> Self {
+        Self {
+            pair_provider,
+            web3,
+        }
+    }
+
     fn read_state(
         &self,
         pair: TokenPair,

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -13,7 +13,7 @@ use shared::{
     sources::{
         self,
         balancer_v2::{pool_fetching::BalancerContracts, BalancerFactoryKind, BalancerPoolFetcher},
-        uniswap_v2::{pool_cache::PoolCache, pool_fetching::PoolFetcher},
+        uniswap_v2::pool_cache::PoolCache,
         BaselineSource,
     },
     token_info::{CachedTokenInfoFetcher, TokenInfoFetcher},
@@ -390,15 +390,14 @@ async fn main() {
     });
     tracing::info!(?baseline_sources, "using baseline sources");
     let pool_caches: HashMap<BaselineSource, Arc<PoolCache>> =
-        sources::pair_providers(&web3, &baseline_sources)
+        sources::uniswap_like_liquidity_sources(&web3, &baseline_sources)
             .await
-            .expect("failed to load baseline source pair providers")
+            .expect("failed to load baseline source uniswap liquidity")
             .into_iter()
-            .map(|(source, pair_provider)| {
-                let fetcher = Box::new(PoolFetcher::uniswap(pair_provider, web3.clone()));
+            .map(|(source, (_, pool_fetcher))| {
                 let pool_cache = PoolCache::new(
                     cache_config,
-                    fetcher,
+                    pool_fetcher,
                     current_block_stream.clone(),
                     metrics.clone(),
                 )


### PR DESCRIPTION
Follow-up to #1719 and #1720 

This PR moves `dyn PoolFetching` initialization into each UniswapV2-like liquidity source module. Previously, each module only created their own `PairProvider` instances since they were liquidity-configuration-dependent (specifically, it depended on the factory address and init code hash which was different for each UniswapV2-like liquidity source). However, it turns out Swapr also has specific pool state fetching logic (see aforementioned PRs for more details), which means that each UniswapV2-like liquidity module **also** needs to be responsible for creating their own `dyn PoolFetching` instance (since the `PoolReading` implementation varies from liquidity source to liquidity source).

The end-result: Swapr liquidity works correctly now! It should no longer have a fixed fee of 0.3% and now read it from the block chain when fetching liquidity.

### Test Plan

CI and Rust type checker. The only "new logic" is that the Swapr `dyn PoolFetching` is created with `SwaprPoolReader` instead of a `DefaultPoolReader`. The existing manual test that fetched an on-chain Swapr pool was modified to use the module-level created `dyn PoolFetching`:

```
% cargo test -p shared -- --ignored --nocapture swapr
    Finished test [unoptimized + debuginfo] target(s) in 0.21s
     Running unittests (target/debug/deps/shared-25ec9fa0fee90af3)

running 1 test
WETH <> wxDAI pool: Pool {
    tokens: TokenPair(
        0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1,
        0xe91d153e0b41518a2ce8dd3d7944fa863463a97d,
    ),
    reserves: (
        379042671808702239633,
        979576897975408422373175,
    ),
    fee: Ratio {
        numer: 1,
        denom: 400,
    },
}
test sources::swapr::reader::tests::fetch_swapr_pool ... ok
```

Note that this test still returns a on-chain fetched fee of 0.25% instead of defaulting to 0.3%

### Release Notes

Swapr liquidity can now be re-enabled on Gnosis Chain.