### PR TITLE
No Minimum Fee Required for Liquidity Owners

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -156,6 +156,7 @@ impl OrderbookServices {
                 ERC20::at(web3, contracts.weth.address()),
                 Default::default(),
             )),
+            Default::default(),
         ));
         let balance_fetcher = Arc::new(Web3BalanceFetcher::new(
             web3.clone(),

--- a/crates/orderbook/src/fee.rs
+++ b/crates/orderbook/src/fee.rs
@@ -109,6 +109,12 @@ impl Default for FeeParameters {
         Self {
             gas_amount: 0.,
             gas_price: 0.,
+            // We can't use `derive(Default)` because then this field would have
+            // a value of `0.` and it is used in division. The actual value we
+            // use here doesn't really matter as long as its non-zero (since the
+            // resulting amount in native token or sell token will be 0
+            // regardless), but the multiplicative identity seemed like a
+            // natural default value to use.
             sell_token_price: 1.,
         }
     }

--- a/crates/orderbook/src/fee.rs
+++ b/crates/orderbook/src/fee.rs
@@ -11,7 +11,7 @@ use shared::{
     price_estimation::{native::NativePriceEstimating, single_estimate},
 };
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
 };
 
@@ -84,6 +84,7 @@ pub struct MinFeeCalculator {
     fee_subsidy: FeeSubsidyConfiguration,
     native_price_estimator: Arc<dyn NativePriceEstimating>,
     cow_subsidy: Arc<dyn CowSubsidy>,
+    liquidity_order_owners: HashSet<H160>,
 }
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
@@ -96,11 +97,21 @@ pub struct FeeData {
 }
 
 /// Everything required to compute the fee amount in sell token
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FeeParameters {
     pub gas_amount: f64,
     pub gas_price: f64,
     pub sell_token_price: f64,
+}
+
+impl Default for FeeParameters {
+    fn default() -> Self {
+        Self {
+            gas_amount: 0.,
+            gas_price: 0.,
+            sell_token_price: 1.,
+        }
+    }
 }
 
 // We want the conversion from f64 to U256 to use ceil because:
@@ -238,6 +249,7 @@ impl MinFeeCalculator {
         fee_subsidy: FeeSubsidyConfiguration,
         native_price_estimator: Arc<dyn NativePriceEstimating>,
         cow_subsidy: Arc<dyn CowSubsidy>,
+        liquidity_order_owners: HashSet<H160>,
     ) -> Self {
         Self {
             price_estimator,
@@ -248,6 +260,7 @@ impl MinFeeCalculator {
             fee_subsidy,
             native_price_estimator,
             cow_subsidy,
+            liquidity_order_owners,
         }
     }
 
@@ -299,6 +312,9 @@ impl MinFeeCalculating for MinFeeCalculator {
         user: H160,
     ) -> Result<Measurement, PriceEstimationError> {
         if fee_data.buy_token == fee_data.sell_token {
+            return Ok((U256::zero(), MAX_DATETIME));
+        }
+        if self.liquidity_order_owners.contains(&user) {
             return Ok((U256::zero(), MAX_DATETIME));
         }
 
@@ -361,6 +377,10 @@ impl MinFeeCalculating for MinFeeCalculator {
         subsidized_fee: U256,
         user: H160,
     ) -> Result<FeeParameters, GetUnsubsidizedMinFeeError> {
+        if self.liquidity_order_owners.contains(&user) {
+            return Ok(FeeParameters::default());
+        }
+
         let cow_factor = self.cow_subsidy.cow_subsidy_factor(user);
         let past_fee = self
             .measurements
@@ -471,7 +491,7 @@ mod tests {
     use chrono::Duration;
     use futures::FutureExt;
     use gas_estimation::{gas_price::EstimatedGasPrice, GasPrice1559};
-    use maplit::hashmap;
+    use maplit::{hashmap, hashset};
     use mockall::{predicate::*, Sequence};
     use shared::{
         bad_token::list_based::ListBasedDetector, gas_price_estimation::FakeGasPriceEstimator,
@@ -509,6 +529,7 @@ mod tests {
                 fee_subsidy: Default::default(),
                 native_price_estimator: create_default_native_token_estimator(price_estimator),
                 cow_subsidy: Arc::new(FixedCowSubsidy::default()),
+                liquidity_order_owners: Default::default(),
             }
         }
     }
@@ -656,6 +677,7 @@ mod tests {
             fee_subsidy: Default::default(),
             native_price_estimator,
             cow_subsidy: Arc::new(FixedCowSubsidy::default()),
+            liquidity_order_owners: Default::default(),
         };
 
         // Selling unsupported token
@@ -733,6 +755,7 @@ mod tests {
             },
             native_price_estimator,
             cow_subsidy: Arc::new(FixedCowSubsidy(0.5)),
+            liquidity_order_owners: Default::default(),
         };
         let (fee, _) = fee_estimator
             .compute_subsidized_min_fee(fee_data, app_data, user)
@@ -835,6 +858,7 @@ mod tests {
             },
             native_price_estimator,
             cow_subsidy: Arc::new(FixedCowSubsidy::default()),
+            liquidity_order_owners: Default::default(),
         };
 
         let (fee, _) = fee_estimator
@@ -940,6 +964,7 @@ mod tests {
             },
             native_price_estimator,
             cow_subsidy: Arc::new(FixedCowSubsidy::default()),
+            liquidity_order_owners: Default::default(),
         };
         let (fee, _) = fee_estimator
             .compute_subsidized_min_fee(fee_data, Default::default(), Default::default())
@@ -954,5 +979,58 @@ mod tests {
             .now_or_never()
             .unwrap()
             .unwrap();
+    }
+
+    #[test]
+    fn no_fees_for_pmms() {
+        let liquidity_order_owner = H160([0x42; 20]);
+        let fee_estimator = MinFeeCalculator {
+            liquidity_order_owners: hashset!(liquidity_order_owner),
+            ..MinFeeCalculator::new_for_test(
+                Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(
+                    EstimatedGasPrice {
+                        legacy: 1.0,
+                        eip1559: None,
+                    },
+                )))),
+                Arc::new(FakePriceEstimator(price_estimation::Estimate {
+                    out_amount: 1.into(),
+                    gas: 9,
+                })),
+                Box::new(Utc::now),
+            )
+        };
+
+        let fee_data = FeeData {
+            sell_token: H160([1; 20]),
+            buy_token: H160([2; 20]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            fee_estimator
+                .compute_subsidized_min_fee(fee_data, AppId::default(), liquidity_order_owner)
+                .now_or_never()
+                .unwrap()
+                .unwrap(),
+            (U256::from(0), MAX_DATETIME),
+        );
+        assert_eq!(
+            fee_estimator
+                .get_unsubsidized_min_fee(
+                    fee_data,
+                    AppId::default(),
+                    0.into(),
+                    liquidity_order_owner
+                )
+                .now_or_never()
+                .unwrap()
+                .unwrap(),
+            FeeParameters {
+                gas_amount: 0.,
+                gas_price: 0.,
+                sell_token_price: 1.
+            },
+        );
     }
 }

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -619,6 +619,7 @@ async fn main() {
             },
             native_price_estimator.clone(),
             cow_subsidy.clone(),
