### PR TITLE
Adds gas price to the json sent to the http solver.

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -488,6 +488,7 @@ mod tests {
           "metadata": {
             "environment": "Such Meta",
             "auction_id": null,
+            "gas_price": null,
           },
         });
         assert_eq!(result, expected);

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -160,6 +160,7 @@ impl SettledBatchAuctionModel {
 pub struct MetadataModel {
     pub environment: Option<String>,
     pub auction_id: Option<u64>,
+    pub gas_price: Option<f64>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -388,6 +389,7 @@ mod tests {
             metadata: Some(MetadataModel {
                 environment: Some(String::from("Such Meta")),
                 auction_id: None,
+                gas_price: None,
             }),
         };
 

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -151,6 +151,7 @@ impl HttpSolver {
             metadata: Some(MetadataModel {
                 environment: Some(self.solver.network_name.clone()),
                 auction_id: Some(auction_id),
+                gas_price: Some(gas_price),
             }),
         };
         Ok((model, SettlementContext { orders, liquidity }))


### PR DESCRIPTION
I am assuming that for price estimation quasimodo won't be querying external liquidity sources, because speed is so important. Let me know if this doesn't make sense - we would have to also pass the gas price in the price estimation.