### PR TITLE
Use u64 to enter subsidy tier threshold to avoid rounding errors

### DIFF
--- a/crates/orderbook/src/cow_subsidy.rs
+++ b/crates/orderbook/src/cow_subsidy.rs
@@ -47,10 +47,10 @@ impl std::str::FromStr for SubsidyTiers {
                 .split_once(':')
                 .with_context(|| format!("too few arguments for subsidy tier in \"{}\"", tier))?;
 
-            let threshold: f64 = threshold
+            let threshold: u64 = threshold
                 .parse()
-                .with_context(|| format!("can not parse threshold \"{}\" as f64", threshold))?;
-            let threshold = U256::from_f64_lossy(threshold * 1e18);
+                .with_context(|| format!("can not parse threshold \"{}\" as u64", threshold))?;
+            let threshold = U256::from(threshold).saturating_mul(U256::exp10(18));
 
             let fee_factor: f64 = fee_factor
                 .parse()

--- a/crates/orderbook/src/cow_subsidy.rs
+++ b/crates/orderbook/src/cow_subsidy.rs
@@ -50,7 +50,9 @@ impl std::str::FromStr for SubsidyTiers {
             let threshold: u64 = threshold
                 .parse()
                 .with_context(|| format!("can not parse threshold \"{}\" as u64", threshold))?;
-            let threshold = U256::from(threshold).saturating_mul(U256::exp10(18));
+            let threshold = U256::from(threshold)
+                .checked_mul(U256::exp10(18))
+                .with_context(|| format!("threshold {threshold} would overflow U256"))?;
 
             let fee_factor: f64 = fee_factor
                 .parse()

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -177,10 +177,11 @@ struct Arguments {
     )]
     partner_additional_fee_factors: HashMap<AppId, f64>,
 
-    /// Used to configure how much of the regular fee a user should pay based on their COW balance.
+    /// Used to configure how much of the regular fee a user should pay based on their
+    /// COW + VCOW balance of the current network.
     ///
-    /// The expected format is "10.2:0.75,150:0.5" for 2 subsidy tiers.
-    /// A balance of [10.2,150) COW will cause you to pay 75% of the regular fee and a balance of
+    /// The expected format is "10:0.75,150:0.5" for 2 subsidy tiers.
+    /// A balance of [10,150) COW will cause you to pay 75% of the regular fee and a balance of
     /// [150, inf) COW will cause you to pay 50% of the regular fee.
     #[clap(long, env)]
     cow_fee_factors: Option<SubsidyTiers>,

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -178,7 +178,7 @@ struct Arguments {
     partner_additional_fee_factors: HashMap<AppId, f64>,
 
     /// Used to configure how much of the regular fee a user should pay based on their
-    /// COW + VCOW balance of the current network.
+    /// COW + VCOW balance in base units on the current network.
     ///
     /// The expected format is "10:0.75,150:0.5" for 2 subsidy tiers.
     /// A balance of [10,150) COW will cause you to pay 75% of the regular fee and a balance of


### PR DESCRIPTION
Since people are voting on very specific tier thresholds we should avoid rounding errors if possible.
Luckily this can be done easily in this case by parsing the cow based tier subsidy threshold as an `u64` which allows a lossless conversion to `U256`.

Note:
Also updated the help text to reflect the contents of what is currently being voted on: [CIP-3](https://forum.cow.fi/t/cip-3-trading-fee-discount-for-cow-holders/325)

### Test Plan
CI
