### PR TITLE
Support encoding approvals for HTTP solvers

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -480,6 +480,25 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_approval_model() {
+        let approval = r#"
+            {
+                "token": "0x7777777777777777777777777777777777777777",
+                "spender": "0x5555555555555555555555555555555555555555",
+                "amount": "1337"
+            }
+        "#;
+        assert_eq!(
+            serde_json::from_str::<ApprovalModel>(approval).unwrap(),
+            ApprovalModel {
+                token: addr!("7777777777777777777777777777777777777777"),
+                spender: addr!("5555555555555555555555555555555555555555"),
+                amount: 1337.into(),
+            }
+        );
+    }
+
+    #[test]
     fn decode_empty_solution() {
         let empty_solution = r#"
             {

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -109,6 +109,14 @@ pub struct FeeModel {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct ApprovalModel {
+    pub token: H160,
+    pub spender: H160,
+    #[serde(with = "u256_decimal")]
+    pub amount: U256,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct InteractionData {
     pub target: H160,
     pub value: U256,
@@ -125,6 +133,8 @@ pub struct SettledBatchAuctionModel {
     pub ref_token: Option<H160>,
     #[serde_as(as = "HashMap<_, DecimalU256>")]
     pub prices: HashMap<H160, U256>,
+    #[serde(default)]
+    pub approvals: Vec<ApprovalModel>,
     #[serde(default)]
     pub interaction_data: Vec<InteractionData>,
     pub metadata: Option<SettledBatchAuctionMetadataModel>,

--- a/crates/solver/src/interactions/allowances.rs
+++ b/crates/solver/src/interactions/allowances.rs
@@ -107,7 +107,7 @@ impl Allowances {
 }
 
 /// An ERC20 approval interaction.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Approval {
     /// The existing allowance is sufficient, so no additional `approve` is required.
     AllowanceSufficient,

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -174,7 +174,7 @@ pub fn tenderly_link(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::interactions::allowances::Allowances;
+    use crate::interactions::allowances::{Allowances, MockAllowanceManaging};
     use crate::liquidity::{
         balancer_v2::SettlementHandler, order_converter::OrderConverter, uniswap_v2::Inner,
         ConstantProductOrder, Liquidity, StablePoolOrder,
@@ -579,9 +579,14 @@ mod tests {
         "#;
         let parsed_response = serde_json::from_str::<SettledBatchAuctionModel>(quasimodo_response);
 
-        let settlements = convert_settlement(parsed_response.unwrap(), settlement_context)
-            .map(|settlement| vec![settlement])
-            .unwrap();
+        let settlements = convert_settlement(
+            parsed_response.unwrap(),
+            settlement_context,
+            Arc::new(MockAllowanceManaging::new()),
+        )
+        .await
+        .map(|settlement| vec![settlement])
+        .unwrap();
         let settlement = settlements.get(0).unwrap();
         let settlement_encoded = settlement.encoder.clone().finish();
         println!("Settlement_encoded: {:?}", settlement_encoded);

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -184,6 +184,10 @@ pub fn create(
         web3.clone(),
         settlement_contract.address(),
     ));
+    let allowance_mananger = Arc::new(AllowanceManager::new(
+        web3.clone(),
+        settlement_contract.address(),
+    ));
     let http_solver_cache = http_solver::InstanceCache::default();
     // Helper function to create http solver instances.
     let create_http_solver =
@@ -201,6 +205,7 @@ pub fn create(
                 native_token,
                 token_info_fetcher.clone(),
                 buffer_retriever.clone(),
+                allowance_mananger.clone(),
                 http_solver_cache.clone(),
             )
         };
@@ -298,10 +303,7 @@ pub fn create(
                             balancer_sor_url.clone(),
                             chain_id,
                         )?),
-                        Arc::new(AllowanceManager::new(
-                            web3.clone(),
-                            settlement_contract.address(),
-                        )),
+                        allowance_mananger.clone(),
                     ),
                     solver_metrics.clone(),
                 )),

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -1,15 +1,18 @@
-use crate::encoding::EncodedInteraction;
-use crate::settlement::Interaction;
 use crate::{
+    encoding::EncodedInteraction,
+    interactions::allowances::{AllowanceManaging, Approval, ApprovalRequest},
     liquidity::{AmmOrderExecution, LimitOrder, Liquidity},
-    settlement::Settlement,
+    settlement::{Interaction, Settlement},
 };
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context as _, Result};
 use ethcontract::Bytes;
 use model::order::OrderKind;
 use primitive_types::{H160, U256};
 use shared::http_solver::model::*;
-use std::collections::{hash_map::Entry, HashMap};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    sync::Arc,
+};
 
 // To send an instance to the solver we need to identify tokens and orders through strings. This
 // struct combines the created model and a mapping of those identifiers to their original value.
@@ -19,11 +22,13 @@ pub struct SettlementContext {
     pub liquidity: Vec<Liquidity>,
 }
 
-pub fn convert_settlement(
+pub async fn convert_settlement(
     settled: SettledBatchAuctionModel,
     context: SettlementContext,
+    allowance_manager: Arc<dyn AllowanceManaging>,
 ) -> Result<Settlement> {
-    match IntermediateSettlement::new(settled.clone(), context)
+    match IntermediateSettlement::new(settled.clone(), context, allowance_manager)
+        .await
         .and_then(|intermediate| intermediate.into_settlement())
     {
         Ok(settlement) => Ok(settlement),
@@ -54,6 +59,7 @@ impl Execution {
 // the error checking up front and then working with a more convenient representation.
 struct IntermediateSettlement {
     executed_limit_orders: Vec<ExecutedLimitOrder>,
+    approvals: Vec<Approval>,
     executions: Vec<Execution>, // executions are sorted by execution coordinate.
     prices: HashMap<H160, U256>,
 }
@@ -89,7 +95,11 @@ impl Interaction for InteractionData {
 }
 
 impl IntermediateSettlement {
-    fn new(settled: SettledBatchAuctionModel, context: SettlementContext) -> Result<Self> {
+    async fn new(
+        settled: SettledBatchAuctionModel,
+        context: SettlementContext,
+        allowance_manager: Arc<dyn AllowanceManaging>,
+    ) -> Result<Self> {
         let executed_limit_orders =
             match_prepared_and_settled_orders(context.orders, settled.orders)?;
         let executions_amm = match_prepared_and_settled_amms(context.liquidity, settled.amms)?;
@@ -100,19 +110,24 @@ impl IntermediateSettlement {
             .collect();
         let executions = merge_and_order_executions(executions_amm, executions_interactions)?;
         let prices = match_settled_prices(executed_limit_orders.as_slice(), settled.prices)?;
+        let approvals = compute_approvals(allowance_manager, settled.approvals).await?;
         Ok(Self {
             executed_limit_orders,
             executions,
             prices,
+            approvals,
         })
     }
 
     fn into_settlement(self) -> Result<Settlement> {
         let mut settlement = Settlement::new(self.prices);
-        for order in self.executed_limit_orders.iter() {
+        for order in self.executed_limit_orders {
             settlement.with_liquidity(&order.order, order.executed_amount())?;
         }
-        for execution in self.executions.iter() {
+        for approval in self.approvals {
+            settlement.encoder.append_to_execution_plan(approval);
+        }
+        for execution in self.executions {
             match execution {
                 Execution::ExecutionAmm(executed_amm) => {
                     let execution = AmmOrderExecution {
@@ -134,7 +149,7 @@ impl IntermediateSettlement {
                 Execution::ExecutionCustomInteraction(interaction_data) => {
                     settlement
                         .encoder
-                        .append_to_execution_plan(*interaction_data.clone());
+                        .append_to_execution_plan(*interaction_data);
                 }
             }
         }
@@ -219,12 +234,46 @@ fn match_settled_prices(
     Ok(prices)
 }
 
+async fn compute_approvals(
+    allowance_manager: Arc<dyn AllowanceManaging>,
+    approvals: Vec<ApprovalModel>,
+) -> Result<Vec<Approval>> {
+    if approvals.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let requests = approvals
+        .into_iter()
+        .try_fold(HashMap::new(), |mut grouped, approval| {
+            let amount = grouped
+                .entry((approval.token, approval.spender))
+                .or_insert(U256::zero());
+            *amount = amount
+                .checked_add(approval.amount)
+                .context("overflow when computing total approval amount")?;
+
+            Result::<_>::Ok(grouped)
+        })?
+        .into_iter()
+        .map(|((token, spender), amount)| ApprovalRequest {
+            token,
+            spender,
+            amount,
+        })
+        .collect::<Vec<_>>();
+
+    allowance_manager.get_approvals(&requests).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::liquidity::{
-        tests::CapturingSettlementHandler, ConstantProductOrder, StablePoolOrder,
-        WeightedProductOrder,
+    use crate::{
+        interactions::allowances::MockAllowanceManaging,
+        liquidity::{
+            tests::CapturingSettlementHandler, ConstantProductOrder, StablePoolOrder,
+            WeightedProductOrder,
+        },
     };
     use hex_literal::hex;
     use maplit::hashmap;
@@ -237,8 +286,8 @@ mod tests {
         swap::fixed_point::Bfp,
     };
 
-    #[test]
-    fn convert_settlement_() {
+    #[tokio::test]
+    async fn convert_settlement_() {
         let t0 = H160::zero();
         let t1 = H160::from_low_u64_be(1);
 
@@ -351,13 +400,17 @@ mod tests {
             amms: hashmap! { 0 => updated_uniswap, 1 => updated_balancer_weighted, 2 => updated_balancer_stable },
             ref_token: Some(t0),
             prices: hashmap! { t0 => 10.into(), t1 => 11.into() },
+            approvals: Vec::new(),
             interaction_data: Vec::new(),
             metadata: None,
         };
 
         let prepared = SettlementContext { orders, liquidity };
 
-        let settlement = convert_settlement(settled, prepared).unwrap();
+        let settlement =
+            convert_settlement(settled, prepared, Arc::new(MockAllowanceManaging::new()))
+                .await
+                .unwrap();
         assert_eq!(
             settlement.clearing_prices(),
             &hashmap! { t0 => 10.into(), t1 => 11.into() }
@@ -696,5 +749,92 @@ mod tests {
                 interactions.get(0).unwrap().clone()
             ]
         );
+    }
+
+    #[tokio::test]
+    pub async fn compute_approvals_groups_approvals_by_spender_and_token() {
+        let mut allowance_manager = MockAllowanceManaging::new();
+        allowance_manager
+            .expect_get_approvals()
+            .withf(|requests| {
+                // deal with underterministic ordering because of grouping
+                // implementation.
+                let grouped = requests
+                    .iter()
+                    .map(|request| ((request.token, request.spender), request.amount))
+                    .collect::<HashMap<_, _>>();
+
+                requests.len() == grouped.len()
+                    && grouped
+                        == hashmap! {
+                            (H160([1; 20]), H160([0xf1; 20])) => U256::from(12),
+                            (H160([1; 20]), H160([0xf2; 20])) => U256::from(3),
+                            (H160([2; 20]), H160([0xf1; 20])) => U256::from(4),
+                            (H160([2; 20]), H160([0xf2; 20])) => U256::from(5),
+                        }
+            })
+            .returning(|requests| {
+                Ok(requests
+                    .iter()
+                    .map(|_| Approval::AllowanceSufficient)
+                    .collect())
+            });
+
+        assert_eq!(
+            compute_approvals(
+                Arc::new(allowance_manager),
+                vec![
+                    ApprovalModel {
+                        token: H160([1; 20]),
+                        spender: H160([0xf1; 20]),
+                        amount: 10.into()
+                    },
+                    ApprovalModel {
+                        token: H160([1; 20]),
+                        spender: H160([0xf2; 20]),
+                        amount: 3.into(),
+                    },
+                    ApprovalModel {
+                        token: H160([1; 20]),
+                        spender: H160([0xf1; 20]),
+                        amount: 2.into(),
+                    },
+                    ApprovalModel {
+                        token: H160([2; 20]),
+                        spender: H160([0xf1; 20]),
+                        amount: 4.into(),
+                    },
+                    ApprovalModel {
+                        token: H160([2; 20]),
+                        spender: H160([0xf2; 20]),
+                        amount: 5.into(),
+                    },
+                ],
+            )
+            .await
+            .unwrap(),
+            vec![Approval::AllowanceSufficient; 4],
+        );
+    }
+
+    #[tokio::test]
+    pub async fn compute_approvals_errors_on_overflow() {
+        assert!(compute_approvals(
+            Arc::new(MockAllowanceManaging::new()),
+            vec![
+                ApprovalModel {
+                    token: H160([1; 20]),
+                    spender: H160([2; 20]),
+                    amount: U256::MAX,
+                },
+                ApprovalModel {
+                    token: H160([1; 20]),
+                    spender: H160([2; 20]),
+                    amount: 1.into(),
+                },
+            ],
+        )
+        .await
+        .is_err());
     }
 }

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -124,9 +124,14 @@ impl IntermediateSettlement {
         for order in self.executed_limit_orders {
             settlement.with_liquidity(&order.order, order.executed_amount())?;
         }
+
+        // Make sure to always add approval interactions **before** any
+        // interactions from the execution plan - the execution plan typically
+        // consists of AMM swaps that require these approvals to be in place.
         for approval in self.approvals {
             settlement.encoder.append_to_execution_plan(approval);
         }
+
         for execution in self.executions {
             match execution {
                 Execution::ExecutionAmm(executed_amm) => {


### PR DESCRIPTION
This PR adds support for encoding ERC20 approvals on behalf of solvers.

The motivation behind this change is that the HTTP solver will get liquidity from sources other than the driver (Uniswap V3 and Curve for example). Because of this, it will now send settlements with raw interactions and will it will have to encode approvals to the respective token transfer proxy contracts (for example the Uniswap V3 router).

This change adds a convenient `approvals` field to the solution model that the HTTP solvers return. Approvals specified this way use the common logic to determine if an approval interaction is actually needed or if the settlement contract already has sufficient allowance.

See #1744 for more details.

### Test Plan

Added new unit test to verify approval folding logic and another to check deserialization works as expected.