+            args.shared.liquidity_order_owners.iter().copied().collect(),
         ))
     };
     let fee_calculator = create_fee_calculator(price_estimator.clone());


### PR DESCRIPTION
This PR modifies the `MinFeeCalculator` to be aware of of liquidity order owners and require 0 minimum fees.

The rationale is that they already pay very small fees, so there is no reason not to make them 0. This is especially true considering we want to allow PMMs to place partially fillable orders, where they can pretty much achieve 0-fees by placing larger orders such that the executed fee is very tiny (and effectively pretty much 0).

One concern we had about this was that PMMs could use 0-fee orders for wash trading. However, I don't think this is a legitimate concern since solvers already don't settle PMM orders unless it facilitates a user trade and improves over a similar settlement with an AMM. Thus, 0-fee PMM orders would not be very effective for wash trading.

I had implemented this by extending the `MinFeeCalculator` type. It could have been implemented by wrapping it instead with something like:
```rust
struct LiquidityOrderOwnerAwareMinFeeCalculator {
    inner: Arc<dyn MinFeeCalculating>,
    liquidity_order_owners: HashSet<H160>,
}
```

But it felt a bit overkill for the small additional condition this change added. WDYT?

### Test Plan

Added a unit test verifying that PMMs indeed pay no fees.

Additionally, I ran a local orderbook and solver on Rinkeby and placed a user order with a counter PMM order: <https://rinkeby.etherscan.io/tx/0xd37d653712d05d33506095331cf2d4cab9aa3dcd159bcc0ee26f7bc2b75dfb37>. Unfortunately, [Tenderly isn't printing a very helpful call trace](https://dashboard.tenderly.co/gp-v2/staging/tx/rinkeby/0xd37d653712d05d33506095331cf2d4cab9aa3dcd159bcc0ee26f7bc2b75dfb37/debugger?trace=0.1), but it does at least indicate that its hitting the `partiallyFillable` order path:

<img width="801" alt="image" src="https://user-images.githubusercontent.com/4210206/158274089-bf878db5-e5e1-4e79-928c-69098509f7e4.png">

<details><summary>Additionally, I was able to query my local orderbook for the PMM order and see it was only partially filled:</summary>

```
% curl -s 'http://localhost:8080/api/v1/orders/0x8D0F6FD101C12B7032F4D7F00C95D147F5C79F1C83B24FC4DA54C9AD4C1EFB743A2C5D8F209F12BDCD84A46D6EEB136CBB0CCB9C80000000' | jq
{
  "creationDate": "2022-03-14T22:09:35.167076Z",
  "owner": "0x3a2c5d8f209f12bdcd84a46d6eeb136cbb0ccb9c",
  "uid": "0x8d0f6fd101c12b7032f4d7f00c95d147f5c79f1c83b24fc4da54c9ad4c1efb743a2c5d8f209f12bdcd84a46d6eeb136cbb0ccb9c80000000",
  "availableBalance": "7666960556003232805048",
  "executedBuyAmount": "999779582997575397",
  "executedSellAmount": "1333039443996767194952",
  "executedSellAmountBeforeFees": "1333039443996767194952",
  "executedFeeAmount": "0",
  "invalidated": false,
  "status": "open",
  "settlementContract": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
  "fullFeeAmount": "0",
  "sellToken": "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d",
  "buyToken": "0xc778417e063141139fce010982780140aa0cd5ab",
  "receiver": "0x0000000000000000000000000000000000000000",
  "sellAmount": "2400000000000000000000",
  "buyAmount": "1800000000000000000",
  "validTo": 2147483648,
  "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
  "feeAmount": "0",
  "kind": "sell",
  "partiallyFillable": true,
  "signingScheme": "eip712",
  "signature": "0xbbfe981aa66900a36d7f13d2407c0b0062ae0bf5913c89b7803f4d4bb488ed2f236abd920c023608670ded935890ceadad307a43d12315396d4a2f9ee43de90f1c",
  "sellTokenBalance": "erc20",
  "buyTokenBalance": "erc20"
}
```

</details>

### Release notes

PMM addresses should now be configured as liquidity order owners instead of using custom app IDs.
