### PR TITLE
Differentiate between user and liquidity orders for metrics

### DIFF
--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -254,9 +254,18 @@ impl Metrics {
 
 impl SolverMetrics for Metrics {
     fn orders_fetched(&self, orders: &[LimitOrder]) {
+        let user_orders = orders
+            .iter()
+            .filter(|order| !order.is_liquidity_order)
+            .count();
+        let liquidity_orders = orders.len() - user_orders;
+
         self.liquidity
-            .with_label_values(&["Limit"])
-            .set(orders.len() as _);
+            .with_label_values(&["UserOrder"])
+            .set(user_orders as _);
+        self.liquidity
+            .with_label_values(&["LiquidityOrder"])
+            .set(liquidity_orders as _);
     }
 
     fn liquidity_fetched(&self, liquidity: &[Liquidity]) {


### PR DESCRIPTION
This PR just changes the metrics that we record for counting CowSwap orders to distinguish between user (i.e. normal) orders and liquidity orders.

### Test Plan

Run the solver locally with a liquidity order owner configured and see different counts:
```
% curl -s http://localhost:9587/metrics | rg 'liquidity'
# HELP gp_v2_solver_liquidity_gauge Amount of orders labeled by liquidity type currently available to the solvers
# TYPE gp_v2_solver_liquidity_gauge gauge
gp_v2_solver_liquidity_gauge{liquidity_type="BalancerStable"} 0
gp_v2_solver_liquidity_gauge{liquidity_type="BalancerWeighted"} 0
gp_v2_solver_liquidity_gauge{liquidity_type="ConstantProduct"} 9
gp_v2_solver_liquidity_gauge{liquidity_type="LiquidityOrder"} 1
gp_v2_solver_liquidity_gauge{liquidity_type="UserOrder"} 6
```