### PR TITLE
Add metrics for bad token detection

### DIFF
--- a/crates/shared/src/bad_token/instrumented.rs
+++ b/crates/shared/src/bad_token/instrumented.rs
@@ -1,0 +1,62 @@
+use super::{BadTokenDetecting, TokenQuality};
+use crate::metrics::get_metric_storage_registry;
+use anyhow::Result;
+use prometheus::CounterVec;
+use prometheus_metric_storage::MetricStorage;
+
+pub trait InstrumentedBadTokenDetectorExt {
+    fn instrumented(self) -> InstrumentedBadTokenDetector;
+}
+
+impl<T: BadTokenDetecting + 'static> InstrumentedBadTokenDetectorExt for T {
+    fn instrumented(self) -> InstrumentedBadTokenDetector {
+        InstrumentedBadTokenDetector {
+            inner: Box::new(self),
+        }
+    }
+}
+
+#[derive(MetricStorage, Clone, Debug)]
+#[metric(subsystem = "token_quality")]
+struct Metrics {
+    /// Tracks how many token detections result in good or bad token quality or an error.
+    #[metric(labels("quality"))]
+    results: CounterVec,
+}
+
+pub struct InstrumentedBadTokenDetector {
+    inner: Box<dyn BadTokenDetecting>,
+}
+
+#[async_trait::async_trait]
+impl BadTokenDetecting for InstrumentedBadTokenDetector {
+    async fn detect(&self, token: ethcontract::H160) -> Result<TokenQuality> {
+        let result = self.inner.detect(token).await;
+
+        let label = match &result {
+            Ok(TokenQuality::Good) => "good",
+            // prometheus isn't very good for string based data so we simply log the bad
+            // tokens/errors and get the information from Kibana when we need it.
+            Err(err) => {
+                tracing::warn!(
+                    "bad token detection for {:?} returned error:\n{:?}",
+                    token,
+                    err
+                );
+                "error"
+            }
+            Ok(quality @ TokenQuality::Bad { .. }) => {
+                tracing::warn!("bad token detection for {:?} returned {:?}", token, quality);
+                "bad"
+            }
+        };
+
+        Metrics::instance(get_metric_storage_registry())
+            .expect("unexpected error getting metrics instance")
+            .results
+            .with_label_values(&[label])
+            .inc();
+
+        result
+    }
+}

--- a/crates/shared/src/bad_token/mod.rs
+++ b/crates/shared/src/bad_token/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod instrumented;
 pub mod list_based;
 pub mod trace_call;
 


### PR DESCRIPTION
Implements first task of #1739 

In order to develop a strategy to handle bad token detection and measure its success we need more information.
This PR covers the following pieces of information:
1. The number of times a bad token detector returns good token, bad token or an error.
2. The error when a bad token detection fails.
3. The reason when a token gets detected as bad.

Because prometheus can't handle string based information very well I decided to simply log that information. When the time comes to evaluate the findings we simply have to query Kibana and look at that data.
To do that I added the `InstrumentedBadTokenDetector` which wraps around a `dyn BadTokenDetecting` and simply takes care of the metrics and logging.
This pattern is already frequently used by us but I also added an extension trait which help us build `BadTokenDetecting` hierarchies with a builder pattern. I think this design is pretty neat and would also help us with the way more complex `dyn PriceEstimating` hierarchies. Let me know what you think.

Note that a good tokens get over reported because requests containing bad tokens return way earlier. This indicates that we are checking tokens more often than we need to.

### Test Plan
Manually tested metrics and logs for error, good quality and bad quality case.

Error:  
```
2022-04-01T11:20:37.776Z  WARN request{id=1}: shared::bad_token::instrumented: bad token detection for 0x134f18a6864efb61ea8636d1bdb0cc3c4c8fd798 returned error:
and some extra context

Caused by:
    0: with context
    1: some test error
```

Bad token:
```
2022-04-01T11:20:46.661Z  WARN request{id=3}: shared::bad_token::instrumented: bad token detection for 0x134f18a6864efb61ea8636d1bdb0cc3c4c8fd797 returned Bad { reason: "deny listed" }
```

Metrics:
```
# HELP gp_v2_api_token_quality_results Tracks how many token detections result in good or bad token quality or an error.
# TYPE gp_v2_api_token_quality_results counter
gp_v2_api_token_quality_results{quality="bad"} 1
gp_v2_api_token_quality_results{quality="error"} 1
gp_v2_api_token_quality_results{quality="good"} 8
```
