### PR TITLE
Fix default solver arguments

### DIFF
--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -98,7 +98,7 @@ struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "Naive,Baseline",
+        default_values = &["Naive", "Baseline"],
         arg_enum,
         ignore_case = true,
         use_value_delimiter = true


### PR DESCRIPTION
This PR just fixes the default values for the solvers parameter. It appears `clap` expects `default_values` and not `default_value` for "multi-value" options.

### Test Plan

Before:
```
% cargo run -p solver
   Compiling solver v0.1.0 (/Users/nlordell/Developer/gp-v2-services/crates/solver)
    Finished dev [unoptimized + debuginfo] target(s) in 4.48s
     Running `target/debug/solver`
thread 'main' panicked at 'Argument `solvers`'s default_value=Naive,Baseline doesn't match possible values', /Users/nlordell/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.1.3/src/build/debug_asserts.rs:678:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:
```
 % cargo run -p solver 
   Compiling shared v0.1.0 (/Users/nlordell/Developer/gp-v2-services/crates/shared)
   Compiling solver v0.1.0 (/Users/nlordell/Developer/gp-v2-services/crates/solver)
    Finished dev [unoptimized + debuginfo] target(s) in 13.46s
     Running `target/debug/solver`
2022-03-15T18:51:33.323Z  INFO solver: running solver with validated Arguments {
...
```