### PR TITLE
Printing auction_id for easier solution finding

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -156,9 +156,10 @@ impl SettledBatchAuctionModel {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Default)]
 pub struct MetadataModel {
     pub environment: Option<String>,
+    pub auction_id: Option<u64>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -386,6 +387,7 @@ mod tests {
             },
             metadata: Some(MetadataModel {
                 environment: Some(String::from("Such Meta")),
+                auction_id: None,
             }),
         };
 

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -485,6 +485,7 @@ mod tests {
           },
           "metadata": {
             "environment": "Such Meta",
+            "auction_id": null,
           },
         });
         assert_eq!(result, expected);

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -178,7 +178,7 @@ impl Driver {
             Ok(receipt) => {
                 let name = solver.name();
                 tracing::info!(
-                    "Successfully submitted settlement id {} for the auction {} with tx hash {:?}",
+                    "Successfully submitted settlement id {} for the auction id {} with tx hash {:?}",
                     rated_settlement.id,
                     auction_id,
                     receipt.transaction_hash
@@ -430,16 +430,17 @@ impl Driver {
 
         let mut solver_settlements = Vec::new();
 
+        let auction_id = self.next_auction_id();
         let auction = Auction {
-            id: self.next_auction_id(),
+            id: auction_id,
             orders: orders.clone(),
             liquidity,
             gas_price: gas_price.effective_gas_price(),
             deadline: Instant::now() + self.solver_time_limit,
             external_prices: external_prices.clone(),
         };
-        tracing::debug!("solving auction ID {}", auction.id);
-        let run_solver_results = self.run_solvers(auction.clone()).await;
+        tracing::debug!("solving auction id {}", auction.id);
+        let run_solver_results = self.run_solvers(auction).await;
         for (solver, settlements) in run_solver_results {
             let name = solver.name();
 
@@ -474,7 +475,7 @@ impl Driver {
                     "solver {} found solution:\n{:?} for auction id: {:}",
                     name,
                     settlement,
-                    auction.id
+                    auction_id
                 );
             }
 
@@ -536,10 +537,10 @@ impl Driver {
             .rate_settlements(solver_settlements, &external_prices, gas_price)
             .await?;
         tracing::info!(
-            "{} settlements passed simulation and {} failed for auctionId: {}",
+            "{} settlements passed simulation and {} failed for auction id: {}",
             rated_settlements.len(),
             errors.len(),
-            auction.id
+            auction_id
         );
         for (solver, _, _) in &rated_settlements {
             self.metrics.settlement_simulation_succeeded(solver.name());
@@ -587,7 +588,7 @@ impl Driver {
             let start = Instant::now();
             if let Ok(receipt) = self
                 .submit_settlement(
-                    auction.id,
+                    auction_id,
                     winning_solver.clone(),
                     winning_settlement.clone(),
                 )

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -472,10 +472,10 @@ impl Driver {
 
             for settlement in &settlements {
                 tracing::debug!(
-                    "solver {} found solution:\n{:?} for auction id: {:}",
+                    "for auction id {} solver {} found solution:\n{:?} ",
+                    auction_id,
                     name,
-                    settlement,
-                    auction_id
+                    settlement
                 );
             }
 
@@ -537,7 +537,7 @@ impl Driver {
             .rate_settlements(solver_settlements, &external_prices, gas_price)
             .await?;
         tracing::info!(
-            "{} settlements passed simulation and {} failed for auction id: {}",
+            "{} settlements passed simulation and {} failed for auction id {}",
             rated_settlements.len(),
             errors.len(),
             auction_id

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -86,6 +86,7 @@ impl HttpSolver {
 
     async fn prepare_model(
         &self,
+        auction_id: u64,
         orders: Vec<LimitOrder>,
         liquidity: Vec<Liquidity>,
         gas_price: f64,
@@ -149,6 +150,7 @@ impl HttpSolver {
             amms: amm_models,
             metadata: Some(MetadataModel {
                 environment: Some(self.solver.network_name.clone()),
+                auction_id: Some(auction_id),
             }),
         };
         Ok((model, SettlementContext { orders, liquidity }))
@@ -393,7 +395,7 @@ impl Solver for HttpSolver {
                 Some(data) if data.solve_id == id => (data.model.clone(), data.context.clone()),
                 _ => {
                     let (model, context) = self
-                        .prepare_model(orders, liquidity, gas_price, external_prices)
+                        .prepare_model(id, orders, liquidity, gas_price, external_prices)
                         .await?;
                     *guard = Some(InstanceData {
                         solve_id: id,
@@ -517,7 +519,7 @@ mod tests {
             settlement_handling: CapturingSettlementHandler::arc(),
         })];
         let (model, _context) = solver
-            .prepare_model(limit_orders, liquidity, gas_price, Default::default())
+            .prepare_model(0u64, limit_orders, liquidity, gas_price, Default::default())
             .await
             .unwrap();
         let settled = solver


### PR DESCRIPTION
The solver team spends quite some time to find their logs for a corresponding tx-settlement. With this PR, it should get much easier. One can just search for the tx_hash in kibana and will find an auction id. This auction id will be also passed to the http_solvers and then the http solver will be able to make all their data searchable with this auction_id in kibana.

Hopefully, this saves us some time in the future.

### Test Plan
none

### 

in a future PR, we can make the auction_id unique, in order to make it even more easy