### PR TITLE
skip "already known transaction" errors

### DIFF
--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -17,6 +17,15 @@ use futures::FutureExt;
 use gas_estimation::{EstimatedGasPrice, GasPrice1559};
 use shared::Web3;
 
+const ALREADY_KNOWN_TRANSACTION: [&str] = [
+    "Transaction gas price supplied is too low", //openethereum
+    "Transaction nonce is too low",              //openethereum
+    "already known",                             //infura
+    "nonce too low",                             //infura
+    "OldNonce",                                  //erigon
+    "INTERNAL_ERROR: nonce too low",             //erigon
+];
+
 #[derive(Clone)]
 pub struct CustomNodesApi {
     nodes: Vec<Web3>,
@@ -64,8 +73,16 @@ impl TransactionSubmitting for CustomNodesApi {
                     });
                 }
                 Err(err) => {
-                    tracing::warn!(?err, ?lable, "single custom node tx failed");
-                    super::track_submission_success(lable.as_str(), false);
+                    // error is not real error if transaction pool responded that received transaction is already in the pool
+                    let real_error = if let web3::Error::Rpc(rpc_error) = err {
+                        !ALREADY_KNOWN_TRANSACTION
+                            .iter()
+                            .any(|message| rpc_error.message.starts_with(message))
+                    };
+                    if real_error {
+                        tracing::warn!(?err, ?lable, "single custom node tx failed");
+                        super::track_submission_success(lable.as_str(), false);
+                    }
                     if rest.is_empty() {
                         return Err(anyhow::Error::from(err).context("all custom nodes tx failed"));
                     }

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -74,7 +74,7 @@ impl TransactionSubmitting for CustomNodesApi {
                 }
                 Err(err) => {
                     // error is not real error if transaction pool responded that received transaction is already in the pool
-                    let real_error = match err.clone() {
+                    let real_error = match &err {
                         web3::Error::Rpc(rpc_error) => !ALREADY_KNOWN_TRANSACTION
                             .iter()
                             .any(|message| rpc_error.message.starts_with(message)),

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -17,7 +17,7 @@ use futures::FutureExt;
 use gas_estimation::{EstimatedGasPrice, GasPrice1559};
 use shared::Web3;
 
-const ALREADY_KNOWN_TRANSACTION: [&str; 6] = [
+const ALREADY_KNOWN_TRANSACTION: &[&str] = &[
     "Transaction gas price supplied is too low", //openethereum
     "Transaction nonce is too low",              //openethereum
     "already known",                             //infura


### PR DESCRIPTION
This PR skips node submission errors that are related to already known transactions.
Discussed here: https://cowservices.slack.com/archives/C0361CDD1FZ/p1648897295271429

 
