### PR TITLE
Query 0x liquidity only fillable by GPv2Settlement contract

### DIFF
--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -3,7 +3,7 @@ use crate::interactions::ZeroExInteraction;
 use crate::liquidity::{Exchange, LimitOrder, Liquidity};
 use crate::settlement::SettlementEncoder;
 use anyhow::Result;
-use contracts::IZeroEx;
+use contracts::{GPv2Settlement, IZeroEx};
 use model::order::OrderKind;
 use model::TokenPair;
 use primitive_types::U256;
@@ -15,11 +15,24 @@ pub struct ZeroExLiquidity {
     pub api: Arc<dyn ZeroExApi>,
     pub zeroex: IZeroEx,
     pub base_tokens: Arc<BaseTokens>,
+    pub gpv2: GPv2Settlement,
 }
 
 impl ZeroExLiquidity {
     pub async fn get_liquidity(&self, user_orders: &[LimitOrder]) -> Result<Vec<Liquidity>> {
-        let zeroex_orders = self.api.get_orders(&OrdersQuery::default()).await?;
+        let queries = &[
+            // orders fillable by anyone
+            OrdersQuery::default(),
+            // orders fillable only by our settlement contract
+            OrdersQuery {
+                sender: Some(self.gpv2.address()),
+                ..Default::default()
+            },
+        ];
+
+        let zeroex_orders =
+            futures::future::try_join_all(queries.iter().map(|query| self.api.get_orders(query)))
+                .await?;
 
         let user_order_pairs = user_orders
             .iter()
@@ -28,6 +41,7 @@ impl ZeroExLiquidity {
 
         let filtered_zeroex_orders = zeroex_orders
             .into_iter()
+            .flatten()
             .filter(|record| {
                 match TokenPair::new(record.order.taker_token, record.order.maker_token) {
                     Some(pair) => relevant_pairs.contains(&pair),

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -542,6 +542,7 @@ async fn main() {
             api: zeroex_api,
             zeroex: contracts::IZeroEx::deployed(&web3).await.unwrap(),
             base_tokens,
+            gpv2: settlement_contract.clone(),
         })
     } else {
         None


### PR DESCRIPTION
Fixes #1769 

Before this change we only queried 0x orders as liquidity which can be filled by anybody. But 0x also offers the option to make your limit order only fillable by a specific address.
If people want to become private market makers for cow protocol using 0x they simply have to set the `sender` address of their order to the address of our settlement contract.
Now we only have to additionally query those 0x limit orders and we are done.
At the moment this gives us no additional liquidity because nobody uses this option, yet. But at least we are prepared already.
Since the additional orders get fetched in parallel this PR should add no runtime overhead to the liquidity collection.

Note:
This only other way to become a PMM at the moment is to contact us directly so we can list your address as a market maker which entails the privilege of submitting partially fillable orders. Because the 0x integration goes through the 0x smart contract it's less gas efficient but offers a lower barrier of entry to becoming a market maker. This way also enables people to earn a fee by market making for us.

### Test Plan
CI
