### PR TITLE
Scale Partially Filled Limit Orders

### DIFF
--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -107,6 +107,7 @@ impl Order {
                 sell_amount: self.creation.sell_amount,
                 buy_amount: self.creation.buy_amount,
                 fee_amount: self.creation.fee_amount,
+                full_fee_amount: self.metadata.full_fee_amount,
             });
         }
 
@@ -136,6 +137,7 @@ impl Order {
             sell_amount: scale(self.creation.sell_amount)?,
             buy_amount: scale(self.creation.buy_amount)?,
             fee_amount: scale(self.creation.fee_amount)?,
+            full_fee_amount: scale(self.metadata.full_fee_amount)?,
         })
     }
 }
@@ -146,6 +148,7 @@ pub struct RemainingOrderAmounts {
     pub sell_amount: U256,
     pub buy_amount: U256,
     pub fee_amount: U256,
+    pub full_fee_amount: U256,
 }
 
 #[derive(Clone, Default, Debug)]
@@ -942,7 +945,10 @@ mod tests {
                     partially_fillable: false,
                     ..Default::default()
                 },
-                ..Default::default()
+                metadata: OrderMetadata {
+                    full_fee_amount: 42.into(),
+                    ..Default::default()
+                },
             }
             .remaining_amounts()
             .unwrap(),
@@ -950,6 +956,7 @@ mod tests {
                 sell_amount: 1000.into(),
                 buy_amount: U256::MAX,
                 fee_amount: 337.into(),
+                full_fee_amount: 42.into(),
             },
         );
 
@@ -967,6 +974,7 @@ mod tests {
                 },
                 metadata: OrderMetadata {
                     executed_sell_amount_before_fees: 0.into(),
+                    full_fee_amount: 13.into(),
                     ..Default::default()
                 },
             }
@@ -976,6 +984,7 @@ mod tests {
                 sell_amount: 10.into(),
                 buy_amount: 11.into(),
                 fee_amount: 12.into(),
+                full_fee_amount: 13.into(),
             },
         );
 
@@ -993,6 +1002,7 @@ mod tests {
                 },
                 metadata: OrderMetadata {
                     executed_sell_amount_before_fees: 90.into(),
+                    full_fee_amount: 200.into(),
                     ..Default::default()
                 },
             }
@@ -1002,6 +1012,7 @@ mod tests {
                 sell_amount: 10.into(),
                 buy_amount: 10.into(),
                 fee_amount: 10.into(),
+                full_fee_amount: 20.into(),
             },
         );
         assert_eq!(
@@ -1016,6 +1027,7 @@ mod tests {
                 },
                 metadata: OrderMetadata {
                     executed_buy_amount: 9_u32.into(),
+                    full_fee_amount: 200.into(),
                     ..Default::default()
                 },
             }
