### PR TITLE
Base submission error alerts off of metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2758,6 +2758,7 @@ dependencies = [
  "num",
  "primitive-types",
  "prometheus",
+ "prometheus-metric-storage",
  "rand",
  "reqwest",
  "serde",

--- a/crates/solver/Cargo.toml
+++ b/crates/solver/Cargo.toml
@@ -35,6 +35,7 @@ model = { path = "../model" }
 num = "0.4"
 primitive-types = { version = "0.10", features = ["fp-conversion"] }
 prometheus = "0.13"
+prometheus-metric-storage = "0.4"
 rand = "0.8"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -556,20 +556,20 @@ async fn find_mined_transaction(web3: &Web3, hashes: &[H256]) -> Option<Transact
 }
 
 #[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
-#[metric(subsystem = "transaction_submissions")]
+#[metric(subsystem = "submission_strategies")]
 struct Metrics {
     /// Tracks how many transactions get successfully submitted with the different submission
     /// strategies.
-    #[metric(labels("submitter", "successful"))]
+    #[metric(labels("submitter", "result"))]
     submissions: prometheus::CounterVec,
 }
 
-pub(crate) fn track_submission_success(submitter: &str, success: bool) {
-    let label = if success { "successes" } else { "failures" };
+pub(crate) fn track_submission_success(submitter: &str, was_successful: bool) {
+    let result = if was_successful { "success" } else { "error" };
     Metrics::instance(shared::metrics::get_metric_storage_registry())
         .expect("unexpected error getting metrics instance")
         .submissions
-        .with_label_values(&[submitter, label])
+        .with_label_values(&[submitter, result])
         .inc();
 }
 

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -51,24 +51,6 @@ pub struct SubmitterParams {
 }
 
 #[derive(Debug)]
-/// Enum used to handle all kind of messages received from implementers of trait TransactionSubmitting
-pub enum SubmitApiError {
-    InvalidNonce,
-    ReplacementTransactionUnderpriced,
-    OpenEthereumTooCheapToReplace, // todo ds safe to remove after dropping OE support
-    /// EDEN network will reject transactions where the maximum gas cost in ETH
-    /// is over 1.0.
-    EdenTransactionTooExpensive,
-    Other(anyhow::Error),
-}
-
-impl From<anyhow::Error> for SubmitApiError {
-    fn from(err: anyhow::Error) -> Self {
-        Self::Other(err)
-    }
-}
-
-#[derive(Debug)]
 pub enum SubmissionLoopStatus {
     Enabled(AdditionalTip),
     Disabled(DisabledReason),
@@ -107,12 +89,9 @@ pub trait TransactionSubmitting: Send + Sync {
     async fn submit_transaction(
         &self,
         tx: TransactionBuilder<DynTransport>,
-    ) -> Result<TransactionHandle, SubmitApiError>;
+    ) -> anyhow::Result<TransactionHandle>;
     /// Cancels already submitted transaction using the cancel handle
-    async fn cancel_transaction(
-        &self,
-        id: &CancelHandle,
-    ) -> Result<TransactionHandle, SubmitApiError>;
+    async fn cancel_transaction(&self, id: &CancelHandle) -> anyhow::Result<TransactionHandle>;
     /// Try to find submitted transaction from previous submission loop (in this case we don't have a TransactionHandle)
     async fn recover_pending_transaction(
         &self,
@@ -457,29 +436,7 @@ impl<'a> Submitter<'a> {
                     );
                     transactions.push((handle, gas_price));
                 }
-                Err(err) => match err {
-                    SubmitApiError::InvalidNonce => {
-                        tracing::warn!("{} submission failed: invalid nonce", submitter_name)
-                    }
-                    SubmitApiError::ReplacementTransactionUnderpriced => {
-                        tracing::warn!(
-                            "{} submission failed: replacement transaction underpriced",
-                            submitter_name
-                        )
-                    }
-                    SubmitApiError::OpenEthereumTooCheapToReplace => {
-                        tracing::debug!("{} submission failed: OE has different replacement rules than our algorithm", submitter_name)
-                    }
-                    SubmitApiError::EdenTransactionTooExpensive => {
-                        tracing::warn!(
-                            "{} submission failed: eden transaction too expensive",
-                            submitter_name
-                        )
-                    }
-                    SubmitApiError::Other(err) => {
-                        tracing::error!("{} submission failed: {:?}", submitter_name, err)
-                    }
-                },
+                Err(err) => tracing::warn!("submission failed: {:?}", err),
             }
             tokio::time::sleep(params.retry_interval).await;
         }
