### PR TITLE
Access list logging and metrics

### DIFF
--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -210,7 +210,7 @@ async fn eth_integration(web3: Web3) {
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),
         web3.clone(),
-        network_id,
+        network_id.clone(),
         1,
         Duration::from_secs(30),
         None,
@@ -237,6 +237,7 @@ async fn eth_integration(web3: Web3) {
                     &[AccessListEstimatorType::Web3],
                     None,
                     None,
+                    network_id,
                 )
                 .await
                 .unwrap(),
@@ -248,6 +249,7 @@ async fn eth_integration(web3: Web3) {
         0.0,
         15000000u128,
         1.0,
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -215,7 +215,7 @@ async fn onchain_settlement(web3: Web3) {
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),
         web3.clone(),
-        network_id,
+        network_id.clone(),
         1,
         Duration::from_secs(30),
         None,
@@ -242,6 +242,7 @@ async fn onchain_settlement(web3: Web3) {
                     &[AccessListEstimatorType::Web3],
                     None,
                     None,
+                    network_id,
                 )
                 .await
                 .unwrap(),
@@ -253,6 +254,7 @@ async fn onchain_settlement(web3: Web3) {
         0.0,
         15000000u128,
         1.0,
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -204,7 +204,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),
         web3.clone(),
-        network_id,
+        network_id.clone(),
         1,
         Duration::from_secs(10),
         Some(market_makable_token_list),
@@ -231,6 +231,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
                     &[AccessListEstimatorType::Web3],
                     None,
                     None,
+                    network_id,
                 )
                 .await
                 .unwrap(),
@@ -242,6 +243,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         0.0,
         15000000u128,
         1.0,
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -173,7 +173,7 @@ async fn smart_contract_orders(web3: Web3) {
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),
         web3.clone(),
-        network_id,
+        network_id.clone(),
         1,
         Duration::from_secs(30),
         None,
@@ -200,6 +200,7 @@ async fn smart_contract_orders(web3: Web3) {
                     &[AccessListEstimatorType::Web3],
                     None,
                     None,
+                    network_id,
                 )
                 .await
                 .unwrap(),
