### PR TITLE
Make native price estimator streaming

### DIFF
--- a/crates/orderbook/src/fee.rs
+++ b/crates/orderbook/src/fee.rs
@@ -7,7 +7,10 @@ use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
 use shared::{
     bad_token::BadTokenDetecting,
-    price_estimation::{self, ensure_token_supported, PriceEstimating, PriceEstimationError},
+    price_estimation::{
+        self, ensure_token_supported, native::native_single_estimate, PriceEstimating,
+        PriceEstimationError,
+    },
     price_estimation::{native::NativePriceEstimating, single_estimate},
 };
 use std::{
@@ -267,8 +270,7 @@ impl MinFeeCalculator {
                 .estimate()
                 .map_err(PriceEstimationError::from),
             single_estimate(self.price_estimator.as_ref(), &buy_token_query),
-            self.native_price_estimator
-                .estimate_native_price(&fee_data.sell_token)
+            native_single_estimate(self.native_price_estimator.as_ref(), &fee_data.sell_token),
         )?;
         let gas_price = gas_estimate.effective_gas_price();
         let gas_amount = buy_token_estimate.gas as f64;

--- a/crates/orderbook/src/solvable_orders.rs
+++ b/crates/orderbook/src/solvable_orders.rs
@@ -7,8 +7,11 @@ use anyhow::Result;
 use model::{auction::Auction, order::Order};
 use primitive_types::{H160, U256};
 use shared::{
-    bad_token::BadTokenDetecting, current_block::CurrentBlockStream, maintenance::Maintaining,
-    price_estimation::native::NativePriceEstimating, time::now_in_epoch_seconds,
+    bad_token::BadTokenDetecting,
+    current_block::CurrentBlockStream,
+    maintenance::Maintaining,
+    price_estimation::native::{native_vec_estimates, NativePriceEstimating},
+    time::now_in_epoch_seconds,
 };
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
@@ -309,8 +312,7 @@ async fn get_orders_with_native_prices(
         .collect::<HashSet<_>>()
         .into_iter()
         .collect::<Vec<_>>();
-    let prices = native_price_estimator
-        .estimate_native_prices(&traded_tokens)
+    let prices = native_vec_estimates(native_price_estimator, &traded_tokens)
         .await
         .into_iter()
         .zip(traded_tokens)
@@ -359,6 +361,7 @@ mod tests {
         database::orders::SolvableOrders as DbOrders, metrics::NoopMetrics,
     };
     use chrono::{DateTime, NaiveDateTime, Utc};
+    use futures::StreamExt;
     use maplit::{btreemap, hashmap, hashset};
     use model::order::{OrderBuilder, OrderCreation, OrderMetadata, SellTokenSource};
     use primitive_types::H160;
@@ -486,9 +489,9 @@ mod tests {
             .return_once(|_| Vec::new());
 
         let mut native = MockNativePriceEstimating::new();
-        native
-            .expect_estimate_native_prices()
-            .returning(|a| vec![Ok(1.0); a.len()]);
+        native.expect_estimate_native_prices().returning(|a| {
+            futures::stream::iter(std::iter::repeat(Ok(1.0)).take(a.len()).enumerate()).boxed()
+        });
 
         let cache = SolvableOrdersCache::new(
             Duration::from_secs(0),
@@ -601,7 +604,7 @@ mod tests {
             .returning({
                 let prices = prices.clone();
                 move |tokens| {
-                    tokens
+                    let results = tokens
                         .iter()
                         .map(|token| {
                             prices
@@ -609,7 +612,9 @@ mod tests {
                                 .copied()
                                 .ok_or(PriceEstimationError::NoLiquidity)
                         })
-                        .collect()
+                        .enumerate()
+                        .collect::<Vec<_>>();
+                    futures::stream::iter(results).boxed()
                 }
             });
 

--- a/crates/shared/src/price_estimation/buffered.rs
+++ b/crates/shared/src/price_estimation/buffered.rs
@@ -1,12 +1,13 @@
 use crate::price_estimation::{
     old_estimator_to_stream, vec_estimates, PriceEstimateResult, PriceEstimating, Query,
 };
-use futures::future::WeakShared;
-use futures::FutureExt;
-use std::collections::HashMap;
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::{Arc, Mutex, MutexGuard};
+use futures::{future::WeakShared, FutureExt};
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex, MutexGuard},
+};
 
 type SharedEstimationRequest =
     WeakShared<Pin<Box<dyn Future<Output = PriceEstimateResult> + Send>>>;


### PR DESCRIPTION
Similar to the normal PriceEstimating . Here we can see one advantage of the stream: the cached native results can be returned immediately.

### Test Plan

CI, existing tests keep working

