### PR TITLE
Check price deviation between external prices and settlements

### DIFF
--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -249,6 +249,8 @@ async fn eth_integration(web3: Web3) {
         0.0,
         15000000u128,
         1.0,
+        None,
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -250,7 +250,7 @@ async fn eth_integration(web3: Web3) {
         15000000u128,
         1.0,
         None,
-        None,
+        None.into(),
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -254,6 +254,8 @@ async fn onchain_settlement(web3: Web3) {
         0.0,
         15000000u128,
         1.0,
+        None,
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -255,7 +255,7 @@ async fn onchain_settlement(web3: Web3) {
         15000000u128,
         1.0,
         None,
-        None,
+        None.into(),
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -243,6 +243,8 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         0.0,
         15000000u128,
         1.0,
+        None,
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -244,7 +244,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         15000000u128,
         1.0,
         None,
-        None,
+        None.into(),
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -213,7 +213,7 @@ async fn smart_contract_orders(web3: Web3) {
         15000000u128,
         1.0,
         None,
-        None,
+        None.into(),
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -212,6 +212,8 @@ async fn smart_contract_orders(web3: Web3) {
         0.0,
         15000000u128,
         1.0,
+        None,
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -193,6 +193,8 @@ async fn vault_balances(web3: Web3) {
         0.0,
         15000000u128,
         1.0,
+        None,
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -194,7 +194,7 @@ async fn vault_balances(web3: Web3) {
         15000000u128,
         1.0,
         None,
-        None,
+        None.into(),
     );
     driver.single_run().await.unwrap();
 

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -463,7 +463,7 @@ impl Driver {
                                 auction_id,
                                 solver.name(),
                                 &external_prices,
-                                &max_settlement_price_deviation,
+                                max_settlement_price_deviation,
                                 &self.token_list_for_price_checks,
                             )
                         });

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -60,7 +60,7 @@ pub struct Driver {
     simulation_gas_limit: u128,
     fee_objective_scaling_factor: BigRational,
     max_settlement_price_deviation: Option<Ratio<BigInt>>,
-    token_list_for_price_checks: Option<HashSet<H160>>,
+    token_list_restriction_for_price_checks: Option<HashSet<H160>>,
 }
 impl Driver {
     #[allow(clippy::too_many_arguments)]
@@ -87,7 +87,7 @@ impl Driver {
         simulation_gas_limit: u128,
         fee_objective_scaling_factor: f64,
         max_settlement_price_deviation: Option<Ratio<BigInt>>,
-        token_list_for_price_checks: Option<HashSet<H160>>,
+        token_list_restriction_for_price_checks: Option<HashSet<H160>>,
     ) -> Self {
         let post_processing_pipeline = PostProcessingPipeline::new(
             native_token,
@@ -122,7 +122,7 @@ impl Driver {
             fee_objective_scaling_factor: BigRational::from_float(fee_objective_scaling_factor)
                 .unwrap(),
             max_settlement_price_deviation,
-            token_list_for_price_checks,
+            token_list_restriction_for_price_checks,
         }
     }
 
@@ -464,7 +464,7 @@ impl Driver {
                                 solver.name(),
                                 &external_prices,
                                 max_settlement_price_deviation,
-                                &self.token_list_for_price_checks,
+                                &self.token_list_restriction_for_price_checks,
                             )
                         });
                     }

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -8,7 +8,7 @@ use crate::{
     liquidity_collector::LiquidityCollector,
     metrics::{SolverMetrics, SolverRunOutcome},
     orderbook::OrderBookApi,
-    settlement::{external_prices::ExternalPrices, Settlement},
+    settlement::{external_prices::ExternalPrices, Settlement, TokensForPriceCheck},
     settlement_post_processing::PostProcessingPipeline,
     settlement_simulation::{self, settle_method},
     settlement_submission::SolutionSubmitter,
@@ -29,7 +29,6 @@ use shared::{
     Web3,
 };
 use std::{
-    collections::HashSet,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -60,7 +59,7 @@ pub struct Driver {
     simulation_gas_limit: u128,
     fee_objective_scaling_factor: BigRational,
     max_settlement_price_deviation: Option<Ratio<BigInt>>,
-    token_list_restriction_for_price_checks: Option<HashSet<H160>>,
+    token_list_restriction_for_price_checks: TokensForPriceCheck,
 }
 impl Driver {
     #[allow(clippy::too_many_arguments)]
@@ -87,7 +86,7 @@ impl Driver {
         simulation_gas_limit: u128,
         fee_objective_scaling_factor: f64,
         max_settlement_price_deviation: Option<Ratio<BigInt>>,
-        token_list_restriction_for_price_checks: Option<HashSet<H160>>,
+        token_list_restriction_for_price_checks: TokensForPriceCheck,
     ) -> Self {
         let post_processing_pipeline = PostProcessingPipeline::new(
             native_token,

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -8,7 +8,7 @@ use crate::{
     liquidity_collector::LiquidityCollector,
     metrics::{SolverMetrics, SolverRunOutcome},
     orderbook::OrderBookApi,
-    settlement::{external_prices::ExternalPrices, Settlement, TokensForPriceCheck},
+    settlement::{external_prices::ExternalPrices, PriceCheckTokens, Settlement},
     settlement_post_processing::PostProcessingPipeline,
     settlement_simulation::{self, settle_method},
     settlement_submission::SolutionSubmitter,
@@ -59,7 +59,7 @@ pub struct Driver {
     simulation_gas_limit: u128,
     fee_objective_scaling_factor: BigRational,
     max_settlement_price_deviation: Option<Ratio<BigInt>>,
-    token_list_restriction_for_price_checks: TokensForPriceCheck,
+    token_list_restriction_for_price_checks: PriceCheckTokens,
 }
 impl Driver {
     #[allow(clippy::too_many_arguments)]
@@ -86,7 +86,7 @@ impl Driver {
         simulation_gas_limit: u128,
         fee_objective_scaling_factor: f64,
         max_settlement_price_deviation: Option<Ratio<BigInt>>,
-        token_list_restriction_for_price_checks: TokensForPriceCheck,
+        token_list_restriction_for_price_checks: PriceCheckTokens,
     ) -> Self {
         let post_processing_pipeline = PostProcessingPipeline::new(
             native_token,

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -85,7 +85,6 @@ impl Driver {
         weth_unwrap_factor: f64,
         simulation_gas_limit: u128,
         fee_objective_scaling_factor: f64,
-
         max_settlement_price_deviation: Option<u64>,
         token_list_for_price_checks: Option<Vec<H160>>,
     ) -> Self {

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -458,20 +458,13 @@ impl Driver {
                         self.max_settlement_price_deviation
                     {
                         settlement.retain(|settlement| {
-                            let satisfies_price_check = settlement.satisfies_price_checks(
+                            settlement.satisfies_price_checks(
+                                auction_id,
+                                solver.name(),
                                 &external_prices,
                                 max_settlement_price_deviation,
                                 &self.token_list_for_price_checks,
-                            );
-                            if !satisfies_price_check {
-                                tracing::debug!(
-                                    "For auction id {} there is a price violation from solver {:} for the settlement: {:?}",
-                                    auction_id,
-                                    solver.name(),
-                                    settlement
-                                );
-                            }
-                            satisfies_price_check
+                            )
                         });
                     }
                     if settlement.is_empty() {

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -280,6 +280,19 @@ struct Arguments {
     /// but at the same time we don't restrict solutions sizes too much
     #[clap(long, env, default_value = "15000000")]
     simulation_gas_limit: u128,
+
+    /// In order to protect against malicious solvers, the driver will check that settlements prices do not
+    /// exceed a max price deviation compared to the external prices of the driver, if this optional0 value is set.
+    /// The max deviation value should be provided as a percentage value. E.g. for a max price deviation
+    /// of 3%, one should set it to 3u64
+    #[clap(long, env)]
+    max_settlement_price_deviation: Option<u64>,
+
+    /// This variable allows to restrict the set of tokens for which a price deviation check of settlement
+    /// prices and external prices is executed. If the value is set to none, then all tokens included
+    /// in the settlement are checked for price deviation.
+    #[clap(long, env)]
+    token_list_for_price_checks: Option<Vec<H160>>,
 }
 
 #[derive(Copy, Clone, Debug, clap::ArgEnum)]
@@ -649,6 +662,8 @@ async fn main() {
         args.weth_unwrap_factor,
         args.simulation_gas_limit,
         args.fee_objective_scaling_factor,
+        args.max_settlement_price_deviation,
+        args.token_list_for_price_checks,
     );
 
     let maintainer = ServiceMaintenance {

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -40,12 +40,7 @@ use solver::{
     },
     solver::SolverType,
 };
-use std::{
-    collections::{HashMap, HashSet},
-    str::FromStr,
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
 #[derive(Debug, Parser)]
 struct Arguments {
@@ -671,8 +666,7 @@ async fn main() {
         args.fee_objective_scaling_factor,
         args.max_settlement_price_deviation
             .map(|max_price_deviation| Ratio::from_float(max_price_deviation).unwrap()),
-        args.token_list_restriction_for_price_checks
-            .map(HashSet::from_iter),
+        args.token_list_restriction_for_price_checks.into(),
     );
 
     let maintainer = ServiceMaintenance {

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -282,7 +282,7 @@ struct Arguments {
     simulation_gas_limit: u128,
 
     /// In order to protect against malicious solvers, the driver will check that settlements prices do not
-    /// exceed a max price deviation compared to the external prices of the driver, if this optional0 value is set.
+    /// exceed a max price deviation compared to the external prices of the driver, if this optional value is set.
     /// The max deviation value should be provided as a percentage value. E.g. for a max price deviation
     /// of 3%, one should set it to 3u64
     #[clap(long, env)]

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -298,7 +298,7 @@ struct Arguments {
     /// prices and external prices is executed. If the value is not set, then all tokens included
     /// in the settlement are checked for price deviation.
     #[clap(long, env)]
-    token_list_for_price_checks: Option<Vec<H160>>,
+    token_list_restriction_for_price_checks: Option<Vec<H160>>,
 }
 
 #[derive(Copy, Clone, Debug, clap::ArgEnum)]
@@ -671,7 +671,8 @@ async fn main() {
         args.fee_objective_scaling_factor,
         args.max_settlement_price_deviation
             .map(|max_price_deviation| Ratio::from_float(max_price_deviation).unwrap()),
-        args.token_list_for_price_checks.map(HashSet::from_iter),
+        args.token_list_restriction_for_price_checks
+            .map(HashSet::from_iter),
     );
 
     let maintainer = ServiceMaintenance {

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -7,13 +7,16 @@ use crate::{
     encoding::{self, EncodedInteraction, EncodedSettlement, EncodedTrade},
     liquidity::Settleable,
 };
-use itertools::Itertools;
 use anyhow::Result;
+use itertools::Itertools;
 use model::order::{Order, OrderKind};
 use num::{rational::Ratio, BigInt, BigRational, One, Signed, Zero};
 use primitive_types::{H160, U256};
 use shared::conversions::U256Ext as _;
-use std::{collections::HashMap, ops::{Mul, Sub}};
+use std::{
+    collections::HashMap,
+    ops::{Mul, Sub},
+};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Trade {
@@ -313,7 +316,7 @@ impl Settlement {
         // For the linear implementation, one would have to find a unique scaling factor that scales the external prices into
         // the settlement prices. Though, this scaling factor is not easy to define, if reference tokens like ETH are missing.
         // Since the checks would heavily depend on this scaling factor, and its
-        // derivation is non-trivial, we decided to go for the implementation with quadratic run time. Settlements 
+        // derivation is non-trivial, we decided to go for the implementation with quadratic run time. Settlements
         // will not have enough tokens, such that the run-time is important.
         !self
             .clearing_prices()
@@ -551,20 +554,30 @@ pub mod tests {
         let clearing_prices =
             hashmap! {token0 => 50i32.into(), token1 => 100i32.into(), token2 => 103i32.into()};
         let settlement = test_settlement(clearing_prices, vec![], vec![]);
-       
+
         let external_prices = ExternalPrices(
             hashmap! {token0 => BigInt::from(50i32).into(), token1 => BigInt::from(100i32).into(), token2 => BigInt::from(100i32).into()},
         );
         // Tolerance exceed on token2
-        assert!(!settlement.satisfies_price_checks(0u64, "test_solver", &external_prices, 2u64, &None));
+        assert!(!settlement.satisfies_price_checks(
+            0u64,
+            "test_solver",
+            &external_prices,
+            2u64,
+            &None
+        ));
         // No tolerance exceeded on token0 and token1
-        assert!(settlement.satisfies_price_checks(0u64, "test_solver",
+        assert!(settlement.satisfies_price_checks(
+            0u64,
+            "test_solver",
             &external_prices,
             2u64,
             &Some(vec![token0, token1])
         ));
         // Tolerance exceeded on token2
-        assert!(!settlement.satisfies_price_checks(0u64, "test_solver",
+        assert!(!settlement.satisfies_price_checks(
+            0u64,
+            "test_solver",
             &external_prices,
             2u64,
             &Some(vec![token1, token2])
@@ -574,17 +587,31 @@ pub mod tests {
             hashmap! {token0 => BigInt::from(100i32).into(), token1 => BigInt::from(200i32).into(), token2 => BigInt::from(205i32).into()},
         );
         // No tolerance exceeded
-        assert!(settlement.satisfies_price_checks(0u64, "test_solver",&external_prices, 2u64, &None));
+        assert!(settlement.satisfies_price_checks(
+            0u64,
+            "test_solver",
+            &external_prices,
+            2u64,
+            &None
+        ));
 
         let external_prices = ExternalPrices(hashmap! {token0 => BigInt::from(200i32).into()});
         // If only 1 token should be checked: trivially satisfies equation
-        assert!(settlement.satisfies_price_checks(0u64, "test_solver",&external_prices, 2u64, &None));
-        
+        assert!(settlement.satisfies_price_checks(
+            0u64,
+            "test_solver",
+            &external_prices,
+            2u64,
+            &None
+        ));
+
         let external_prices = ExternalPrices(
             hashmap! {token0 => BigInt::from(200i32).into(), token1 => BigInt::from(300i32).into()},
         );
         // Can deal with missing token1, tolerance exceeded on token1
-        assert!(!settlement.satisfies_price_checks(0u64, "test_solver",
+        assert!(!settlement.satisfies_price_checks(
+            0u64,
+            "test_solver",
             &external_prices,
             2u64,
             &Some(vec![token0, token1, token2])
@@ -594,7 +621,9 @@ pub mod tests {
             hashmap! {token0 => BigInt::from(100i32).into(), token2 => BigInt::from(205i32).into()},
         );
         // Can deal with missing token1, tolerance not exceeded
-        assert!(settlement.satisfies_price_checks(0u64, "test_solver",
+        assert!(settlement.satisfies_price_checks(
+            0u64,
+            "test_solver",
             &external_prices,
             2u64,
             &Some(vec![token0, token1, token2])

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -361,7 +361,7 @@ impl Settlement {
                 };
                 // Condition to check: Deviation of clearing prices is bigger than max_settlement_price deviation
                 //
-                // |clearing_price_sell_token / clearing_price_buy_token - external_price_sell_token/external_price_buy_token)|
+                // |clearing_price_sell_token / clearing_price_buy_token - external_price_sell_token / external_price_buy_token)|
                 // |----------------------------------------------------------------------------------------------------------|
                 // |                     clearing_price_sell_token / clearing_price_buy_token                                 |
                 // is bigger than:

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -205,17 +205,17 @@ pub enum Revertable {
     HighRisk,
 }
 
-pub enum TokensForPriceCheck {
+pub enum PriceCheckTokens {
     All,
     Tokens(HashSet<H160>),
 }
 
-impl From<Option<Vec<H160>>> for TokensForPriceCheck {
+impl From<Option<Vec<H160>>> for PriceCheckTokens {
     fn from(token_list: Option<Vec<H160>>) -> Self {
         if let Some(tokens) = token_list {
-            TokensForPriceCheck::Tokens(HashSet::from_iter(tokens.into_iter()))
+            PriceCheckTokens::Tokens(HashSet::from_iter(tokens.into_iter()))
         } else {
-            TokensForPriceCheck::All
+            PriceCheckTokens::All
         }
     }
 }
@@ -325,9 +325,9 @@ impl Settlement {
         solver_name: &str,
         external_prices: &ExternalPrices,
         max_settlement_price_deviation: &Ratio<BigInt>,
-        tokens_to_satisfy_price_test: &TokensForPriceCheck,
+        tokens_to_satisfy_price_test: &PriceCheckTokens,
     ) -> bool {
-        if matches!(tokens_to_satisfy_price_test, TokensForPriceCheck::Tokens(token_list) if token_list.is_empty())
+        if matches!(tokens_to_satisfy_price_test, PriceCheckTokens::Tokens(token_list) if token_list.is_empty())
         {
             return true;
         }
@@ -347,7 +347,7 @@ impl Settlement {
                 let (buy_token, buy_price) = clearing_price_vector_combination[1];
                 let clearing_price_buy_token = buy_price.to_big_rational();
 
-                if matches!(tokens_to_satisfy_price_test, TokensForPriceCheck::Tokens(token_list) if (!token_list.contains(sell_token)) || !token_list.contains(buy_token))
+                if matches!(tokens_to_satisfy_price_test, PriceCheckTokens::Tokens(token_list) if (!token_list.contains(sell_token)) || !token_list.contains(buy_token))
                 {
                     return true;
                 }

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -342,7 +342,6 @@ impl Settlement {
                     Some(price) => price,
                     None => return false,
                 };
-  
                 // Condition to check: Deviation of clearing prices is bigger than max_settlement_price deviation
                 //
                 // |clearing_price_sell_token / clearing_price_buy_token - external_price_sell_token/external_price_buy_token)|

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -363,7 +363,7 @@ impl Settlement {
                 //
                 // |clearing_price_sell_token / clearing_price_buy_token - external_price_sell_token/external_price_buy_token)|
                 // |----------------------------------------------------------------------------------------------------------|
-                // |                     clearing_price_sell_token / clearing_price_buy_token                                  |
+                // |                     clearing_price_sell_token / clearing_price_buy_token                                 |
                 // is bigger than:
                 // max_settlement_price_deviation
                 //

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -367,8 +367,8 @@ impl Settlement {
                 // is bigger than:
                 // max_settlement_price_deviation
                 //
-                // This is equal to: |clearing_price_sell_token*external_price_buy_token-external_price_sell_token*clearing_price_buy_token|>
-                // max_settlement_price_deviation*clearing_price_buy_token*external_price_buy_token *clearing_price_sell_token
+                // This is equal to: |clearing_price_sell_token * external_price_buy_token - external_price_sell_token * clearing_price_buy_token|>
+                // max_settlement_price_deviation * clearing_price_buy_token * external_price_buy_token * clearing_price_sell_token
 
                 let price_check_result = clearing_price_sell_token
                     .clone()

--- a/crates/solver/src/settlement/external_prices.rs
+++ b/crates/solver/src/settlement/external_prices.rs
@@ -16,7 +16,7 @@ use std::collections::{BTreeMap, HashMap};
 /// A collection of external prices used for converting token amounts to native
 /// assets.
 #[derive(Clone, Debug)]
-pub struct ExternalPrices(pub HashMap<H160, BigRational>);
+pub struct ExternalPrices(HashMap<H160, BigRational>);
 
 impl ExternalPrices {
     /// Creates a new set of external prices for the specified exchange rates.
@@ -53,6 +53,14 @@ impl ExternalPrices {
                 .map(|(token, price)| (token, to_native_xrate(price)))
                 .collect(),
         )
+    }
+
+    /// Returns the price of a token relative to the native token.
+    /// I.e., the price of the native token is 1 and
+    /// the price of a token T is represented as how much native token
+    // is needed in order to buy 1 atom of the token T
+    pub fn price(&self, token: &H160) -> Option<&BigRational> {
+        self.0.get(token)
     }
 
     /// Converts a token amount into its native asset equivalent.

--- a/crates/solver/src/settlement/external_prices.rs
+++ b/crates/solver/src/settlement/external_prices.rs
@@ -16,7 +16,7 @@ use std::collections::{BTreeMap, HashMap};
 /// A collection of external prices used for converting token amounts to native
 /// assets.
 #[derive(Clone, Debug)]
-pub struct ExternalPrices(HashMap<H160, BigRational>);
+pub struct ExternalPrices(pub HashMap<H160, BigRational>);
 
 impl ExternalPrices {
     /// Creates a new set of external prices for the specified exchange rates.


### PR DESCRIPTION
In order to ensure that the driver only settles solutions from the solvers that are reasonable, we will check that settlement prices do not deviate too much from external prices (AMM spot prices calculated in the /auction endpoint in the orderbook).

Since for some tokens, the price deviation to external prices could be quite huge - due to a big slippage -, this PR allows providing a token list, on which the checks will be performed. E.g. we could start with USDC, DAI, USDT, UST, ETH, WETH, WBTC and an allowed price deviation of 3%.

More background information can be found here: https://cowservices.slack.com/archives/C0375NV72SC/p1648801241277359

### Test Plan
Unit tests

--- 
This is only a quick and dirty solution. Later one, we will likely replace this check by some envy checks for AMMs.