@@ -211,6 +212,7 @@ async fn smart_contract_orders(web3: Web3) {
         0.0,
         15000000u128,
         1.0,
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -154,7 +154,7 @@ async fn vault_balances(web3: Web3) {
         Duration::from_secs(0),
         Arc::new(NoopMetrics::default()),
         web3.clone(),
-        network_id,
+        network_id.clone(),
         1,
         Duration::from_secs(30),
         None,
@@ -181,6 +181,7 @@ async fn vault_balances(web3: Web3) {
                     &[AccessListEstimatorType::Web3],
                     None,
                     None,
+                    network_id,
                 )
                 .await
                 .unwrap(),
@@ -192,6 +193,7 @@ async fn vault_balances(web3: Web3) {
         0.0,
         15000000u128,
         1.0,
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -14,7 +14,7 @@ use crate::{
     settlement_submission::SolutionSubmitter,
     solver::{Auction, SettlementWithError, SettlementWithSolver, Solver, Solvers},
 };
-use anyhow::{ensure, Context, Result};
+use anyhow::{Context, Result};
 use contracts::GPv2Settlement;
 use futures::future::join_all;
 use gas_estimation::{EstimatedGasPrice, GasPriceEstimating};
@@ -220,12 +220,13 @@ impl Driver {
     }
 
     async fn metric_access_list_gas_saved(&self, transaction_hash: H256) -> Result<()> {
-        ensure!(self.tenderly.is_some(), "tenderly disabled");
-        let web3 = &self.web3;
-        let tenderly = self.tenderly.as_ref().unwrap();
-        let network_id = self.network_id.clone();
-        let gas_saved =
-            simulate_before_after_access_list(web3, tenderly, network_id, transaction_hash).await?;
+        let gas_saved = simulate_before_after_access_list(
+            &self.web3,
+            self.tenderly.as_ref().context("tenderly disabled")?,
+            self.network_id.clone(),
+            transaction_hash,
+        )
+        .await?;
         self.metrics.settlement_access_list_saved_gas(gas_saved);
         Ok(())
     }

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -221,13 +221,11 @@ impl Driver {
 
     async fn metric_access_list_gas_saved(&self, transaction_hash: H256) -> Result<()> {
         ensure!(self.tenderly.is_some(), "tenderly disabled");
-        let gas_saved = simulate_before_after_access_list(
-            &self.web3,
-            self.tenderly.as_ref().unwrap(),
-            self.network_id.clone(),
-            transaction_hash,
-        )
-        .await?;
+        let web3 = &self.web3;
+        let tenderly = self.tenderly.as_ref().unwrap();
+        let network_id = self.network_id.clone();
+        let gas_saved =
+            simulate_before_after_access_list(web3, tenderly, network_id, transaction_hash).await?;
         self.metrics.settlement_access_list_saved_gas(gas_saved);
         Ok(())
     }

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -618,14 +618,10 @@ async fn main() {
         liquidity_order_owners: args.shared.liquidity_order_owners.into_iter().collect(),
         fee_objective_scaling_factor: args.fee_objective_scaling_factor,
     };
-    let tenderly = {
-        if let Some(tenderly_url) = args.tenderly_url {
-            if let Some(tenderly_api_key) = args.tenderly_api_key.as_ref() {
-                TenderlyApi::new(tenderly_url, client.clone(), tenderly_api_key).ok();
-            }
-        }
-        None
-    };
+    let tenderly = args
+        .tenderly_url
+        .zip(args.tenderly_api_key)
+        .and_then(|(url, api_key)| TenderlyApi::new(url, client.clone(), &api_key).ok());
 
     let mut driver = Driver::new(
         settlement_contract,

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -70,6 +70,7 @@ pub trait SolverMetrics: Send + Sync {
     fn single_order_solver_failed(&self, solver: &'static str);
     fn settlement_simulation_failed(&self, solver: &'static str);
     fn settlement_submitted(&self, outcome: SettlementSubmissionOutcome, solver: &'static str);
+    fn settlement_access_list_saved_gas(&self, gas_saved: f64);
     fn settlement_revertable_status(&self, status: Revertable, solver: &'static str);
     fn orders_matched_but_not_settled(&self, count: usize);
     fn report_order_surplus(&self, surplus_diff: f64);
@@ -88,6 +89,7 @@ pub struct Metrics {
     settlement_simulations: IntCounterVec,
     settlement_submissions: IntCounterVec,
     settlement_revertable_status: IntCounterVec,
+    settlement_access_list_saved_gas: Histogram,
     solver_runs: IntCounterVec,
     single_order_solver_runs: IntCounterVec,
     matched_but_unsettled_orders: IntCounter,
@@ -155,6 +157,12 @@ impl Metrics {
             &["result", "solver_type"],
         )?;
         registry.register(Box::new(settlement_revertable_status.clone()))?;
+
+        let settlement_access_list_saved_gas = Histogram::with_opts(HistogramOpts::new(
+            "settlement_access_list_saved_gas",
+            "Saved gas by using access list for transaction submission",
+        ))?;
+        registry.register(Box::new(settlement_access_list_saved_gas.clone()))?;
 
         let solver_runs = IntCounterVec::new(
             Opts::new("solver_run", "Success/Failure counts"),
@@ -248,6 +256,7 @@ impl Metrics {
             complete_runloop_until_transaction,
             transaction_submission,
             transaction_gas_price_gwei,
+            settlement_access_list_saved_gas,
         })
     }
 }
@@ -349,6 +358,10 @@ impl SolverMetrics for Metrics {
             .inc()
     }
 
+    fn settlement_access_list_saved_gas(&self, gas_saved: f64) {
+        self.settlement_access_list_saved_gas.observe(gas_saved);
+    }
+
     fn orders_matched_but_not_settled(&self, count: usize) {
         self.matched_but_unsettled_orders.inc_by(count as u64);
     }
@@ -441,6 +454,7 @@ impl SolverMetrics for NoopMetrics {
     fn settlement_simulation_failed(&self, _: &'static str) {}
     fn settlement_submitted(&self, _: SettlementSubmissionOutcome, _: &'static str) {}
     fn settlement_revertable_status(&self, _: Revertable, _: &'static str) {}
+    fn settlement_access_list_saved_gas(&self, _: f64) {}
     fn orders_matched_but_not_settled(&self, _: usize) {}
     fn report_order_surplus(&self, _: f64) {}
     fn runloop_completed(&self) {}

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -1,5 +1,5 @@
 use crate::{encoding::EncodedSettlement, settlement::Settlement};
-use anyhow::{Error, Result};
+use anyhow::{anyhow, Error, Result};
 use contracts::GPv2Settlement;
 use ethcontract::{
     batch::CallBatch,
@@ -7,13 +7,18 @@ use ethcontract::{
     dyns::{DynMethodBuilder, DynTransport},
     errors::ExecutionError,
     transaction::TransactionBuilder,
-    Account,
+    Account, Address,
 };
 use futures::FutureExt;
 use gas_estimation::EstimatedGasPrice;
-use primitive_types::U256;
+use primitive_types::{H256, U256};
+use reqwest::{
+    header::{HeaderMap, HeaderValue},
+    Client, IntoUrl, Url,
+};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use shared::Web3;
-use web3::types::{AccessList, BlockId};
+use web3::types::{AccessList, BlockId, Bytes};
 
 const SIMULATE_BATCH_SIZE: usize = 10;
 
@@ -119,6 +124,75 @@ pub async fn simulate_and_error_with_tenderly_link(
         .collect()
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct TenderlyResponse {
+    transaction: TenderlyTransaction,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct TenderlyTransaction {
+    gas_used: u64,
+}
+
+pub async fn simulate_before_after_access_list(
+    web3: &Web3,
+    tenderly: &TenderlyApi,
+    network_id: String,
+    transaction_hash: H256,
+) -> Result<f64> {
+    let transaction = web3
+        .eth()
+        .transaction(transaction_hash.into())
+        .await?
+        .ok_or_else(|| anyhow!("no transaction found"))?;
+
+    if transaction.access_list.is_none() {
+        return Err(anyhow!(
+            "no need to analyze access list since no access list was found in mined transaction"
+        ));
+    }
+
+    let (block_number, from, to, transaction_index) = (
+        transaction
+            .block_number
+            .ok_or_else(|| anyhow!("no block number field exist"))?
+            .as_u64(),
+        transaction
+            .from
+            .ok_or_else(|| anyhow!("no from field exist"))?,
+        transaction.to.ok_or_else(|| anyhow!("no to field exist"))?,
+        transaction
+            .transaction_index
+            .ok_or_else(|| anyhow!("no transaction_index field exist"))?
+            .as_u64(),
+    );
+
+    let request = TenderlyRequest {
+        network_id,
+        block_number,
+        from,
+        input: transaction.input,
+        to,
+        generate_access_list: false,
+        transaction_index: Some(transaction_index),
+    };
+
+    let gas_used_without_access_list = tenderly
+        .send::<TenderlyResponse>(request)
+        .await?
+        .transaction
+        .gas_used;
+    let gas_used_with_access_list = web3
+        .eth()
+        .transaction_receipt(transaction_hash)
+        .await?
+        .ok_or_else(|| anyhow!("no transaction receipt"))?
+        .gas_used
+        .ok_or_else(|| anyhow!("no gas used field"))?;
+
+    Ok(gas_used_without_access_list as f64 - gas_used_with_access_list.to_f64_lossy())
+}
+
 pub fn settle_method(
     gas_price: EstimatedGasPrice,
     contract: &GPv2Settlement,
@@ -171,6 +245,72 @@ pub fn tenderly_link(
     )
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TenderlyRequest {
+    pub network_id: String,
+    pub block_number: u64,
+    pub from: Address,
+    pub input: Bytes,
+    pub to: Address,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_index: Option<u64>,
+    pub generate_access_list: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BlockNumber {
+    pub block_number: u64,
+}
+
+#[derive(Debug)]
+pub struct TenderlyApi {
+    url: Url,
+    client: Client,
+    header: HeaderMap,
+}
+
+impl TenderlyApi {
+    pub fn new(url: impl IntoUrl, client: Client, api_key: &str) -> Result<Self> {
+        Ok(Self {
+            url: url.into_url()?,
+            client,
+            header: {
+                let mut header = HeaderMap::new();
+                header.insert("x-access-key", HeaderValue::from_str(api_key)?);
+                header
+            },
+        })
+    }
+
+    pub async fn send<T>(&self, body: TenderlyRequest) -> reqwest::Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        self.client
+            .post(self.url.clone())
+            .headers(self.header.clone())
+            .json(&body)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+    }
+
+    pub async fn block_number(&self, network_id: &str) -> reqwest::Result<BlockNumber> {
+        self.client
+            .get(format!(
+                "https://api.tenderly.co/api/v1/network/{}/block-number",
+                network_id
+            ))
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -189,6 +329,7 @@ mod tests {
     use shared::http_solver::model::SettledBatchAuctionModel;
     use shared::sources::balancer_v2::pools::{common::TokenState, stable::AmplificationParameter};
     use shared::transport::create_env_test_transport;
+    use std::str::FromStr;
     use std::sync::{Arc, Mutex};
 
     // cargo test -p solver settlement_simulation::tests::mainnet -- --ignored --nocapture
@@ -619,5 +760,32 @@ mod tests {
         .await
         .unwrap();
         let _ = dbg!(result);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn simulate_before_after_access_list_test() {
+        let transport = create_env_test_transport();
+        let web3 = Web3::new(transport);
+        let transaction_hash =
+            H256::from_str("e337fcd52afd6b98847baab279cda6c3980fcb185da9e959fd489ffd210eac60")
+                .unwrap();
+        let tenderly_api = TenderlyApi::new(
+            // http://api.tenderly.co/api/v1/account/<USER_NAME>/project/<PROJECT_NAME>/simulate
+            Url::parse(&std::env::var("TENDERLY_URL").unwrap()).unwrap(),
+            Client::new(),
+            &std::env::var("TENDERLY_API_KEY").unwrap(),
+        )
+        .unwrap();
+        let gas_saved = simulate_before_after_access_list(
+            &web3,
+            &tenderly_api,
+            "1".to_string(),
+            transaction_hash,
+        )
+        .await
+        .unwrap();
+
+        dbg!(gas_saved);
     }
 }

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -1,5 +1,5 @@
 use crate::{encoding::EncodedSettlement, settlement::Settlement};
-use anyhow::{anyhow, Error, Result};
+use anyhow::{anyhow, Context, Error, Result};
 use contracts::GPv2Settlement;
 use ethcontract::{
     batch::CallBatch,
@@ -144,7 +144,7 @@ pub async fn simulate_before_after_access_list(
         .eth()
         .transaction(transaction_hash.into())
         .await?
-        .ok_or_else(|| anyhow!("no transaction found"))?;
+        .context("no transaction found")?;
 
     if transaction.access_list.is_none() {
         return Err(anyhow!(
@@ -155,15 +155,13 @@ pub async fn simulate_before_after_access_list(
     let (block_number, from, to, transaction_index) = (
         transaction
             .block_number
-            .ok_or_else(|| anyhow!("no block number field exist"))?
+            .context("no block number field exist")?
             .as_u64(),
-        transaction
-            .from
-            .ok_or_else(|| anyhow!("no from field exist"))?,
-        transaction.to.ok_or_else(|| anyhow!("no to field exist"))?,
+        transaction.from.context("no from field exist")?,
+        transaction.to.context("no to field exist")?,
         transaction
             .transaction_index
-            .ok_or_else(|| anyhow!("no transaction_index field exist"))?
+            .context("no transaction_index field exist")?
             .as_u64(),
     );
 

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -13,7 +13,7 @@ use ethcontract::{
 };
 use futures::FutureExt;
 use gas_estimation::GasPriceEstimating;
-use primitive_types::U256;
+use primitive_types::{H256, U256};
 use shared::Web3;
 use std::{
     sync::Arc,
@@ -171,6 +171,17 @@ impl SubmissionError {
             Self::Canceled(_) => SettlementSubmissionOutcome::Cancel,
             Self::Disabled(_) => SettlementSubmissionOutcome::Disabled,
             Self::Other(_) => SettlementSubmissionOutcome::Failed,
+        }
+    }
+
+    pub fn transaction_hash(&self) -> Option<H256> {
+        match self {
+            Self::SimulationRevert(_) => None,
+            Self::Timeout => None,
+            Self::Revert(hash) => Some(*hash),
+            Self::Canceled(hash) => Some(*hash),
+            Self::Disabled(_) => None,
+            Self::Other(_) => None,
         }
     }
 

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -486,9 +486,10 @@ impl<'a> Submitter<'a> {
         )?;
 
         ensure!(
-            gas_before_access_list > gas_after_access_list && gas_before_access_list > U256::zero(),
-            "access list exist but does not lower the gas usage or bad gas estimat"
+            gas_before_access_list > gas_after_access_list,
+            "access list exist but does not lower the gas usage"
         );
+        ensure!(gas_before_access_list > U256::zero(), "bad gas estimation");
         let gas_percent_saved = (gas_before_access_list.to_f64_lossy()
             - gas_after_access_list.to_f64_lossy())
             / gas_before_access_list.to_f64_lossy()

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -500,7 +500,6 @@ impl<'a> Submitter<'a> {
             access_list,
             gas_percent_saved
         );
-        track_access_list_gas_saved(gas_percent_saved);
         Ok(access_list)
     }
 
@@ -589,21 +588,6 @@ pub(crate) fn track_submission_success(submitter: &str, was_successful: bool) {
         .inc();
 }
 
-#[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
-#[metric(subsystem = "submission_strategies")]
-struct AccessListMetrics {
-    /// Tracks how much gas in percent is saved by using access list.
-    #[metric(labels("access_list_gas_percent_saved"))]
-    access_list_gas_percent: prometheus::Histogram,
-}
-
-fn track_access_list_gas_saved(gas_percent_saved: f64) {
-    AccessListMetrics::instance(shared::metrics::get_metric_storage_registry())
-        .expect("unexpected error getting metrics instance")
-        .access_list_gas_percent
-        .observe(gas_percent_saved);
-}
-
 #[cfg(test)]
 mod tests {
 
@@ -660,6 +644,7 @@ mod tests {
                 &[AccessListEstimatorType::Web3],
                 None,
                 None,
+                "1".to_string(),
             )
             .await
             .unwrap(),

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -578,10 +578,6 @@ struct Metrics {
     /// Tracks how many transactions get successfully submitted with the different submission strategies.
     #[metric(labels("submitter", "result"))]
     submissions: prometheus::CounterVec,
-
-    /// Tracks how much gas in percent is saved by using access list.
-    #[metric(labels("access_list_gas_percent_saved"))]
-    access_list_gas_percent: prometheus::Histogram,
 }
 
 pub(crate) fn track_submission_success(submitter: &str, was_successful: bool) {
@@ -593,8 +589,16 @@ pub(crate) fn track_submission_success(submitter: &str, was_successful: bool) {
         .inc();
 }
 
+#[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
+#[metric(subsystem = "submission_strategies")]
+struct AccessListMetrics {
+    /// Tracks how much gas in percent is saved by using access list.
+    #[metric(labels("access_list_gas_percent_saved"))]
+    access_list_gas_percent: prometheus::Histogram,
+}
+
 fn track_access_list_gas_saved(gas_percent_saved: f64) {
-    Metrics::instance(shared::metrics::get_metric_storage_registry())
+    AccessListMetrics::instance(shared::metrics::get_metric_storage_registry())
         .expect("unexpected error getting metrics instance")
         .access_list_gas_percent
         .observe(gas_percent_saved);

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -489,7 +489,6 @@ impl<'a> Submitter<'a> {
             gas_before_access_list > gas_after_access_list,
             "access list exist but does not lower the gas usage"
         );
-        ensure!(gas_before_access_list > U256::zero(), "bad gas estimation");
         let gas_percent_saved = (gas_before_access_list.to_f64_lossy()
             - gas_after_access_list.to_f64_lossy())
             / gas_before_access_list.to_f64_lossy()


### PR DESCRIPTION
This PR adds metrics for gas saved by using access lists for settlement submission.

Additional refactoring is done to enable this:
1. Extracted basic tenderly simulation and moved to `settlement_simulation.rs`
2. Basic tenderly simulation made generic over response type, since the native response is huge, therefore different components using basic tenderly simulation should define their own struct for deserialization of response.
3. Refactored `TenderlyAccessList` to use basic tenderly simulation.