@@ -1025,6 +1037,7 @@ mod tests {
                 sell_amount: 10.into(),
                 buy_amount: 1.into(),
                 fee_amount: 10.into(),
+                full_fee_amount: 20.into(),
             },
         );
     }

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -377,7 +377,15 @@ impl Driver {
         let orders = auction
             .orders
             .into_iter()
-            .map(|order| self.order_converter.normalize_limit_order(order))
+            .filter_map(
+                |order| match self.order_converter.normalize_limit_order(order) {
+                    Ok(order) => Some(order),
+                    Err(err) => {
+                        tracing::error!(?err, "error normalizing limit order");
+                        None
+                    }
+                },
+            )
             .collect::<Vec<_>>();
         tracing::info!("got {} orders: {:?}", orders.len(), orders);
 

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -381,6 +381,8 @@ impl Driver {
                 |order| match self.order_converter.normalize_limit_order(order) {
                     Ok(order) => Some(order),
                     Err(err) => {
+                        // This should never happen unless we are getting malformed
+                        // orders from the API - so raise an alert if this happens.
                         tracing::error!(?err, "error normalizing limit order");
                         None
                     }

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -112,7 +112,9 @@ impl Settleable for LimitOrder {
 #[cfg(test)]
 impl From<Order> for LimitOrder {
     fn from(order: Order) -> Self {
-        order_converter::OrderConverter::test(H160([0x42; 20])).normalize_limit_order(order)
+        order_converter::OrderConverter::test(H160([0x42; 20]))
+            .normalize_limit_order(order)
+            .unwrap()
     }
 }
 

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -25,7 +25,7 @@ impl OrderConverter {
     }
 
     /// Converts a GPv2 order into a `LimitOrder` type liquidity for solvers.
-    pub fn normalize_limit_order(&self, order: Order) -> LimitOrder {
+    pub fn normalize_limit_order(&self, order: Order) -> Result<LimitOrder> {
         let native_token = self.native_token.clone();
         let buy_token = if order.creation.buy_token == BUY_ETH_ADDRESS {
             native_token.address()
@@ -33,23 +33,25 @@ impl OrderConverter {
             order.creation.buy_token
         };
 
+        let remaining = order.remaining_amounts()?;
+
         // The reported fee amount that is used for objective computation is the
         // order's full full amount scaled by a constant factor.
         let scaled_fee_amount = U256::from_f64_lossy(
-            order.metadata.full_fee_amount.to_f64_lossy() * self.fee_objective_scaling_factor,
+            remaining.full_fee_amount.to_f64_lossy() * self.fee_objective_scaling_factor,
         );
         let is_liquidity_order = self.liquidity_order_owners.contains(&order.metadata.owner);
-        LimitOrder {
+        Ok(LimitOrder {
             id: order.metadata.uid.to_string(),
             sell_token: order.creation.sell_token,
             buy_token,
             // TODO discount previously executed sell amount
             // https://github.com/gnosis/gp-v2-services/issues/673
-            sell_amount: order.creation.sell_amount,
-            buy_amount: order.creation.buy_amount,
+            sell_amount: remaining.sell_amount,
+            buy_amount: remaining.buy_amount,
             kind: order.creation.kind,
             partially_fillable: order.creation.partially_fillable,
-            unscaled_subsidized_fee: order.creation.fee_amount,
+            unscaled_subsidized_fee: remaining.fee_amount,
             scaled_unsubsidized_fee: scaled_fee_amount,
             is_liquidity_order,
             settlement_handling: Arc::new(OrderSettlementHandler {
@@ -58,7 +60,7 @@ impl OrderConverter {
                 scaled_unsubsidized_fee_amount: scaled_fee_amount,
                 is_liquidity_order,
             }),
-        }
+        })
     }
 }
 
@@ -126,7 +128,7 @@ pub mod tests {
         };
 
         assert_eq!(
-            converter.normalize_limit_order(order).buy_token,
+            converter.normalize_limit_order(order).unwrap().buy_token,
             native_token,
         );
     }
@@ -143,7 +145,10 @@ pub mod tests {
             ..Default::default()
         };
 
-        assert_eq!(converter.normalize_limit_order(order).buy_token, buy_token);
+        assert_eq!(
+            converter.normalize_limit_order(order).unwrap().buy_token,
+            buy_token
+        );
     }
 
     #[test]
@@ -165,6 +170,7 @@ pub mod tests {
                         ..Default::default()
                     }
                 })
+                .unwrap()
                 .scaled_unsubsidized_fee,
             30.into(),
         );
@@ -180,7 +186,8 @@ pub mod tests {
                         full_fee_amount: 50.into(),
                         ..Default::default()
                     },
-                },)
+                })
+                .unwrap()
                 .scaled_unsubsidized_fee,
             75.into(),
         );
@@ -323,5 +330,35 @@ pub mod tests {
                 assert!(encoder.add_trade(order, executed_amount, 0.into()).is_ok());
             },
         );
+    }
+
+    #[test]
+    fn scales_limit_order_amounts_for_partially_filled_orders() {
+        let converter = OrderConverter {
+            fee_objective_scaling_factor: 1.5,
+            ..OrderConverter::test(H160::default())
+        };
+        let order = converter
+            .normalize_limit_order(Order {
+                creation: OrderCreation {
+                    sell_amount: 10.into(),
+                    buy_amount: 20.into(),
+                    fee_amount: 30.into(),
+                    kind: OrderKind::Sell,
+                    partially_fillable: true,
+                    ..Default::default()
+                },
+                metadata: OrderMetadata {
+                    executed_sell_amount_before_fees: 5.into(),
+                    full_fee_amount: 40.into(),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+
+        assert_eq!(order.sell_amount, 5.into());
+        assert_eq!(order.buy_amount, 10.into());
+        assert_eq!(order.unscaled_subsidized_fee, 15.into());
+        assert_eq!(order.scaled_unsubsidized_fee, 30.into());
     }
 }

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -45,8 +45,6 @@ impl OrderConverter {
             id: order.metadata.uid.to_string(),
             sell_token: order.creation.sell_token,
             buy_token,
-            // TODO discount previously executed sell amount
-            // https://github.com/gnosis/gp-v2-services/issues/673
             sell_amount: remaining.sell_amount,
             buy_amount: remaining.buy_amount,
             kind: order.creation.kind,

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -373,7 +373,7 @@ mod tests {
         let orders = vec![order0, order1, order2];
         let orders = orders
             .into_iter()
-            .map(|order| order_converter.normalize_limit_order(order))
+            .map(|order| order_converter.normalize_limit_order(order).unwrap())
             .collect::<Vec<_>>();
 
         let cpo_0 = ConstantProductOrder {


### PR DESCRIPTION
This PR modifies the limit order converter to scale partially filled orders into the `LimitOrder` liquidity type. This uses the shared code for computing remaining amounts that was introduced in #1722.

### Test Plan

Added a unit test verifying partially filled orders get scaled.
