### PR TITLE
Reduce max memory usage when enabling zeroex liquidity

### DIFF
--- a/crates/solver/src/liquidity_collector.rs
+++ b/crates/solver/src/liquidity_collector.rs
@@ -46,7 +46,7 @@ impl LiquidityCollector {
             amms.extend(stable_orders.into_iter().map(Liquidity::BalancerStable));
         }
         if let Some(zeroex_liquidity) = self.zeroex_liquidity.as_ref() {
-            amms.append(&mut zeroex_liquidity.get_liquidity().await?)
+            amms.append(&mut zeroex_liquidity.get_liquidity(limit_orders).await?)
         }
         tracing::debug!("got {} AMMs", amms.len());
 

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -497,7 +497,7 @@ async fn main() {
     let solver = solver::solver::create(
         web3.clone(),
         solvers,
-        base_tokens,
+        base_tokens.clone(),
         native_token_contract.address(),
         args.mip_solver_url,
         args.cow_dex_ag_solver_url,
@@ -526,6 +526,7 @@ async fn main() {
         Some(ZeroExLiquidity {
             api: zeroex_api,
             zeroex: contracts::IZeroEx::deployed(&web3).await.unwrap(),
+            base_tokens,
         })
     } else {
         None


### PR DESCRIPTION
Edit: Filtering results after they got parsed is actually good enough so the solution this PR eventually implemented is way simpler than what is described 👇 . But I will leave the original description in place because it could be an interesting reference for similar problems in the future.

<br>  

### Original Desription
ZeroEx usually offers >1000 limit orders as liquidity. The current implementation simply queries all orders and forwards them to the solvers without filtering out any orders. This results in a significantly higher max memory usage than usual.
Unfortunately the solution is not as easy as deserializing every order and filtering the results afterwards because the max memory usage happens while parsing.
A simple solution would be to decrease the page size when querying the zeroex orders. This unfortunately adds some latency because we would have to do 10 times as many requests to get reasonable memory usage.

Instead I extended the `ZeroExApi` such that you can pass a `Filter<OrderRecord>` which allows you to discard any orders you are not interested in while they are being parsed.
This approach has a few consequences:
1. Because this use case is very niche we can not simply derive the implementation of `Deserialize` but have to write some specialized deserialization logic instead.
2. The code to determine when we reached the final page of limit orders needed to be adapted slightly.
3. `get_orders()` can't use the generic `DefaultZeroExApi::request()` and has to use a specialised implementation which knows how to apply the passed `Filter<OrderRecord>`.

With that functionality in place we can filter out many zeroex limit orders by only collecting the ones where the order trades one of our 6 base tokens against one of the user order tokens. This behavior is already used for other liquidity sources so it should be fine.

The manual benchmarks showed a decrease of the max used memory from ~213MB to ~40MB which is only slightly higher than when the zeroex liquidity is disabled (~37MB).
1. Current implementation (0x disabled)
2. Filtering orders while parsing (0x disabled)
3. Current implementation (0x enabled)
4. Filtering orders while parsing (0x enabled)
<img width="961" alt="Screenshot 2022-03-30 at 11 11 16" src="https://user-images.githubusercontent.com/19190235/160832064-e06cf052-e7d7-4e59-8206-a8243c583fc4.png">

Notes:
1. The benchmarks were done in release mode.
2. The benchmark also shows a significant reduction in CPU utilization while parsing.
3. The reduced number of collected limit orders should also decrease the computation time of the quasimodo solver.
4. During my benchmarks the current implementation always got a lower max memory usage than in the staging environment so the memory usage improvements of this change might be a little different when it gets deployed.
[here](https://cowservices.slack.com/archives/C0361CDD1FZ/p1648239893644589?thread_ts=1648218890.934519&cid=C0361CDD1FZ) is the memory usage on staging.

### Test Plan
Benchmarks of max memory usage
added unit test for new filter while parsing logic
updated some existing tests