### PR TITLE
Filter Banned User Orders

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -164,6 +164,7 @@ impl OrderbookServices {
         let solvable_orders_cache = SolvableOrdersCache::new(
             Duration::from_secs(120),
             db.clone(),
+            Default::default(),
             balance_fetcher.clone(),
             bad_token_detector.clone(),
             current_block_stream.clone(),

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -653,6 +653,7 @@ async fn main() {
     let solvable_orders_cache = SolvableOrdersCache::new(
         args.min_order_validity_period,
         database.clone(),
+        args.banned_users.iter().copied().collect(),
         balance_fetcher.clone(),
         bad_token_detector.clone(),
         current_block_stream.clone(),
@@ -667,7 +668,7 @@ async fn main() {
     let order_validator = Arc::new(OrderValidator::new(
         Box::new(web3.clone()),
         native_token.clone(),
-        args.banned_users.into_iter().collect(),
+        args.banned_users.iter().copied().collect(),
         args.shared.liquidity_order_owners.into_iter().collect(),
         args.min_order_validity_period,
         fee_calculator.clone(),

--- a/crates/orderbook/src/solvable_orders.rs
+++ b/crates/orderbook/src/solvable_orders.rs
@@ -37,6 +37,7 @@ pub trait AuctionMetrics: Send + Sync + 'static {
 pub struct SolvableOrdersCache {
     min_order_validity_period: Duration,
     database: Arc<dyn OrderStoring>,
+    banned_users: HashSet<H160>,
     balance_fetcher: Arc<dyn BalanceFetching>,
     bad_token_detector: Arc<dyn BadTokenDetecting>,
     notify: Notify,
@@ -62,9 +63,11 @@ pub struct SolvableOrders {
 }
 
 impl SolvableOrdersCache {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         min_order_validity_period: Duration,
         database: Arc<dyn OrderStoring>,
+        banned_users: HashSet<H160>,
         balance_fetcher: Arc<dyn BalanceFetching>,
         bad_token_detector: Arc<dyn BadTokenDetecting>,
         current_block: CurrentBlockStream,
@@ -74,6 +77,7 @@ impl SolvableOrdersCache {
         let self_ = Arc::new(Self {
             min_order_validity_period,
             database,
+            banned_users,
             balance_fetcher,
             bad_token_detector,
             notify: Default::default(),
@@ -124,9 +128,8 @@ impl SolvableOrdersCache {
     pub async fn update(&self, block: u64) -> Result<()> {
         let min_valid_to = now_in_epoch_seconds() + self.min_order_validity_period.as_secs() as u32;
         let db_solvable_orders = self.database.solvable_orders(min_valid_to).await?;
-        let orders =
-            filter_unsupported_tokens(db_solvable_orders.orders, self.bad_token_detector.as_ref())
-                .await?;
+        let orders = filter_banned_user_orders(db_solvable_orders.orders, &self.banned_users);
+        let orders = filter_unsupported_tokens(orders, self.bad_token_detector.as_ref()).await?;
 
         // If we update due to an explicit notification we can reuse existing balances as they
         // cannot have changed.
@@ -191,6 +194,12 @@ impl SolvableOrdersCache {
 
         Ok(())
     }
+}
+
+/// Filters all orders whose owners are in the set of "banned" users.
+fn filter_banned_user_orders(mut orders: Vec<Order>, banned_users: &HashSet<H160>) -> Vec<Order> {
+    orders.retain(|order| !banned_users.contains(&order.metadata.owner));
+    orders
 }
 
 /// Returns existing balances and Vec of queries that need to be peformed.
@@ -555,6 +564,7 @@ mod tests {
         let cache = SolvableOrdersCache::new(
             Duration::from_secs(0),
             Arc::new(order_storing),
+            Default::default(),
             Arc::new(balance_fetcher),
             Arc::new(bad_token_detector),
             receiver,
@@ -813,5 +823,38 @@ mod tests {
         assert_eq!(prices.len(), 2);
         assert!(prices.contains_key(&orders_[0].creation.sell_token));
         assert!(prices.contains_key(&orders_[0].creation.buy_token));
+    }
+
+    #[test]
+    fn filters_banned_users() {
+        let banned_users = hashset!(H160([0xba; 20]), H160([0xbb; 20]));
+        let orders = [
+            H160([1; 20]),
+            H160([1; 20]),
+            H160([0xba; 20]),
+            H160([2; 20]),
+            H160([0xba; 20]),
+            H160([0xbb; 20]),
+            H160([3; 20]),
+        ]
+        .into_iter()
+        .map(|owner| Order {
+            metadata: OrderMetadata {
+                owner,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .collect();
+
+        let filtered_orders = filter_banned_user_orders(orders, &banned_users);
+        let filtered_owners = filtered_orders
+            .iter()
+            .map(|order| order.metadata.owner)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            filtered_owners,
+            [H160([1; 20]), H160([1; 20]), H160([2; 20]), H160([3; 20])],
+        );
     }
 }


### PR DESCRIPTION
This PR adds logic to filter banned user orders from the auction endpoint.

We are now allowing partially fillable orders for select users, some of which are using this to market make stable coins with a bot. In order to protect the orderbook from potential bugs with this bot, we pass the existing `--banned-user` configuration option to the `SolvableOrderCache` component so that it can filters out these orders - allowing us to quickly react and remove orders if something goes awry.

### Test Plan

Added a unit test for filtering logic.

Also, you can run a manual test:

1. Run the orderbook with an order from a banned user:
    ```
    % cargo run -p orderbook -- --skip-trace-api true --skip-event-sync --banned-users 0x3a2c5d8f209f12bdcd84a46d6eeb136cbb0ccb9c
    % curl -s http://localhost:8080/api/v1/auction | jq '.orders'
    []
    ```
2. Run without a banned user and see that it is no longer filtered:
    ```
    % cargo run -p orderbook -- --skip-trace-api true --skip-event-sync
    % curl -s http://localhost:8080/api/v1/auction | jq '.orders'
    [
      {
        "owner": "0x3a2c5d8f209f12bdcd84a46d6eeb136cbb0ccb9c",
        ...
      }
    ]
    ```