@@ -550,7 +507,7 @@ impl<'a> Submitter<'a> {
         transaction: &TransactionHandle,
         gas_price: &EstimatedGasPrice,
         nonce: U256,
-    ) -> Result<TransactionHandle, SubmitApiError> {
+    ) -> anyhow::Result<TransactionHandle> {
         let cancel_handle = CancelHandle {
             submitted_transaction: *transaction,
             noop_transaction: self.build_noop_transaction(&gas_price.bump(3.), nonce),

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -89,9 +89,9 @@ pub trait TransactionSubmitting: Send + Sync {
     async fn submit_transaction(
         &self,
         tx: TransactionBuilder<DynTransport>,
-    ) -> anyhow::Result<TransactionHandle>;
+    ) -> Result<TransactionHandle>;
     /// Cancels already submitted transaction using the cancel handle
-    async fn cancel_transaction(&self, id: &CancelHandle) -> anyhow::Result<TransactionHandle>;
+    async fn cancel_transaction(&self, id: &CancelHandle) -> Result<TransactionHandle>;
     /// Try to find submitted transaction from previous submission loop (in this case we don't have a TransactionHandle)
     async fn recover_pending_transaction(
         &self,
@@ -507,7 +507,7 @@ impl<'a> Submitter<'a> {
         transaction: &TransactionHandle,
         gas_price: &EstimatedGasPrice,
         nonce: U256,
-    ) -> anyhow::Result<TransactionHandle> {
+    ) -> Result<TransactionHandle> {
         let cancel_handle = CancelHandle {
             submitted_transaction: *transaction,
             noop_transaction: self.build_noop_transaction(&gas_price.bump(3.), nonce),

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -558,8 +558,7 @@ async fn find_mined_transaction(web3: &Web3, hashes: &[H256]) -> Option<Transact
 #[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
 #[metric(subsystem = "submission_strategies")]
 struct Metrics {
-    /// Tracks how many transactions get successfully submitted with the different submission
-    /// strategies.
+    /// Tracks how many transactions get successfully submitted with the different submission strategies.
     #[metric(labels("submitter", "result"))]
     submissions: prometheus::CounterVec,
 }

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -555,6 +555,24 @@ async fn find_mined_transaction(web3: &Web3, hashes: &[H256]) -> Option<Transact
     None
 }
 
+#[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
+#[metric(subsystem = "transaction_submissions")]
+struct Metrics {
+    /// Tracks how many transactions get successfully submitted with the different submission
+    /// strategies.
+    #[metric(labels("submitter", "successful"))]
+    submissions: prometheus::CounterVec,
+}
+
+pub(crate) fn track_submission_success(submitter: &str, success: bool) {
+    let label = if success { "successes" } else { "failures" };
+    Metrics::instance(shared::metrics::get_metric_storage_registry())
+        .expect("unexpected error getting metrics instance")
+        .submissions
+        .with_label_values(&[submitter, label])
+        .inc();
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/crates/solver/src/settlement_submission/submitter/common.rs
+++ b/crates/solver/src/settlement_submission/submitter/common.rs
@@ -1,4 +1,5 @@
 use super::super::submitter::TransactionHandle;
+use anyhow::Result;
 use ethcontract::transaction::{Transaction, TransactionBuilder};
 use futures::FutureExt;
 use shared::{Web3, Web3Transport};
@@ -23,7 +24,7 @@ impl PrivateNetwork {
     pub async fn submit_raw_transaction(
         &self,
         tx: TransactionBuilder<Web3Transport>,
-    ) -> anyhow::Result<TransactionHandle> {
+    ) -> Result<TransactionHandle> {
         let (raw_signed_transaction, tx_hash) = match tx.build().now_or_never().unwrap().unwrap() {
             Transaction::Request(_) => unreachable!("verified offline account was used"),
             Transaction::Raw { bytes, hash } => (bytes.0, hash),

--- a/crates/solver/src/settlement_submission/submitter/common.rs
+++ b/crates/solver/src/settlement_submission/submitter/common.rs
@@ -1,8 +1,5 @@
-use super::super::submitter::{SubmitApiError, TransactionHandle};
-use ethcontract::{
-    jsonrpc::types::error::Error as RpcError,
-    transaction::{Transaction, TransactionBuilder},
-};
+use super::super::submitter::TransactionHandle;
+use ethcontract::transaction::{Transaction, TransactionBuilder};
 use futures::FutureExt;
 use shared::{Web3, Web3Transport};
 use web3::{api::Namespace, types::Bytes};
@@ -26,7 +23,7 @@ impl PrivateNetwork {
     pub async fn submit_raw_transaction(
         &self,
         tx: TransactionBuilder<Web3Transport>,
-    ) -> Result<TransactionHandle, SubmitApiError> {
+    ) -> anyhow::Result<TransactionHandle> {
         let (raw_signed_transaction, tx_hash) = match tx.build().now_or_never().unwrap().unwrap() {
             Transaction::Request(_) => unreachable!("verified offline account was used"),
             Transaction::Raw { bytes, hash } => (bytes.0, hash),
@@ -37,26 +34,8 @@ impl PrivateNetwork {
             .eth()
             .send_raw_transaction(Bytes(raw_signed_transaction))
             .await
-            .map_err(convert_web3_to_submission_error)?;
+            .map_err(anyhow::Error::new)?;
 
         Ok(TransactionHandle { tx_hash, handle })
     }
-}
-
-fn convert_web3_to_submission_error(err: web3::Error) -> SubmitApiError {
-    if let web3::Error::Rpc(RpcError { message, .. }) = &err {
-        if message.starts_with("invalid nonce") || message.starts_with("nonce too low") {
-            return SubmitApiError::InvalidNonce;
-        } else if message.starts_with("Transaction gas price supplied is too low") {
-            return SubmitApiError::OpenEthereumTooCheapToReplace;
-        } else if message.starts_with("replacement transaction underpriced") {
-            return SubmitApiError::ReplacementTransactionUnderpriced;
-        } else if message.contains("tx fee") && message.contains("exceeds the configured cap") {
-            return SubmitApiError::EdenTransactionTooExpensive;
-        }
-    }
-
-    anyhow::Error::new(err)
-        .context("transaction submission error")
-        .into()
 }

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -33,7 +33,7 @@ impl TransactionSubmitting for CustomNodesApi {
     async fn submit_transaction(
         &self,
         tx: TransactionBuilder<DynTransport>,
-    ) -> anyhow::Result<TransactionHandle> {
+    ) -> Result<TransactionHandle> {
         let transaction_request = tx.build().now_or_never().unwrap().unwrap();
         let mut futures = self
             .nodes
@@ -75,7 +75,7 @@ impl TransactionSubmitting for CustomNodesApi {
         }
     }
 
-    async fn cancel_transaction(&self, id: &CancelHandle) -> anyhow::Result<TransactionHandle> {
+    async fn cancel_transaction(&self, id: &CancelHandle) -> Result<TransactionHandle> {
         self.submit_transaction(id.noop_transaction.clone()).await
     }
 

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -53,7 +53,7 @@ impl TransactionSubmitting for CustomNodesApi {
 
         loop {
             let (result, index, rest) = futures::future::select_all(futures).await;
-            let lable = "custom_nodes_".to_string() + &index.to_string();
+            let lable = format!("custom_nodes_{}", index);
             match result {
                 Ok(tx_hash) => {
                     super::track_submission_success(lable.as_str(), true);

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -53,7 +53,7 @@ impl TransactionSubmitting for CustomNodesApi {
 
         loop {
             let (result, index, rest) = futures::future::select_all(futures).await;
-            let lable = format!("custom_nodes_{}", index);
+            let lable = format!("custom_nodes_{index}");
             match result {
                 Ok(tx_hash) => {
                     super::track_submission_success(lable.as_str(), true);

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -63,14 +63,12 @@ impl TransactionSubmitting for CustomNodesApi {
                         handle: tx_hash,
                     });
                 }
-                Err(err) if rest.is_empty() => {
-                    tracing::debug!("error {}", err);
-                    super::track_submission_success(lable.as_str(), false);
-                    return Err(anyhow::Error::from(err).context("all nodes tx failed"));
-                }
                 Err(err) => {
-                    tracing::warn!(?err, "single node tx failed");
+                    tracing::warn!(?err, ?lable, "single custom node tx failed");
                     super::track_submission_success(lable.as_str(), false);
+                    if rest.is_empty() {
+                        return Err(anyhow::Error::from(err).context("all custom nodes tx failed"));
+                    }
                     futures = rest;
                 }
             }

--- a/crates/solver/src/settlement_submission/submitter/eden_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/eden_api.rs
@@ -49,7 +49,7 @@ impl EdenApi {
     async fn submit_slot_transaction(
         &self,
         tx: TransactionBuilder<Web3Transport>,
-    ) -> anyhow::Result<TransactionHandle> {
+    ) -> Result<TransactionHandle> {
         let (raw_signed_transaction, tx_hash) = match tx.build().now_or_never().unwrap().unwrap() {
             Transaction::Request(_) => unreachable!("verified offline account was used"),
             Transaction::Raw { bytes, hash } => (bytes.0, hash),
@@ -85,7 +85,7 @@ impl TransactionSubmitting for EdenApi {
     async fn submit_transaction(
         &self,
         tx: TransactionBuilder<Web3Transport>,
-    ) -> anyhow::Result<TransactionHandle> {
+    ) -> Result<TransactionHandle> {
         // try to submit with slot method
         let result = self
             .submit_slot_transaction(tx.clone())
@@ -112,7 +112,7 @@ impl TransactionSubmitting for EdenApi {
         result
     }
 
-    async fn cancel_transaction(&self, id: &CancelHandle) -> anyhow::Result<TransactionHandle> {
+    async fn cancel_transaction(&self, id: &CancelHandle) -> Result<TransactionHandle> {
         self.rpc
             .api::<PrivateNetwork>()
             .submit_raw_transaction(id.noop_transaction.clone())

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -35,10 +35,15 @@ impl TransactionSubmitting for FlashbotsApi {
         &self,
         tx: TransactionBuilder<Web3Transport>,
     ) -> anyhow::Result<TransactionHandle> {
-        self.rpc
+        let result = self
+            .rpc
             .api::<PrivateNetwork>()
             .submit_raw_transaction(tx)
-            .await
+            .await;
+
+        super::track_submission_success("flashbots", result.is_ok());
+
+        result
     }
 
     // https://docs.flashbots.net/flashbots-protect/rpc/cancellations

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -34,7 +34,7 @@ impl TransactionSubmitting for FlashbotsApi {
     async fn submit_transaction(
         &self,
         tx: TransactionBuilder<Web3Transport>,
-    ) -> anyhow::Result<TransactionHandle> {
+    ) -> Result<TransactionHandle> {
         let result = self
             .rpc
             .api::<PrivateNetwork>()
@@ -47,7 +47,7 @@ impl TransactionSubmitting for FlashbotsApi {
     }
 
     // https://docs.flashbots.net/flashbots-protect/rpc/cancellations
-    async fn cancel_transaction(&self, id: &CancelHandle) -> anyhow::Result<TransactionHandle> {
+    async fn cancel_transaction(&self, id: &CancelHandle) -> Result<TransactionHandle> {
         self.rpc
             .api::<PrivateNetwork>()
             .submit_raw_transaction(id.noop_transaction.clone())

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -1,7 +1,7 @@
 use crate::settlement::{Revertable, Settlement};
 
 use super::{
-    super::submitter::{SubmitApiError, TransactionHandle, TransactionSubmitting},
+    super::submitter::{TransactionHandle, TransactionSubmitting},
     common::PrivateNetwork,
     AdditionalTip, CancelHandle, SubmissionLoopStatus,
 };
@@ -34,7 +34,7 @@ impl TransactionSubmitting for FlashbotsApi {
     async fn submit_transaction(
         &self,
         tx: TransactionBuilder<Web3Transport>,
-    ) -> Result<TransactionHandle, SubmitApiError> {
+    ) -> anyhow::Result<TransactionHandle> {
         self.rpc
             .api::<PrivateNetwork>()
             .submit_raw_transaction(tx)
@@ -42,10 +42,7 @@ impl TransactionSubmitting for FlashbotsApi {
     }
 
     // https://docs.flashbots.net/flashbots-protect/rpc/cancellations
-    async fn cancel_transaction(
-        &self,
-        id: &CancelHandle,
-    ) -> Result<TransactionHandle, SubmitApiError> {
+    async fn cancel_transaction(&self, id: &CancelHandle) -> anyhow::Result<TransactionHandle> {
         self.rpc
             .api::<PrivateNetwork>()
             .submit_raw_transaction(id.noop_transaction.clone())


### PR DESCRIPTION
Submitting a transaction can error for all sorts of reasons. Because so many different things can go wrong on-call can receive many alerts which ultimately don't point to a systemic problem but to a bunch of one-off errors.
Instead of always alerting for certain errors I would like to try keeping metrics for every type of submission strategy and alert when one consistently reports errors.

Individual submission success/failure metrics will be maintained for eden, flashbots and each individual custom node the driver is using.
This way it should be mostly obvious from the alert which submission strategy is having an actual problem.
It's mostly obvious because there is no nice way of labeling the individual custom nodes so they will be named based on the index they have in the `--transaction-submission-nodes` argument.

Another notable change is that we are currently try to be smart about errors we receive from the rpc endpoint. This means we try to read the error message and turn the generic error into a custom error. Every error which we didn't anticipate will cause an alert (instead of being logged as a warning). This can lead to too many alerts for benign errors and needs to be kept in sync with the specific nodes rpc client implementation (which error messages does it produce?).
Also we don't really make decisions based on that custom error type. We just log more generic error messages for each known error. Combined with the transition to metrics based errors I don't really see the need to keep this logic and instead use `tracing::warn()` for every (uninterpreted) `web3::Error`. If the metrics cause an alert it's still easy enough to use kibana to search for all the errors related to that submission strategy.

### Test Plan
Used a local grafana and prometheus instance to see that the metrics can be used to generate meaningful graphs.
Also this is how the new metrics show when you query the `/metrics` endpoint:
```
# HELP gp_v2_solver_submission_strategies_submissions Tracks how many transactions get successfully submitted with the different submission strategies.
# TYPE gp_v2_solver_submission_strategies_submissions counter
gp_v2_solver_submission_strategies_submissions{result="error",submitter="custom_nodes_0"} 62
gp_v2_solver_submission_strategies_submissions{result="success",submitter="custom_nodes_0"} 62
```
