### PR TITLE
Print debug information for submission errors

### DIFF
--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -462,7 +462,7 @@ impl<'a> Submitter<'a> {
                     SubmitApiError::EdenTransactionTooExpensive => {
                         tracing::warn!("submission failed: eden transaction too expensive")
                     }
-                    SubmitApiError::Other(err) => tracing::error!("submission failed: {}", err),
+                    SubmitApiError::Other(err) => tracing::error!("submission failed: {:?}", err),
                 },
             }
             tokio::time::sleep(params.retry_interval).await;


### PR DESCRIPTION
The most common alerts we get are for settlement submission errors.
Some of the error messages are very specific and give a good idea about what is happening but the [fallback error message](https://gnosisinc.slack.com/archives/CUD4MUCUF/p1647335545026619) is very generic and doesn't help very much to debug the underlying issue.

When we encounter a generic error during settlement submission we wrap some `anyhow::Context` around it and propagate it. 
```rust
fn convert_web3_to_submission_error(err: web3::Error) -> SubmitApiError {
    if let web3::Error::Rpc(RpcError { message, .. }) = &err {
        if message.starts_with("invalid nonce") || message.starts_with("nonce too low") {
            return SubmitApiError::InvalidNonce;
        } else if message.starts_with("Transaction gas price supplied is too low") {
            return SubmitApiError::OpenEthereumTooCheapToReplace;
        } else if message.starts_with("replacement transaction underpriced") {
            return SubmitApiError::ReplacementTransactionUnderpriced;
        } else if message.contains("tx fee") && message.contains("exceeds the configured cap") {
            return SubmitApiError::EdenTransactionTooExpensive;
        }
    }

    anyhow::Error::new(err)
        .context("transaction submission error")
        .into()
}
```

Unfortunately when we actually print the error we only print the outer most `Context` and not the underlying `web3::Error` which could hold more useful information.

This PR would cause all the available information of the error to be printed.
To see the difference between the printing options  of `anyhow::Error` check out this [example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=b5b8df9eead500671ca627e334d1d49d).

Note: Since I'm not very familiar with the possible errors during settlement submission it's possible that this change doesn't help us very much if the underlying `web3::Error` is already very unhelpful.
I guess @sunce86 would know best if there is much to gain here.

### Test Plan
CI
