### PR TITLE
Make --cow-fee-factors argument optional

### DIFF
--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -187,7 +187,7 @@ struct Arguments {
     /// A balance of [10.2,150) COW will cause you to pay 75% of the regular fee and a balance of
     /// [150, inf) COW will cause you to pay 50% of the regular fee.
     #[clap(long, env)]
-    cow_fee_factors: SubsidyTiers,
+    cow_fee_factors: Option<SubsidyTiers>,
 
     /// Address of the cow token used for extra subsidy.
     #[clap(long, env)]
@@ -609,7 +609,7 @@ async fn main() {
     let cow_subsidy = match args.cow_token_address {
         Some(address) => Arc::new(CowSubsidyImpl::new(
             ERC20::at(&web3, address),
-            args.cow_fee_factors,
+            args.cow_fee_factors.unwrap_or_default(),
         )) as Arc<dyn CowSubsidy>,
         None => Arc::new(FixedCowSubsidy(1.0)) as Arc<dyn CowSubsidy>,
     };


### PR DESCRIPTION
In order to not have to pass a value for `--cow-fee-factors` I made it optional.
If no tiers are configured the system defaults to `1.0` as the additional fee factor which is a no-op.

### Test Plan
Manual test
